### PR TITLE
Upgrade to Flow 0.201.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -24,7 +24,6 @@ autoimports=true
 exact_by_default=true
 format.bracket_spacing=false
 format.single_quotes=true
-inference_mode=lti
 module.name_mapper.extension='less' -> '<PROJECT_ROOT>/root/flowstub.js.flow'
 react.runtime=automatic
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -17,7 +17,7 @@
 
 [lints]
 unnecessary-invariant=error
-unused-promise-in-async-scope=error
+unused-promise=error
 
 [options]
 autoimports=true

--- a/.flowconfig
+++ b/.flowconfig
@@ -24,7 +24,7 @@ autoimports=true
 exact_by_default=true
 format.bracket_spacing=false
 format.single_quotes=true
-inference_mode=constrain_writes
+inference_mode=lti
 module.name_mapper.extension='less' -> '<PROJECT_ROOT>/root/flowstub.js.flow'
 react.runtime=automatic
 

--- a/flow-typed/npm/react-table_v7.x.x.js
+++ b/flow-typed/npm/react-table_v7.x.x.js
@@ -73,18 +73,15 @@ declare module 'react-table' {
     +rows: $ReadOnlyArray<Row<D>>,
   };
 
-  declare type GetColumnOptions<D> = <V>(V) => ColumnOptions<D, V>;
-
-  declare export type UseTableOptions<CV, D> = {
-    +columns: $TupleMap<CV, GetColumnOptions<D>>,
+  declare export type UseTableOptions<D> = {
+    +columns: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
     +data: $ReadOnlyArray<D>,
   };
 
   /*
-   * CV = cell values, an array/tuple of the value types of each column cell.
    * D = data, the type of row data used to populate the table.
    */
-  declare export function useTable<CV, D>(
-    UseTableOptions<CV, D>,
+  declare export function useTable<D>(
+    UseTableOptions<D>,
   ): UseTableInstance<D>;
 }

--- a/lib/MusicBrainz/Server/Data/AreaAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/AreaAliasType.pm
@@ -7,6 +7,8 @@ extends 'MusicBrainz::Server::Data::Entity';
 
 with 'MusicBrainz::Server::Data::Role::AliasType';
 
+sub _entity_class { 'MusicBrainz::Server::Entity::AreaAliasType' }
+
 sub _table { 'area_alias_type' }
 
 sub _type { 'area_alias_type' }

--- a/lib/MusicBrainz/Server/Data/ArtistAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/ArtistAliasType.pm
@@ -7,6 +7,8 @@ extends 'MusicBrainz::Server::Data::Entity';
 
 with 'MusicBrainz::Server::Data::Role::AliasType';
 
+sub _entity_class { 'MusicBrainz::Server::Entity::ArtistAliasType' }
+
 sub _table { 'artist_alias_type' }
 
 sub _type { 'artist_alias_type' }

--- a/lib/MusicBrainz/Server/Data/GenreAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/GenreAliasType.pm
@@ -7,6 +7,8 @@ extends 'MusicBrainz::Server::Data::Entity';
 
 with 'MusicBrainz::Server::Data::Role::AliasType';
 
+sub _entity_class { 'MusicBrainz::Server::Entity::GenreAliasType' }
+
 sub _table { 'genre_alias_type' }
 
 sub _type { 'genre_alias_type' }

--- a/lib/MusicBrainz/Server/Data/InstrumentAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/InstrumentAliasType.pm
@@ -7,6 +7,8 @@ extends 'MusicBrainz::Server::Data::Entity';
 
 with 'MusicBrainz::Server::Data::Role::AliasType';
 
+sub _entity_class { 'MusicBrainz::Server::Entity::InstrumentAliasType' }
+
 sub _table { 'instrument_alias_type' }
 
 sub _type { 'instrument_alias_type' }

--- a/lib/MusicBrainz/Server/Data/LabelAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/LabelAliasType.pm
@@ -7,6 +7,8 @@ extends 'MusicBrainz::Server::Data::Entity';
 
 with 'MusicBrainz::Server::Data::Role::AliasType';
 
+sub _entity_class { 'MusicBrainz::Server::Entity::LabelAliasType' }
+
 sub _table { 'label_alias_type' }
 
 sub _type { 'label_alias_type' }

--- a/lib/MusicBrainz/Server/Data/PlaceAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/PlaceAliasType.pm
@@ -7,6 +7,8 @@ extends 'MusicBrainz::Server::Data::Entity';
 
 with 'MusicBrainz::Server::Data::Role::AliasType';
 
+sub _entity_class { 'MusicBrainz::Server::Entity::PlaceAliasType' }
+
 sub _table { 'place_alias_type' }
 
 sub _type { 'place_alias_type' }

--- a/lib/MusicBrainz/Server/Data/RecordingAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/RecordingAliasType.pm
@@ -7,6 +7,8 @@ extends 'MusicBrainz::Server::Data::Entity';
 
 with 'MusicBrainz::Server::Data::Role::AliasType';
 
+sub _entity_class { 'MusicBrainz::Server::Entity::RecordingAliasType' }
+
 sub _table { 'recording_alias_type' }
 
 sub _type { 'recording_alias_type' }

--- a/lib/MusicBrainz/Server/Data/ReleaseAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseAliasType.pm
@@ -7,6 +7,8 @@ extends 'MusicBrainz::Server::Data::Entity';
 
 with 'MusicBrainz::Server::Data::Role::AliasType';
 
+sub _entity_class { 'MusicBrainz::Server::Entity::ReleaseAliasType' }
+
 sub _table { 'release_alias_type' }
 
 sub _type { 'release_alias_type' }

--- a/lib/MusicBrainz/Server/Data/ReleaseGroupAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroupAliasType.pm
@@ -7,6 +7,8 @@ extends 'MusicBrainz::Server::Data::Entity';
 
 with 'MusicBrainz::Server::Data::Role::AliasType';
 
+sub _entity_class { 'MusicBrainz::Server::Entity::ReleaseGroupAliasType' }
+
 sub _table { 'release_group_alias_type' }
 
 sub _type { 'release_group_alias_type' }

--- a/lib/MusicBrainz/Server/Data/Role/AliasType.pm
+++ b/lib/MusicBrainz/Server/Data/Role/AliasType.pm
@@ -8,8 +8,6 @@ with 'MusicBrainz::Server::Data::Role::OptionsTree';
 
 sub _columns { 'id, gid, name, parent AS parent_id, child_order, description' }
 
-sub _entity_class { 'MusicBrainz::Server::Entity::AliasType' }
-
 sub load {
     my ($self, @objs) = @_;
 

--- a/lib/MusicBrainz/Server/Data/SeriesAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/SeriesAliasType.pm
@@ -7,6 +7,8 @@ extends 'MusicBrainz::Server::Data::Entity';
 
 with 'MusicBrainz::Server::Data::Role::AliasType';
 
+sub _entity_class { 'MusicBrainz::Server::Entity::SeriesAliasType' }
+
 sub _table { 'series_alias_type' }
 
 sub _type { 'series_alias_type' }

--- a/lib/MusicBrainz/Server/Data/WorkAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/WorkAliasType.pm
@@ -7,6 +7,8 @@ extends 'MusicBrainz::Server::Data::Entity';
 
 with 'MusicBrainz::Server::Data::Role::AliasType';
 
+sub _entity_class { 'MusicBrainz::Server::Entity::WorkAliasType' }
+
 sub _table { 'work_alias_type' }
 
 sub _type { 'work_alias_type' }

--- a/lib/MusicBrainz/Server/Entity/Alias.pm
+++ b/lib/MusicBrainz/Server/Entity/Alias.pm
@@ -7,7 +7,6 @@ extends 'MusicBrainz::Server::Entity';
 with 'MusicBrainz::Server::Entity::Role::DatePeriod';
 with 'MusicBrainz::Server::Entity::Role::Name';
 with 'MusicBrainz::Server::Entity::Role::PendingEdits';
-with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'AliasType' };
 
 has 'sort_name' => (
     is => 'rw',

--- a/lib/MusicBrainz/Server/Entity/AliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/AliasType.pm
@@ -5,12 +5,6 @@ use MusicBrainz::Server::Translation::Attributes qw( lp );
 
 extends 'MusicBrainz::Server::Entity';
 
-with 'MusicBrainz::Server::Entity::Role::OptionsTree' => {
-    type => 'AliasType',
-};
-
-sub entity_type { 'alias_type' }
-
 sub l_name {
     my $self = shift;
     return lp($self->name, 'alias_type')

--- a/lib/MusicBrainz/Server/Entity/AliasType.tt
+++ b/lib/MusicBrainz/Server/Entity/AliasType.tt
@@ -2,19 +2,17 @@
     the benefit of people looking at the auto-generated files. To regenerate
     them from this template, run ./script/generate_code.pl. -%]
 # Automatically generated, do not edit.
-package MusicBrainz::Server::Data::[% model %];
+package MusicBrainz::Server::Entity::[% model %];
 
 use Moose;
 
-extends 'MusicBrainz::Server::Data::Entity';
+extends 'MusicBrainz::Server::Entity::AliasType';
 
-with 'MusicBrainz::Server::Data::Role::AliasType';
+with 'MusicBrainz::Server::Entity::Role::OptionsTree' => {
+    type => '[% model %]',
+};
 
-sub _entity_class { 'MusicBrainz::Server::Entity::[% model %]' }
-
-sub _table { '[% table %]' }
-
-sub _type { '[% alias_type %]' }
+sub entity_type { '[% alias_type %]' }
 
 __PACKAGE__->meta->make_immutable;
 
@@ -24,7 +22,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2016 MetaBrainz Foundation
+Copyright (C) 2023 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/AreaAlias.pm
+++ b/lib/MusicBrainz/Server/Entity/AreaAlias.pm
@@ -5,6 +5,8 @@ use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity::Alias';
 
+with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'AreaAliasType' };
+
 sub entity_type { 'area_alias' }
 
 has 'area_id' => (

--- a/lib/MusicBrainz/Server/Entity/AreaAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/AreaAliasType.pm
@@ -1,17 +1,15 @@
 # Automatically generated, do not edit.
-package MusicBrainz::Server::Data::EventAliasType;
+package MusicBrainz::Server::Entity::AreaAliasType;
 
 use Moose;
 
-extends 'MusicBrainz::Server::Data::Entity';
+extends 'MusicBrainz::Server::Entity::AliasType';
 
-with 'MusicBrainz::Server::Data::Role::AliasType';
+with 'MusicBrainz::Server::Entity::Role::OptionsTree' => {
+    type => 'AreaAliasType',
+};
 
-sub _entity_class { 'MusicBrainz::Server::Entity::EventAliasType' }
-
-sub _table { 'event_alias_type' }
-
-sub _type { 'event_alias_type' }
+sub entity_type { 'area_alias_type' }
 
 __PACKAGE__->meta->make_immutable;
 
@@ -21,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2016 MetaBrainz Foundation
+Copyright (C) 2012 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/ArtistAlias.pm
+++ b/lib/MusicBrainz/Server/Entity/ArtistAlias.pm
@@ -5,6 +5,8 @@ use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity::Alias';
 
+with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'ArtistAliasType' };
+
 sub entity_type { 'artist_alias' }
 
 has 'artist_id' => (

--- a/lib/MusicBrainz/Server/Entity/ArtistAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/ArtistAliasType.pm
@@ -1,17 +1,15 @@
 # Automatically generated, do not edit.
-package MusicBrainz::Server::Data::EventAliasType;
+package MusicBrainz::Server::Entity::ArtistAliasType;
 
 use Moose;
 
-extends 'MusicBrainz::Server::Data::Entity';
+extends 'MusicBrainz::Server::Entity::AliasType';
 
-with 'MusicBrainz::Server::Data::Role::AliasType';
+with 'MusicBrainz::Server::Entity::Role::OptionsTree' => {
+    type => 'ArtistAliasType',
+};
 
-sub _entity_class { 'MusicBrainz::Server::Entity::EventAliasType' }
-
-sub _table { 'event_alias_type' }
-
-sub _type { 'event_alias_type' }
+sub entity_type { 'artist_alias_type' }
 
 __PACKAGE__->meta->make_immutable;
 
@@ -21,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2016 MetaBrainz Foundation
+Copyright (C) 2012 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/EventAlias.pm
+++ b/lib/MusicBrainz/Server/Entity/EventAlias.pm
@@ -5,6 +5,8 @@ use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity::Alias';
 
+with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'EventAliasType' };
+
 sub entity_type { 'event_alias' }
 
 has event_id => (

--- a/lib/MusicBrainz/Server/Entity/EventAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/EventAliasType.pm
@@ -1,17 +1,15 @@
 # Automatically generated, do not edit.
-package MusicBrainz::Server::Data::EventAliasType;
+package MusicBrainz::Server::Entity::EventAliasType;
 
 use Moose;
 
-extends 'MusicBrainz::Server::Data::Entity';
+extends 'MusicBrainz::Server::Entity::AliasType';
 
-with 'MusicBrainz::Server::Data::Role::AliasType';
+with 'MusicBrainz::Server::Entity::Role::OptionsTree' => {
+    type => 'EventAliasType',
+};
 
-sub _entity_class { 'MusicBrainz::Server::Entity::EventAliasType' }
-
-sub _table { 'event_alias_type' }
-
-sub _type { 'event_alias_type' }
+sub entity_type { 'event_alias_type' }
 
 __PACKAGE__->meta->make_immutable;
 
@@ -21,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2016 MetaBrainz Foundation
+Copyright (C) 2012 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/GenreAlias.pm
+++ b/lib/MusicBrainz/Server/Entity/GenreAlias.pm
@@ -5,6 +5,8 @@ use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity::Alias';
 
+with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'GenreAliasType' };
+
 sub entity_type { 'genre_alias' }
 
 has genre_id => (

--- a/lib/MusicBrainz/Server/Entity/GenreAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/GenreAliasType.pm
@@ -1,17 +1,15 @@
 # Automatically generated, do not edit.
-package MusicBrainz::Server::Data::EventAliasType;
+package MusicBrainz::Server::Entity::GenreAliasType;
 
 use Moose;
 
-extends 'MusicBrainz::Server::Data::Entity';
+extends 'MusicBrainz::Server::Entity::AliasType';
 
-with 'MusicBrainz::Server::Data::Role::AliasType';
+with 'MusicBrainz::Server::Entity::Role::OptionsTree' => {
+    type => 'GenreAliasType',
+};
 
-sub _entity_class { 'MusicBrainz::Server::Entity::EventAliasType' }
-
-sub _table { 'event_alias_type' }
-
-sub _type { 'event_alias_type' }
+sub entity_type { 'genre_alias_type' }
 
 __PACKAGE__->meta->make_immutable;
 
@@ -21,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2016 MetaBrainz Foundation
+Copyright (C) 2012 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/InstrumentAlias.pm
+++ b/lib/MusicBrainz/Server/Entity/InstrumentAlias.pm
@@ -5,6 +5,8 @@ use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity::Alias';
 
+with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'InstrumentAliasType' };
+
 sub entity_type { 'instrument_alias' }
 
 has 'instrument_id' => (

--- a/lib/MusicBrainz/Server/Entity/InstrumentAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/InstrumentAliasType.pm
@@ -1,17 +1,15 @@
 # Automatically generated, do not edit.
-package MusicBrainz::Server::Data::EventAliasType;
+package MusicBrainz::Server::Entity::InstrumentAliasType;
 
 use Moose;
 
-extends 'MusicBrainz::Server::Data::Entity';
+extends 'MusicBrainz::Server::Entity::AliasType';
 
-with 'MusicBrainz::Server::Data::Role::AliasType';
+with 'MusicBrainz::Server::Entity::Role::OptionsTree' => {
+    type => 'InstrumentAliasType',
+};
 
-sub _entity_class { 'MusicBrainz::Server::Entity::EventAliasType' }
-
-sub _table { 'event_alias_type' }
-
-sub _type { 'event_alias_type' }
+sub entity_type { 'instrument_alias_type' }
 
 __PACKAGE__->meta->make_immutable;
 
@@ -21,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2016 MetaBrainz Foundation
+Copyright (C) 2012 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/LabelAlias.pm
+++ b/lib/MusicBrainz/Server/Entity/LabelAlias.pm
@@ -5,6 +5,8 @@ use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity::Alias';
 
+with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'LabelAliasType' };
+
 sub entity_type { 'label_alias' }
 
 has 'label_id' => (

--- a/lib/MusicBrainz/Server/Entity/LabelAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/LabelAliasType.pm
@@ -1,17 +1,15 @@
 # Automatically generated, do not edit.
-package MusicBrainz::Server::Data::EventAliasType;
+package MusicBrainz::Server::Entity::LabelAliasType;
 
 use Moose;
 
-extends 'MusicBrainz::Server::Data::Entity';
+extends 'MusicBrainz::Server::Entity::AliasType';
 
-with 'MusicBrainz::Server::Data::Role::AliasType';
+with 'MusicBrainz::Server::Entity::Role::OptionsTree' => {
+    type => 'LabelAliasType',
+};
 
-sub _entity_class { 'MusicBrainz::Server::Entity::EventAliasType' }
-
-sub _table { 'event_alias_type' }
-
-sub _type { 'event_alias_type' }
+sub entity_type { 'label_alias_type' }
 
 __PACKAGE__->meta->make_immutable;
 
@@ -21,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2016 MetaBrainz Foundation
+Copyright (C) 2012 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/PlaceAlias.pm
+++ b/lib/MusicBrainz/Server/Entity/PlaceAlias.pm
@@ -5,6 +5,8 @@ use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity::Alias';
 
+with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'PlaceAliasType' };
+
 sub entity_type { 'place_alias' }
 
 has 'place_id' => (

--- a/lib/MusicBrainz/Server/Entity/PlaceAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/PlaceAliasType.pm
@@ -1,17 +1,15 @@
 # Automatically generated, do not edit.
-package MusicBrainz::Server::Data::EventAliasType;
+package MusicBrainz::Server::Entity::PlaceAliasType;
 
 use Moose;
 
-extends 'MusicBrainz::Server::Data::Entity';
+extends 'MusicBrainz::Server::Entity::AliasType';
 
-with 'MusicBrainz::Server::Data::Role::AliasType';
+with 'MusicBrainz::Server::Entity::Role::OptionsTree' => {
+    type => 'PlaceAliasType',
+};
 
-sub _entity_class { 'MusicBrainz::Server::Entity::EventAliasType' }
-
-sub _table { 'event_alias_type' }
-
-sub _type { 'event_alias_type' }
+sub entity_type { 'place_alias_type' }
 
 __PACKAGE__->meta->make_immutable;
 
@@ -21,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2016 MetaBrainz Foundation
+Copyright (C) 2012 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/RecordingAlias.pm
+++ b/lib/MusicBrainz/Server/Entity/RecordingAlias.pm
@@ -5,6 +5,8 @@ use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity::Alias';
 
+with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'RecordingAliasType' };
+
 sub entity_type { 'recording_alias' }
 
 has 'recording_id' => (

--- a/lib/MusicBrainz/Server/Entity/RecordingAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/RecordingAliasType.pm
@@ -1,17 +1,15 @@
 # Automatically generated, do not edit.
-package MusicBrainz::Server::Data::EventAliasType;
+package MusicBrainz::Server::Entity::RecordingAliasType;
 
 use Moose;
 
-extends 'MusicBrainz::Server::Data::Entity';
+extends 'MusicBrainz::Server::Entity::AliasType';
 
-with 'MusicBrainz::Server::Data::Role::AliasType';
+with 'MusicBrainz::Server::Entity::Role::OptionsTree' => {
+    type => 'RecordingAliasType',
+};
 
-sub _entity_class { 'MusicBrainz::Server::Entity::EventAliasType' }
-
-sub _table { 'event_alias_type' }
-
-sub _type { 'event_alias_type' }
+sub entity_type { 'recording_alias_type' }
 
 __PACKAGE__->meta->make_immutable;
 
@@ -21,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2016 MetaBrainz Foundation
+Copyright (C) 2012 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/ReleaseAlias.pm
+++ b/lib/MusicBrainz/Server/Entity/ReleaseAlias.pm
@@ -5,6 +5,8 @@ use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity::Alias';
 
+with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'ReleaseAliasType' };
+
 sub entity_type { 'release_alias' }
 
 has 'release_id' => (

--- a/lib/MusicBrainz/Server/Entity/ReleaseAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/ReleaseAliasType.pm
@@ -1,17 +1,15 @@
 # Automatically generated, do not edit.
-package MusicBrainz::Server::Data::EventAliasType;
+package MusicBrainz::Server::Entity::ReleaseAliasType;
 
 use Moose;
 
-extends 'MusicBrainz::Server::Data::Entity';
+extends 'MusicBrainz::Server::Entity::AliasType';
 
-with 'MusicBrainz::Server::Data::Role::AliasType';
+with 'MusicBrainz::Server::Entity::Role::OptionsTree' => {
+    type => 'ReleaseAliasType',
+};
 
-sub _entity_class { 'MusicBrainz::Server::Entity::EventAliasType' }
-
-sub _table { 'event_alias_type' }
-
-sub _type { 'event_alias_type' }
+sub entity_type { 'release_alias_type' }
 
 __PACKAGE__->meta->make_immutable;
 
@@ -21,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2016 MetaBrainz Foundation
+Copyright (C) 2012 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/ReleaseGroupAlias.pm
+++ b/lib/MusicBrainz/Server/Entity/ReleaseGroupAlias.pm
@@ -5,6 +5,8 @@ use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity::Alias';
 
+with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'ReleaseGroupAliasType' };
+
 sub entity_type { 'release_group_alias' }
 
 has 'release_group_id' => (

--- a/lib/MusicBrainz/Server/Entity/ReleaseGroupAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/ReleaseGroupAliasType.pm
@@ -1,17 +1,15 @@
 # Automatically generated, do not edit.
-package MusicBrainz::Server::Data::EventAliasType;
+package MusicBrainz::Server::Entity::ReleaseGroupAliasType;
 
 use Moose;
 
-extends 'MusicBrainz::Server::Data::Entity';
+extends 'MusicBrainz::Server::Entity::AliasType';
 
-with 'MusicBrainz::Server::Data::Role::AliasType';
+with 'MusicBrainz::Server::Entity::Role::OptionsTree' => {
+    type => 'ReleaseGroupAliasType',
+};
 
-sub _entity_class { 'MusicBrainz::Server::Entity::EventAliasType' }
-
-sub _table { 'event_alias_type' }
-
-sub _type { 'event_alias_type' }
+sub entity_type { 'release_group_alias_type' }
 
 __PACKAGE__->meta->make_immutable;
 
@@ -21,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2016 MetaBrainz Foundation
+Copyright (C) 2012 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/SeriesAlias.pm
+++ b/lib/MusicBrainz/Server/Entity/SeriesAlias.pm
@@ -5,6 +5,8 @@ use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity::Alias';
 
+with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'SeriesAliasType' };
+
 sub entity_type { 'series_alias' }
 
 has series_id => (

--- a/lib/MusicBrainz/Server/Entity/SeriesAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/SeriesAliasType.pm
@@ -1,17 +1,15 @@
 # Automatically generated, do not edit.
-package MusicBrainz::Server::Data::EventAliasType;
+package MusicBrainz::Server::Entity::SeriesAliasType;
 
 use Moose;
 
-extends 'MusicBrainz::Server::Data::Entity';
+extends 'MusicBrainz::Server::Entity::AliasType';
 
-with 'MusicBrainz::Server::Data::Role::AliasType';
+with 'MusicBrainz::Server::Entity::Role::OptionsTree' => {
+    type => 'SeriesAliasType',
+};
 
-sub _entity_class { 'MusicBrainz::Server::Entity::EventAliasType' }
-
-sub _table { 'event_alias_type' }
-
-sub _type { 'event_alias_type' }
+sub entity_type { 'series_alias_type' }
 
 __PACKAGE__->meta->make_immutable;
 
@@ -21,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2016 MetaBrainz Foundation
+Copyright (C) 2012 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/Types.pm
+++ b/lib/MusicBrainz/Server/Entity/Types.pm
@@ -2,30 +2,30 @@ package MusicBrainz::Server::Entity::Types;
 
 use Moose::Util::TypeConstraints;
 
-for my $cls (qw(AggregatedTag AggregatedGenre AliasType Annotation Application
-                Area AreaAlias AreaType
-                Artist ArtistAlias ArtistCredit ArtistCreditName ArtistType
+for my $cls (qw(AggregatedTag AggregatedGenre Annotation Application
+                Area AreaAlias AreaAliasType AreaType
+                Artist ArtistAlias ArtistAliasType ArtistCredit ArtistCreditName ArtistType
                 AutoEditorElection AutoEditorElectionVote
                 Barcode CDTOC CDStub Collection CollectionType Coordinates
                 CoverArtType
                 CritiqueBrainz::Review CritiqueBrainz::User
                 Editor EditorOAuthToken
-                Event EventAlias EventType
-                Gender Genre GenreAlias
-                Instrument InstrumentType
-                Label LabelAlias LabelType
+                Event EventAlias EventAliasType EventType
+                Gender Genre GenreAlias GenreAliasType
+                Instrument InstrumentAlias InstrumentAliasType InstrumentType
+                Label LabelAlias LabelAliasType LabelType
                 Link LinkAttribute LinkAttributeType LinkType LinkTypeAttribute
                 Language
                 Medium MediumCDTOC MediumFormat
                 PartialDate
-                Place PlaceAlias PlaceType
-                Recording RecordingAlias
+                Place PlaceAlias PlaceAliasType PlaceType
+                Recording RecordingAlias RecordingAliasType
                 Relationship RelationshipTargetTypeGroup RelationshipLinkTypeGroup
-                ReleaseGroup ReleaseGroupAlias ReleaseGroupSecondaryType ReleaseGroupType
-                Release ReleaseAlias ReleaseEvent ReleaseStatus ReleasePackaging ReleaseLabel
+                ReleaseGroup ReleaseGroupAlias ReleaseGroupAliasType ReleaseGroupSecondaryType ReleaseGroupType
+                Release ReleaseAlias ReleaseAliasType ReleaseEvent ReleaseStatus ReleasePackaging ReleaseLabel
                 Script Tag Track UserTag
-                Series SeriesOrderingType SeriesType
-                Work WorkAlias WorkType WorkLanguage
+                Series SeriesAlias SeriesAliasType SeriesOrderingType SeriesType
+                Work WorkAlias WorkAliasType WorkType WorkLanguage
                 WorkAttribute WorkAttributeType WorkAttributeTypeAllowedValue)) {
     subtype $cls => as class_type "MusicBrainz::Server::Entity::$cls";
 }

--- a/lib/MusicBrainz/Server/Entity/WorkAlias.pm
+++ b/lib/MusicBrainz/Server/Entity/WorkAlias.pm
@@ -5,6 +5,8 @@ use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity::Alias';
 
+with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'WorkAliasType' };
+
 sub entity_type { 'work_alias' }
 
 has 'work_id' => (

--- a/lib/MusicBrainz/Server/Entity/WorkAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/WorkAliasType.pm
@@ -1,17 +1,15 @@
 # Automatically generated, do not edit.
-package MusicBrainz::Server::Data::EventAliasType;
+package MusicBrainz::Server::Entity::WorkAliasType;
 
 use Moose;
 
-extends 'MusicBrainz::Server::Data::Entity';
+extends 'MusicBrainz::Server::Entity::AliasType';
 
-with 'MusicBrainz::Server::Data::Role::AliasType';
+with 'MusicBrainz::Server::Entity::Role::OptionsTree' => {
+    type => 'WorkAliasType',
+};
 
-sub _entity_class { 'MusicBrainz::Server::Entity::EventAliasType' }
-
-sub _table { 'event_alias_type' }
-
-sub _type { 'event_alias_type' }
+sub entity_type { 'work_alias_type' }
 
 __PACKAGE__->meta->make_immutable;
 
@@ -21,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2016 MetaBrainz Foundation
+Copyright (C) 2012 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.198.2",
+    "flow-bin": "0.199.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.199.0",
+    "flow-bin": "0.199.1",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.199.1",
+    "flow-bin": "0.200.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.200.1",
+    "flow-bin": "0.201.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.197.0",
+    "flow-bin": "0.198.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.200.0",
+    "flow-bin": "0.200.1",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.198.1",
+    "flow-bin": "0.198.2",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.198.0",
+    "flow-bin": "0.198.1",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/root/admin/wikidoc/WikiDocIndex.js
+++ b/root/admin/wikidoc/WikiDocIndex.js
@@ -10,8 +10,8 @@
 import * as React from 'react';
 import type {CellRenderProps} from 'react-table';
 
-import Table from '../../components/Table.js';
 import {SanitizedCatalystContext} from '../../context.mjs';
+import useTable from '../../hooks/useTable.js';
 import Layout from '../../layout/index.js';
 import bracketed from '../../static/scripts/common/utility/bracketed.js';
 import {isWikiTranscluder}
@@ -136,13 +136,11 @@ const WikiDocTable = ({
     ],
   );
 
-  return (
-    <Table
-      className="wiki-pages"
-      columns={columns}
-      data={pages}
-    />
-  );
+  return useTable<WikiDocT>({
+    className: 'wiki-pages',
+    columns,
+    data: pages,
+  });
 };
 
 const WikiDocIndex = (props: PropsT): React.Element<typeof Layout> => {

--- a/root/artist/ArtistIndex.js
+++ b/root/artist/ArtistIndex.js
@@ -116,7 +116,7 @@ const FooterSwitch = ({
       return (
         <>
           {' ('}
-          {links.reduce((accum, link, index) => {
+          {links.reduce((accum: Array<React.Node>, link, index) => {
             accum.push(link);
             if (index < (links.length - 1)) {
               accum.push(' / ');

--- a/root/collection/CollectionMerge.js
+++ b/root/collection/CollectionMerge.js
@@ -10,7 +10,7 @@
 import * as React from 'react';
 import type {ColumnOptions} from 'react-table';
 
-import Table from '../components/Table.js';
+import useTable from '../hooks/useTable.js';
 import Layout from '../layout/index.js';
 import {ENTITY_NAMES} from '../static/scripts/common/constants.js';
 import {
@@ -94,7 +94,7 @@ const CollectionMergeTable = ({
     [collections, form],
   );
 
-  return <Table columns={columns} data={collections} />;
+  return useTable<CollectionT>({columns, data: collections});
 };
 
 const CollectionMerge = ({

--- a/root/components/Aliases/AliasTable.js
+++ b/root/components/Aliases/AliasTable.js
@@ -12,7 +12,7 @@ import * as React from 'react';
 import AliasTableBody from './AliasTableBody.js';
 
 type Props = {
-  +aliases: $ReadOnlyArray<AliasT>,
+  +aliases: $ReadOnlyArray<AnyAiasT>,
   +allowEditing: boolean,
   +entity: EntityWithAliasesT,
 };

--- a/root/components/Aliases/AliasTableBody.js
+++ b/root/components/Aliases/AliasTableBody.js
@@ -12,7 +12,7 @@ import * as React from 'react';
 import AliasTableRow from './AliasTableRow.js';
 
 type Props = {
-  +aliases: $ReadOnlyArray<AliasT>,
+  +aliases: $ReadOnlyArray<AnyAiasT>,
   +allowEditing: boolean,
   +entity: EntityWithAliasesT,
 };

--- a/root/components/Aliases/AliasTableRow.js
+++ b/root/components/Aliases/AliasTableRow.js
@@ -18,7 +18,7 @@ import formatEndDate
 import isolateText from '../../static/scripts/common/utility/isolateText.js';
 
 type Props = {
-  +alias: AliasT,
+  +alias: AnyAiasT,
   +allowEditing: boolean,
   +entity: EntityWithAliasesT,
   +row: string,

--- a/root/components/Aliases/index.js
+++ b/root/components/Aliases/index.js
@@ -36,7 +36,7 @@ function canEdit($c: CatalystContextT, entityType: string) {
 }
 
 type Props = {
-  +aliases: ?$ReadOnlyArray<AliasT>,
+  +aliases: ?$ReadOnlyArray<AnyAiasT>,
   +entity: EntityWithAliasesT,
 };
 

--- a/root/components/RelationshipsTable.js
+++ b/root/components/RelationshipsTable.js
@@ -255,10 +255,10 @@ const RelationshipsTable = ({
       );
       columnsCount = (
         1 +
-        hasCreditColumn +
-        hasAttributeColumn +
-        hasArtistColumn +
-        hasLengthColumn
+        (hasCreditColumn ? 1 : 0) +
+        (hasAttributeColumn ? 1 : 0) +
+        (hasArtistColumn ? 1 : 0) +
+        (hasLengthColumn ? 1 : 0)
       );
 
       rows.push(

--- a/root/components/RelationshipsTable.js
+++ b/root/components/RelationshipsTable.js
@@ -240,7 +240,6 @@ const RelationshipsTable = ({
 
       const target = relationship.target;
       const artistCredit = hasOwnProp(target, 'artistCredit')
-        // $FlowIgnore[prop-missing]
         ? target.artistCredit
         : null;
 
@@ -250,7 +249,6 @@ const RelationshipsTable = ({
       hasArtistColumn = hasArtistColumn || (artistCredit != null);
       hasLengthColumn = hasLengthColumn || (
         hasOwnProp(target, 'length') &&
-        // $FlowIgnore[prop-missing]
         target.length != null
       );
       columnsCount = (

--- a/root/components/VotingPeriod.js
+++ b/root/components/VotingPeriod.js
@@ -29,7 +29,8 @@ const VotingPeriod = ({
   const now = new Date();
 
   if (date > now) {
-    const durationSeconds = Math.floor((date - now) / 1000);
+    const durationSeconds =
+      Math.floor((date.getTime() - now.getTime()) / 1000);
     const durationMinutes = Math.round(durationSeconds / 60);
     const durationHours = Math.round(durationMinutes / 60);
     const durationDays = Math.round(durationHours / 24);

--- a/root/components/list/AreaList.js
+++ b/root/components/list/AreaList.js
@@ -10,13 +10,13 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../../context.mjs';
+import useTable from '../../hooks/useTable.js';
 import {
   defineCheckboxColumn,
   defineNameColumn,
   defineTypeColumn,
   removeFromMergeColumn,
 } from '../../utility/tableColumns.js';
-import Table from '../Table.js';
 
 type Props = {
   +areas: $ReadOnlyArray<AreaT>,
@@ -32,7 +32,7 @@ const AreaList = ({
   mergeForm,
   order,
   sortable,
-}: Props): React.Element<typeof Table> => {
+}: Props): React.Element<'table'> => {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -61,7 +61,7 @@ const AreaList = ({
     [$c.user, areas, checkboxes, mergeForm, order, sortable],
   );
 
-  return <Table columns={columns} data={areas} />;
+  return useTable<AreaT>({columns, data: areas});
 };
 
 export default AreaList;

--- a/root/components/list/ArtistList.js
+++ b/root/components/list/ArtistList.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../../context.mjs';
+import useTable from '../../hooks/useTable.js';
 import {
   defineBeginDateColumn,
   defineCheckboxColumn,
@@ -23,7 +24,6 @@ import {
   defineTypeColumn,
   removeFromMergeColumn,
 } from '../../utility/tableColumns.js';
-import Table from '../Table.js';
 
 type Props = {
   ...InstrumentCreditsAndRelTypesRoleT,
@@ -51,7 +51,7 @@ const ArtistList = ({
   showRatings = false,
   showSortName = false,
   sortable,
-}: Props): React.Element<typeof Table> => {
+}: Props): React.Element<'table'> => {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -153,7 +153,7 @@ const ArtistList = ({
     ],
   );
 
-  return <Table columns={columns} data={artists} />;
+  return useTable<ArtistT>({columns, data: artists});
 };
 
 export default ArtistList;

--- a/root/components/list/EventList.js
+++ b/root/components/list/EventList.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../../context.mjs';
+import useTable from '../../hooks/useTable.js';
 import * as manifest from '../../static/manifest.mjs';
 import {commaOnlyListText}
   from '../../static/scripts/common/i18n/commaOnlyList.js';
@@ -27,7 +28,6 @@ import {
   defineTypeColumn,
   removeFromMergeColumn,
 } from '../../utility/tableColumns.js';
-import Table from '../Table.js';
 
 type Props = {
   ...SeriesItemNumbersRoleT,
@@ -96,7 +96,10 @@ const EventList = ({
         ? defineTextColumn<EventT>({
           columnName: 'performers',
           getText: entity => commaOnlyListText(
-            entity.performers.reduce((result, performer) => {
+            entity.performers.reduce((
+              result: Array<string>,
+              performer,
+            ) => {
               if (performer.entity.id === artist.id) {
                 result.push(...localizeArtistRoles(performer.roles));
               }
@@ -146,9 +149,11 @@ const EventList = ({
     ],
   );
 
+  const table = useTable<EventT>({columns, data: events});
+
   return (
     <>
-      <Table columns={columns} data={events} />
+      {table}
       {manifest.js('common/components/ArtistRoles', {async: 'async'})}
     </>
   );

--- a/root/components/list/InstrumentList.js
+++ b/root/components/list/InstrumentList.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../../context.mjs';
+import useTable from '../../hooks/useTable.js';
 import {
   defineCheckboxColumn,
   defineNameColumn,
@@ -17,7 +18,6 @@ import {
   instrumentDescriptionColumn,
   removeFromMergeColumn,
 } from '../../utility/tableColumns.js';
-import Table from '../Table.js';
 
 type Props = {
   +checkboxes?: string,
@@ -33,7 +33,7 @@ const InstrumentList = ({
   mergeForm,
   order,
   sortable,
-}: Props): React.Element<typeof Table> => {
+}: Props): React.Element<'table'> => {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -65,7 +65,7 @@ const InstrumentList = ({
     [$c.user, checkboxes, instruments, mergeForm, order, sortable],
   );
 
-  return <Table columns={columns} data={instruments} />;
+  return useTable<InstrumentT>({columns, data: instruments});
 };
 
 export default InstrumentList;

--- a/root/components/list/LabelList.js
+++ b/root/components/list/LabelList.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../../context.mjs';
+import useTable from '../../hooks/useTable.js';
 import formatLabelCode from '../../utility/formatLabelCode.js';
 import {
   defineBeginDateColumn,
@@ -22,7 +23,6 @@ import {
   defineTypeColumn,
   removeFromMergeColumn,
 } from '../../utility/tableColumns.js';
-import Table from '../Table.js';
 
 type Props = {
   +checkboxes?: string,
@@ -40,7 +40,7 @@ const LabelList = ({
   order,
   showRatings = false,
   sortable,
-}: Props): React.Element<typeof Table> => {
+}: Props): React.Element<'table'> => {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -109,7 +109,7 @@ const LabelList = ({
     ],
   );
 
-  return <Table columns={columns} data={labels} />;
+  return useTable<LabelT>({columns, data: labels});
 };
 
 export default LabelList;

--- a/root/components/list/PlaceList.js
+++ b/root/components/list/PlaceList.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../../context.mjs';
+import useTable from '../../hooks/useTable.js';
 import {
   defineBeginDateColumn,
   defineCheckboxColumn,
@@ -21,7 +22,6 @@ import {
   defineTypeColumn,
   removeFromMergeColumn,
 } from '../../utility/tableColumns.js';
-import Table from '../Table.js';
 
 type Props = {
   +checkboxes?: string,
@@ -39,7 +39,7 @@ const PlaceList = ({
   places,
   showRatings = false,
   sortable,
-}: Props): React.Element<typeof Table> => {
+}: Props): React.Element<'table'> => {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -99,7 +99,7 @@ const PlaceList = ({
     ],
   );
 
-  return <Table columns={columns} data={places} />;
+  return useTable<PlaceT>({columns, data: places});
 };
 
 export default PlaceList;

--- a/root/components/list/RecordingList.js
+++ b/root/components/list/RecordingList.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 import type {ColumnOptions} from 'react-table';
 
 import {SanitizedCatalystContext} from '../../context.mjs';
+import useTable from '../../hooks/useTable.js';
 import * as manifest from '../../static/manifest.mjs';
 import ReleaseGroupAppearances
   from '../../static/scripts/common/components/ReleaseGroupAppearances.js';
@@ -29,7 +30,6 @@ import {
   isrcsColumn,
   removeFromMergeColumn,
 } from '../../utility/tableColumns.js';
-import Table from '../Table.js';
 
 type Props = {
   ...InstrumentCreditsAndRelTypesRoleT,
@@ -163,12 +163,14 @@ const RecordingList = ({
     ],
   );
 
+  const table = useTable<RecordingWithArtistCreditT>({
+    columns,
+    data: recordings,
+  });
+
   return (
     <>
-      <Table
-        columns={columns}
-        data={recordings}
-      />
+      {table}
       {manifest.js('common/components/AcoustIdCell', {async: 'async'})}
       {manifest.js('common/components/IsrcList', {async: 'async'})}
     </>

--- a/root/components/list/ReleaseGroupList.js
+++ b/root/components/list/ReleaseGroupList.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../../context.mjs';
+import useTable from '../../hooks/useTable.js';
 import {groupBy} from '../../static/scripts/common/utility/arrays.js';
 import parseDate from '../../static/scripts/common/utility/parseDate.js';
 import releaseGroupType from '../../utility/releaseGroupType.js';
@@ -23,7 +24,6 @@ import {
   defineTextColumn,
   removeFromMergeColumn,
 } from '../../utility/tableColumns.js';
-import Table from '../Table.js';
 
 type ReleaseGroupListTableProps = {
   ...SeriesItemNumbersRoleT,
@@ -55,7 +55,7 @@ export const ReleaseGroupListTable = ({
   showRatings = false,
   showType = true,
   sortable,
-}: ReleaseGroupListTableProps): React.Element<typeof Table> => {
+}: ReleaseGroupListTableProps): React.Element<'table'> => {
   const $c = React.useContext(CatalystContext);
 
   function getFirstReleaseYear(entity: ReleaseGroupT) {
@@ -140,13 +140,11 @@ export const ReleaseGroupListTable = ({
     ],
   );
 
-  return (
-    <Table
-      className="release-group-list"
-      columns={columns}
-      data={releaseGroups}
-    />
-  );
+  return useTable<ReleaseGroupT>({
+    className: 'release-group-list',
+    columns,
+    data: releaseGroups,
+  });
 };
 
 const ReleaseGroupList = ({
@@ -157,7 +155,7 @@ const ReleaseGroupList = ({
   seriesItemNumbers,
   showRatings,
   sortable,
-}: ReleaseGroupListProps): Array<React$Node> => {
+}: ReleaseGroupListProps): Array<React.Element<typeof React.Fragment>> => {
   const groupedReleaseGroups = groupBy(releaseGroups, x => x.typeName ?? '');
   const tables = [];
   for (const [type, releaseGroupsOfType] of groupedReleaseGroups) {

--- a/root/components/list/ReleaseList.js
+++ b/root/components/list/ReleaseList.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../../context.mjs';
+import useTable from '../../hooks/useTable.js';
 import * as manifest from '../../static/manifest.mjs';
 import filterReleaseLabels
   from '../../static/scripts/common/utility/filterReleaseLabels.js';
@@ -30,7 +31,6 @@ import {
   removeFromMergeColumn,
   taggerColumn,
 } from '../../utility/tableColumns.js';
-import Table from '../Table.js';
 
 type Props = {
   ...InstrumentCreditsAndRelTypesRoleT,
@@ -118,9 +118,15 @@ const ReleaseList = ({
           sortable: sortable,
         });
       const catnosColumn = defineReleaseCatnosColumn({
-        getLabels: entity => filterLabel
-          ? filterReleaseLabels(entity.labels, filterLabel)
-          : entity.labels,
+        getLabels: (release: ReleaseT) => {
+          const labels = release.labels;
+          if (labels == null) {
+            return [];
+          }
+          return filterLabel
+            ? filterReleaseLabels(labels, filterLabel)
+            : labels;
+        },
         order: order,
         sortable: sortable,
       });
@@ -163,24 +169,24 @@ const ReleaseList = ({
       });
 
       return [
-        ...(checkboxColumn ? [checkboxColumn] : []),
-        ...(seriesNumberColumn ? [seriesNumberColumn] : []),
+        checkboxColumn,
+        seriesNumberColumn,
         nameColumn,
         artistCreditColumn,
         formatColumn,
         tracksColumn,
         releaseEventsColumn,
-        ...(labelsColumn ? [labelsColumn] : []),
+        labelsColumn,
         catnosColumn,
         barcodeColumn,
-        ...(showLanguages ? [releaseLanguageColumn] : []),
-        ...(instrumentUsageColumn ? [instrumentUsageColumn] : []),
-        ...(typeColumn ? [typeColumn] : []),
-        ...(statusColumn ? [statusColumn] : []),
-        ...($c.session?.tport == null ? [] : [taggerColumn]),
-        ...(showRatings ? [ratingsColumn] : []),
-        ...(mergeForm && releases.length > 2 ? [removeFromMergeColumn] : []),
-      ];
+        releaseLanguageColumn,
+        instrumentUsageColumn,
+        typeColumn,
+        statusColumn,
+        ($c.session?.tport == null) ? null : taggerColumn,
+        showRatings ? ratingsColumn : null,
+        (mergeForm && releases.length > 2) ? removeFromMergeColumn : null,
+      ].filter(Boolean);
     },
     [
       $c.session?.tport,
@@ -201,9 +207,11 @@ const ReleaseList = ({
     ],
   );
 
+  const table = useTable<ReleaseT>({columns, data: releases});
+
   return (
     <>
-      <Table columns={columns} data={releases} />
+      {table}
       {manifest.js('common/components/ReleaseEvents', {async: 'async'})}
       {manifest.js('common/components/TaggerIcon', {async: 'async'})}
     </>

--- a/root/components/list/SeriesList.js
+++ b/root/components/list/SeriesList.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../../context.mjs';
+import useTable from '../../hooks/useTable.js';
 import {
   defineCheckboxColumn,
   defineNameColumn,
@@ -17,7 +18,6 @@ import {
   removeFromMergeColumn,
   seriesOrderingTypeColumn,
 } from '../../utility/tableColumns.js';
-import Table from '../Table.js';
 
 type Props = {
   +checkboxes?: string,
@@ -33,7 +33,7 @@ const SeriesList = ({
   order,
   series,
   sortable,
-}: Props): React.Element<typeof Table> => {
+}: Props): React.Element<'table'> => {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -63,7 +63,7 @@ const SeriesList = ({
     [$c.user, checkboxes, mergeForm, order, series, sortable],
   );
 
-  return <Table columns={columns} data={series} />;
+  return useTable<SeriesT>({columns, data: series});
 };
 
 export default SeriesList;

--- a/root/components/list/WorkList.js
+++ b/root/components/list/WorkList.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../../context.mjs';
+import useTable from '../../hooks/useTable.js';
 import * as manifest from '../../static/manifest.mjs';
 import {
   attributesColumn,
@@ -24,7 +25,6 @@ import {
   workArtistsColumn,
   workLanguagesColumn,
 } from '../../utility/tableColumns.js';
-import Table from '../Table.js';
 
 type Props = {
   ...SeriesItemNumbersRoleT,
@@ -100,9 +100,11 @@ const WorkList = ({
     ],
   );
 
+  const table = useTable<WorkT>({columns, data: works});
+
   return (
     <>
-      <Table columns={columns} data={works} />
+      {table}
       {manifest.js('common/components/ArtistRoles', {async: 'async'})}
       {manifest.js('common/components/AttributeList', {async: 'async'})}
       {manifest.js('common/components/IswcList', {async: 'async'})}

--- a/root/entity/Aliases.js
+++ b/root/entity/Aliases.js
@@ -14,7 +14,7 @@ import AliasesComponent from '../components/Aliases/index.js';
 import chooseLayoutComponent from '../utility/chooseLayoutComponent.js';
 
 type Props = {
-  +aliases: $ReadOnlyArray<AliasT>,
+  +aliases: $ReadOnlyArray<AnyAiasT>,
   +artistCredits?: $ReadOnlyArray<{+id: number} & ArtistCreditT>,
   +entity: EntityWithAliasesT,
 };

--- a/root/entity/Edits.js
+++ b/root/entity/Edits.js
@@ -62,7 +62,6 @@ const Edits = ({
   const subHeadingTypeName = localizeTypeNameForEntity(entity);
   let pageSubHeading: Expand2ReactOutput = subHeadingTypeName;
   if (hasOwnProp(entity, 'artistCredit')) {
-    // $FlowIgnore[prop-missing] as per hasOwnProp above
     const artistCredit = entity.artistCredit;
     if (!artistCredit) {
       throw new Error(

--- a/root/entity/Ratings.js
+++ b/root/entity/Ratings.js
@@ -76,7 +76,6 @@ const Ratings = ({
               ) : null}
               {l('Average rating:')}
               {' '}
-              {/* $FlowIgnore[prop-missing] we know it has ratings */}
               <StaticRatingStars rating={entity.rating} />
             </>
           ) : (
@@ -92,7 +91,6 @@ const Ratings = ({
         <>
           <h2>{l('Reviews')}</h2>
 
-          {/* $FlowIgnore[incompatible-type] we know it has reviews */}
           <CritiqueBrainzLinks entity={entity} />
           <div id="critiquebrainz-reviews">
             {mostRecentReview ? (

--- a/root/entity/alias/DeleteAlias.js
+++ b/root/entity/alias/DeleteAlias.js
@@ -17,7 +17,7 @@ import chooseLayoutComponent from '../../utility/chooseLayoutComponent.js';
 import type {AliasDeleteFormT} from './types.js';
 
 type Props = {
-  +alias: AliasT,
+  +alias: AnyAiasT,
   +entity: EntityWithAliasesT,
   +form: AliasDeleteFormT,
   +type: string,

--- a/root/hooks/useTable.js
+++ b/root/hooks/useTable.js
@@ -10,9 +10,10 @@
 import {
   type Cell,
   type ColumnInstance,
+  type ColumnOptionsNoValue,
   type HeaderGroup,
   type Row,
-  useTable,
+  useTable as useReactTable,
 } from 'react-table';
 
 import loopParity from '../utility/loopParity.js';
@@ -37,30 +38,30 @@ const renderTableCell = (cell: Cell<mixed>) => (
   </td>
 );
 
-const renderTableRow = <D>(row: Row<D>, i: number) => (
+const renderTableRow = <D>(row: Row<D>, i: number): React$Element<'tr'> => (
   <tr {...row.getRowProps({className: loopParity(i)})}>
     {row.cells.map(renderTableCell)}
   </tr>
 );
 
-type Props<CV, D> = {
+type Props<D> = {
   className?: string,
-  columns: CV,
+  columns: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
   data: $ReadOnlyArray<D>,
 };
 
-const Table = <CV, D>({
+const useRenderedTable = <D>({
   className: passedClassName,
   columns,
   data,
-}: Props<CV, D>): React$MixedElement => {
+}: Props<D>): React$Element<'table'> => {
   const {
     getTableProps,
     getTableBodyProps,
     headerGroups,
     rows,
     prepareRow,
-  } = useTable({
+  } = useReactTable<D>({
     columns,
     data,
   });
@@ -83,4 +84,4 @@ const Table = <CV, D>({
   );
 };
 
-export default Table;
+export default useRenderedTable;

--- a/root/layout/components/sidebar/SidebarTags.js
+++ b/root/layout/components/sidebar/SidebarTags.js
@@ -33,9 +33,17 @@ const TagList = ({
   tags,
 }: TagListProps) => {
   const upvotedTags = tags ? tags.filter(tag => tag.count > 0) : null;
-  const links = upvotedTags ? upvotedTags.reduce((accum, t) => {
-    if (Boolean(t.tag.genre) === isGenreList) {
-      accum.push(<TagLink key={'tag-' + t.tag.name} tag={t.tag.name} />);
+  const links = upvotedTags ? upvotedTags.reduce((
+    accum: Array<React.Element<typeof TagLink>>,
+    aggregatedTag,
+  ) => {
+    if (Boolean(aggregatedTag.tag.genre) === isGenreList) {
+      accum.push(
+        <TagLink
+          key={'tag-' + aggregatedTag.tag.name}
+          tag={aggregatedTag.tag.name}
+        />,
+      );
     }
     return accum;
   }, []) : null;

--- a/root/relationship/linkattributetype/RelationshipAttributeTypesList.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypesList.js
@@ -97,7 +97,9 @@ const AttributeDetails = ({
   );
 };
 
-const AttributeTree = ({attribute}: AttributeTreeProps) => {
+const AttributeTree = ({
+  attribute,
+}: AttributeTreeProps): React.Element<'li'> => {
   const childrenAttrs = attribute.children || [];
   return (
     <li style={{marginTop: '0.25em'}}>

--- a/root/relationship/linktype/RelationshipTypePairTree.js
+++ b/root/relationship/linktype/RelationshipTypePairTree.js
@@ -34,7 +34,7 @@ type RelationshipTypePairTreeProps = {
 
 const RelationshipTypeDetails = ({
   relType,
-}: RelationshipTypeDetailsProps) => {
+}: RelationshipTypeDetailsProps): React.Element<'li'> => {
   const $c = React.useContext(SanitizedCatalystContext);
   const childrenTypes = relType.children || [];
   return (

--- a/root/report/components/ArtistList.js
+++ b/root/report/components/ArtistList.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 import type {ColumnOptionsNoValue} from 'react-table';
 
 import PaginatedResults from '../../components/PaginatedResults.js';
-import Table from '../../components/Table.js';
+import useTable from '../../hooks/useTable.js';
 import {
   defineEntityColumn,
   defineTextColumn,
@@ -32,7 +32,10 @@ const ArtistList = <D: {+artist: ?ArtistT, ...}>({
   pager,
   subPath,
 }: Props<D>): React.Element<typeof PaginatedResults> => {
-  const existingArtistItems = items.reduce((result, item) => {
+  const existingArtistItems = items.reduce((
+    result: Array<D>,
+    item,
+  ) => {
     if (item.artist != null) {
       result.push(item);
     }
@@ -69,9 +72,14 @@ const ArtistList = <D: {+artist: ?ArtistT, ...}>({
     [columnsAfter, columnsBefore, subPath],
   );
 
+  const table = useTable<D>({
+    columns,
+    data: existingArtistItems,
+  });
+
   return (
     <PaginatedResults pager={pager}>
-      <Table columns={columns} data={existingArtistItems} />
+      {table}
     </PaginatedResults>
   );
 };

--- a/root/report/components/CDTocList.js
+++ b/root/report/components/CDTocList.js
@@ -10,7 +10,7 @@
 import * as React from 'react';
 
 import PaginatedResults from '../../components/PaginatedResults.js';
-import Table from '../../components/Table.js';
+import useTable from '../../hooks/useTable.js';
 import formatTrackLength
   from '../../static/scripts/common/utility/formatTrackLength.js';
 import {
@@ -28,7 +28,10 @@ const CDTocList = ({
   items,
   pager,
 }: Props): React.Element<typeof PaginatedResults> => {
-  const existingCDTocItems = items.reduce((result, item) => {
+  const existingCDTocItems = items.reduce((
+    result: Array<ReportCDTocT>,
+    item,
+  ) => {
     if (item.cdtoc != null) {
       result.push(item);
     }
@@ -60,9 +63,14 @@ const CDTocList = ({
     [],
   );
 
+  const table = useTable<ReportCDTocT>({
+    columns,
+    data: existingCDTocItems,
+  });
+
   return (
     <PaginatedResults pager={pager}>
-      <Table columns={columns} data={existingCDTocItems} />
+      {table}
     </PaginatedResults>
   );
 };

--- a/root/report/components/CDTocReleaseList.js
+++ b/root/report/components/CDTocReleaseList.js
@@ -10,7 +10,7 @@
 import * as React from 'react';
 
 import PaginatedResults from '../../components/PaginatedResults.js';
-import Table from '../../components/Table.js';
+import useTable from '../../hooks/useTable.js';
 import {
   defineArtistCreditColumn,
   defineCDTocColumn,
@@ -27,7 +27,10 @@ const CDTocReleaseList = ({
   items,
   pager,
 }: Props): React.Element<typeof PaginatedResults> => {
-  const existingCDTocItems = items.reduce((result, item) => {
+  const existingCDTocItems = items.reduce((
+    result: Array<ReportCDTocReleaseT>,
+    item,
+  ) => {
     if (item.cdtoc != null) {
       result.push(item);
     }
@@ -61,9 +64,14 @@ const CDTocReleaseList = ({
     [],
   );
 
+  const table = useTable<ReportCDTocReleaseT>({
+    columns,
+    data: existingCDTocItems,
+  });
+
   return (
     <PaginatedResults pager={pager}>
-      <Table columns={columns} data={existingCDTocItems} />
+      {table}
     </PaginatedResults>
   );
 };

--- a/root/report/components/EditorList.js
+++ b/root/report/components/EditorList.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 import type {CellRenderProps} from 'react-table';
 
 import PaginatedResults from '../../components/PaginatedResults.js';
-import Table from '../../components/Table.js';
+import useTable from '../../hooks/useTable.js';
 import EditorLink from '../../static/scripts/common/components/EditorLink.js';
 import bracketed from '../../static/scripts/common/utility/bracketed.js';
 import {
@@ -28,7 +28,10 @@ const EditorList = ({
   items,
   pager,
 }: Props): React.Element<typeof PaginatedResults> => {
-  const existingEditorItems = items.reduce((result, item) => {
+  const existingEditorItems = items.reduce((
+    result: Array<ReportEditorT>,
+    item,
+  ) => {
     if (item.editor != null) {
       result.push(item);
     }
@@ -92,9 +95,14 @@ const EditorList = ({
     [],
   );
 
+  const table = useTable<ReportEditorT>({
+    columns,
+    data: existingEditorItems,
+  });
+
   return (
     <PaginatedResults pager={pager}>
-      <Table columns={columns} data={existingEditorItems} />
+      {table}
     </PaginatedResults>
   );
 };

--- a/root/report/components/EventList.js
+++ b/root/report/components/EventList.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 import type {ColumnOptionsNoValue} from 'react-table';
 
 import PaginatedResults from '../../components/PaginatedResults.js';
-import Table from '../../components/Table.js';
+import useTable from '../../hooks/useTable.js';
 import * as manifest from '../../static/manifest.mjs';
 import {
   defineArtistRolesColumn,
@@ -20,7 +20,6 @@ import {
   defineLocationColumn,
   defineTextColumn,
 } from '../../utility/tableColumns.js';
-import type {ReportEventT} from '../types.js';
 
 type Props<D: {+event: ?EventT, ...}> = {
   +columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
@@ -35,7 +34,10 @@ const EventList = <D: {+event: ?EventT, ...}>({
   items,
   pager,
 }: Props<D>): React.Element<typeof PaginatedResults> => {
-  const existingEventItems = items.reduce((result, item) => {
+  const existingEventItems = items.reduce((
+    result: Array<D>,
+    item,
+  ) => {
     if (item.event != null) {
       result.push(item);
     }
@@ -44,13 +46,13 @@ const EventList = <D: {+event: ?EventT, ...}>({
 
   const columns = React.useMemo(
     () => {
-      const nameColumn = defineEntityColumn<ReportEventT>({
+      const nameColumn = defineEntityColumn<D>({
         columnName: 'event',
         descriptive: false, // since dates have their own column
         getEntity: result => result.event ?? null,
         title: l('Event'),
       });
-      const typeColumn = defineTextColumn<ReportEventT>({
+      const typeColumn = defineTextColumn<D>({
         columnName: 'type',
         getText: result => {
           const typeName = result.event?.typeName;
@@ -61,20 +63,20 @@ const EventList = <D: {+event: ?EventT, ...}>({
         },
         title: l('Type'),
       });
-      const artistsColumn = defineArtistRolesColumn<ReportEventT>({
+      const artistsColumn = defineArtistRolesColumn<D>({
         columnName: 'performers',
         getRoles: result => result.event?.performers ?? [],
         title: l('Artists'),
       });
-      const locationColumn = defineLocationColumn<ReportEventT>({
+      const locationColumn = defineLocationColumn<D>({
         getEntity: result => result.event ?? null,
       });
-      const timeColumn = defineTextColumn<ReportEventT>({
+      const timeColumn = defineTextColumn<D>({
         columnName: 'time',
         getText: result => result.event?.time ?? '',
         title: l('Time'),
       });
-      const dateColumn = defineDatePeriodColumn<ReportEventT>({
+      const dateColumn = defineDatePeriodColumn<D>({
         getEntity: result => result.event ?? null,
       });
 
@@ -92,9 +94,11 @@ const EventList = <D: {+event: ?EventT, ...}>({
     [columnsAfter, columnsBefore],
   );
 
+  const table = useTable<D>({columns, data: existingEventItems});
+
   return (
     <PaginatedResults pager={pager}>
-      <Table columns={columns} data={existingEventItems} />
+      {table}
       {manifest.js('common/components/ArtistRoles', {async: 'async'})}
     </PaginatedResults>
   );

--- a/root/report/components/InstrumentList.js
+++ b/root/report/components/InstrumentList.js
@@ -10,8 +10,8 @@
 import * as React from 'react';
 
 import PaginatedResults from '../../components/PaginatedResults.js';
-import Table from '../../components/Table.js';
 import {CatalystContext} from '../../context.mjs';
+import useTable from '../../hooks/useTable.js';
 import formatUserDate from '../../utility/formatUserDate.js';
 import {
   defineEntityColumn,
@@ -29,7 +29,10 @@ const InstrumentList = ({
   pager,
 }: Props): React.Element<typeof PaginatedResults> => {
   const $c = React.useContext(CatalystContext);
-  const existingInstrumentItems = items.reduce((result, item) => {
+  const existingInstrumentItems = items.reduce((
+    result: Array<ReportInstrumentT>,
+    item,
+  ) => {
     if (item.instrument != null) {
       result.push(item);
     }
@@ -75,9 +78,14 @@ const InstrumentList = ({
     [$c],
   );
 
+  const table = useTable<ReportInstrumentT>({
+    columns,
+    data: existingInstrumentItems,
+  });
+
   return (
     <PaginatedResults pager={pager}>
-      <Table columns={columns} data={existingInstrumentItems} />
+      {table}
     </PaginatedResults>
   );
 };

--- a/root/report/components/LabelList.js
+++ b/root/report/components/LabelList.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 import type {ColumnOptionsNoValue} from 'react-table';
 
 import PaginatedResults from '../../components/PaginatedResults.js';
-import Table from '../../components/Table.js';
+import useTable from '../../hooks/useTable.js';
 import {
   defineEntityColumn,
 } from '../../utility/tableColumns.js';
@@ -29,7 +29,10 @@ const LabelList = <D: {+label: ?LabelT, ...}>({
   items,
   pager,
 }: Props<D>): React.Element<typeof PaginatedResults> => {
-  const existingLabelItems = items.reduce((result, item) => {
+  const existingLabelItems = items.reduce((
+    result: Array<D>,
+    item,
+  ) => {
     if (item.label != null) {
       result.push(item);
     }
@@ -53,9 +56,11 @@ const LabelList = <D: {+label: ?LabelT, ...}>({
     [columnsAfter, columnsBefore],
   );
 
+  const table = useTable<D>({columns, data: existingLabelItems});
+
   return (
     <PaginatedResults pager={pager}>
-      <Table columns={columns} data={existingLabelItems} />
+      {table}
     </PaginatedResults>
   );
 };

--- a/root/report/components/PlaceList.js
+++ b/root/report/components/PlaceList.js
@@ -11,11 +11,10 @@ import * as React from 'react';
 import type {ColumnOptionsNoValue} from 'react-table';
 
 import PaginatedResults from '../../components/PaginatedResults.js';
-import Table from '../../components/Table.js';
+import useTable from '../../hooks/useTable.js';
 import {
   defineEntityColumn,
 } from '../../utility/tableColumns.js';
-import type {ReportPlaceRelationshipT} from '../types.js';
 
 type Props<D: {+place: ?PlaceT, ...}> = {
   +columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
@@ -30,7 +29,10 @@ const PlaceList = <D: {+place: ?PlaceT, ...}>({
   items,
   pager,
 }: Props<D>): React.Element<typeof PaginatedResults> => {
-  const existingPlaceItems = items.reduce((result, item) => {
+  const existingPlaceItems = items.reduce((
+    result: Array<D>,
+    item,
+  ) => {
     if (item.place != null) {
       result.push(item);
     }
@@ -39,7 +41,7 @@ const PlaceList = <D: {+place: ?PlaceT, ...}>({
 
   const columns = React.useMemo(
     () => {
-      const nameColumn = defineEntityColumn<ReportPlaceRelationshipT>({
+      const nameColumn = defineEntityColumn<D>({
         columnName: 'place',
         getEntity: result => result.place ?? null,
         title: l('Place'),
@@ -54,9 +56,11 @@ const PlaceList = <D: {+place: ?PlaceT, ...}>({
     [columnsAfter, columnsBefore],
   );
 
+  const table = useTable<D>({columns, data: existingPlaceItems});
+
   return (
     <PaginatedResults pager={pager}>
-      <Table columns={columns} data={existingPlaceItems} />
+      {table}
     </PaginatedResults>
   );
 };

--- a/root/report/components/RecordingList.js
+++ b/root/report/components/RecordingList.js
@@ -11,12 +11,11 @@ import * as React from 'react';
 import type {ColumnOptionsNoValue} from 'react-table';
 
 import PaginatedResults from '../../components/PaginatedResults.js';
-import Table from '../../components/Table.js';
+import useTable from '../../hooks/useTable.js';
 import {
   defineArtistCreditColumn,
   defineEntityColumn,
 } from '../../utility/tableColumns.js';
-import type {ReportRecordingT} from '../types.js';
 
 type Props<D: {+recording: ?RecordingT, ...}> = {
   +columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
@@ -31,7 +30,10 @@ const RecordingList = <D: {+recording: ?RecordingT, ...}>({
   items,
   pager,
 }: Props<D>): React.Element<typeof PaginatedResults> => {
-  const existingRecordingItems = items.reduce((result, item) => {
+  const existingRecordingItems = items.reduce((
+    result: Array<D>,
+    item,
+  ) => {
     if (item.recording != null) {
       result.push(item);
     }
@@ -40,14 +42,14 @@ const RecordingList = <D: {+recording: ?RecordingT, ...}>({
 
   const columns = React.useMemo(
     () => {
-      const recordingColumn = defineEntityColumn<ReportRecordingT>({
+      const recordingColumn = defineEntityColumn<D>({
         columnName: 'recording',
         descriptive: false,
         getEntity: result => result.recording ?? null,
         title: l('Recording'),
       });
       const artistCreditColumn =
-        defineArtistCreditColumn<ReportRecordingT>({
+        defineArtistCreditColumn<D>({
           columnName: 'artist',
           getArtistCredit: result => result.recording?.artistCredit ?? null,
           title: l('Artist'),
@@ -63,9 +65,11 @@ const RecordingList = <D: {+recording: ?RecordingT, ...}>({
     [columnsAfter, columnsBefore],
   );
 
+  const table = useTable<D>({columns, data: existingRecordingItems});
+
   return (
     <PaginatedResults pager={pager}>
-      <Table columns={columns} data={existingRecordingItems} />
+      {table}
     </PaginatedResults>
   );
 };

--- a/root/report/components/ReleaseGroupList.js
+++ b/root/report/components/ReleaseGroupList.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 import type {ColumnOptionsNoValue} from 'react-table';
 
 import PaginatedResults from '../../components/PaginatedResults.js';
-import Table from '../../components/Table.js';
+import useTable from '../../hooks/useTable.js';
 import {
   defineArtistCreditColumn,
   defineEntityColumn,
@@ -31,7 +31,10 @@ const ReleaseGroupList = <D: {+release_group: ?ReleaseGroupT, ...}>({
   items,
   pager,
 }: Props<D>): React.Element<typeof PaginatedResults> => {
-  const existingReleaseGroupItems = items.reduce((result, item) => {
+  const existingReleaseGroupItems = items.reduce((
+    result: Array<D>,
+    item,
+  ) => {
     if (item.release_group != null) {
       result.push(item);
     }
@@ -73,9 +76,11 @@ const ReleaseGroupList = <D: {+release_group: ?ReleaseGroupT, ...}>({
     [columnsAfter, columnsBefore],
   );
 
+  const table = useTable<D>({columns, data: existingReleaseGroupItems});
+
   return (
     <PaginatedResults pager={pager}>
-      <Table columns={columns} data={existingReleaseGroupItems} />
+      {table}
     </PaginatedResults>
   );
 };

--- a/root/report/components/ReleaseList.js
+++ b/root/report/components/ReleaseList.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 import type {ColumnOptionsNoValue} from 'react-table';
 
 import PaginatedResults from '../../components/PaginatedResults.js';
-import Table from '../../components/Table.js';
+import useTable from '../../hooks/useTable.js';
 import {
   defineArtistCreditColumn,
   defineEntityColumn,
@@ -32,7 +32,10 @@ const ReleaseList = <D: {+release: ?ReleaseT, ...}>({
   pager,
   subPath,
 }: Props<D>): React.Element<typeof PaginatedResults> => {
-  const existingReleaseItems = items.reduce((result, item) => {
+  const existingReleaseItems = items.reduce((
+    result: Array<D>,
+    item,
+  ) => {
     if (item.release != null) {
       result.push(item);
     }
@@ -65,9 +68,11 @@ const ReleaseList = <D: {+release: ?ReleaseT, ...}>({
     [columnsAfter, columnsBefore, subPath],
   );
 
+  const table = useTable<D>({columns, data: existingReleaseItems});
+
   return (
     <PaginatedResults pager={pager}>
-      <Table columns={columns} data={existingReleaseItems} />
+      {table}
     </PaginatedResults>
   );
 };

--- a/root/report/components/SeriesList.js
+++ b/root/report/components/SeriesList.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 import type {ColumnOptionsNoValue} from 'react-table';
 
 import PaginatedResults from '../../components/PaginatedResults.js';
-import Table from '../../components/Table.js';
+import useTable from '../../hooks/useTable.js';
 import {
   defineEntityColumn,
 } from '../../utility/tableColumns.js';
@@ -29,7 +29,10 @@ const SeriesList = <D: {+series: ?SeriesT, ...}>({
   items,
   pager,
 }: Props<D>): React.Element<typeof PaginatedResults> => {
-  const existingSeriesItems = items.reduce((result, item) => {
+  const existingSeriesItems = items.reduce((
+    result: Array<D>,
+    item,
+  ) => {
     if (item.series != null) {
       result.push(item);
     }
@@ -53,9 +56,11 @@ const SeriesList = <D: {+series: ?SeriesT, ...}>({
     [columnsAfter, columnsBefore],
   );
 
+  const table = useTable<D>({columns, data: existingSeriesItems});
+
   return (
     <PaginatedResults pager={pager}>
-      <Table columns={columns} data={existingSeriesItems} />
+      {table}
     </PaginatedResults>
   );
 };

--- a/root/report/components/UrlList.js
+++ b/root/report/components/UrlList.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 import type {ColumnOptionsNoValue} from 'react-table';
 
 import PaginatedResults from '../../components/PaginatedResults.js';
-import Table from '../../components/Table.js';
+import useTable from '../../hooks/useTable.js';
 import {defineLinkColumn} from '../../utility/tableColumns.js';
 
 type Props<D: {+url: ?UrlT, ...}> = {
@@ -27,7 +27,10 @@ const UrlList = <D: {+url: ?UrlT, ...}>({
   items,
   pager,
 }: Props<D>): React.Element<typeof PaginatedResults> => {
-  const existingUrlItems = items.reduce((result, item) => {
+  const existingUrlItems = items.reduce((
+    result: Array<D>,
+    item,
+  ) => {
     if (item.url != null) {
       result.push(item);
     }
@@ -59,9 +62,11 @@ const UrlList = <D: {+url: ?UrlT, ...}>({
     [columnsAfter, columnsBefore],
   );
 
+  const table = useTable<D>({columns, data: existingUrlItems});
+
   return (
     <PaginatedResults pager={pager}>
-      <Table columns={columns} data={existingUrlItems} />
+      {table}
     </PaginatedResults>
   );
 };

--- a/root/report/components/WorkList.js
+++ b/root/report/components/WorkList.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 import type {ColumnOptionsNoValue} from 'react-table';
 
 import PaginatedResults from '../../components/PaginatedResults.js';
-import Table from '../../components/Table.js';
+import useTable from '../../hooks/useTable.js';
 import * as manifest from '../../static/manifest.mjs';
 import {
   defineArtistRolesColumn,
@@ -32,7 +32,10 @@ const WorkList = <D: {+work: ?WorkT, ...}>({
   items,
   pager,
 }: Props<D>): React.Element<typeof PaginatedResults> => {
-  const existingWorkItems = items.reduce((result, item) => {
+  const existingWorkItems = items.reduce((
+    result: Array<D>,
+    item,
+  ) => {
     if (item.work != null) {
       result.push(item);
     }
@@ -74,9 +77,11 @@ const WorkList = <D: {+work: ?WorkT, ...}>({
     [columnsAfter, columnsBefore],
   );
 
+  const table = useTable<D>({columns, data: existingWorkItems});
+
   return (
     <PaginatedResults pager={pager}>
-      <Table columns={columns} data={existingWorkItems} />
+      {table}
       {manifest.js('common/components/ArtistRoles', {async: 'async'})}
     </PaginatedResults>
   );

--- a/root/static/scripts/alias/AliasEditForm.js
+++ b/root/static/scripts/alias/AliasEditForm.js
@@ -224,18 +224,24 @@ const AliasEditForm = ({
     dispatch({action, type: 'update-sortname'});
   }, [dispatch]);
 
-  const setLocale = React.useCallback((event) => {
+  const setLocale = React.useCallback((
+    event: SyntheticEvent<HTMLSelectElement>,
+  ) => {
     dispatch({locale: event.currentTarget.value, type: 'set-locale'});
   }, [dispatch]);
 
-  const setPrimaryForLocale = React.useCallback((event) => {
+  const setPrimaryForLocale = React.useCallback((
+    event: SyntheticEvent<HTMLInputElement>,
+  ) => {
     dispatch({
       enabled: event.currentTarget.checked,
       type: 'set-primary-for-locale',
     });
   }, [dispatch]);
 
-  const setType = React.useCallback((event) => {
+  const setType = React.useCallback((
+    event: SyntheticEvent<HTMLSelectElement>,
+  ) => {
     dispatch({type: 'set-type', type_id: event.currentTarget.value});
   }, [dispatch]);
 

--- a/root/static/scripts/annotation/AnnotationHistoryTable.js
+++ b/root/static/scripts/annotation/AnnotationHistoryTable.js
@@ -13,6 +13,7 @@ import {SanitizedCatalystContext} from '../../../context.mjs';
 import formatUserDate from '../../../utility/formatUserDate.js';
 import EditorLink from '../common/components/EditorLink.js';
 import bracketed from '../common/utility/bracketed.js';
+import parseInteger from '../common/utility/parseInteger.js';
 
 type Props = {
   +annotations: $ReadOnlyArray<AnnotationT>,
@@ -73,12 +74,22 @@ const AnnotationHistoryTable = ({
     createInitialState,
   );
 
-  const handleNew = React.useCallback((event) => {
-    dispatch({index: event.currentTarget.dataset.index, type: 'update-new'});
+  const handleNew = React.useCallback((
+    event: SyntheticEvent<HTMLInputElement>,
+  ) => {
+    dispatch({
+      index: parseInteger(event.currentTarget.dataset.index),
+      type: 'update-new',
+    });
   }, [dispatch]);
 
-  const handleOld = React.useCallback((event) => {
-    dispatch({index: event.currentTarget.dataset.index, type: 'update-old'});
+  const handleOld = React.useCallback((
+    event: SyntheticEvent<HTMLInputElement>,
+  ) => {
+    dispatch({
+      index: parseInteger(event.currentTarget.dataset.index),
+      type: 'update-old',
+    });
   }, [dispatch]);
 
   return (

--- a/root/static/scripts/artist/components/ArtistCreditRenamer.js
+++ b/root/static/scripts/artist/components/ArtistCreditRenamer.js
@@ -151,7 +151,9 @@ const ArtistCreditRenamer = ({
   initialArtistName,
   initialSelectedArtistCreditIds,
 }: ArtistCreditRenamerPropsT): React.MixedElement | null => {
-  const rowsRef = React.useRef(null);
+  const rowsRef = React.useRef<
+    $ReadOnlyArray<React.Element<typeof ArtistCreditRow>> | null,
+  >(null);
 
   const [state, dispatch] = React.useReducer(
     reducer,
@@ -183,7 +185,9 @@ const ArtistCreditRenamer = ({
   const tooManyRows = rows.length > 10;
   const installedArtistNameEvent = React.useRef(false);
 
-  const handleArtistNameChange = React.useCallback((event) => {
+  const handleArtistNameChange = React.useCallback((
+    event: SyntheticInputEvent<HTMLInputElement>,
+  ) => {
     dispatch({name: event.target.value, type: 'set-name'});
   }, [dispatch]);
 

--- a/root/static/scripts/common/components/ArtistCreditLink.js
+++ b/root/static/scripts/common/components/ArtistCreditLink.js
@@ -69,9 +69,9 @@ const ArtistCreditLink = ({
   showEditsPending = true,
   showIcon = false,
   ...props
-}: Props): React.Element<'span'> | Array<React.Node> => {
+}: Props): React.Node => {
   const names = artistCredit.names;
-  const parts = [];
+  const parts: Array<React.Node> = [];
   for (let i = 0; i < names.length; i++) {
     const credit = names[i];
     const artist = credit.artist;

--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -457,7 +457,6 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
         const option = staticItems.find((item) => (
           item.type === 'option' &&
           hasOwnProp(item.entity, 'gid') &&
-          // $FlowIgnore[prop-missing]
           item.entity.gid === mbidMatch[0]
         ));
         if (option) {

--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -65,7 +65,7 @@ function doSearch<T: EntityItemT>(
   dispatch: (ActionT<T>) => void,
   state: StateT<T>,
   xhr: {current: XMLHttpRequest | null},
-) {
+): void {
   const searchXhr = new XMLHttpRequest();
   xhr.current = searchXhr;
 
@@ -246,7 +246,7 @@ const AutocompleteItem = React.memo(<+T: EntityItemT>({
   isSelected,
   item,
   selectItem,
-}: AutocompleteItemPropsT<T>) => {
+}: AutocompleteItemPropsT<T>): React.MixedElement => {
   const itemId = `${autocompleteId}-item-${item.id}`;
   const isDisabled = !!item.disabled;
   const isSeparator = !!item.separator;
@@ -359,7 +359,9 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
     }
   }, [dispatch, pendingSearch]);
 
-  const selectItem = React.useCallback((item) => {
+  const selectItem = React.useCallback((
+    item: ItemT<T>,
+  ) => {
     const isDisabled = !!item.disabled;
 
     if (!isDisabled) {

--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -7,6 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import * as Sentry from '@sentry/browser';
 import * as React from 'react';
 
 import ENTITIES from '../../../../../entities.mjs';
@@ -640,6 +641,9 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
           });
         }, 1);
         return loadedRecentItems;
+      }).catch((error) => {
+        console.error(error);
+        Sentry.captureException(error);
       });
     }
     return () => {

--- a/root/static/scripts/common/components/Autocomplete2/formatters.js
+++ b/root/static/scripts/common/components/Autocomplete2/formatters.js
@@ -65,7 +65,7 @@ function showExtraInfoLine(
   );
 }
 
-function formatName<+T: EntityItemT>(entity: T) {
+function formatName<+T: EntityItemT>(entity: T): string {
   return unwrapNl<string>(entity.name);
 }
 

--- a/root/static/scripts/common/components/Autocomplete2/recentItems.js
+++ b/root/static/scripts/common/components/Autocomplete2/recentItems.js
@@ -262,7 +262,7 @@ export function pushRecentItem<+T: EntityItemT>(
   const entity = item.entity;
   const entityId = _getGidOrId(entity);
 
-  const cachedList: Array<OptionItemT<T>> = [...getRecentItems(key)];
+  const cachedList: Array<OptionItemT<T>> = [...getRecentItems<T>(key)];
   _recentItemsCache.set(key, cachedList);
 
   if (entityId == null) {

--- a/root/static/scripts/common/components/Autocomplete2/recentItems.js
+++ b/root/static/scripts/common/components/Autocomplete2/recentItems.js
@@ -217,7 +217,6 @@ export async function getOrFetchRecentItems<+T: EntityItemT>(
   if (ids.size) {
     const rowIds = _filterFakeIds(ids);
     if (rowIds.length) {
-      // $FlowIgnore[incompatible-return]
       return fetch(
         '/ws/js/entities/' +
         entityType + '/' +
@@ -238,7 +237,6 @@ export async function getOrFetchRecentItems<+T: EntityItemT>(
           const entity = results[id];
           if (entity && entity.entityType === entityType) {
             cachedList.push({
-              // $FlowIgnore[incompatible-return]
               entity,
               id: String(entity.id) + '-recent',
               name: getEntityName(entity),
@@ -266,7 +264,6 @@ export function pushRecentItem<+T: EntityItemT>(
   _recentItemsCache.set(key, cachedList);
 
   if (entityId == null) {
-    // $FlowIgnore[incompatible-return]
     return cachedList;
   }
 

--- a/root/static/scripts/common/components/Autocomplete2/reducer.js
+++ b/root/static/scripts/common/components/Autocomplete2/reducer.js
@@ -72,7 +72,7 @@ function initSearch<+T: EntityItemT>(
 export function generateItems<+T: EntityItemT>(
   state: StateT<T>,
 ): $ReadOnlyArray<ItemT<T>> {
-  const items = [];
+  const items: Array<ItemT<T>> = [];
 
   if (state.error) {
     switch (state.error) {

--- a/root/static/scripts/common/components/Autocomplete2/searchItems.js
+++ b/root/static/scripts/common/components/Autocomplete2/searchItems.js
@@ -22,7 +22,6 @@ const itemIndexes:
   WeakMap<
     // $FlowIgnore[unclear-type]
     $ReadOnlyArray<ItemT<any>>,
-    // $FlowIgnore[unclear-type]
     Map<
       string, // gram
       // $FlowIgnore[unclear-type]

--- a/root/static/scripts/common/components/Autocomplete2/searchItems.js
+++ b/root/static/scripts/common/components/Autocomplete2/searchItems.js
@@ -159,7 +159,7 @@ export default function searchItems<+T: EntityItemT>(
     index,
     'The items to be searched have not been indexed',
   );
-  const itemRanks = new Map();
+  const itemRanks = new Map<OptionItemT<T>, number>();
   const addMatchingItems = (
     n: number,
     items: Set<OptionItemT<T>>,

--- a/root/static/scripts/common/components/ButtonPopover.js
+++ b/root/static/scripts/common/components/ButtonPopover.js
@@ -110,7 +110,7 @@ const ButtonPopover = (props: PropsT): React.MixedElement => {
         }
       }}
       ref={buttonRef}
-      title={buttonTitle == null ? null : unwrapNl(buttonTitle)}
+      title={buttonTitle == null ? null : unwrapNl<string>(buttonTitle)}
       type="button"
       {...customButtonProps}
     >

--- a/root/static/scripts/common/components/ButtonPopover.js
+++ b/root/static/scripts/common/components/ButtonPopover.js
@@ -22,7 +22,7 @@ type PropsT = {
     className?: string,
     id?: string,
     title?: string | (() => string),
-  },
+  } | null,
   +buttonRef: {current: HTMLButtonElement | null},
   +className?: string,
   +closeOnOutsideClick?: boolean,
@@ -90,7 +90,7 @@ const ButtonPopover = (props: PropsT): React.MixedElement => {
   const customButtonProps = buttonProps ? {
     id: buttonProps.id,
     title: nonEmpty(buttonProps.title)
-      ? unwrapNl(buttonProps.title)
+      ? unwrapNl<string>(buttonProps.title)
       : undefined,
     className: buttonProps.className,
   } : null;

--- a/root/static/scripts/common/components/DescriptiveLink.js
+++ b/root/static/scripts/common/components/DescriptiveLink.js
@@ -60,7 +60,6 @@ const DescriptiveLink = ({
     ...sharedProps,
   };
 
-  // $FlowFixMe
   const artistCredit = customArtistCredit || entity.artistCredit;
 
   if (entity.entityType === 'area' && entity.gid) {

--- a/root/static/scripts/common/components/Dialog.js
+++ b/root/static/scripts/common/components/Dialog.js
@@ -82,7 +82,7 @@ const Dialog = ({
   title,
   trapFocus = false,
 }: PropsT): React.Element<'div'> => {
-  const tabbableElementRef = React.useRef(null);
+  const tabbableElementRef = React.useRef<HTMLElement | null>(null);
 
   React.useLayoutEffect(() => {
     const dialogNode = getElementFromRef(dialogRef);

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -387,7 +387,7 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
     }
   }
 
-  const parts = [content];
+  const parts: Array<Expand2ReactOutput> = [content];
 
   if (showIcon) {
     parts.unshift(

--- a/root/static/scripts/common/components/FingerprintTable.js
+++ b/root/static/scripts/common/components/FingerprintTable.js
@@ -33,7 +33,8 @@ function orderTracks(a: AcoustIdTrackT, b: AcoustIdTrackT) {
 }
 
 const FingerprintTable = ({recording}: {recording: RecordingT}) => {
-  const [tracks, setTracks] = React.useState([]);
+  const [tracks, setTracks] =
+    React.useState<$ReadOnlyArray<AcoustIdTrackT>>([]);
   const [isLoaded, setIsLoaded] = React.useState(false);
 
   // We ensure fetch only runs client-side since it's not in node

--- a/root/static/scripts/common/components/RelatedSeries.js
+++ b/root/static/scripts/common/components/RelatedSeries.js
@@ -29,9 +29,7 @@ export function isNotSeriesPart(r: RelationshipT): boolean {
 }
 
 const RelatedSeries = ({seriesIds}: Props): React.MixedElement => {
-  const createArgs = [
-    React.Fragment,
-    null,
+  const parts: Array<React.Node> = [
     /* eslint-disable react/jsx-key */
     <h2 className="related-series">
       {l('Related series')}
@@ -39,7 +37,7 @@ const RelatedSeries = ({seriesIds}: Props): React.MixedElement => {
   ];
   for (let i = 0; i < seriesIds.length; i++) {
     const series = linkedEntities.series[seriesIds[i]];
-    createArgs.push(
+    parts.push(
       <h3>
         <EntityLink entity={series} showIcon />
       </h3>,
@@ -53,7 +51,7 @@ const RelatedSeries = ({seriesIds}: Props): React.MixedElement => {
       />,
     );
   }
-  return React.createElement.apply(React, createArgs);
+  return React.createElement(React.Fragment, null, ...parts);
 };
 
 export default RelatedSeries;

--- a/root/static/scripts/common/components/RelatedWorks.js
+++ b/root/static/scripts/common/components/RelatedWorks.js
@@ -29,9 +29,7 @@ type Props = {
 };
 
 const RelatedWorks = ({workIds}: Props): React.MixedElement => {
-  const createArgs = [
-    React.Fragment,
-    null,
+  const parts: Array<React.Node> = [
     /* eslint-disable react/jsx-key */
     <h2 className="related-works">
       {l('Related works')}
@@ -39,7 +37,7 @@ const RelatedWorks = ({workIds}: Props): React.MixedElement => {
   ];
   for (let i = 0; i < workIds.length; i++) {
     const work = linkedEntities.work[workIds[i]];
-    createArgs.push(
+    parts.push(
       <h3>
         <EntityLink entity={work} showIcon />
       </h3>,
@@ -50,7 +48,7 @@ const RelatedWorks = ({workIds}: Props): React.MixedElement => {
       />,
     );
   }
-  return React.createElement.apply(React, createArgs);
+  return React.createElement(React.Fragment, null, ...parts);
 };
 
 export default RelatedWorks;

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -96,8 +96,8 @@ const VoteButton = ({
   const isActive = vote === currentVote;
   const className = 'tag-vote tag-' + VOTE_ACTIONS[vote];
   const buttonTitle = isActive
-    ? unwrapNl(activeTitle)
-    : (currentVote === 0 ? unwrapNl(title) : l('Withdraw vote'));
+    ? unwrapNl<string>(activeTitle)
+    : (currentVote === 0 ? unwrapNl<string>(title) : l('Withdraw vote'));
 
   return (
     <button
@@ -322,7 +322,14 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
     } {
     const tags = this.state.tags;
 
-    return tags.reduce((accum, t, index) => {
+    return tags.reduce((
+      accum: {
+        +genres: Array<React.MixedElement>,
+        +tags: Array<React.MixedElement>,
+      },
+      t: UserTagT,
+      index: number,
+    ) => {
       const callback = (newVote: VoteT) => {
         this.updateVote(index, newVote);
         this.addPendingVote(t.tag, newVote, index);
@@ -704,12 +711,12 @@ export const SidebarTagEditor = (hydrate<TagEditorProps>(
 function createInitialTagState(
   aggregatedTags: $ReadOnlyArray<AggregatedTagT>,
   userTags: $ReadOnlyArray<UserTagT>,
-) {
+): $ReadOnlyArray<UserTagT> {
   const userTagsByName = keyBy(userTags, t => t.tag.name);
 
-  const used = new Set();
+  const used = new Set<string>();
 
-  const combined = aggregatedTags.map(function (t) {
+  const combined: Array<UserTagT> = aggregatedTags.map(function (t) {
     const userTag = userTagsByName.get(t.tag.name);
 
     used.add(t.tag.name);

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -295,11 +295,11 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
 
     for (const [action, items] of Object.entries(actions)) {
       const url = action + '?tags=' +
-        encodeURIComponent((items: any).map(x => x.tag.name).join(','));
+        encodeURIComponent(items.map(x => x.tag.name).join(','));
 
       doRequest({url: url})
         .done(data => this.updateTags(data.updates))
-        .fail(() => (items: any).forEach(x => x.fail()));
+        .fail(() => items.forEach(x => x.fail()));
     }
   }
 

--- a/root/static/scripts/common/entity2.js
+++ b/root/static/scripts/common/entity2.js
@@ -253,7 +253,7 @@ export function createReleaseObject(
   return {
     artist: '',
     artistCredit: {
-      names: [],
+      names: ([]: $ReadOnlyArray<ArtistCreditNameT>),
     },
     barcode: null,
     comment: '',

--- a/root/static/scripts/common/hooks/useEventTrap.js
+++ b/root/static/scripts/common/hooks/useEventTrap.js
@@ -24,7 +24,7 @@ function setupEventHandler(
     return cachedTargetActions;
   }
 
-  const targetActions = new Map();
+  const targetActions: TargetRefsT = new Map();
   EVENTS.set(eventType, targetActions);
 
   document.addEventListener((

--- a/root/static/scripts/common/hooks/usePagedMediumTable.js
+++ b/root/static/scripts/common/hooks/usePagedMediumTable.js
@@ -60,7 +60,7 @@ export default function usePagedMediumTable(
     dispatch: (LazyReleaseActionT) => void,
     getColumnCount: (boolean) => number,
     handleLinkedEntities?:
-      (update: ?$ReadOnly<$Partial<LinkedEntitiesT>>) => void,
+      (update: ?$ReadOnly<Partial<LinkedEntitiesT>>) => void,
     hasUnloadedTracks: boolean,
     isExpanded: boolean,
     medium: MediumWithRecordingsT,

--- a/root/static/scripts/common/i18n/expand2.js
+++ b/root/static/scripts/common/i18n/expand2.js
@@ -53,7 +53,7 @@ export class VarArgs<+T, +U = T> implements VarArgsClass<T | U> {
 export type Parser<+T, -V> = (VarArgsClass<V>) => T;
 
 const EMPTY_OBJECT = Object.freeze({});
-const EMPTY_VARARGS = new VarArgs(EMPTY_OBJECT);
+const EMPTY_VARARGS = new VarArgs<empty, empty>(EMPTY_OBJECT);
 
 type State = {
   /*

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -114,10 +114,10 @@ const parseVarSubst = createVarSubstParser<Output, Input>(
   getVarSubstArg,
 );
 
-const parseLinkSubst = saveMatch<
+const parseLinkSubst: Parser<
   React.Element<'a'> | string | NO_MATCH,
   Input,
->(function (args) {
+> = saveMatch(function (args) {
   const name = accept(linkSubstStart);
   if (typeof name !== 'string') {
     return NO_MATCH_VALUE;
@@ -197,8 +197,9 @@ const parseHtmlAttrValue = (args: VarArgsClass<Input>) => (
   parseContinuousString(htmlAttrValueParsers, args)
 );
 
-const parseHtmlAttrValueCondSubst =
-  createCondSubstParser<string, Input>(
+const parseHtmlAttrValueCondSubst:
+  Parser<string | NO_MATCH, Input> =
+  createCondSubstParser(
     args => parseContinuousString(htmlAttrCondSubstThenParsers, args),
     args => parseContinuousString(htmlAttrCondSubstElseParsers, args),
   );
@@ -307,10 +308,11 @@ function parseHtmlTag(args: VarArgsClass<Input>) {
   );
 }
 
-const parseCondSubst = createCondSubstParser<Array<Output>, Input>(
-  args => parseContinuousArray(condSubstThenParsers, args),
-  args => parseContinuousArray(condSubstElseParsers, args),
-);
+const parseCondSubst: Parser<Array<Output> | string | NO_MATCH, Input> =
+  createCondSubstParser(
+    args => parseContinuousArray(condSubstThenParsers, args),
+    args => parseContinuousArray(condSubstElseParsers, args),
+  );
 
 const condSubstThenParsers = [
   createTextContentParser<Output, Input>(
@@ -323,7 +325,9 @@ const condSubstThenParsers = [
   parseHtmlTag,
 ];
 
-const condSubstElseParsers = [
+const condSubstElseParsers: $ReadOnlyArray<
+  Parser<Output | Array<Output> | string | NO_MATCH, Input>,
+> = [
   parseRootTextContent,
   parseVarSubst,
   parseLinkSubst,
@@ -331,7 +335,9 @@ const condSubstElseParsers = [
   parseHtmlTag,
 ];
 
-const rootParsers = [
+const rootParsers: $ReadOnlyArray<
+  Parser<Output | Array<Output> | string | NO_MATCH, Input>,
+> = [
   parseRootTextContent,
   parseVarSubst,
   parseLinkSubst,

--- a/root/static/scripts/common/i18n/expand2text.js
+++ b/root/static/scripts/common/i18n/expand2text.js
@@ -14,6 +14,8 @@ import {
 } from '../i18n.js';
 
 import expand, {
+  type NO_MATCH,
+  type Parser,
   type VarArgsClass,
   type VarArgsObject,
   createCondSubstParser,
@@ -35,20 +37,23 @@ function handleTextContentText(text: string) {
   return handledText;
 }
 
-const parseRootTextContent = createTextContentParser(
-  textContent,
-  handleTextContentText,
-);
+const parseRootTextContent: Parser<string | NO_MATCH, StrOrNum> =
+  createTextContentParser(
+    textContent,
+    handleTextContentText,
+  );
 
-const parseCondSubst = createCondSubstParser<string, StrOrNum>(
-  args => parseContinuousString<StrOrNum>(condSubstThenParsers, args),
-  args => parseContinuousString<StrOrNum>(condSubstElseParsers, args),
-);
+const parseCondSubst: Parser<string | NO_MATCH, StrOrNum> =
+  createCondSubstParser<string, StrOrNum>(
+    args => parseContinuousString<StrOrNum>(condSubstThenParsers, args),
+    args => parseContinuousString<StrOrNum>(condSubstElseParsers, args),
+  );
 
-const parseCondSubstThenTextContent = createTextContentParser(
-  condSubstThenTextContent,
-  handleTextContentText,
-);
+const parseCondSubstThenTextContent: Parser<string | NO_MATCH, StrOrNum> =
+  createTextContentParser(
+    condSubstThenTextContent,
+    handleTextContentText,
+  );
 
 const condSubstThenParsers = [
   parseCondSubstThenTextContent,

--- a/root/static/scripts/common/linkedEntities.mjs
+++ b/root/static/scripts/common/linkedEntities.mjs
@@ -7,6 +7,8 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import isObjectEmpty from './utility/isObjectEmpty.js';
+
 export type LinkedEntitiesT = {
   area: {
     [areaId: number]: AreaT,
@@ -154,57 +156,55 @@ export type LinkedEntitiesT = {
 // $FlowIgnore[method-unbinding]
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
-const EMPTY_OBJECT = Object.freeze({});
-
-const linkedEntities: LinkedEntitiesT = Object.create(Object.seal({
-  area:                           EMPTY_OBJECT,
-  area_alias_type:                EMPTY_OBJECT,
-  area_type:                      EMPTY_OBJECT,
-  artist:                         EMPTY_OBJECT,
-  artist_alias_type:              EMPTY_OBJECT,
-  artist_type:                    EMPTY_OBJECT,
-  collection_type:                EMPTY_OBJECT,
-  edit:                           EMPTY_OBJECT,
-  editor:                         EMPTY_OBJECT,
-  event:                          EMPTY_OBJECT,
-  event_alias_type:               EMPTY_OBJECT,
-  event_type:                     EMPTY_OBJECT,
-  genre:                          EMPTY_OBJECT,
-  genre_alias_type:               EMPTY_OBJECT,
-  instrument:                     EMPTY_OBJECT,
-  instrument_alias_type:          EMPTY_OBJECT,
-  instrument_type:                EMPTY_OBJECT,
-  label:                          EMPTY_OBJECT,
-  label_alias_type:               EMPTY_OBJECT,
-  label_type:                     EMPTY_OBJECT,
-  language:                       EMPTY_OBJECT,
-  link_attribute_type:            EMPTY_OBJECT,
-  link_type:                      EMPTY_OBJECT,
-  link_type_tree:                 EMPTY_OBJECT,
-  place:                          EMPTY_OBJECT,
-  place_alias_type:               EMPTY_OBJECT,
-  place_type:                     EMPTY_OBJECT,
-  recording:                      EMPTY_OBJECT,
-  recording_alias_type:           EMPTY_OBJECT,
-  release:                        EMPTY_OBJECT,
-  release_alias_type:             EMPTY_OBJECT,
-  release_group:                  EMPTY_OBJECT,
-  release_group_alias_type:       EMPTY_OBJECT,
-  release_group_primary_type:     EMPTY_OBJECT,
-  release_group_secondary_type:   EMPTY_OBJECT,
-  release_packaging:              EMPTY_OBJECT,
-  release_status:                 EMPTY_OBJECT,
-  script:                         EMPTY_OBJECT,
-  series:                         EMPTY_OBJECT,
-  series_alias_type:              EMPTY_OBJECT,
-  series_ordering_type:           EMPTY_OBJECT,
-  series_type:                    EMPTY_OBJECT,
-  url:                            EMPTY_OBJECT,
-  work:                           EMPTY_OBJECT,
-  work_alias_type:                EMPTY_OBJECT,
-  work_attribute_type:            EMPTY_OBJECT,
-  work_type:                      EMPTY_OBJECT,
-}));
+const linkedEntities: LinkedEntitiesT = Object.seal({
+  area:                           {},
+  area_alias_type:                {},
+  area_type:                      {},
+  artist:                         {},
+  artist_alias_type:              {},
+  artist_type:                    {},
+  collection_type:                {},
+  edit:                           {},
+  editor:                         {},
+  event:                          {},
+  event_alias_type:               {},
+  event_type:                     {},
+  genre:                          {},
+  genre_alias_type:               {},
+  instrument:                     {},
+  instrument_alias_type:          {},
+  instrument_type:                {},
+  label:                          {},
+  label_alias_type:               {},
+  label_type:                     {},
+  language:                       {},
+  link_attribute_type:            {},
+  link_type:                      {},
+  link_type_tree:                 {},
+  place:                          {},
+  place_alias_type:               {},
+  place_type:                     {},
+  recording:                      {},
+  recording_alias_type:           {},
+  release:                        {},
+  release_alias_type:             {},
+  release_group:                  {},
+  release_group_alias_type:       {},
+  release_group_primary_type:     {},
+  release_group_secondary_type:   {},
+  release_packaging:              {},
+  release_status:                 {},
+  script:                         {},
+  series:                         {},
+  series_alias_type:              {},
+  series_ordering_type:           {},
+  series_type:                    {},
+  url:                            {},
+  work:                           {},
+  work_alias_type:                {},
+  work_attribute_type:            {},
+  work_type:                      {},
+});
 
 export default linkedEntities;
 
@@ -214,10 +214,14 @@ export function mergeLinkedEntities(
   if (update) {
     for (const [type, entities] of Object.entries(update)) {
       if (hasOwnProperty.call(linkedEntities, type)) {
-        Object.assign(linkedEntities[type], entities);
-      } else if (type in linkedEntities) {
-        // $FlowIgnore[incompatible-type]
-        linkedEntities[type] = entities;
+        if (entities != null) {
+          if (isObjectEmpty(linkedEntities[type])) {
+            // $FlowIgnore[incompatible-type]
+            linkedEntities[type] = entities;
+          } else {
+            Object.assign(linkedEntities[type], entities);
+          }
+        }
       } else {
         throw new Error(
           JSON.stringify(type) +
@@ -228,18 +232,19 @@ export function mergeLinkedEntities(
   }
 }
 
+const linkedEntityTypes = Object.keys(linkedEntities);
+
 export function setLinkedEntities(
-  update: ?LinkedEntitiesT,
+  update: ?$Partial<LinkedEntitiesT>,
 ): void {
-  for (const key of Object.keys(linkedEntities)) {
-    // $FlowIgnore[incompatible-type]
-    delete linkedEntities[key];
-    /*
-     * The above line is deleting the own property only, not the one on the
-     * prototype. However, Flow thinks it'll make the object key undefined.
-     */
+  for (const key of linkedEntityTypes) {
+    if (!isObjectEmpty(linkedEntities[key])) {
+      linkedEntities[key] = {};
+    }
   }
   if (update) {
-    Object.assign(linkedEntities, update);
+    mergeLinkedEntities(update);
   }
 }
+
+setLinkedEntities({artist: undefined});

--- a/root/static/scripts/common/linkedEntities.mjs
+++ b/root/static/scripts/common/linkedEntities.mjs
@@ -11,11 +11,17 @@ export type LinkedEntitiesT = {
   area: {
     [areaId: number]: AreaT,
   },
+  area_type: {
+    [areaTypeId: number]: AreaTypeT,
+  },
   artist: {
     [artistId: number]: ArtistT,
   },
   artist_type: {
     [artistId: number]: ArtistTypeT,
+  },
+  collection_type: {
+    [collectionTypeId: number]: CollectionTypeT,
   },
   edit: {
     [editId: number]: EditWithIdT,
@@ -26,14 +32,23 @@ export type LinkedEntitiesT = {
   event: {
     [eventId: number]: EventT,
   },
+  event_type: {
+    [eventTypeId: number]: EventTypeT,
+  },
   genre: {
     [genreId: number]: GenreT,
   },
   instrument: {
     [instrumentId: number]: InstrumentT,
   },
+  instrument_type: {
+    [instrumentTypeId: number]: InstrumentTypeT,
+  },
   label: {
     [labelId: number]: LabelT,
+  },
+  label_type: {
+    [labelTypeId: number]: LabelTypeT,
   },
   language: {
     [languageId: number]: LanguageT,
@@ -49,6 +64,9 @@ export type LinkedEntitiesT = {
   },
   place: {
     [placeId: number]: PlaceT,
+  },
+  place_type: {
+    [placeTypeId: number]: PlaceTypeT,
   },
   recording: {
     [recordingId: number]: RecordingT,
@@ -104,19 +122,25 @@ const EMPTY_OBJECT = Object.freeze({});
 
 const linkedEntities: LinkedEntitiesT = Object.create(Object.seal({
   area:                           EMPTY_OBJECT,
+  area_type:                      EMPTY_OBJECT,
   artist:                         EMPTY_OBJECT,
   artist_type:                    EMPTY_OBJECT,
+  collection_type:                EMPTY_OBJECT,
   edit:                           EMPTY_OBJECT,
   editor:                         EMPTY_OBJECT,
   event:                          EMPTY_OBJECT,
+  event_type:                     EMPTY_OBJECT,
   genre:                          EMPTY_OBJECT,
   instrument:                     EMPTY_OBJECT,
+  instrument_type:                EMPTY_OBJECT,
   label:                          EMPTY_OBJECT,
+  label_type:                     EMPTY_OBJECT,
   language:                       EMPTY_OBJECT,
   link_attribute_type:            EMPTY_OBJECT,
   link_type:                      EMPTY_OBJECT,
   link_type_tree:                 EMPTY_OBJECT,
   place:                          EMPTY_OBJECT,
+  place_type:                     EMPTY_OBJECT,
   recording:                      EMPTY_OBJECT,
   release:                        EMPTY_OBJECT,
   release_group:                  EMPTY_OBJECT,

--- a/root/static/scripts/common/linkedEntities.mjs
+++ b/root/static/scripts/common/linkedEntities.mjs
@@ -11,11 +11,17 @@ export type LinkedEntitiesT = {
   area: {
     [areaId: number]: AreaT,
   },
+  area_alias_type: {
+    [typeId: number]: AreaAliasTypeT,
+  },
   area_type: {
     [areaTypeId: number]: AreaTypeT,
   },
   artist: {
     [artistId: number]: ArtistT,
+  },
+  artist_alias_type: {
+    [typeId: number]: ArtistAliasTypeT,
   },
   artist_type: {
     [artistId: number]: ArtistTypeT,
@@ -32,20 +38,32 @@ export type LinkedEntitiesT = {
   event: {
     [eventId: number]: EventT,
   },
+  event_alias_type: {
+    [typeId: number]: EventAliasTypeT,
+  },
   event_type: {
     [eventTypeId: number]: EventTypeT,
   },
   genre: {
     [genreId: number]: GenreT,
   },
+  genre_alias_type: {
+    [typeId: number]: GenreAliasTypeT,
+  },
   instrument: {
     [instrumentId: number]: InstrumentT,
+  },
+  instrument_alias_type: {
+    [typeId: number]: InstrumentAliasTypeT,
   },
   instrument_type: {
     [instrumentTypeId: number]: InstrumentTypeT,
   },
   label: {
     [labelId: number]: LabelT,
+  },
+  label_alias_type: {
+    [typeId: number]: LabelAliasTypeT,
   },
   label_type: {
     [labelTypeId: number]: LabelTypeT,
@@ -65,17 +83,29 @@ export type LinkedEntitiesT = {
   place: {
     [placeId: number]: PlaceT,
   },
+  place_alias_type: {
+    [typeId: number]: PlaceAliasTypeT,
+  },
   place_type: {
     [placeTypeId: number]: PlaceTypeT,
   },
   recording: {
     [recordingId: number]: RecordingT,
   },
+  recording_alias_type: {
+    [typeId: number]: RecordingAliasTypeT,
+  },
   release: {
     [releaseId: number]: ReleaseT,
   },
+  release_alias_type: {
+    [typeId: number]: ReleaseAliasTypeT,
+  },
   release_group: {
     [releaseGroupId: number]: ReleaseGroupT,
+  },
+  release_group_alias_type: {
+    [typeId: number]: ReleaseGroupAliasTypeT,
   },
   release_group_primary_type: {
     [releaseGroupPrimaryTypeId: number]: ReleaseGroupTypeT,
@@ -95,6 +125,9 @@ export type LinkedEntitiesT = {
   series: {
     [seriesId: number]: SeriesT,
   },
+  series_alias_type: {
+    [typeId: number]: SeriesAliasTypeT,
+  },
   series_ordering_type: {
     [seriesOrderingTypeId: number]: SeriesOrderingTypeT,
   },
@@ -106,6 +139,9 @@ export type LinkedEntitiesT = {
   },
   work: {
     [workId: number]: WorkT,
+  },
+  work_alias_type: {
+    [typeId: number]: WorkAliasTypeT,
   },
   work_attribute_type: {
     [workAttributeTypeId: number]: WorkAttributeTypeT,
@@ -122,38 +158,50 @@ const EMPTY_OBJECT = Object.freeze({});
 
 const linkedEntities: LinkedEntitiesT = Object.create(Object.seal({
   area:                           EMPTY_OBJECT,
+  area_alias_type:                EMPTY_OBJECT,
   area_type:                      EMPTY_OBJECT,
   artist:                         EMPTY_OBJECT,
+  artist_alias_type:              EMPTY_OBJECT,
   artist_type:                    EMPTY_OBJECT,
   collection_type:                EMPTY_OBJECT,
   edit:                           EMPTY_OBJECT,
   editor:                         EMPTY_OBJECT,
   event:                          EMPTY_OBJECT,
+  event_alias_type:               EMPTY_OBJECT,
   event_type:                     EMPTY_OBJECT,
   genre:                          EMPTY_OBJECT,
+  genre_alias_type:               EMPTY_OBJECT,
   instrument:                     EMPTY_OBJECT,
+  instrument_alias_type:          EMPTY_OBJECT,
   instrument_type:                EMPTY_OBJECT,
   label:                          EMPTY_OBJECT,
+  label_alias_type:               EMPTY_OBJECT,
   label_type:                     EMPTY_OBJECT,
   language:                       EMPTY_OBJECT,
   link_attribute_type:            EMPTY_OBJECT,
   link_type:                      EMPTY_OBJECT,
   link_type_tree:                 EMPTY_OBJECT,
   place:                          EMPTY_OBJECT,
+  place_alias_type:               EMPTY_OBJECT,
   place_type:                     EMPTY_OBJECT,
   recording:                      EMPTY_OBJECT,
+  recording_alias_type:           EMPTY_OBJECT,
   release:                        EMPTY_OBJECT,
+  release_alias_type:             EMPTY_OBJECT,
   release_group:                  EMPTY_OBJECT,
+  release_group_alias_type:       EMPTY_OBJECT,
   release_group_primary_type:     EMPTY_OBJECT,
   release_group_secondary_type:   EMPTY_OBJECT,
   release_packaging:              EMPTY_OBJECT,
   release_status:                 EMPTY_OBJECT,
   script:                         EMPTY_OBJECT,
   series:                         EMPTY_OBJECT,
+  series_alias_type:              EMPTY_OBJECT,
   series_ordering_type:           EMPTY_OBJECT,
   series_type:                    EMPTY_OBJECT,
   url:                            EMPTY_OBJECT,
   work:                           EMPTY_OBJECT,
+  work_alias_type:                EMPTY_OBJECT,
   work_attribute_type:            EMPTY_OBJECT,
   work_type:                      EMPTY_OBJECT,
 }));

--- a/root/static/scripts/common/linkedEntities.mjs
+++ b/root/static/scripts/common/linkedEntities.mjs
@@ -209,7 +209,7 @@ const linkedEntities: LinkedEntitiesT = Object.seal({
 export default linkedEntities;
 
 export function mergeLinkedEntities(
-  update: ?$ReadOnly<$Partial<LinkedEntitiesT>>,
+  update: ?$ReadOnly<Partial<LinkedEntitiesT>>,
 ): void {
   if (update) {
     for (const [type, entities] of Object.entries(update)) {
@@ -235,7 +235,7 @@ export function mergeLinkedEntities(
 const linkedEntityTypes = Object.keys(linkedEntities);
 
 export function setLinkedEntities(
-  update: ?$Partial<LinkedEntitiesT>,
+  update: ?Partial<LinkedEntitiesT>,
 ): void {
   for (const key of linkedEntityTypes) {
     if (!isObjectEmpty(linkedEntities[key])) {

--- a/root/static/scripts/common/utility/arrays.js
+++ b/root/static/scripts/common/utility/arrays.js
@@ -41,7 +41,7 @@ export function compactMap<T, U>(
   array: $ReadOnlyArray<T>,
   func: (T) => ?U,
 ): $ReadOnlyArray<U> {
-  return array.reduce(function (result, item) {
+  return array.reduce(function (result: Array<U>, item) {
     const mappedValue = func(item);
     /*
      * The Flow lint is disabled because we intend to

--- a/root/static/scripts/common/utility/buildOptionList.js
+++ b/root/static/scripts/common/utility/buildOptionList.js
@@ -28,7 +28,10 @@ export default function buildOptionList<+T>(
     );
   };
 
-  const getOptionsByParentId = (parentId: number | null, level: number) => {
+  const getOptionsByParentId = (
+    parentId: number | null,
+    level: number,
+  ): OptionListT => {
     const options = optionsByParentId.get(parentId);
     if (!options) {
       return [];

--- a/root/static/scripts/common/utility/coerceToError.js
+++ b/root/static/scripts/common/utility/coerceToError.js
@@ -1,0 +1,16 @@
+/*
+ * @flow strict
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+export default function coerceToError(value: mixed): Error {
+  return (
+    value instanceof Error
+      ? value
+      : new Error(String(value))
+  );
+}

--- a/root/static/scripts/common/utility/formatSetlist.js
+++ b/root/static/scripts/common/utility/formatSetlist.js
@@ -51,7 +51,7 @@ export default function formatSetlist(
   setlistText: string,
 ): Expand2ReactOutput {
   const rawLines = setlistText.split(/(?:\r\n|\n\r|\r|\n)/);
-  const elements = [];
+  const elements: Array<React.Node> = [];
 
   for (const rawLine of rawLines) {
     if (empty(rawLine)) {

--- a/root/static/scripts/common/utility/isObjectEmpty.js
+++ b/root/static/scripts/common/utility/isObjectEmpty.js
@@ -1,0 +1,21 @@
+/*
+ * @flow strict
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+/*
+ * Returns false if `object` has any enumerable properties, or true
+ * otherwise. (This includes properties in the prototype chain.)
+ */
+export default function isObjectEmpty(
+  object: {__proto__: null, ...} | {...},
+): boolean {
+  for (const key in object) {
+    return false;
+  }
+  return true;
+}

--- a/root/static/scripts/common/utility/pThrottle.js
+++ b/root/static/scripts/common/utility/pThrottle.js
@@ -90,7 +90,7 @@ const pThrottle = <
           clearTimeout(timeout);
           aborted = true;
         },
-        promise: new Promise((resolve, reject) => {
+        promise: new Promise<R>((resolve, reject) => {
           const execute = () => {
             if (aborted) {
               reject(new ThrottleAbortError());

--- a/root/static/scripts/common/utility/renderMergeCheckboxElement.js
+++ b/root/static/scripts/common/utility/renderMergeCheckboxElement.js
@@ -8,7 +8,7 @@
  */
 
 export default function renderMergeCheckboxElement(
-  entity: CoreEntityT,
+  entity: CoreEntityT | CollectionT,
   form: MergeFormT | MergeReleasesFormT,
   index: number,
 ): React$MixedElement {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -450,7 +450,6 @@ const CLEANUPS: CleanupEntries = {
   },
   '45cat': {
     match: [new RegExp('^(https?://)?(www\\.)?45cat\\.com/', 'i')],
-    // $FlowIssue[incompatible-type]: Array<mixed>
     restrict: [LINK_TYPES.otherdatabases],
     clean: function (url) {
       return url.replace(/^(?:https?:\/\/)?(?:www\.)?45cat\.com\/([a-z]+\/[^\/?&#]+)(?:[\/?&#].*)?$/, 'https://www.45cat.com/$1');

--- a/root/static/scripts/edit/components/AddEntityDialog.js
+++ b/root/static/scripts/edit/components/AddEntityDialog.js
@@ -31,6 +31,11 @@ type PropsT = {
   +name?: string,
 };
 
+type InstanceT = {
+  +adjustDialogSize: (WindowProxy) => void,
+  +close: () => void,
+};
+
 const AddEntityDialog = ({
   callback,
   close,
@@ -39,19 +44,21 @@ const AddEntityDialog = ({
 }: PropsT): React.Element<typeof Modal> => {
   const dialogRef = React.useRef<HTMLDivElement | null>(null);
   const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
-  const instanceRef = React.useRef(null);
+  const instanceRef = React.useRef<InstanceT | null>(null);
   const [isLoading, setLoading] = React.useState(true);
 
   /*
    * Make sure click events within the dialog don't bubble and cause
    * side-effects.
    */
-  const handleModalClick = React.useCallback((event) => {
+  const handleModalClick = React.useCallback((
+    event: SyntheticMouseEvent<HTMLDivElement>,
+  ) => {
     event.stopPropagation();
   }, []);
 
   const handlePageLoad = (event: SyntheticEvent<HTMLIFrameElement>) => {
-    const contentWindow = event.currentTarget.contentWindow;
+    const contentWindow: WindowProxy = event.currentTarget.contentWindow;
 
     if (contentWindow.dialogResult) {
       callback(contentWindow.dialogResult);
@@ -63,7 +70,9 @@ const AddEntityDialog = ({
     setLoading(false);
   };
 
-  const adjustDialogSize = React.useCallback((contentWindow) => {
+  const adjustDialogSize = React.useCallback((
+    contentWindow: WindowProxy,
+  ) => {
     const iframe = iframeRef.current;
     if (iframe) {
       iframe.style.height = String(contentWindow.outerHeight) + 'px';

--- a/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
+++ b/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
@@ -144,7 +144,9 @@ const ExternalLinkAttributeDialog = (props: PropsT): React.MixedElement => {
     dispatch({type: 'update-initial-date-period', props});
   }, [props]);
 
-  const dateDispatch = React.useCallback((action) => {
+  const dateDispatch = React.useCallback((
+    action: DateRangeFieldsetActionT,
+  ) => {
     dispatch({action, type: 'update-date-period'});
   }, [dispatch]);
 

--- a/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
+++ b/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
@@ -32,7 +32,7 @@ import DateRangeFieldset, {
 } from './DateRangeFieldset.js';
 
 type PropsT = {
-  onConfirm: ($ReadOnly<$Partial<LinkStateT>>) => void,
+  onConfirm: ($ReadOnly<Partial<LinkStateT>>) => void,
   relationship: LinkRelationshipT,
 };
 

--- a/root/static/scripts/edit/components/Multiselect.js
+++ b/root/static/scripts/edit/components/Multiselect.js
@@ -82,7 +82,7 @@ export function accumulateMultiselectValues<
   values: $ReadOnlyArray<$Exact<VS>>,
 ): $ReadOnlyArray<V> {
   return values.reduce(
-    (accum, valueState) => {
+    (accum: Array<V>, valueState) => {
       const item = valueState.autocomplete.selectedItem?.entity;
       if (item) {
         accum.push(item);
@@ -128,7 +128,7 @@ export function runReducer<
       break;
     }
     case 'remove-value': {
-      newState.values = updateValue(
+      newState.values = updateValue<V, VS>(
         newState.values,
         action.valueKey,
         (x) => ({...x, removed: true}),
@@ -136,7 +136,7 @@ export function runReducer<
       break;
     }
     case 'update-value-autocomplete': {
-      newState.values = updateValue(
+      newState.values = updateValue<V, VS>(
         newState.values,
         action.valueKey,
         (x) => ({

--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -25,7 +25,7 @@ type PropsT = {
 };
 
 const URLInputPopover = (props: PropsT): React.MixedElement => {
-  const popoverButtonRef = React.useRef(null);
+  const popoverButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
   const [link, setLink] = React.useState<LinkRelationshipT>(props.link);
 

--- a/root/static/scripts/edit/components/withLoadedTypeInfo.js
+++ b/root/static/scripts/edit/components/withLoadedTypeInfo.js
@@ -17,8 +17,8 @@ import {
   exportLinkTypeInfo,
 } from '../../relationship-editor/utility/exportTypeInfo.js';
 
-const typeInfoPromises = new Map();
-const loadedTypeInfo = new Set();
+const typeInfoPromises = new Map<string, Promise<void>>();
+const loadedTypeInfo = new Set<string>();
 
 export default function withLoadedTypeInfo<-Config, +Instance = mixed>(
   WrappedComponent: React.AbstractComponent<Config, Instance>,
@@ -39,7 +39,9 @@ export default function withLoadedTypeInfo<-Config, +Instance = mixed>(
 
     const loadingCanceledRef = React.useRef<boolean>(false);
 
-    const loadTypeInfo = React.useCallback(async function (typeName) {
+    const loadTypeInfo = React.useCallback(async function (
+      typeName: string,
+    ) {
       const fetchUrl = '/ws/js/type-info/' + typeName;
 
       const response = await fetch(fetchUrl);

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -247,7 +247,7 @@ export class _ExternalLinksEditor
 
   setLinkState(
     index: number,
-    state: $ReadOnly<$Partial<LinkStateT>>,
+    state: $ReadOnly<Partial<LinkStateT>>,
     callback?: () => void,
   ) {
     const newLinks: Array<LinkStateT> = this.state.links.slice(0);
@@ -1137,7 +1137,7 @@ type ExternalLinkRelationshipProps = {
   +highlight: HighlightT,
   +isOnlyRelationship: boolean,
   +link: LinkRelationshipT,
-  +onAttributesChange: (number, $ReadOnly<$Partial<LinkStateT>>) => void,
+  +onAttributesChange: (number, $ReadOnly<Partial<LinkStateT>>) => void,
   +onLinkRemove: (number) => void,
   +onTypeBlur: (number, SyntheticFocusEvent<HTMLSelectElement>) => void,
   +onTypeChange: (number, SyntheticEvent<HTMLSelectElement>) => void,
@@ -1272,7 +1272,7 @@ type LinkProps = {
   +duplicate: number | null,
   +error: ErrorT | null,
   +getRelationshipHighlightType: (LinkRelationshipT) => HighlightT,
-  +handleAttributesChange: (number, $ReadOnly<$Partial<LinkStateT>>) => void,
+  +handleAttributesChange: (number, $ReadOnly<Partial<LinkStateT>>) => void,
   +handleLinkRemove: (number) => void,
   +handleLinkSubmit: (SyntheticKeyboardEvent<HTMLInputElement>) => void,
   +handleUrlBlur: (SyntheticFocusEvent<HTMLInputElement>) => void,
@@ -1551,7 +1551,7 @@ const defaultLinkState: LinkStateT = {
   video: false,
 };
 
-function newLinkState(state: $ReadOnly<$Partial<LinkStateT>>) {
+function newLinkState(state: $ReadOnly<Partial<LinkStateT>>) {
   return {...defaultLinkState, ...state};
 }
 

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -117,7 +117,7 @@ type LinksEditorState = {
   +links: $ReadOnlyArray<LinkStateT>,
 };
 
-class _ExternalLinksEditor
+export class _ExternalLinksEditor
   extends React.Component<LinksEditorProps, LinksEditorState> {
   tableRef: {current: HTMLTableElement | null};
 
@@ -250,7 +250,7 @@ class _ExternalLinksEditor
     state: $ReadOnly<$Partial<LinkStateT>>,
     callback?: () => void,
   ) {
-    const newLinks: Array<LinkStateT> = this.state.links.concat();
+    const newLinks: Array<LinkStateT> = this.state.links.slice(0);
     newLinks[index] = {...newLinks[index], ...state};
     this.setState({links: newLinks}, callback);
   }
@@ -490,7 +490,7 @@ class _ExternalLinksEditor
 
   removeLink(index: number) {
     this.setState(prevState => {
-      const newLinks = prevState.links.concat();
+      const newLinks = prevState.links.slice(0);
       const link = newLinks[index];
       if (isPositiveInteger(link.relationship)) { // Old link, toggle deleted
         newLinks[index] = {...link, deleted: !link.deleted};
@@ -1637,8 +1637,8 @@ export function parseRelationships(
 function groupLinksByUrl(
   links: $ReadOnlyArray<LinkStateT>,
 ): Map<string, Array<LinkRelationshipT>> {
-  const map = new Map();
-  const urlTypePairs = new Set();
+  const map = new Map<string, Array<LinkRelationshipT>>();
+  const urlTypePairs = new Set<string>();
   let urlIndex = 0;
   links.forEach((link, index) => {
     const relationship = {
@@ -1760,7 +1760,7 @@ export function createExternalLinksEditor(
     root = ReactDOMClient.createRoot(mountPoint);
     $(mountPoint).data('react-root', root);
   }
-  const externalLinksEditorRef = React.createRef();
+  const externalLinksEditorRef = React.createRef<_ExternalLinksEditor>();
   root.render(
     <ExternalLinksEditor
       errorObservable={options?.errorObservable}

--- a/root/static/scripts/edit/hooks/useDateRangeFieldset.js
+++ b/root/static/scripts/edit/hooks/useDateRangeFieldset.js
@@ -53,9 +53,9 @@ export default function useDateRangeFieldset(
     dispatch({action, type: 'update-end-date'});
   }, [dispatch]);
 
-  const beginYearInputRef = React.useRef(null);
+  const beginYearInputRef = React.useRef<HTMLInputElement | null>(null);
 
-  const endYearInputRef = React.useRef(null);
+  const endYearInputRef = React.useRef<HTMLInputElement | null>(null);
 
   return {
     beginDateDispatch,

--- a/root/static/scripts/edit/utility/diffArtistCredits.js
+++ b/root/static/scripts/edit/utility/diffArtistCredits.js
@@ -57,8 +57,8 @@ export default function diffArtistCredits(
     areArtistCreditNamesEqual,
   );
 
-  const oldNames = [];
-  const newNames = [];
+  const oldNames: Array<React.Node> = [];
+  const newNames: Array<React.Node> = [];
 
   for (let i = 0; i < diffs.length; i++) {
     const diff = diffs[i];

--- a/root/static/scripts/edit/utility/editDiff.js
+++ b/root/static/scripts/edit/utility/editDiff.js
@@ -28,7 +28,7 @@ const CLASS_MAP: {+[editType: EditType]: string} = {
   [INSERT]: 'diff-only-b',
 };
 
-const FAST_DIFF_CHANGE_TYPE_MAP = new Map([
+const FAST_DIFF_CHANGE_TYPE_MAP = new Map<number, EditType>([
   [fastDiff.INSERT, INSERT],
   [fastDiff.EQUAL, EQUAL],
   [fastDiff.DELETE, DELETE],
@@ -48,7 +48,7 @@ export type StringEditDiff = {
   +type: EditType,
 };
 
-function getChangeType<+T>(diff: GenericEditDiff<T>) {
+function getChangeType<+T>(diff: GenericEditDiff<T>): EditType {
   if (!diff.added && !diff.removed) {
     return EQUAL;
   }

--- a/root/static/scripts/edit/utility/linkPhrase.js
+++ b/root/static/scripts/edit/utility/linkPhrase.js
@@ -25,7 +25,6 @@ import displayLinkAttribute, {displayLinkAttributeText}
 
 const EMPTY_OBJECT = Object.freeze({});
 
-const emptyResult = Object.freeze(['', []]);
 const entity0Subst = /\{entity0\}/;
 const entity1Subst = /\{entity1\}/;
 
@@ -216,7 +215,7 @@ export function getPhraseAndExtraAttributes<T>(
 ): [T | string, Array<LinkAttrT>] {
   let phraseSource = l_relationships(linkType[phraseProp]);
   if (!phraseSource) {
-    return emptyResult;
+    return ['', []];
   }
 
   const attributesByRootName = _getAttributesByRootName<T | string>(

--- a/root/static/scripts/edit/utility/reducerWithErrorHandling.js
+++ b/root/static/scripts/edit/utility/reducerWithErrorHandling.js
@@ -9,6 +9,8 @@
 
 import * as Sentry from '@sentry/browser';
 
+import coerceToError from '../../common/utility/coerceToError.js';
+
 /*
  * Wraps a reducer function, returning a new reducer that catches
  * any exceptions in the original. In that event, we log the exception
@@ -26,7 +28,7 @@ export default function reducerWithErrorHandling<
     try {
       return reducer(state, action);
     } catch (e) {
-      error = e instanceof Error ? e : new Error(String(e));
+      error = coerceToError(e);
       if (
         !hasOwnProp(error, 'doNotLogToSentry') ||
         // $FlowIgnore[prop-missing]

--- a/root/static/scripts/genre/components/GenreEditForm.js
+++ b/root/static/scripts/genre/components/GenreEditForm.js
@@ -29,6 +29,7 @@ import {
   createInitialState as createGuessCaseOptionsState,
 } from '../../edit/components/GuessCaseOptions.js';
 import {
+  _ExternalLinksEditor,
   ExternalLinksEditor,
   prepareExternalLinksHtmlFormSubmission,
 } from '../../edit/externalLinks.js';
@@ -114,7 +115,7 @@ const GenreEditForm = ({
   const genre = $c.stash.source_entity;
   invariant(genre && genre.entityType === 'genre');
 
-  const externalLinksEditorRef = React.createRef();
+  const externalLinksEditorRef = React.createRef<_ExternalLinksEditor>();
 
   const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     if (hasErrors) {

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
@@ -34,7 +34,11 @@ class GuessCaseHandler {
 
   // Member functions
 
-  checkSpecialCase(): number {
+  /*
+   * The `inputString` argument is specified to prevent Flow from
+   * triggering an extra-arg error where we invoke `checkSpecialCase`.
+   */
+  checkSpecialCase(/*:: inputString?: string */): number {
     return this.specialCaseValues.NOT_A_SPECIALCASE;
   }
 

--- a/root/static/scripts/guess-case/MB/GuessCase/Main.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Main.js
@@ -13,6 +13,7 @@ import * as flags from '../../flags.js';
 
 import GuessCaseAreaHandler from './Handler/Area.js';
 import GuessCaseArtistHandler from './Handler/Artist.js';
+import GuessCaseHandler from './Handler/Base.js';
 import GuessCaseLabelHandler from './Handler/Label.js';
 import GuessCasePlaceHandler from './Handler/Place.js';
 import GuessCaseReleaseHandler from './Handler/Release.js';
@@ -108,12 +109,15 @@ class GuessCase {
 
   // Member functions
 
-  guess(handlerName: string, method: string): (string) => string {
+  guess(
+    handlerName: string,
+    method: 'process' | 'guessSortName',
+  ): (string) => string {
     if (handlerName === 'genre' || handlerName === 'instrument') {
       return ((inputString) => this.lowercaseEntityName(inputString));
     }
 
-    let handler;
+    let handler: GuessCaseHandler;
     const handlerPicker = {
       area: GuessCaseAreaHandler,
       artist: GuessCaseArtistHandler,
@@ -148,6 +152,8 @@ class GuessCase {
       const output = handler.isSpecialCase(num)
         ? handler.getSpecialCaseFormatted(inputString, num)
         // if it was not a special case, start guessing
+        // eslint-disable-next-line multiline-comment-style
+        // $FlowIgnore[prop-missing]
         : handler[method].apply(handler, arguments);
 
       return output;

--- a/root/static/scripts/relationship-editor/components/DialogAttribute/MultiselectAttribute.js
+++ b/root/static/scripts/relationship-editor/components/DialogAttribute/MultiselectAttribute.js
@@ -72,7 +72,10 @@ function _createLinkAttributeTypeOptions(
  * for the autocomplete component. Sets a `level` property on each item
  * which is used by the autocomplete for visual indentation.
  */
-const linkAttributeTypeOptionsCache = new Map();
+const linkAttributeTypeOptionsCache = new Map<
+  number,
+  $ReadOnlyArray<OptionItemT<LinkAttrTypeT>>,
+>();
 const createLinkAttributeTypeOptions = (
   rootAttributeType: LinkAttrTypeT,
 ) => {
@@ -129,7 +132,10 @@ export function reducer(
 
   switch (action.type) {
     case 'set-value-credit': {
-      newState.values = updateMultiselectValue(
+      newState.values = updateMultiselectValue<
+        LinkAttrTypeT,
+        DialogMultiselectAttributeValueStateT,
+      >(
         newState.values,
         action.valueKey,
         (x) => ({...x, creditedAs: action.creditedAs}),
@@ -170,11 +176,15 @@ const MultiselectAttribute = (React.memo<PropsT>(({
   const linkTypeAttributeType = state.type;
   const addLabel = addAttributeLabels[linkTypeAttributeType.id];
 
-  const multiselectDispatch = React.useCallback((action) => {
+  const multiselectDispatch = React.useCallback((
+    action: DialogMultiselectAttributeActionT,
+  ) => {
     dispatch(state.key, action);
   }, [dispatch, state.key]);
 
-  const buildExtraValueChildren = React.useCallback((valueState) => {
+  const buildExtraValueChildren = React.useCallback((
+    valueState: DialogMultiselectAttributeValueStateT,
+  ) => {
     const attributeType = valueState.autocomplete.selectedItem?.entity;
 
     const handleCreditChange = (event: SyntheticEvent<HTMLInputElement>) => {

--- a/root/static/scripts/relationship-editor/components/DialogDatePeriod.js
+++ b/root/static/scripts/relationship-editor/components/DialogDatePeriod.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 
 import isDateEmpty from '../../common/utility/isDateEmpty.js';
 import type {
-  ActionT,
+  ActionT as DateRangeFieldsetActionT,
   StateT,
 } from '../../edit/components/DateRangeFieldset.js';
 import {
@@ -29,6 +29,8 @@ type PropsT = {
   +isHelpVisible: boolean,
   +state: StateT,
 };
+
+export type ActionT = DateRangeFieldsetActionT;
 
 const DialogDatePeriod = (React.memo<PropsT>(({
   dispatch,

--- a/root/static/scripts/relationship-editor/components/DialogEntityCredit.js
+++ b/root/static/scripts/relationship-editor/components/DialogEntityCredit.js
@@ -74,7 +74,7 @@ const DialogEntityCredit = (React.memo<PropsT, void>(({
   targetType,
 }: PropsT): React.MixedElement => {
   const origCredit = React.useRef(state.creditedAs || '');
-  const inputRef = React.useRef(null);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
   const inputId = React.useId();
 
   function handleCreditedAsChange(event: SyntheticEvent<HTMLInputElement>) {

--- a/root/static/scripts/relationship-editor/components/DialogLinkType.js
+++ b/root/static/scripts/relationship-editor/components/DialogLinkType.js
@@ -19,6 +19,7 @@ import {
   default as autocompleteReducer,
 } from '../../common/components/Autocomplete2/reducer.js';
 import type {
+  ActionT as AutocompleteActionT,
   OptionItemT as AutocompleteOptionItemT,
   PropsT as AutocompletePropsT,
 } from '../../common/components/Autocomplete2/types.js';
@@ -275,7 +276,9 @@ const DialogLinkType = (React.memo<PropsT>(({
     error,
   } = state;
 
-  const autocompleteDispatch = React.useCallback((action) => {
+  const autocompleteDispatch = React.useCallback((
+    action: AutocompleteActionT<LinkTypeT>,
+  ) => {
     dispatch({
       action,
       source,

--- a/root/static/scripts/relationship-editor/components/DialogTargetEntity.js
+++ b/root/static/scripts/relationship-editor/components/DialogTargetEntity.js
@@ -15,6 +15,7 @@ import Autocomplete2, {
 import {default as autocompleteReducer}
   from '../../common/components/Autocomplete2/reducer.js';
 import type {
+  ActionT as AutocompleteActionT,
   OptionItemT,
   PropsT as AutocompletePropsT,
   StateT as AutocompleteStateT,
@@ -35,6 +36,7 @@ import type {
   TargetTypeOptionsT,
 } from '../types.js';
 import type {
+  DialogEntityCreditActionT,
   DialogTargetEntityActionT,
   UpdateTargetEntityAutocompleteActionT,
 } from '../types/actions.js';
@@ -312,7 +314,9 @@ const DialogTargetEntity = (React.memo<PropsT>((
     }
   }
 
-  const autocompleteDispatch = React.useCallback((action) => {
+  const autocompleteDispatch = React.useCallback((
+    action: AutocompleteActionT<NonUrlCoreEntityT>,
+  ) => {
     dispatch({
       action,
       linkType,
@@ -328,7 +332,9 @@ const DialogTargetEntity = (React.memo<PropsT>((
     });
   }
 
-  const creditDispatch = React.useCallback((action) => {
+  const creditDispatch = React.useCallback((
+    action: DialogEntityCreditActionT,
+  ) => {
     dispatch({action, type: 'update-credit'});
   }, [dispatch]);
 

--- a/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
@@ -59,6 +59,10 @@ import type {
 } from '../types.js';
 import type {
   DialogActionT,
+  DialogAttributeActionT,
+  DialogEntityCreditActionT,
+  DialogLinkTypeActionT,
+  DialogTargetEntityActionT,
   UpdateRelationshipActionT,
 } from '../types/actions.js';
 import {
@@ -78,7 +82,9 @@ import DialogAttributes, {
   reducer as dialogAttributesReducer,
 } from './DialogAttributes.js';
 import DialogButtons from './DialogButtons.js';
-import DialogDatePeriod from './DialogDatePeriod.js';
+import DialogDatePeriod, {
+  type ActionT as DialogDatePeriodActionT,
+} from './DialogDatePeriod.js';
 import DialogLinkOrder from './DialogLinkOrder.js';
 import DialogLinkType, {
   createInitialState as createDialogLinkTypeState,
@@ -525,11 +531,15 @@ const AttributesSection = (React.memo<AttributesSectionPropsT>(({
   dispatch,
   isHelpVisible,
 }) => {
-  const attributesDispatch = React.useCallback((action) => {
+  const attributesDispatch = React.useCallback((
+    action: DialogAttributeActionT,
+  ) => {
     dispatch({action, type: 'update-attribute'});
   }, [dispatch]);
 
-  const dateDispatch = React.useCallback((action) => {
+  const dateDispatch = React.useCallback((
+    action: DialogDatePeriodActionT,
+  ) => {
     dispatch({action, type: 'update-date-period'});
   }, [dispatch]);
 
@@ -840,11 +850,15 @@ const RelationshipDialogContent = (React.memo<PropsT>((
     closeDialogWithEvent('cancel');
   }, [closeDialogWithEvent]);
 
-  const sourceEntityDispatch = React.useCallback((action) => {
+  const sourceEntityDispatch = React.useCallback((
+    action: DialogEntityCreditActionT,
+  ) => {
     dispatch({action, type: 'update-source-entity'});
   }, [dispatch]);
 
-  const targetEntityDispatch = React.useCallback((action) => {
+  const targetEntityDispatch = React.useCallback((
+    action: DialogTargetEntityActionT,
+  ) => {
     dispatch({
       action,
       source,
@@ -852,7 +866,9 @@ const RelationshipDialogContent = (React.memo<PropsT>((
     });
   }, [dispatch, source]);
 
-  const linkTypeDispatch = React.useCallback((action) => {
+  const linkTypeDispatch = React.useCallback((
+    action: DialogLinkTypeActionT,
+  ) => {
     dispatch({action, source, type: 'update-link-type'});
   }, [dispatch, source]);
 

--- a/root/static/scripts/relationship-editor/components/RelationshipEditor.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipEditor.js
@@ -334,7 +334,7 @@ export function runReducer(
     case 'remove-relationship': {
       const {relationship} = action;
 
-      const updates = [
+      const updates: Array<RelationshipUpdateT> = [
         {
           relationship,
           throwIfNotExists: true,
@@ -371,7 +371,7 @@ export function runReducer(
         linkPhraseGroup,
       } = action;
 
-      const updates = [];
+      const updates: Array<RelationshipUpdateT> = [];
       let nextLogicalLinkOrder = 1;
 
       for (
@@ -453,7 +453,7 @@ export function runReducer(
           newRelationshipState,
           sourceEntity,
         );
-        const updates = [];
+        const updates: Array<RelationshipUpdateT> = [];
 
         if (
           oldRelationshipState != null &&

--- a/root/static/scripts/relationship-editor/components/RelationshipEditor.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipEditor.js
@@ -117,7 +117,6 @@ export function* getInitialRelationshipUpdates(
      * the source and target entity types are the same; see e.g. MBS-12850.
      */
     if (!isDatabaseRowId(target.id)) {
-      // $FlowIssue[incompatible-cast] - Flow doesn't like spreading unions
       target = ({...target, id: uniqueNegativeId()}: CoreEntityT);
     }
 

--- a/root/static/scripts/relationship-editor/components/RelationshipEditor.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipEditor.js
@@ -25,6 +25,7 @@ import {
   getCatalystContext,
   getSourceEntityDataForRelationshipEditor,
 } from '../../common/utility/catalyst.js';
+import coerceToError from '../../common/utility/coerceToError.js';
 import isDatabaseRowId from '../../common/utility/isDatabaseRowId.js';
 import {uniqueNegativeId} from '../../common/utility/numbers.js';
 import {hasSessionStorage} from '../../common/utility/storage.js';
@@ -589,11 +590,7 @@ const RelationshipEditor = (
 
           captureException(error);
 
-          setPrepareSubmissionError(
-            error instanceof Error
-              ? error
-              : new Error(String(error)),
-          );
+          setPrepareSubmissionError(coerceToError(error));
         }
       }
     };

--- a/root/static/scripts/relationship-editor/components/RelationshipItem.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipItem.js
@@ -189,7 +189,9 @@ const RelationshipItem = (React.memo<PropsT>(({
     user,
   });
 
-  const setDialogOpen = React.useCallback((open) => {
+  const setDialogOpen = React.useCallback((
+    open: boolean,
+  ) => {
     dispatch({
       location: open ? {
         backward,

--- a/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
@@ -95,7 +95,7 @@ const RelationshipPhraseGroup = (React.memo<PropsT>(({
 
   const buildNewRelationshipData = React.useCallback(() => {
     let maxLinkOrder = 0;
-    let newAttributesData = null;
+    let newAttributesData: tree.ImmutableTree<LinkAttrT> | null = null;
 
     for (const relationship of tree.iterate(relationships)) {
       if (canBeOrdered) {
@@ -170,7 +170,9 @@ const RelationshipPhraseGroup = (React.memo<PropsT>(({
     title: l('Add Relationship'),
   });
 
-  const setAddDialogOpen = React.useCallback((open) => {
+  const setAddDialogOpen = React.useCallback((
+    open: boolean,
+  ) => {
     dispatch({
       location: open ? {
         backward,

--- a/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroups.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroups.js
@@ -89,7 +89,9 @@ const RelationshipTargetTypeGroups = (React.memo<PropsT>(({
     dialogLocation.targetType == null
   );
 
-  const setAddDialogOpen = React.useCallback((open) => {
+  const setAddDialogOpen = React.useCallback((
+    open: boolean,
+  ) => {
     dispatch({
       location: open ? {source, track: track} : null,
       type: 'update-dialog-location',

--- a/root/static/scripts/relationship-editor/hooks/useRangeSelectionHandler.js
+++ b/root/static/scripts/relationship-editor/hooks/useRangeSelectionHandler.js
@@ -12,8 +12,8 @@ import * as React from 'react';
 export default function useRangeSelectionHandler(
   className: string,
 ): (event: MouseEvent) => void {
-  const lastClicked = React.useRef(null);
-  const ignoreEvents = React.useRef(false);
+  const lastClicked = React.useRef<HTMLInputElement | null>(null);
+  const ignoreEvents = React.useRef<boolean>(false);
 
   return React.useCallback(function (event: MouseEvent) {
     if (ignoreEvents.current) {

--- a/root/static/scripts/relationship-editor/hooks/useRelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/hooks/useRelationshipDialogContent.js
@@ -137,7 +137,7 @@ export function useAddRelationshipDialogContent(
     ...CommonOptionsT,
     +backward?: boolean,
     +buildNewRelationshipData?:
-      () => $Partial<RelationshipStateT> | null,
+      () => Partial<RelationshipStateT> | null,
     +preselectedTargetType: CoreEntityTypeT | null,
     +targetTypeOptions?: TargetTypeOptionsT | null,
   }>,

--- a/root/static/scripts/relationship-editor/utility/moveRelationship.js
+++ b/root/static/scripts/relationship-editor/utility/moveRelationship.js
@@ -34,6 +34,7 @@ import {
 import getRelationshipEditStatus from './getRelationshipEditStatus.js';
 import isRelationshipBackward from './isRelationshipBackward.js';
 import updateRelationships, {
+  type RelationshipUpdateT,
   ADD_RELATIONSHIP,
   REMOVE_RELATIONSHIP,
 } from './updateRelationships.js';
@@ -79,7 +80,7 @@ export default function moveRelationship(
 
   const nextLogicalLinkOrder =
     Math.max(0, relationship.linkOrder + (moveForward ? 1 : -1));
-  const updates = [];
+  const updates: Array<RelationshipUpdateT> = [];
 
   const relationshipWithNewLinkOrder = (
     relationship: RelationshipStateT,

--- a/root/static/scripts/relationship-editor/utility/splitRelationshipByAttributes.js
+++ b/root/static/scripts/relationship-editor/utility/splitRelationshipByAttributes.js
@@ -66,14 +66,17 @@ export default function splitRelationshipByAttributes(
    * Attributes that will be preserved on the original relationship,
    * if this is an existing relationship in the database.
    */
-  let attributesForExistingRelationship = null;
+  let attributesForExistingRelationship:
+    tree.ImmutableTree<LinkAttrT> | null = null;
   /*
    * Individual instrument and vocal attributes that are to be split
    * into separate relationships.
    */
-  let newAttributesToSplit = null;
+  let newAttributesToSplit:
+    tree.ImmutableTree<LinkAttrT> | null = null;
   // Common attributes that will exist on all split relationships.
-  let commonAttributes = null;
+  let commonAttributes:
+    tree.ImmutableTree<LinkAttrT> | null = null;
   let newAttributes = relationship.attributes;
   let origInstrumentsAndVocals = tree.fromDistinctAscArray(
     tree.toArray(origRelationship ? origRelationship.attributes : null)

--- a/root/static/scripts/relationship-editor/utility/updateRecordingStates.js
+++ b/root/static/scripts/relationship-editor/utility/updateRecordingStates.js
@@ -23,14 +23,15 @@ export function compareRecordingIdWithRecordingState(
   return recordingId - recordingState.recording.id;
 }
 
-const createSet = () => new Set();
+const createSet = <T>(): Set<T> => new Set<T>();
 
 export default function updateRecordingStates(
   writableRootState: ReleaseRelationshipEditorStateT,
   recordings: Iterable<RecordingT>,
   updateRecordingState: (MediumRecordingStateT) => MediumRecordingStateT,
 ): void {
-  const recordingsByMedium = new Map();
+  const recordingsByMedium =
+    new Map<MediumWithRecordingsT, Set<RecordingT>>();
 
   for (const recording of recordings) {
     const mediums =

--- a/root/static/scripts/relationship-editor/utility/updateRelationships.js
+++ b/root/static/scripts/relationship-editor/utility/updateRelationships.js
@@ -298,8 +298,8 @@ export default function updateRelationships(
     | {...ReleaseRelationshipEditorStateT},
   updates: Iterable<RelationshipUpdateT>,
 ): void {
-  const sourceGroupUpdates = new Map();
-  const allUpdates =
+  const sourceGroupUpdates = new Map<string, TargetTypeGroupUpdatesT>();
+  const allUpdates: Array<RelationshipUpdateT> | null =
     writableRootState.entity.entityType === 'release' ? [] : null;
 
   for (const update of updates) {

--- a/root/static/scripts/relationship-editor/utility/updateReleaseRelationships.js
+++ b/root/static/scripts/relationship-editor/utility/updateReleaseRelationships.js
@@ -51,7 +51,7 @@ export default function updateReleaseRelationships(
     writableRootState.entity.entityType === 'release',
   );
 
-  let updatedRecordings = null;
+  let updatedRecordings: tree.ImmutableTree<RecordingT> | null = null;
 
   for (const update of updates) {
     const relationship = update.relationship;
@@ -103,7 +103,7 @@ export default function updateReleaseRelationships(
     }
   }
 
-  let selectedWorksToRemove = null;
+  let selectedWorksToRemove: tree.ImmutableTree<WorkT> | null = null;
 
   updateRecordingStates(
     writableRootState,
@@ -116,7 +116,7 @@ export default function updateReleaseRelationships(
         recordingState.recording,
       );
 
-      const recordingWorkIds = new Set();
+      const recordingWorkIds = new Set<number>();
 
       for (
         const work of iterateTargetEntitiesOfType<WorkT>(

--- a/root/static/scripts/relationship-editor/utility/updateWorkStates.js
+++ b/root/static/scripts/relationship-editor/utility/updateWorkStates.js
@@ -57,8 +57,9 @@ export default function updateWorkStates(
   works: Iterable<WorkT>,
   updateWorkState: (MediumWorkStateT) => MediumWorkStateT,
 ): void {
-  const worksByRecordingId = new Map();
-  let recordingsToUpdate = null;
+  const worksByRecordingId =
+    new Map<number, tree.ImmutableTree<WorkT> | null>();
+  let recordingsToUpdate: tree.ImmutableTree<RecordingT> | null = null;
 
   for (const work of works) {
     for (

--- a/root/static/scripts/release/components/BatchCreateWorksDialog.js
+++ b/root/static/scripts/release/components/BatchCreateWorksDialog.js
@@ -16,6 +16,7 @@ import {
 import {createRecordingObject} from '../../common/entity2.js';
 import linkedEntities from '../../common/linkedEntities.mjs';
 import {
+  type MultiselectActionT,
   accumulateMultiselectValues,
 } from '../../edit/components/Multiselect.js';
 import Tooltip from '../../edit/components/Tooltip.js';
@@ -37,6 +38,8 @@ import type {
 import type {
   AcceptBatchCreateWorksDialogActionT,
   BatchCreateWorksDialogActionT,
+  DialogAttributeActionT,
+  DialogLinkTypeActionT,
   ReleaseRelationshipEditorActionT,
 } from '../../relationship-editor/types/actions.js';
 import getDialogLinkTypeOptions
@@ -144,7 +147,9 @@ const BatchCreateWorksDialogContent = React.memo<
     attributes.attributesList.some(x => x.error)
   );
 
-  const linkTypeDispatch = React.useCallback((action) => {
+  const linkTypeDispatch = React.useCallback((
+    action: DialogLinkTypeActionT,
+  ) => {
     dispatch({
       action,
       source: RECORDING_PLACEHOLDER,
@@ -152,11 +157,15 @@ const BatchCreateWorksDialogContent = React.memo<
     });
   }, [dispatch]);
 
-  const attributesDispatch = React.useCallback((action) => {
+  const attributesDispatch = React.useCallback((
+    action: DialogAttributeActionT,
+  ) => {
     dispatch({action, type: 'update-attribute'});
   }, [dispatch]);
 
-  const languagesDispatch = React.useCallback((action) => {
+  const languagesDispatch = React.useCallback((
+    action: MultiselectActionT<LanguageT>,
+  ) => {
     dispatch({action, type: 'update-languages'});
   }, [dispatch]);
 
@@ -246,7 +255,7 @@ export const BatchCreateWorksButtonPopover = (React.memo<
 }: BatchCreateWorksButtonPopoverPropsT): React.MixedElement => {
   const addButtonRef = React.useRef<HTMLButtonElement | null>(null);
 
-  const setOpen = React.useCallback((open) => {
+  const setOpen = React.useCallback((open: boolean) => {
     dispatch({
       location: open ? {
         batchSelection: true,

--- a/root/static/scripts/release/components/EditWorkDialog.js
+++ b/root/static/scripts/release/components/EditWorkDialog.js
@@ -125,7 +125,9 @@ const EditWorkDialog: React.AbstractComponent<
     dispatch({name: event.currentTarget.value, type: 'update-name'});
   };
 
-  const languagesDispatch = React.useCallback((action) => {
+  const languagesDispatch = React.useCallback((
+    action: MultiselectActionT<LanguageT>,
+  ) => {
     dispatch({action, type: 'update-languages'});
   }, [dispatch]);
 

--- a/root/static/scripts/release/components/MediumRelationshipEditor.js
+++ b/root/static/scripts/release/components/MediumRelationshipEditor.js
@@ -51,7 +51,7 @@ function compareRecordingWithRecordingState(
 }
 
 function handleLinkedEntitiesForMedium(
-  update: ?$ReadOnly<$Partial<LinkedEntitiesT>>,
+  update: ?$ReadOnly<Partial<LinkedEntitiesT>>,
 ): void {
   if (update) {
     /*

--- a/root/static/scripts/release/components/RelationshipEditorBatchTools.js
+++ b/root/static/scripts/release/components/RelationshipEditorBatchTools.js
@@ -70,7 +70,7 @@ const BatchAddRelationshipButtonPopover = ({
     title: l('Add Relationship'),
   });
 
-  const setOpen = React.useCallback((open) => {
+  const setOpen = React.useCallback((open: boolean) => {
     dispatch({
       location: open ? {
         batchSelection: true,

--- a/root/static/scripts/release/components/ReleaseRelationshipEditor.js
+++ b/root/static/scripts/release/components/ReleaseRelationshipEditor.js
@@ -122,6 +122,7 @@ import updateRecordingStates, {
   compareRecordingIdWithRecordingState,
 } from '../../relationship-editor/utility/updateRecordingStates.js';
 import updateRelationships, {
+  type RelationshipUpdateT,
   ADD_RELATIONSHIP,
   REMOVE_RELATIONSHIP,
 } from '../../relationship-editor/utility/updateRelationships.js';
@@ -344,7 +345,7 @@ async function submitWorkEdits(
   dispatch: (ReleaseRelationshipEditorActionT) => void,
   state: ReleaseRelationshipEditorStateT,
 ): Promise<void> {
-  const seenWorks = new Set();
+  const seenWorks = new Set<number>();
 
   function getWorkEditsForEntity(
     targetTypeGroups: RelationshipTargetTypeGroupsT,
@@ -392,7 +393,9 @@ async function submitWorkEdits(
     }
   }
 
-  const workEdits = [];
+  const workEdits: Array<
+    [Array<RelationshipStateT>, WsJsEditWorkCreateT],
+  > = [];
 
   for (const [/* position */, mediumState] of tree.iterate(state.mediums)) {
     for (const recordingState of tree.iterate(mediumState)) {
@@ -415,7 +418,7 @@ function* getAllRelationshipEdits(
   void,
   void,
 > {
-  const seenRelationships = new Map();
+  const seenRelationships = new Map<string, RelationshipStateT>();
 
   function linkAttributeEditData(
     attr: LinkAttrT,
@@ -1028,7 +1031,7 @@ const reducer = reducerWithErrorHandling<
         newState.relationshipsBySource,
         oldWork,
       );
-      const updates = [];
+      const updates: Array<RelationshipUpdateT> = [];
       for (
         const relationship of
         iterateRelationshipsInTargetTypeGroups(targetTypeGroups)
@@ -1061,7 +1064,7 @@ const reducer = reducerWithErrorHandling<
       break;
     }
     case 'toggle-select-all-recordings': {
-      let allRecordings = null;
+      let allRecordings: tree.ImmutableTree<RecordingT> | null = null;
       for (
         const [/* mediumPosition */, recordingStateTree] of
         tree.iterate(newState.mediums)
@@ -1084,7 +1087,7 @@ const reducer = reducerWithErrorHandling<
       break;
     }
     case 'toggle-select-all-works': {
-      let allWorks = null;
+      let allWorks: tree.ImmutableTree<WorkT> | null = null;
       for (
         const [/* mediumPosition */, recordingStateTree] of
         tree.iterate(newState.mediums)
@@ -1125,7 +1128,7 @@ const reducer = reducerWithErrorHandling<
       break;
     }
     case 'toggle-select-medium-recordings': {
-      let mediumRecordings = null;
+      let mediumRecordings: tree.ImmutableTree<RecordingT> | null = null;
       for (const recordingState of tree.iterate(action.recordingStates)) {
         mediumRecordings = tree.insertIfNotExists(
           mediumRecordings,
@@ -1143,7 +1146,7 @@ const reducer = reducerWithErrorHandling<
       break;
     }
     case 'toggle-select-medium-works': {
-      let mediumWorks = null;
+      let mediumWorks: tree.ImmutableTree<WorkT> | null = null;
       for (const recordingState of tree.iterate(action.recordingStates)) {
         for (const workState of tree.iterate(recordingState.relatedWorks)) {
           mediumWorks = tree.insertIfNotExists(
@@ -1240,7 +1243,7 @@ const reducer = reducerWithErrorHandling<
         );
       };
 
-      const updates = [];
+      const updates: Array<RelationshipUpdateT> = [];
       for (let i = 0; i < edits.length; i++) {
         const [relationships, wsJsEdit] = edits[i];
         const response = responseData.edits[i];
@@ -1707,14 +1710,18 @@ let ReleaseRelationshipEditor: React.AbstractComponent<{}, void> = (
     state.relationshipsBySource,
   ]);
 
-  const handleEditNoteChange = React.useCallback((event) => {
+  const handleEditNoteChange = React.useCallback((
+    event: SyntheticEvent<HTMLTextAreaElement>,
+  ) => {
     dispatch({
       editNote: event.currentTarget.value,
       type: 'update-edit-note',
     });
   }, [dispatch]);
 
-  const handleMakeVotableChange = React.useCallback((event) => {
+  const handleMakeVotableChange = React.useCallback((
+    event: SyntheticEvent<HTMLInputElement>,
+  ) => {
     dispatch({
       checked: event.currentTarget.checked,
       type: 'update-make-votable',

--- a/root/static/scripts/release/components/TrackRelationshipEditor.js
+++ b/root/static/scripts/release/components/TrackRelationshipEditor.js
@@ -106,9 +106,11 @@ const RelatedWorkHeading = ({
   removeWorkButton,
   work,
 }: RelatedWorkHeadingPropsT) => {
-  const selectWork = React.useCallback((event) => {
+  const selectWork = React.useCallback((
+    event: SyntheticEvent<HTMLInputElement>,
+  ) => {
     dispatch({
-      isSelected: event.target.checked,
+      isSelected: event.currentTarget.checked,
       type: 'toggle-select-work',
       work,
     });
@@ -145,15 +147,18 @@ const NewRelatedWorkHeading = ({
   removeWorkButton,
   work,
 }: RelatedWorkHeadingPropsT) => {
-  const selectWork = React.useCallback((event) => {
+  const selectWork = React.useCallback((
+    event: SyntheticEvent<HTMLInputElement>,
+  ) => {
     dispatch({
-      isSelected: event.target.checked,
+      isSelected: event.currentTarget.checked,
       type: 'toggle-select-work',
       work,
     });
   }, [dispatch, work]);
 
-  const editWorkButtonRef = React.useRef(null);
+  const editWorkButtonRef =
+    React.useRef<HTMLButtonElement | null>(null);
 
   const [
     isEditWorkDialogOpen,
@@ -161,7 +166,7 @@ const NewRelatedWorkHeading = ({
   ] = React.useState(false);
 
   const buildEditWorkPopoverContent = React.useCallback(
-    (closeAndReturnFocus) => (
+    (closeAndReturnFocus: () => void) => (
       <EditWorkDialog
         closeDialog={closeAndReturnFocus}
         rootDispatch={dispatch}
@@ -363,7 +368,8 @@ const RelatedWorksRelationshipEditor = React.memo<
     );
   }
 
-  const addRelatedWorkButtonRef = React.useRef(null);
+  const addRelatedWorkButtonRef =
+    React.useRef<HTMLButtonElement | null>(null);
 
   const buildNewRelatedWorkRelationshipData = React.useCallback(() => ({
     entity0: recording,
@@ -382,7 +388,9 @@ const RelatedWorksRelationshipEditor = React.memo<
     title: l('Add Relationship'),
   });
 
-  const setAddRelatedWorkDialogOpen = React.useCallback((open) => {
+  const setAddRelatedWorkDialogOpen = React.useCallback((
+    open: boolean,
+  ) => {
     dispatch({
       location: open ? {
         source: track.recording,

--- a/root/static/scripts/release/components/TracklistAndCredits.js
+++ b/root/static/scripts/release/components/TracklistAndCredits.js
@@ -136,7 +136,10 @@ export function getMediumTracks(
   return loadedTracks.get(medium.position) || medium.tracks || null;
 }
 
-const combinedTrackRelsCache = new WeakMap();
+const combinedTrackRelsCache = new WeakMap<
+  $ReadOnlyArray<TrackWithRecordingT>,
+  $ReadOnlyArray<RelationshipTargetTypeGroupT>,
+>();
 
 function getCombinedTrackRelationships(
   tracks: $ReadOnlyArray<TrackWithRecordingT> | null,

--- a/root/static/scripts/release/components/WorkLanguageMultiselect.js
+++ b/root/static/scripts/release/components/WorkLanguageMultiselect.js
@@ -54,7 +54,7 @@ export function createInitialState(
   const newState = {
     max: null,
     staticItems: languageOptions,
-    values: [],
+    values: ([]: Array<MultiselectLanguageValueStateT>),
   };
   if (initialLanguages?.length) {
     for (const language of initialLanguages) {
@@ -94,7 +94,7 @@ export function createSelectedLanguageValue(
 }
 
 export function createEmptyLanguageValue(
-  newState: {...MultiselectLanguageStateT},
+  newState: {...MultiselectLanguageStateT, ...},
 ): MultiselectLanguageValueStateT {
   return createSelectedLanguageValue(newState.staticItems, null);
 }

--- a/root/static/scripts/release/components/WorkTypeSelect.js
+++ b/root/static/scripts/release/components/WorkTypeSelect.js
@@ -44,10 +44,12 @@ const WorkTypeSelect: React.AbstractComponent<
     return buildOptionList(workTypes, l_languages);
   }, []);
 
-  const handleWorkTypeChange = React.useCallback((event) => {
+  const handleWorkTypeChange = React.useCallback((
+    event: SyntheticEvent<HTMLSelectElement>,
+  ) => {
     dispatch({
       type: 'update-work-type',
-      workType: parseIntegerOrNull(event.target.value),
+      workType: parseIntegerOrNull(event.currentTarget.value),
     });
   }, [dispatch]);
 

--- a/root/static/scripts/release/types.js
+++ b/root/static/scripts/release/types.js
@@ -33,7 +33,7 @@ export type ActionT =
 
 export type PropsT = {
   +initialCreditsMode: CreditsModeT,
-  +initialLinkedEntities: $ReadOnly<$Partial<LinkedEntitiesT>>,
+  +initialLinkedEntities: $ReadOnly<Partial<LinkedEntitiesT>>,
   +noScript: boolean,
   +release: ReleaseWithMediumsT,
 };

--- a/root/static/scripts/tests/autocomplete2.js
+++ b/root/static/scripts/tests/autocomplete2.js
@@ -53,12 +53,12 @@ const attributeTypeOptions = (
   let level = 0;
   let parentId = type.parent_id;
   let parentType =
-    parentId == null ? null : attributeTypesById.get(parentId);
+    parentId == null ? null : attributeTypesById.get(String(parentId));
   while (parentType) {
     level++;
     parentId = parentType.parent_id;
     parentType =
-      parentId == null ? null : attributeTypesById.get(parentId);
+      parentId == null ? null : attributeTypesById.get(String(parentId));
   }
   return {
     entity: type,
@@ -160,7 +160,9 @@ $(function () {
       createInitialState,
     );
 
-    const entityAutocompleteDispatch = React.useCallback((action) => {
+    const entityAutocompleteDispatch = React.useCallback((
+      action: AutocompleteActionT<NonUrlCoreEntityT>,
+    ) => {
       dispatch({
         action,
         prop: 'entityAutocomplete',
@@ -168,7 +170,9 @@ $(function () {
       });
     }, []);
 
-    const attributeTypeAutocompleteDispatch = React.useCallback((action) => {
+    const attributeTypeAutocompleteDispatch = React.useCallback((
+      action: AutocompleteActionT<LinkAttrTypeT>,
+    ) => {
       dispatch({
         action,
         prop: 'attributeTypeAutocomplete',

--- a/root/static/scripts/tests/autocomplete2.js
+++ b/root/static/scripts/tests/autocomplete2.js
@@ -215,7 +215,6 @@ $(function () {
         </div>
         <div>
           <h2>{'Attribute type autocomplete'}</h2>
-          {/* $FlowIssue[incompatible-use] */}
           <Autocomplete2
             dispatch={attributeTypeAutocompleteDispatch}
             state={state.attributeTypeAutocomplete}

--- a/root/static/scripts/tests/dialog.js
+++ b/root/static/scripts/tests/dialog.js
@@ -58,9 +58,9 @@ const DialogTest = () => {
     createInitialState,
   );
 
-  const modalButtonRef = React.useRef(null);
-  const popoverButtonRef = React.useRef(null);
-  const modalDialogRef = React.useRef(null);
+  const modalButtonRef = React.useRef<HTMLButtonElement | null>(null);
+  const popoverButtonRef = React.useRef<HTMLButtonElement | null>(null);
+  const modalDialogRef = React.useRef<HTMLDivElement | null>(null);
   const focusModalButton = useReturnFocus(modalButtonRef);
 
   const openModal = React.useCallback(() => {
@@ -83,7 +83,7 @@ const DialogTest = () => {
   }, []);
 
   const buildPopoverChildren = React.useCallback((
-    closeAndReturnFocus,
+    closeAndReturnFocus: () => void,
   ) => (
     <form
       onSubmit={(event) => {

--- a/root/static/scripts/tests/edit/utility/linkPhrase.js
+++ b/root/static/scripts/tests/edit/utility/linkPhrase.js
@@ -105,7 +105,10 @@ test('required attributes are left with forGrouping', function (t) {
     true, /* forGrouping */
   );
 
-  t.deepEqual(result, ['supporting guitar for', []]);
+  t.deepEqual(
+    result,
+    ['supporting guitar for', ([]: Array<LinkAttrT>)],
+  );
 });
 
 
@@ -140,7 +143,10 @@ test('non-required attributes are stripped with forGrouping', function (t) {
     'reverse_link_phrase',
     true, /* forGrouping */
   );
-  t.deepEqual(result, ['instrumental recordings', []]);
+  t.deepEqual(
+    result,
+    ['instrumental recordings', ([]: Array<LinkAttrT>)],
+  );
 });
 
 test('MBS-6129: Interpolating link phrases containing %', function (t) {
@@ -194,7 +200,10 @@ test('MBS-6129: Interpolating link phrases containing %', function (t) {
     'link_phrase',
     true, /* forGrouping */
   );
-  t.deepEqual(result, ['vocals', []]);
+  t.deepEqual(
+    result,
+    ['vocals', ([]: Array<LinkAttrT>)],
+  );
 
   result = getPhraseAndExtraAttributesText(
     linkedEntities.link_type[10001],
@@ -202,5 +211,8 @@ test('MBS-6129: Interpolating link phrases containing %', function (t) {
     'link_phrase',
     true, /* forGrouping */
   );
-  t.deepEqual(result, ['lead vocals', []]);
+  t.deepEqual(
+    result,
+    ['lead vocals', ([]: Array<LinkAttrT>)],
+  );
 });

--- a/root/static/scripts/tests/relationship-editor.js
+++ b/root/static/scripts/tests/relationship-editor.js
@@ -45,6 +45,7 @@ import relationshipsAreIdentical
 import splitRelationshipByAttributes
   from '../relationship-editor/utility/splitRelationshipByAttributes.js';
 import updateRelationships, {
+  type RelationshipUpdateT,
   ADD_RELATIONSHIP,
 } from '../relationship-editor/utility/updateRelationships.js';
 
@@ -786,7 +787,10 @@ function createRelationshipSourceGroups(
   const writableRootState = {...initialState};
   updateRelationships(
     writableRootState,
-    relationships.reduce((accum, relationship) => {
+    relationships.reduce((
+      accum: Array<RelationshipUpdateT>,
+      relationship,
+    ) => {
       if (relationship) {
         accum.push({
           relationship,

--- a/root/static/scripts/work/edit.js
+++ b/root/static/scripts/work/edit.js
@@ -168,8 +168,7 @@ class WorkAttribute {
     }), this, 'beforeChange');
 
     this.typeID.subscribe(newTypeID => {
-      // != is used intentionally for type coercion.
-      if (this.previousTypeID != newTypeID) { // eslint-disable-line eqeqeq
+      if (String(this.previousTypeID ?? '') !== String(newTypeID ?? '')) {
         // Don't blank text value if user e.g. misclicked and corrects type
         if (!(this.allowsFreeText(this.previousTypeID) &&
               this.allowsFreeText(newTypeID))) {
@@ -184,8 +183,7 @@ class WorkAttribute {
     }), this, 'beforeChange');
 
     this.attributeValue.subscribe(newValue => {
-      // != is used intentionally for type coercion.
-      if (this.previousValue != newValue) { // eslint-disable-line eqeqeq
+      if (String(this.previousValue ?? '') !== String(newValue ?? '')) {
         this.resetErrors();
       }
     });

--- a/root/statistics/Relationships.js
+++ b/root/statistics/Relationships.js
@@ -50,7 +50,7 @@ const TypeRows = ({
   parent,
   stats,
   type,
-}: TypeRowsPropsT) => {
+}: TypeRowsPropsT): React.MixedElement => {
   const $c = React.useContext(CatalystContext);
   return (
     <>

--- a/root/types/alias.js
+++ b/root/types/alias.js
@@ -8,15 +8,76 @@
  */
 
 // MusicBrainz::Server::Entity::Alias::TO_JSON
-declare type AliasT = {
+declare type AliasT<+T> = $ReadOnly<{
   ...DatePeriodRoleT,
   ...EntityRoleT<'alias'>,
   ...PendingEditsRoleT,
-  ...TypeRoleT<AliasTypeT>,
+  ...TypeRoleT<T>,
   +locale: string | null,
   +name: string,
   +primary_for_locale: boolean,
   +sort_name: string,
-};
+}>;
 
-declare type AliasTypeT = OptionTreeT<'alias_type'>;
+declare type AreaAliasTypeT = OptionTreeT<'area_alias_type'>;
+
+declare type AreaAliasT = AliasT<AreaAliasTypeT>;
+
+declare type ArtistAliasTypeT = OptionTreeT<'artist_alias_type'>;
+
+declare type ArtistAliasT = AliasT<ArtistAliasTypeT>;
+
+declare type EventAliasTypeT = OptionTreeT<'event_alias_type'>;
+
+declare type EventAliasT = AliasT<EventAliasTypeT>;
+
+declare type GenreAliasTypeT = OptionTreeT<'genre_alias_type'>;
+
+declare type GenreAliasT = AliasT<GenreAliasTypeT>;
+
+declare type InstrumentAliasTypeT = OptionTreeT<'instrument_alias_type'>;
+
+declare type InstrumentAliasT = AliasT<InstrumentAliasTypeT>;
+
+declare type LabelAliasTypeT = OptionTreeT<'label_alias_type'>;
+
+declare type LabelAliasT = AliasT<LabelAliasTypeT>;
+
+declare type PlaceAliasTypeT = OptionTreeT<'place_alias_type'>;
+
+declare type PlaceAliasT = AliasT<PlaceAliasTypeT>;
+
+declare type RecordingAliasTypeT = OptionTreeT<'recording_alias_type'>;
+
+declare type RecordingAliasT = AliasT<RecordingAliasTypeT>;
+
+declare type ReleaseAliasTypeT = OptionTreeT<'release_alias_type'>;
+
+declare type ReleaseAliasT = AliasT<ReleaseAliasTypeT>;
+
+declare type ReleaseGroupAliasTypeT = OptionTreeT<'releaseGroup_alias_type'>;
+
+declare type ReleaseGroupAliasT = AliasT<ReleaseGroupAliasTypeT>;
+
+declare type SeriesAliasTypeT = OptionTreeT<'series_alias_type'>;
+
+declare type SeriesAliasT = AliasT<SeriesAliasTypeT>;
+
+declare type WorkAliasTypeT = OptionTreeT<'work_alias_type'>;
+
+declare type WorkAliasT = AliasT<WorkAliasTypeT>;
+
+declare type AnyAiasT = AliasT<
+ | AreaAliasTypeT
+ | ArtistAliasTypeT
+ | EventAliasTypeT
+ | GenreAliasTypeT
+ | InstrumentAliasTypeT
+ | LabelAliasTypeT
+ | PlaceAliasTypeT
+ | RecordingAliasTypeT
+ | ReleaseAliasTypeT
+ | ReleaseGroupAliasTypeT
+ | SeriesAliasTypeT
+ | WorkAliasTypeT
+>;

--- a/root/types/collection.js
+++ b/root/types/collection.js
@@ -8,7 +8,7 @@
  */
 
 // MusicBrainz::Server::Entity::Collection::TO_JSON
-declare type CollectionT = {
+declare type CollectionT = $ReadOnly<{
   ...EntityRoleT<'collection'>,
   ...TypeRoleT<CollectionTypeT>,
   +collaborators: $ReadOnlyArray<EditorT>,
@@ -22,7 +22,7 @@ declare type CollectionT = {
   +name: string,
   +public: boolean,
   +subscribed?: boolean,
-};
+}>;
 
 declare type CollectionTypeT = {
   ...OptionTreeT<'collection_type'>,

--- a/root/types/edit_types.js
+++ b/root/types/edit_types.js
@@ -343,7 +343,7 @@ declare type AddReleaseLabelEditT = $ReadOnly<{
   +edit_type: EDIT_RELEASE_ADDRELEASELABEL_T,
 }>;
 
-declare type AddRemoveAliasEditGenericT = $ReadOnly<{
+declare type AddRemoveAliasEditGenericT<+T> = $ReadOnly<{
   ...GenericEditT,
   +display_data: {
     +[coreEntityType: CoreEntityTypeT]: CoreEntityT,
@@ -355,127 +355,127 @@ declare type AddRemoveAliasEditGenericT = $ReadOnly<{
     +locale: string | null,
     +primary_for_locale: boolean,
     +sort_name: string | null,
-    +type: AliasTypeT | null,
+    +type: T | null,
   },
 }>;
 
 declare type AddAreaAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<AreaAliasTypeT>,
   +edit_type: EDIT_AREA_ADD_ALIAS_T,
 }>;
 
 declare type AddArtistAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<ArtistAliasTypeT>,
   +edit_type: EDIT_ARTIST_ADD_ALIAS_T,
 }>;
 
 declare type AddEventAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<EventAliasTypeT>,
   +edit_type: EDIT_EVENT_ADD_ALIAS_T,
 }>;
 
 declare type AddGenreAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<GenreAliasTypeT>,
   +edit_type: EDIT_GENRE_ADD_ALIAS_T,
 }>;
 
 declare type AddInstrumentAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<InstrumentAliasTypeT>,
   +edit_type: EDIT_INSTRUMENT_ADD_ALIAS_T,
 }>;
 
 declare type AddLabelAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<LabelAliasTypeT>,
   +edit_type: EDIT_LABEL_ADD_ALIAS_T,
 }>;
 
 declare type AddPlaceAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<PlaceAliasTypeT>,
   +edit_type: EDIT_PLACE_ADD_ALIAS_T,
 }>;
 
 declare type AddRecordingAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<RecordingAliasTypeT>,
   +edit_type: EDIT_RECORDING_ADD_ALIAS_T,
 }>;
 
 declare type AddReleaseGroupAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<ReleaseGroupAliasTypeT>,
   +edit_type: EDIT_RELEASEGROUP_ADD_ALIAS_T,
 }>;
 
 declare type AddReleaseAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<ReleaseAliasTypeT>,
   +edit_type: EDIT_RELEASE_ADD_ALIAS_T,
 }>;
 
 declare type AddSeriesAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<SeriesAliasTypeT>,
   +edit_type: EDIT_SERIES_ADD_ALIAS_T,
 }>;
 
 declare type AddWorkAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<WorkAliasTypeT>,
   +edit_type: EDIT_WORK_ADD_ALIAS_T,
 }>;
 
 declare type RemoveAreaAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<AreaAliasTypeT>,
   +edit_type: EDIT_AREA_DELETE_ALIAS_T,
 }>;
 
 declare type RemoveArtistAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<ArtistAliasTypeT>,
   +edit_type: EDIT_ARTIST_DELETE_ALIAS_T,
 }>;
 
 declare type RemoveEventAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<EventAliasTypeT>,
   +edit_type: EDIT_EVENT_DELETE_ALIAS_T,
 }>;
 
 declare type RemoveGenreAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<GenreAliasTypeT>,
   +edit_type: EDIT_GENRE_DELETE_ALIAS_T,
 }>;
 
 declare type RemoveInstrumentAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<InstrumentAliasTypeT>,
   +edit_type: EDIT_INSTRUMENT_DELETE_ALIAS_T,
 }>;
 
 declare type RemoveLabelAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<LabelAliasTypeT>,
   +edit_type: EDIT_LABEL_DELETE_ALIAS_T,
 }>;
 
 declare type RemovePlaceAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<PlaceAliasTypeT>,
   +edit_type: EDIT_PLACE_DELETE_ALIAS_T,
 }>;
 
 declare type RemoveRecordingAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<RecordingAliasTypeT>,
   +edit_type: EDIT_RECORDING_DELETE_ALIAS_T,
 }>;
 
 declare type RemoveReleaseGroupAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<ReleaseGroupAliasTypeT>,
   +edit_type: EDIT_RELEASEGROUP_DELETE_ALIAS_T,
 }>;
 
 declare type RemoveReleaseAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<ReleaseAliasTypeT>,
   +edit_type: EDIT_RELEASE_DELETE_ALIAS_T,
 }>;
 
 declare type RemoveSeriesAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<SeriesAliasTypeT>,
   +edit_type: EDIT_SERIES_DELETE_ALIAS_T,
 }>;
 
 declare type RemoveWorkAliasEditT = $ReadOnly<{
-  ...AddRemoveAliasEditGenericT,
+  ...AddRemoveAliasEditGenericT<WorkAliasTypeT>,
   +edit_type: EDIT_WORK_DELETE_ALIAS_T,
 }>;
 
@@ -564,9 +564,9 @@ declare type ChangeWikiDocEditT = $ReadOnly<{
   +edit_type: EDIT_WIKIDOC_CHANGE_T,
 }>;
 
-declare type EditAliasEditGenericT = $ReadOnly<{
+declare type EditAliasEditGenericT<+A, +T> = $ReadOnly<{
   ...GenericEditT,
-  +alias: AliasT | null,
+  +alias: A | null,
   +display_data: {
     +[coreEntityType: CoreEntityTypeT]: CoreEntityT,
     +alias: CompT<string>,
@@ -577,67 +577,67 @@ declare type EditAliasEditGenericT = $ReadOnly<{
     +locale: CompT<string | null>,
     +primary_for_locale: CompT<boolean>,
     +sort_name: CompT<string>,
-    +type: CompT<AliasTypeT | null>,
+    +type: CompT<T | null>,
   },
 }>;
 
 declare type EditAreaAliasEditT = $ReadOnly<{
-  ...EditAliasEditGenericT,
+  ...EditAliasEditGenericT<AreaAliasT, AreaAliasTypeT>,
   +edit_type: EDIT_AREA_EDIT_ALIAS_T,
 }>;
 
 declare type EditArtistAliasEditT = $ReadOnly<{
-  ...EditAliasEditGenericT,
+  ...EditAliasEditGenericT<ArtistAliasT, ArtistAliasTypeT>,
   +edit_type: EDIT_ARTIST_EDIT_ALIAS_T,
 }>;
 
 declare type EditEventAliasEditT = $ReadOnly<{
-  ...EditAliasEditGenericT,
+  ...EditAliasEditGenericT<EventAliasT, EventAliasTypeT>,
   +edit_type: EDIT_EVENT_EDIT_ALIAS_T,
 }>;
 
 declare type EditGenreAliasEditT = $ReadOnly<{
-  ...EditAliasEditGenericT,
+  ...EditAliasEditGenericT<GenreAliasT, GenreAliasTypeT>,
   +edit_type: EDIT_GENRE_EDIT_ALIAS_T,
 }>;
 
 declare type EditInstrumentAliasEditT = $ReadOnly<{
-  ...EditAliasEditGenericT,
+  ...EditAliasEditGenericT<InstrumentAliasT, InstrumentAliasTypeT>,
   +edit_type: EDIT_INSTRUMENT_EDIT_ALIAS_T,
 }>;
 
 declare type EditLabelAliasEditT = $ReadOnly<{
-  ...EditAliasEditGenericT,
+  ...EditAliasEditGenericT<LabelAliasT, LabelAliasTypeT>,
   +edit_type: EDIT_LABEL_EDIT_ALIAS_T,
 }>;
 
 declare type EditPlaceAliasEditT = $ReadOnly<{
-  ...EditAliasEditGenericT,
+  ...EditAliasEditGenericT<PlaceAliasT, PlaceAliasTypeT>,
   +edit_type: EDIT_PLACE_EDIT_ALIAS_T,
 }>;
 
 declare type EditRecordingAliasEditT = $ReadOnly<{
-  ...EditAliasEditGenericT,
+  ...EditAliasEditGenericT<RecordingAliasT, RecordingAliasTypeT>,
   +edit_type: EDIT_RECORDING_EDIT_ALIAS_T,
 }>;
 
 declare type EditReleaseGroupAliasEditT = $ReadOnly<{
-  ...EditAliasEditGenericT,
+  ...EditAliasEditGenericT<ReleaseGroupAliasT, ReleaseGroupAliasTypeT>,
   +edit_type: EDIT_RELEASEGROUP_EDIT_ALIAS_T,
 }>;
 
 declare type EditReleaseAliasEditT = $ReadOnly<{
-  ...EditAliasEditGenericT,
+  ...EditAliasEditGenericT<ReleaseAliasT, ReleaseAliasTypeT>,
   +edit_type: EDIT_RELEASE_EDIT_ALIAS_T,
 }>;
 
 declare type EditSeriesAliasEditT = $ReadOnly<{
-  ...EditAliasEditGenericT,
+  ...EditAliasEditGenericT<SeriesAliasT, SeriesAliasTypeT>,
   +edit_type: EDIT_SERIES_EDIT_ALIAS_T,
 }>;
 
 declare type EditWorkAliasEditT = $ReadOnly<{
-  ...EditAliasEditGenericT,
+  ...EditAliasEditGenericT<WorkAliasT, WorkAliasTypeT>,
   +edit_type: EDIT_WORK_EDIT_ALIAS_T,
 }>;
 

--- a/root/types/wsjs.js
+++ b/root/types/wsjs.js
@@ -45,7 +45,7 @@ declare type WsJsEditRelationshipCreateT = $ReadOnly<{
 }>;
 
 declare type WsJsEditRelationshipEditT = $ReadOnly<{
-  ...$Partial<WsJsRelationshipCommonT>,
+  ...Partial<WsJsRelationshipCommonT>,
   +edit_type: EDIT_RELATIONSHIP_EDIT_T,
   +id: number,
   +linkTypeID: number,

--- a/root/user/UserCollections.js
+++ b/root/user/UserCollections.js
@@ -10,10 +10,10 @@
 import * as React from 'react';
 import type {ColumnOptions} from 'react-table';
 
-import Table from '../components/Table.js';
 import UserAccountLayout, {type AccountLayoutUserT}
   from '../components/UserAccountLayout.js';
 import {SanitizedCatalystContext} from '../context.mjs';
+import useTable from '../hooks/useTable.js';
 import {formatPluralEntityTypeName}
   from '../static/scripts/common/utility/formatEntityTypeName.js';
 import {
@@ -141,18 +141,23 @@ const CollectionsEntityTypeSection = ({
         typeColumn,
         sizeColumn,
         collaboratorsColumn,
-        ...(activeUserId == null ? [] : [subscriptionColumn]),
-        ...(viewingOwnProfile || isCollaborative ? [privacyColumn] : []),
-        ...(viewingOwnProfile && !isCollaborative ? [actionsColumn] : []),
-      ];
+        (activeUserId == null) ? null : subscriptionColumn,
+        (viewingOwnProfile || isCollaborative) ? privacyColumn : null,
+        (viewingOwnProfile && !isCollaborative) ? actionsColumn : null,
+      ].filter(Boolean);
     },
     [activeUserId, isCollaborative, type, user.id],
   );
 
+  const table = useTable<CollectionWithSubscribedT>({
+    columns,
+    data: collections,
+  });
+
   return (
     <>
       <h3>{collectionsListTitles[type]()}</h3>
-      <Table columns={columns} data={collections} />
+      {table}
     </>
   );
 };

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -59,8 +59,10 @@ const ADDED_ENTITIES_TYPES = {
   work:         N_l('Work'),
 };
 
-function generateUserTypesList(user: UnsanitizedEditorT) {
-  const typesList = [];
+function generateUserTypesList(
+  user: UnsanitizedEditorT,
+): $ReadOnlyArray<VarSubstArg> {
+  const typesList: Array<VarSubstArg> = [];
   if (user.deleted) {
     typesList.push(l('Deleted User'));
   }

--- a/root/utility/compactEntityJson.js
+++ b/root/utility/compactEntityJson.js
@@ -94,7 +94,6 @@ function _indexValue(
       }
       break;
     }
-    // $FlowIssue[illegal-typeof]
     case 'bigint':
     case 'function':
     case 'symbol':

--- a/root/utility/compactEntityJson.js
+++ b/root/utility/compactEntityJson.js
@@ -49,7 +49,7 @@ function _indexValue(
     case 'object': {
       if (value) {
         if (Array.isArray(value)) {
-          compactValue = [];
+          compactValue = ([]: Array<number>);
           for (const arrayItem of value) {
             compactValue.push(
               _indexValue(
@@ -110,7 +110,7 @@ function _indexValue(
 export function compactEntityJson(
   value: mixed,
 ): $ReadOnlyArray<mixed> {
-  const result = [];
+  const result: Array<mixed> = [];
   _indexValue(value, new Map(), result);
   return result;
 }
@@ -118,7 +118,10 @@ export function compactEntityJson(
 export function decompactEntityJson(
   compactedArray: $ReadOnlyArray<mixed>,
 ): mixed {
-  const resolved = new Array(compactedArray.length);
+  const resolved = new Array<
+    | Array<mixed>
+    | {[objectKey: string]: mixed},
+  >(compactedArray.length);
 
   function _decompactIndex(
     index: number,

--- a/root/utility/formatUserDate.js
+++ b/root/utility/formatUserDate.js
@@ -9,7 +9,7 @@
 
 import parseIsoDate from './parseIsoDate.js';
 
-const formatterCache = new Map();
+const formatterCache = new Map<string, Intl$DateTimeFormat>();
 
 /*
  * This maps the `strftime` patterns we use to `Intl.DateTimeFormat` options.

--- a/root/utility/generateFlowType.js
+++ b/root/utility/generateFlowType.js
@@ -161,7 +161,7 @@ exports.generateFlowType = async function (
     +isEditDataTypeInfo: boolean,
   } */,
 )/*: Promise<string> */ {
-  const seenTypes = new Set();
+  const seenTypes = new Set/*:: <string> */();
   const isEditDataTypeInfo = options && options.isEditDataTypeInfo;
   const rootTypeInfo = new TypeInfo(
     null,

--- a/root/utility/hydrate.js
+++ b/root/utility/hydrate.js
@@ -39,7 +39,7 @@ type PropsDataT =
  * `GLOBAL_JS_NAMESPACE`; we otherwise may need to relax this check for
  * admin-only forms in the future.
  */
-let checkForUnsanitizedEditorData;
+let checkForUnsanitizedEditorData: ((PropsDataT) => void);
 if (__DEV__) {
   /*
    * Please keep these keys in sync with what's returned by
@@ -59,7 +59,7 @@ if (__DEV__) {
 
   checkForUnsanitizedEditorData = (
     data: PropsDataT,
-  ) => {
+  ): void => {
     if (data) {
       if (Array.isArray(data)) {
         data.forEach(checkForUnsanitizedEditorData);

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -149,7 +149,10 @@ export function defineArtistRolesColumn<D>(
 
 export function defineBeginDateColumn(
   props: OrderableProps,
-): ColumnOptions<{+begin_date: PartialDateT, ...}, PartialDateT> {
+): ColumnOptions<
+  {+begin_date: PartialDateT | null, ...},
+  PartialDateT | null,
+> {
   const sortable = props.sortable ?? false;
 
   return {
@@ -201,7 +204,7 @@ export function defineCheckboxColumn(
     +mergeForm?: MergeFormT | MergeReleasesFormT,
     +name?: string,
   },
-): ColumnOptions<CoreEntityT, number> {
+): ColumnOptions<NonUrlCoreEntityT | CollectionT, number> {
   return {
     Cell: ({row: {index, original}}) => props.mergeForm
       ? renderMergeCheckboxElement(original, props.mergeForm, index)
@@ -278,7 +281,7 @@ export function defineDatePeriodColumn<D>(
 
 export function defineEndDateColumn(
   props: OrderableProps,
-): ColumnOptions<{...DatePeriodRoleT, ...}, PartialDateT | null> {
+): ColumnOptions<$ReadOnly<{...DatePeriodRoleT, ...}>, PartialDateT | null> {
   const sortable = props.sortable ?? false;
 
   return {
@@ -625,11 +628,11 @@ export function defineTypeColumn(
     ...OrderableProps,
     +typeContext: string,
   },
-): ColumnOptions<{+typeName: string, ...}, string> {
+): ColumnOptions<{+typeName?: string, ...}, string> {
   const sortable = props.sortable ?? false;
 
   return {
-    accessor: x => x.typeName,
+    accessor: x => x.typeName ?? '',
     Cell: ({cell: {value}}) => (value
       ? lp_attributes(value, props.typeContext)
       : null),
@@ -695,7 +698,7 @@ export const iswcsColumn:
   };
 
 export const removeFromMergeColumn:
-  ColumnOptions<ArtistT | RecordingT | ReleaseT, number> = {
+  ColumnOptions<NonUrlCoreEntityT | CollectionT, number> = {
     Cell: ({row: {original}}) => {
       const url = ENTITIES[original.entityType].url;
       return (

--- a/script/generate_code.pl
+++ b/script/generate_code.pl
@@ -8,10 +8,10 @@ use lib "$FindBin::Bin/../lib";
 use MusicBrainz::Server::Constants qw( %ENTITIES entities_with );
 use Template;
 
-my $DATA_DIR = "$FindBin::Bin/../lib/MusicBrainz/Server/Data";
+my $SERVER_DIR = "$FindBin::Bin/../lib/MusicBrainz/Server";
 
 my $TT = Template->new(
-    INCLUDE_PATH => $DATA_DIR,
+    INCLUDE_PATH => $SERVER_DIR,
 );
 
 for my $entity_type (entities_with('aliases')) {
@@ -23,9 +23,12 @@ for my $entity_type (entities_with('aliases')) {
         %{ $ENTITIES{$alias_type} },
     };
 
-    open my $fh, '>', File::Spec->catfile($DATA_DIR, "${model}AliasType.pm");
+    my $fh;
+    open $fh, '>', File::Spec->catfile($SERVER_DIR, "Data/${model}AliasType.pm");
+    $TT->process('Data/AliasType.tt', $vars, $fh);
 
-    $TT->process('AliasType.tt', $vars, $fh);
+    open $fh, '>', File::Spec->catfile($SERVER_DIR, "Entity/${model}AliasType.pm");
+    $TT->process('Entity/AliasType.tt', $vars, $fh);
 }
 
 =head1 COPYRIGHT AND LICENSE

--- a/script/generate_edit_data_flow_type.mjs
+++ b/script/generate_edit_data_flow_type.mjs
@@ -38,8 +38,8 @@ yargs
     }
   }
 
-  await pgClient.query('BEGIN');
-  await pgClient.query('SET LOCAL statement_timeout = 0');
+  await pgClient.query<string>('BEGIN');
+  await pgClient.query<string>('SET LOCAL statement_timeout = 0');
 
   const cursor = pgClient.query(
     new SingleColumnCursor(
@@ -54,7 +54,7 @@ yargs
   const createIterator = () => {
     let buffer: Array<string> | null = [];
     let index = 0;
-    const it = {
+    const it: AsyncIterator<string> = {
       /*:: @@asyncIterator: function () { return it; }, */
       async next() {
         if (buffer == null) {
@@ -66,7 +66,10 @@ yargs
             value: buffer[index++],
           };
         }
-        return new Promise((resolve, reject) => {
+        return new Promise<IteratorResult<string, void>>((
+          resolve,
+          reject,
+        ) => {
           cursor.read(500, (err, rows) => {
             if (err) {
               reject(err);
@@ -98,6 +101,6 @@ yargs
     isEditDataTypeInfo: true,
   }));
 
-  await pgClient.query('ROLLBACK');
+  await pgClient.query<string>('ROLLBACK');
   await pgClient.end();
 }());

--- a/script/generate_edit_data_flow_type.mjs
+++ b/script/generate_edit_data_flow_type.mjs
@@ -92,7 +92,6 @@ yargs
   };
 
   const objectStrings = {
-    // $FlowIssue[prop-missing]
     [Symbol.asyncIterator]: createIterator,
     /*:: @@asyncIterator: createIterator, */
   };

--- a/script/generate_edit_data_flow_type.mjs
+++ b/script/generate_edit_data_flow_type.mjs
@@ -103,4 +103,6 @@ yargs
 
   await pgClient.query<string>('ROLLBACK');
   await pgClient.end();
-}());
+}()).catch((error: mixed) => {
+  throw error;
+});

--- a/script/generate_json_flow_type.js
+++ b/script/generate_json_flow_type.js
@@ -24,4 +24,6 @@ const {generateFlowType} = require('../root/utility/generateFlowType');
       {isEditDataTypeInfo: false},
     ),
   );
-}());
+}()).catch((error: mixed) => {
+  throw error;
+});

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Aliases.pm
@@ -23,7 +23,7 @@ test 'Work alias appears on alias page content and on JSON-LD' => sub {
 
     $mech->get_ok(
         '/work/559be0c1-2c87-45d6-ba43-1b1feb8f831e/aliases',
-        'Fetched release aliases page',
+        'Fetched work aliases page',
     );
     html_ok($mech->content);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.198.1:
-  version "0.198.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.198.1.tgz#5fdad4d572bdc76f9ab24890c335e1f7addcecd4"
-  integrity sha512-9jWC1GJgV5QyeBxvT0GtTQtaw55imDRIh//C5WaS/dijl7IP34CrNY2NgBSwzif516SktkG8KylQWJaslZI2QA==
+flow-bin@0.198.2:
+  version "0.198.2"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.198.2.tgz#e601121a411b4ec5889cc3567d2706369cc510a9"
+  integrity sha512-PML2zhAZVd8EgzDqS9oSJF+OxUtJ+YLEdVVsVO7d1BwnrXCgiVrLjxiQP8/hur820grzC51Xb2CI3J+ohH/bMg==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.198.0:
-  version "0.198.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.198.0.tgz#c5edf94b3f0bf4569e9a9f20b66a3f115e5f469d"
-  integrity sha512-sUNcC9FD30/4p2uSYi7WwQSMMvZNbeIMMbyjZkGfUrIJTEjb+SiLEXT3TH3SV/isFEwm7H/9k9528vhZwtoMcA==
+flow-bin@0.198.1:
+  version "0.198.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.198.1.tgz#5fdad4d572bdc76f9ab24890c335e1f7addcecd4"
+  integrity sha512-9jWC1GJgV5QyeBxvT0GtTQtaw55imDRIh//C5WaS/dijl7IP34CrNY2NgBSwzif516SktkG8KylQWJaslZI2QA==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.200.0:
-  version "0.200.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.200.0.tgz#bae10e7454aca131f72f084f64371f5098c5be07"
-  integrity sha512-4KquALYPkCCTCZ43GIqTDZDOf4znU3/kXsigpiwwORV8l/ctqwvKkqCOhjqvGy5DtbiL6WTPBqLwGAlxeGeNIA==
+flow-bin@0.200.1:
+  version "0.200.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.200.1.tgz#6d32ef92972709ab7c06b27cb7fa4137c6e2c9eb"
+  integrity sha512-0VCo3uZb0XIYF/sNFuLsGRpsUWnXbPi27MQ3AW7F1n7yAy2FEgMxDS/XQ3ubh5ga4M+yKrdeDsZ3IXwYyRNXMQ==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.200.1:
-  version "0.200.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.200.1.tgz#6d32ef92972709ab7c06b27cb7fa4137c6e2c9eb"
-  integrity sha512-0VCo3uZb0XIYF/sNFuLsGRpsUWnXbPi27MQ3AW7F1n7yAy2FEgMxDS/XQ3ubh5ga4M+yKrdeDsZ3IXwYyRNXMQ==
+flow-bin@0.201.0:
+  version "0.201.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.201.0.tgz#bc8d7c3687526313d7a24dd920873a0273148d81"
+  integrity sha512-fqx6CMOhX9Xm4mN+tq/c7sqcm8aHFV1ipbLz2ZCzoNcPuUNZPoSVYm4p0qZqH0HyzMMEP1OWlU7dIkuSJ02cpg==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.199.1:
-  version "0.199.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.199.1.tgz#678eac2303fa898227f4d103264b6ce49f4430c1"
-  integrity sha512-Ic0Mp9iZ2exbH0mNj/XhzUWPZa9JylHb6uQARZnnYCTRwumOpjNOP0qwyRTltWrbCpfHjnWngNO9VLaVKHz2aQ==
+flow-bin@0.200.0:
+  version "0.200.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.200.0.tgz#bae10e7454aca131f72f084f64371f5098c5be07"
+  integrity sha512-4KquALYPkCCTCZ43GIqTDZDOf4znU3/kXsigpiwwORV8l/ctqwvKkqCOhjqvGy5DtbiL6WTPBqLwGAlxeGeNIA==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.198.2:
-  version "0.198.2"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.198.2.tgz#e601121a411b4ec5889cc3567d2706369cc510a9"
-  integrity sha512-PML2zhAZVd8EgzDqS9oSJF+OxUtJ+YLEdVVsVO7d1BwnrXCgiVrLjxiQP8/hur820grzC51Xb2CI3J+ohH/bMg==
+flow-bin@0.199.0:
+  version "0.199.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.199.0.tgz#e710c0834d4e1032529a633e0cf32d89a102fcfb"
+  integrity sha512-8N8jn59ghgtDSogFoy1Ld1P8NlfdlVUcXSRADDf8WyX3SMMA6b1SbqraTRXxJDNn0F3WdVBHKdufdUg73y4Nhw==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.197.0:
-  version "0.197.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.197.0.tgz#a26ec0e495678676031acb414c1211d59f1d8fff"
-  integrity sha512-6g0c4Hj+JeS9nRayORAC3qUUzecX1RAjYap086yXivjfN2hlaqMYEi4ZDNPhtUOM8IqB4IE8HXPHt17uLsi0zw==
+flow-bin@0.198.0:
+  version "0.198.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.198.0.tgz#c5edf94b3f0bf4569e9a9f20b66a3f115e5f469d"
+  integrity sha512-sUNcC9FD30/4p2uSYi7WwQSMMvZNbeIMMbyjZkGfUrIJTEjb+SiLEXT3TH3SV/isFEwm7H/9k9528vhZwtoMcA==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.199.0:
-  version "0.199.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.199.0.tgz#e710c0834d4e1032529a633e0cf32d89a102fcfb"
-  integrity sha512-8N8jn59ghgtDSogFoy1Ld1P8NlfdlVUcXSRADDf8WyX3SMMA6b1SbqraTRXxJDNn0F3WdVBHKdufdUg73y4Nhw==
+flow-bin@0.199.1:
+  version "0.199.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.199.1.tgz#678eac2303fa898227f4d103264b6ce49f4430c1"
+  integrity sha512-Ic0Mp9iZ2exbH0mNj/XhzUWPZa9JylHb6uQARZnnYCTRwumOpjNOP0qwyRTltWrbCpfHjnWngNO9VLaVKHz2aQ==
 
 follow-redirects@^1.0.0:
   version "1.15.2"


### PR DESCRIPTION
https://medium.com/flow-type/local-type-inference-for-flow-aaa65d071347

One notable change related to our react-table usage was that I had to change the `<Table>` component into a `useTable` hook, because Flow still doesn't allow you to pass a type argument to React components. But it doesn't matter for us if it's a component or not.