### PR TITLE
MBS-12552 (pre): Refine some Flow.js types

### DIFF
--- a/root/artist_credit/ArtistCreditIndex.js
+++ b/root/artist_credit/ArtistCreditIndex.js
@@ -27,7 +27,7 @@ type Props = {
   +creditedEntities: {
     +[entityType: string]: {
       +count: number,
-      +entities: $ReadOnlyArray<CoreEntityT | TrackT>,
+      +entities: $ReadOnlyArray<EntityWithArtistCreditsT>,
     },
   },
 };

--- a/root/artist_credit/EntityList.js
+++ b/root/artist_credit/EntityList.js
@@ -37,7 +37,7 @@ const noEntitiesText = {
 
 type Props = {
   +artistCredit: $ReadOnly<{...ArtistCreditT, +id: number}>,
-  +entities: $ReadOnlyArray<CoreEntityT | TrackT>,
+  +entities: $ReadOnlyArray<EntityWithArtistCreditsT>,
   +entityType: string,
   +page: string,
   +pager: PagerT,

--- a/root/collection/CollectionIndex.js
+++ b/root/collection/CollectionIndex.js
@@ -31,7 +31,7 @@ import UserInlineList from '../user/components/UserInlineList.js';
 
 import CollectionLayout from './CollectionLayout.js';
 
-type PropsForEntity<T: CollectableCoreEntityT> = {
+type PropsForEntity<T: CollectableEntityT> = {
   +collection: CollectionT,
   +collectionEntityType: T['entityType'],
   +entities: $ReadOnlyArray<T>,

--- a/root/collection/CollectionIndex.js
+++ b/root/collection/CollectionIndex.js
@@ -31,7 +31,7 @@ import UserInlineList from '../user/components/UserInlineList.js';
 
 import CollectionLayout from './CollectionLayout.js';
 
-type PropsForEntity<T: CoreEntityT> = {
+type PropsForEntity<T: CollectableCoreEntityT> = {
   +collection: CollectionT,
   +collectionEntityType: T['entityType'],
   +entities: $ReadOnlyArray<T>,

--- a/root/components/Aliases/AliasTable.js
+++ b/root/components/Aliases/AliasTable.js
@@ -14,7 +14,7 @@ import AliasTableBody from './AliasTableBody.js';
 type Props = {
   +aliases: $ReadOnlyArray<AliasT>,
   +allowEditing: boolean,
-  +entity: CoreEntityT,
+  +entity: EntityWithAliasesT,
 };
 
 const AliasTable = (props: Props): React.Element<'table'> => (

--- a/root/components/Aliases/AliasTableBody.js
+++ b/root/components/Aliases/AliasTableBody.js
@@ -14,7 +14,7 @@ import AliasTableRow from './AliasTableRow.js';
 type Props = {
   +aliases: $ReadOnlyArray<AliasT>,
   +allowEditing: boolean,
-  +entity: CoreEntityT,
+  +entity: EntityWithAliasesT,
 };
 
 const AliasTableBody = ({

--- a/root/components/Aliases/AliasTableRow.js
+++ b/root/components/Aliases/AliasTableRow.js
@@ -20,7 +20,7 @@ import isolateText from '../../static/scripts/common/utility/isolateText.js';
 type Props = {
   +alias: AliasT,
   +allowEditing: boolean,
-  +entity: CoreEntityT,
+  +entity: EntityWithAliasesT,
   +row: string,
 };
 

--- a/root/components/Aliases/ArtistCreditList.js
+++ b/root/components/Aliases/ArtistCreditList.js
@@ -20,7 +20,7 @@ import loopParity from '../../utility/loopParity.js';
 
 type Props = {
   +artistCredits: $ReadOnlyArray<{+id: number} & ArtistCreditT>,
-  +entity: CoreEntityT,
+  +entity: ArtistT,
 };
 
 const ArtistCreditList = ({

--- a/root/components/Aliases/index.js
+++ b/root/components/Aliases/index.js
@@ -37,7 +37,7 @@ function canEdit($c: CatalystContextT, entityType: string) {
 
 type Props = {
   +aliases: ?$ReadOnlyArray<AliasT>,
-  +entity: CoreEntityT,
+  +entity: EntityWithAliasesT,
 };
 
 const Aliases = ({aliases, entity}: Props): React.MixedElement => {

--- a/root/entity/Aliases.js
+++ b/root/entity/Aliases.js
@@ -34,11 +34,10 @@ const Aliases = ({
       title={l('Aliases')}
     >
       <AliasesComponent aliases={aliases} entity={entity} />
-      {artistCredits?.length ? (
+      {/*:: entity.entityType === 'artist' && */ artistCredits?.length ? (
         <ArtistCreditList
           artistCredits={artistCredits}
-          // $FlowIgnore[unclear-type] Only artists have credits
-          entity={((entity: any): ArtistT)}
+          entity={entity}
         />
       ) : null}
     </LayoutComponent>

--- a/root/entity/Aliases.js
+++ b/root/entity/Aliases.js
@@ -37,7 +37,8 @@ const Aliases = ({
       {artistCredits?.length ? (
         <ArtistCreditList
           artistCredits={artistCredits}
-          entity={entity}
+          // $FlowIgnore[unclear-type] Only artists have credits
+          entity={((entity: any): ArtistT)}
         />
       ) : null}
     </LayoutComponent>

--- a/root/entity/Aliases.js
+++ b/root/entity/Aliases.js
@@ -16,7 +16,7 @@ import chooseLayoutComponent from '../utility/chooseLayoutComponent.js';
 type Props = {
   +aliases: $ReadOnlyArray<AliasT>,
   +artistCredits?: $ReadOnlyArray<{+id: number} & ArtistCreditT>,
-  +entity: CoreEntityT,
+  +entity: EntityWithAliasesT,
 };
 
 const Aliases = ({

--- a/root/entity/alias/AddOrEditAlias.js
+++ b/root/entity/alias/AddOrEditAlias.js
@@ -19,7 +19,7 @@ import type {AliasEditFormT} from './types.js';
 
 type Props = {
   +aliasTypes: SelectOptionsT,
-  +entity: CoreEntityT,
+  +entity: EntityWithAliasesT,
   +form: AliasEditFormT,
   +formType: string,
   +locales: SelectOptionsT,

--- a/root/entity/alias/DeleteAlias.js
+++ b/root/entity/alias/DeleteAlias.js
@@ -18,7 +18,7 @@ import type {AliasDeleteFormT} from './types.js';
 
 type Props = {
   +alias: AliasT,
-  +entity: CoreEntityT,
+  +entity: EntityWithAliasesT,
   +form: AliasDeleteFormT,
   +type: string,
 };

--- a/root/layout/components/sidebar/CollectionLinks.js
+++ b/root/layout/components/sidebar/CollectionLinks.js
@@ -16,7 +16,7 @@ import EntityLink
 import CollectionList from './CollectionList.js';
 
 type Props = {
-  +entity: CollectableCoreEntityT,
+  +entity: CollectableEntityT,
 };
 
 const noCollectionsStrings = {

--- a/root/layout/components/sidebar/CollectionList.js
+++ b/root/layout/components/sidebar/CollectionList.js
@@ -15,7 +15,7 @@ import typeof EntityLink
 import entityHref from '../../../static/scripts/common/utility/entityHref.js';
 import {returnToCurrentPage} from '../../../utility/returnUri.js';
 
-function entityArg(entity: CollectableCoreEntityT) {
+function entityArg(entity: CollectableEntityT) {
   return '?' + entity.entityType + '=' +
     encodeURIComponent(String(entity.id));
 }
@@ -23,7 +23,7 @@ function entityArg(entity: CollectableCoreEntityT) {
 function collectionUrl(
   $c: CatalystContextT,
   collection: CollectionT,
-  entity: CollectableCoreEntityT,
+  entity: CollectableEntityT,
   action: string,
 ) {
   return entityHref(collection, 'collection_collaborator/' + action) +
@@ -41,19 +41,19 @@ function hasEntity(
 
 type CollectionAddRemoveProps = {
   +collections?: $ReadOnlyArray<CollectionT>,
-  +entity: CollectableCoreEntityT,
+  +entity: CollectableEntityT,
   +noneText?: string,
 };
 
 type CollaborativeCollectionListProps = {
   +collections?: $ReadOnlyArray<CollectionT>,
-  +entity: CollectableCoreEntityT,
+  +entity: CollectableEntityT,
 };
 
 type OwnCollectionListProps = {
   +addText: string,
   +collections?: $ReadOnlyArray<CollectionT>,
-  +entity: CollectableCoreEntityT,
+  +entity: CollectableEntityT,
   +noneText: string,
 };
 
@@ -61,7 +61,7 @@ type CollectionListProps = {
   +addCollectionText: string,
   +collaborativeCollections?: $ReadOnlyArray<CollectionT>,
   +collaborativeCollectionsHeader: string,
-  +entity: CollectableCoreEntityT,
+  +entity: CollectableEntityT,
   +header: string,
   +ownCollections?: $ReadOnlyArray<CollectionT>,
   +ownCollectionsHeader: string,

--- a/root/layout/components/sidebar/CollectionList.js
+++ b/root/layout/components/sidebar/CollectionList.js
@@ -15,7 +15,7 @@ import typeof EntityLink
 import entityHref from '../../../static/scripts/common/utility/entityHref.js';
 import {returnToCurrentPage} from '../../../utility/returnUri.js';
 
-function entityArg(entity: CoreEntityT) {
+function entityArg(entity: CollectableCoreEntityT) {
   return '?' + entity.entityType + '=' +
     encodeURIComponent(String(entity.id));
 }
@@ -23,7 +23,7 @@ function entityArg(entity: CoreEntityT) {
 function collectionUrl(
   $c: CatalystContextT,
   collection: CollectionT,
-  entity: CoreEntityT,
+  entity: CollectableCoreEntityT,
   action: string,
 ) {
   return entityHref(collection, 'collection_collaborator/' + action) +
@@ -41,19 +41,19 @@ function hasEntity(
 
 type CollectionAddRemoveProps = {
   +collections?: $ReadOnlyArray<CollectionT>,
-  +entity: CoreEntityT,
+  +entity: CollectableCoreEntityT,
   +noneText?: string,
 };
 
 type CollaborativeCollectionListProps = {
   +collections?: $ReadOnlyArray<CollectionT>,
-  +entity: CoreEntityT,
+  +entity: CollectableCoreEntityT,
 };
 
 type OwnCollectionListProps = {
   +addText: string,
   +collections?: $ReadOnlyArray<CollectionT>,
-  +entity: CoreEntityT,
+  +entity: CollectableCoreEntityT,
   +noneText: string,
 };
 
@@ -61,7 +61,7 @@ type CollectionListProps = {
   +addCollectionText: string,
   +collaborativeCollections?: $ReadOnlyArray<CollectionT>,
   +collaborativeCollectionsHeader: string,
-  +entity: CoreEntityT,
+  +entity: CollectableCoreEntityT,
   +header: string,
   +ownCollections?: $ReadOnlyArray<CollectionT>,
   +ownCollectionsHeader: string,

--- a/root/static/scripts/alias/AliasEditForm.js
+++ b/root/static/scripts/alias/AliasEditForm.js
@@ -50,7 +50,7 @@ import {
 
 type Props = {
   +aliasTypes: SelectOptionsT,
-  +entity: CoreEntityT,
+  +entity: EntityWithAliasesT,
   +form: AliasEditFormT,
   +locales: SelectOptionsT,
   +searchHintType: number,

--- a/root/types/entity.js
+++ b/root/types/entity.js
@@ -41,7 +41,7 @@ declare type CoreEntityRoleT<+T> = {
   +relationships?: $ReadOnlyArray<RelationshipT>,
 };
 
-declare type CollectableCoreEntityT =
+declare type CollectableEntityT =
   | AreaT
   | ArtistT
   | EventT
@@ -55,7 +55,7 @@ declare type CollectableCoreEntityT =
   | WorkT;
 
 declare type NonUrlCoreEntityT =
-  | CollectableCoreEntityT
+  | CollectableEntityT
   | GenreT;
 
 declare type CoreEntityT =

--- a/root/types/entity.js
+++ b/root/types/entity.js
@@ -7,6 +7,20 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+declare type EntityWithAliasesT =
+  | AreaT
+  | ArtistT
+  | EventT
+  | GenreT
+  | InstrumentT
+  | LabelT
+  | PlaceT
+  | RecordingT
+  | ReleaseGroupT
+  | ReleaseT
+  | SeriesT
+  | WorkT;
+
 declare type AppearancesT<T> = {
   +hits: number,
   +results: $ReadOnlyArray<T>,

--- a/root/types/entity.js
+++ b/root/types/entity.js
@@ -66,6 +66,12 @@ declare type CoreEntityTypeT =
   | NonUrlCoreEntityTypeT
   | 'url';
 
+declare type EntityWithArtistCreditsT =
+  | RecordingT
+  | ReleaseGroupT
+  | ReleaseT
+  | TrackT;
+
 declare type DatePeriodRoleT = {
   +begin_date: PartialDateT | null,
   +end_date: PartialDateT | null,


### PR DESCRIPTION
# Problem

In preparation for MBS-12552, many occurrences of generic types such as `CoreEntityT` are abusively used. It’s better than `any` but it can be refined.



# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

- Introduce `EntityWithAliasesT` and `EntityWithArtistCreditsT`;
- Replace some (but not all) occurrences of `CoreEntityTypeT` with these;
- Drop unneeded `Core` from `CollectableCoreEntityT`.

# Testing

Not needed but ESLint and Flow, as just changing types.