### PR TITLE
Allow for JSX in .mjs files 

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -375,6 +375,5 @@ rules:
       ["^\\.\\.(?!/?$)", "^\\.\\./?$"],
       # Other relative imports. Put same-folder imports and `.` last.
       ["^\\./(?=.*/)(?!/?$)", "^\\.(?!/?$)", "^\\./?$"],
-    ],
-  }]
+    ]}]
   simple-import-sort/exports: warn

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -290,7 +290,7 @@ rules:
   react/jsx-closing-tag-location: error
   react/jsx-curly-spacing: [error, {when: never, children: true}]
   react/jsx-equals-spacing: [error, never]
-  react/jsx-filename-extension: [error, {extensions: [.js]}]
+  react/jsx-filename-extension: [error, {extensions: [.js, .mjs]}]
   react/jsx-first-prop-new-line: [error, multiline-multiprop]
   react/jsx-handler-names: warn
   react/jsx-indent: [error, 2]


### PR DESCRIPTION
# Problem
We have JSX in several `.mjs` files, and this was triggering an eslint error.

# Solution
Tell `jsx-filename-extension` that it is ok to have JSX in `.mjs` files.

I also changed the formatting of one rule because VSCode was telling me it was incorrect YAML formatting - although it did seem to still work anyway?

# Testing
The errors went away.