### PR TITLE
MBS-12963: Also run initializeToggleEnded for artists

### DIFF
--- a/root/artist/edit_form.tt
+++ b/root/artist/edit_form.tt
@@ -106,6 +106,7 @@
 
     MB.initializeDuplicateChecker('artist');
 
+    MB.initializeToggleEnded('id-edit-artist');
     MB.initializeTooShortYearChecks('artist');
 
     MB.Control.initializeBubble("#ipi-bubble", "input[name=edit-artist\\.ipi_codes\\.0]");


### PR DESCRIPTION
### Fix MBS-12963

# Problem
Most entity editors with dates (such as label) mark the ended checkbox when you enter an end date, but the artist editor does not.

# Solution
Other entity editors use `date_range_fieldset` which already calls `initializeToggleEnded`, but artist has a custom one because of the begin/end areas. As such, we need to actively call `initializeToggleEnded` there too.

We could consider also setting ended when an end *area* is set, but for now this just brings it to parity with other editors.

# Testing
Manually - it now checks the checkbox as expected.