### PR TITLE
MBS-12994: Treat email as case-insensitive for admin email search

### DIFF
--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -198,7 +198,7 @@ sub search_by_email {
 
     my $query = 'SELECT ' . $self->_columns .
         ' FROM ' . $self->_table .
-        q" WHERE (regexp_replace(regexp_replace(email, '[@+].*', ''), '\.', '', 'g') || regexp_replace(email, '.*@', '@')) ~ ?" .
+        q" WHERE (regexp_replace(regexp_replace(email, '[@+].*', ''), '\.', '', 'g') || regexp_replace(email, '.*@', '@')) ~* ?" .
         ' ORDER BY member_since DESC LIMIT 100';
 
     $self->query_to_list($query, [$email_regexp]);

--- a/t/lib/t/MusicBrainz/Server/Data/Editor.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Editor.pm
@@ -489,25 +489,25 @@ test 'Searching editor by email (for admin only)' => sub {
 
     my @editors;
 
-    # Bounded search with trimmed user info and escaped host name (recommended)
+    diag('Bounded search with trimmed user info and escaped host name (recommended)');
     @editors = $editor_data->search_by_email('^abc@f\.g\.h$');
     is(@editors => 2, 'found 2 editors');
     is($editors[0]->id => 1, 'is editor #1');
     is($editors[1]->id => 2, 'is editor #2');
 
-    # Bounded search with trimmed user info and escaped host name (ALL CAPS)
+    diag('Bounded search with trimmed user info and escaped host name (ALL CAPS)');
     @editors = $editor_data->search_by_email('^ABC@F\.G\.H$');
     is(@editors => 2, 'found 2 editors');
     is($editors[0]->id => 1, 'is editor #1');
     is($editors[1]->id => 2, 'is editor #2');
 
-    # Search with trimmed user info suffix and escaped host name prefix
+    diag('Search with trimmed user info suffix and escaped host name prefix');
     @editors = $editor_data->search_by_email('bc@f\.g');
     is(@editors => 2, 'found 2 editors');
     is($editors[0]->id => 1, 'is editor #1');
     is($editors[1]->id => 2, 'is editor #2');
 
-    # Search with trimmed user info and unescaped host name
+    diag('Search with trimmed user info and unescaped host name');
     @editors = $editor_data->search_by_email('abc@f.g.h');
     is(@editors => 3, 'found 3 editors');
     is($editors[0]->id => 1, 'is editor #1');
@@ -515,7 +515,7 @@ test 'Searching editor by email (for admin only)' => sub {
     # Special character '.' matches '-'
     is($editors[2]->id => 3, 'is editor #3');
 
-    # Search with trimmed user info only
+    diag('Search with trimmed user info only');
     @editors = $editor_data->search_by_email('abc@');
     is(@editors => 4, 'found 4 editors');
     is($editors[0]->id => 1, 'is editor #1');
@@ -523,11 +523,11 @@ test 'Searching editor by email (for admin only)' => sub {
     is($editors[2]->id => 3, 'is editor #3');
     is($editors[3]->id => 5, 'is editor #5');
 
-    # Search with untrimmed unescaped user info only
+    diag('Search with untrimmed unescaped user info only');
     @editors = $editor_data->search_by_email('a.b.c+d.e@');
     is(@editors => 0, 'found 0 editor');
 
-    # Search with untrimmed escaped user info only
+    diag('Search with untrimmed escaped user info only');
     @editors = $editor_data->search_by_email('a\.b\.c\+d\.e@');
     is(@editors => 0, 'found 0 editor');
 };

--- a/t/lib/t/MusicBrainz/Server/Data/Editor.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Editor.pm
@@ -495,6 +495,12 @@ test 'Searching editor by email (for admin only)' => sub {
     is($editors[0]->id => 1, 'is editor #1');
     is($editors[1]->id => 2, 'is editor #2');
 
+    # Bounded search with trimmed user info and escaped host name (ALL CAPS)
+    @editors = $editor_data->search_by_email('^ABC@F\.G\.H$');
+    is(@editors => 2, 'found 2 editors');
+    is($editors[0]->id => 1, 'is editor #1');
+    is($editors[1]->id => 2, 'is editor #2');
+
     # Search with trimmed user info suffix and escaped host name prefix
     @editors = $editor_data->search_by_email('bc@f\.g');
     is(@editors => 2, 'found 2 editors');


### PR DESCRIPTION
### Implement MBS-12994

# Problem
While technically email addresses are [meant to be case-sensitive](https://blog.teknkl.com/email-addresses-case-sensitive-but-anyway/) the whole internet treats them as if the were not. Just today I was going to answer to a user who wanted to be deleted that we did not have them on the DB to begin with, until I realized they had typed their email with different caps in different places and I notice we do check our emails case-sensitively in `search_by_email`. We don't elsewhere (our `is_email_used_elsewhere` comparison does `lower()` for comparison).

# Solution
Turn the regex matching in `search_by_email` to case-insensitive.

# Testing
Manually, making sure a search for my email but CAPITALIZED still matches my user(s) now. Also added a test case to Data::Editor.