### PR TITLE
Load Entity::*AliasType classes from Data::*AliasType

### DIFF
--- a/lib/MusicBrainz/Server/Data/AliasType.tt
+++ b/lib/MusicBrainz/Server/Data/AliasType.tt
@@ -5,6 +5,7 @@
 package MusicBrainz::Server::Data::[% model %];
 
 use Moose;
+use MusicBrainz::Server::Entity::[% model %];
 
 extends 'MusicBrainz::Server::Data::Entity';
 

--- a/lib/MusicBrainz/Server/Data/AreaAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/AreaAliasType.pm
@@ -2,6 +2,7 @@
 package MusicBrainz::Server::Data::AreaAliasType;
 
 use Moose;
+use MusicBrainz::Server::Entity::AreaAliasType;
 
 extends 'MusicBrainz::Server::Data::Entity';
 

--- a/lib/MusicBrainz/Server/Data/ArtistAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/ArtistAliasType.pm
@@ -2,6 +2,7 @@
 package MusicBrainz::Server::Data::ArtistAliasType;
 
 use Moose;
+use MusicBrainz::Server::Entity::ArtistAliasType;
 
 extends 'MusicBrainz::Server::Data::Entity';
 

--- a/lib/MusicBrainz/Server/Data/EventAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/EventAliasType.pm
@@ -2,6 +2,7 @@
 package MusicBrainz::Server::Data::EventAliasType;
 
 use Moose;
+use MusicBrainz::Server::Entity::EventAliasType;
 
 extends 'MusicBrainz::Server::Data::Entity';
 

--- a/lib/MusicBrainz/Server/Data/GenreAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/GenreAliasType.pm
@@ -2,6 +2,7 @@
 package MusicBrainz::Server::Data::GenreAliasType;
 
 use Moose;
+use MusicBrainz::Server::Entity::GenreAliasType;
 
 extends 'MusicBrainz::Server::Data::Entity';
 

--- a/lib/MusicBrainz/Server/Data/InstrumentAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/InstrumentAliasType.pm
@@ -2,6 +2,7 @@
 package MusicBrainz::Server::Data::InstrumentAliasType;
 
 use Moose;
+use MusicBrainz::Server::Entity::InstrumentAliasType;
 
 extends 'MusicBrainz::Server::Data::Entity';
 

--- a/lib/MusicBrainz/Server/Data/LabelAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/LabelAliasType.pm
@@ -2,6 +2,7 @@
 package MusicBrainz::Server::Data::LabelAliasType;
 
 use Moose;
+use MusicBrainz::Server::Entity::LabelAliasType;
 
 extends 'MusicBrainz::Server::Data::Entity';
 

--- a/lib/MusicBrainz/Server/Data/PlaceAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/PlaceAliasType.pm
@@ -2,6 +2,7 @@
 package MusicBrainz::Server::Data::PlaceAliasType;
 
 use Moose;
+use MusicBrainz::Server::Entity::PlaceAliasType;
 
 extends 'MusicBrainz::Server::Data::Entity';
 

--- a/lib/MusicBrainz/Server/Data/RecordingAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/RecordingAliasType.pm
@@ -2,6 +2,7 @@
 package MusicBrainz::Server::Data::RecordingAliasType;
 
 use Moose;
+use MusicBrainz::Server::Entity::RecordingAliasType;
 
 extends 'MusicBrainz::Server::Data::Entity';
 

--- a/lib/MusicBrainz/Server/Data/ReleaseAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseAliasType.pm
@@ -2,6 +2,7 @@
 package MusicBrainz::Server::Data::ReleaseAliasType;
 
 use Moose;
+use MusicBrainz::Server::Entity::ReleaseAliasType;
 
 extends 'MusicBrainz::Server::Data::Entity';
 

--- a/lib/MusicBrainz/Server/Data/ReleaseGroupAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroupAliasType.pm
@@ -2,6 +2,7 @@
 package MusicBrainz::Server::Data::ReleaseGroupAliasType;
 
 use Moose;
+use MusicBrainz::Server::Entity::ReleaseGroupAliasType;
 
 extends 'MusicBrainz::Server::Data::Entity';
 

--- a/lib/MusicBrainz/Server/Data/SeriesAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/SeriesAliasType.pm
@@ -2,6 +2,7 @@
 package MusicBrainz::Server::Data::SeriesAliasType;
 
 use Moose;
+use MusicBrainz::Server::Entity::SeriesAliasType;
 
 extends 'MusicBrainz::Server::Data::Entity';
 

--- a/lib/MusicBrainz/Server/Data/WorkAliasType.pm
+++ b/lib/MusicBrainz/Server/Data/WorkAliasType.pm
@@ -2,6 +2,7 @@
 package MusicBrainz::Server::Data::WorkAliasType;
 
 use Moose;
+use MusicBrainz::Server::Entity::WorkAliasType;
 
 extends 'MusicBrainz::Server::Data::Entity';
 

--- a/lib/MusicBrainz/Server/Entity/AreaAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/AreaAliasType.pm
@@ -19,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012 MetaBrainz Foundation
+Copyright (C) 2023 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/ArtistAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/ArtistAliasType.pm
@@ -19,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012 MetaBrainz Foundation
+Copyright (C) 2023 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/EventAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/EventAliasType.pm
@@ -19,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012 MetaBrainz Foundation
+Copyright (C) 2023 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/GenreAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/GenreAliasType.pm
@@ -19,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012 MetaBrainz Foundation
+Copyright (C) 2023 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/InstrumentAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/InstrumentAliasType.pm
@@ -19,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012 MetaBrainz Foundation
+Copyright (C) 2023 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/LabelAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/LabelAliasType.pm
@@ -19,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012 MetaBrainz Foundation
+Copyright (C) 2023 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/PlaceAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/PlaceAliasType.pm
@@ -19,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012 MetaBrainz Foundation
+Copyright (C) 2023 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/RecordingAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/RecordingAliasType.pm
@@ -19,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012 MetaBrainz Foundation
+Copyright (C) 2023 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/ReleaseAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/ReleaseAliasType.pm
@@ -19,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012 MetaBrainz Foundation
+Copyright (C) 2023 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/ReleaseGroupAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/ReleaseGroupAliasType.pm
@@ -19,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012 MetaBrainz Foundation
+Copyright (C) 2023 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/SeriesAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/SeriesAliasType.pm
@@ -19,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012 MetaBrainz Foundation
+Copyright (C) 2023 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Entity/WorkAliasType.pm
+++ b/lib/MusicBrainz/Server/Entity/WorkAliasType.pm
@@ -19,7 +19,7 @@ no Moose;
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012 MetaBrainz Foundation
+Copyright (C) 2023 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any


### PR DESCRIPTION
# Load Entity::*AliasType classes from Data::*AliasType

## Problem

Loading /add-alias pages in production usually throw an error (though not always):

```
Can't locate object method "id" via package "MusicBrainz::Server::Entity::WorkAliasType" at lib/MusicBrainz/Server/Data/Role/OptionsTree.pm line 18. at lib/MusicBrainz/Server/Data/Role/OptionsTree.pm line 18
MusicBrainz::Server::Data::Role::OptionsTree::get_tree(?) called at lib/MusicBrainz/Server/Form/Utils.pm line 114
MusicBrainz::Server::Form::Utils::select_options_tree(?, ?) called at lib/MusicBrainz/Server/Form/Alias.pm line 107
HTML::FormHandler::new(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) called at lib/MusicBrainz/Server.pm line 229
MusicBrainz::Server::form(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) called at lib/MusicBrainz/Server/Controller.pm line 154
MusicBrainz::Server::Controller::edit_action(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) called at lib/MusicBrainz/Server/Controller/Role/EditRelationships.pm line 297
MusicBrainz::Server::Controller::Work::edit_action(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) called at lib/MusicBrainz/Server/Controller/Role/Alias.pm line 111
Catalyst::dispatch(?) called at lib/MusicBrainz/Server.pm line 390
MusicBrainz::Server::__ANON__ at lib/MusicBrainz/Server.pm line 355
MusicBrainz::Server::with_translations(?, ?) called at lib/MusicBrainz/Server.pm line 391
Class::MOP::Method::Wrapped::__ANON__(?) called at lib/MusicBrainz/Server.pm line 405
Class::MOP::Method::Wrapped::__ANON__(?) called at lib/MusicBrainz/Server.pm line 493
```

# Solution

Load each `Entity::*AliasType` class from its corresponding `Data::*AliasType` class.

# Testing

I wrote a script inside the musicbrainz-website-prod container on patton, alias_test.pl:

```Perl
use MusicBrainz::Server::Context;
use MusicBrainz::Server::Data::WorkAliasType;
use Data::Dumper;

my $c = MusicBrainz::Server::Context->create_script_context(database => 'READWRITE');

my $root = $c->model('WorkAliasType')->get_tree;
print Dumper($root) . "\n";
```

When invoked with `carton exec -- perl -Ilib alias_test.pl` before the patch this fails, but after applying the patch inside the container, it works fine.