### PR TITLE
MBS-13001: Actually set source_type and target_type for historic rels

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Historic/Relationship.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/Relationship.pm
@@ -247,7 +247,9 @@ sub _display_relationships {
                 entity0_id => $entity0_id,
                 entity1_id => $entity1_id,
                 source => $entity0,
+                source_type => $entity0_type,
                 target => $entity1,
+                target_type => $entity1_type,
                 link    => Link->new(
                     id         => $data->{link_id},
                     begin_date => PartialDate->new($data->{begin_date}),


### PR DESCRIPTION
### Fix MBS-13001

# Problem
https://beta.musicbrainz.org/edit/11760720 was giving a malformed JSON ISE.

# Solution
Actually set a `source_type` (and `target_type`, just in case) on `Edit::Historic::Relationship::_display_relationships`.

These being missing was causing a beta ISE when combined with commit 268d6e51db045be90b3b2ec49d28190d2cfb1fe5 - which makes us a lot more demanding wrt what we send to `linkedEntities`. For some reason, despite the fact that `Entity::Relationship` theoretically requires a `source_type`, this wasn't causing any Moose errors (I keep getting the feeling that Moose types are fucking useless).

Basically, the `TO_JSON` method for `Entity::Relationship` adds the rel source to linkedEntities using the source ID, the source itself, but for some reason the `source_type` for the relationship entity rather than `source->entity_type`. This might be in case the "source entity" is a historical Frankenstein monster of an object, but in any case the historical relationships were not setting a `source_type` at all, and unsurprisingly `"" is not a valid type assignable to linkedEntities`.

For what it's worth, `_display_relationships` seems to already add the source (`entity0`) to `linkedEntities` itself, which is probably why these edits still worked fine. We might want to drop the double linking?

# Testing
Made sure `/edit/11760720` loads fine now.
