### PR TITLE
MBS-12976: Changing a work can cause duplication/key errors

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Medium.pm
+++ b/lib/MusicBrainz/Server/Entity/Medium.pm
@@ -171,14 +171,15 @@ around TO_JSON => sub {
     my ($orig, $self) = @_;
 
     my $track_count = $self->track_count;
+    my $format_id = $self->format_id;
 
     my $data = {
         %{ $self->$orig },
         cdtocs      => [map { $_->cdtoc->toc } $self->all_cdtocs],
         format      => $self->format ? $self->format->TO_JSON : undef,
-        format_id   => $self->format_id,
-        position    => $self->position,
-        release_id  => $self->release_id,
+        format_id   => defined $format_id ? (0 + $format_id) : undef,
+        position    => (0 + $self->position),
+        release_id  => (0 + $self->release_id),
         track_count => defined $track_count ? (0 + $track_count) : undef,
     };
 

--- a/root/static/scripts/relationship-editor/components/RelationshipEditor.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipEditor.js
@@ -94,6 +94,7 @@ export type PropsT = {
 export type InitialStateArgsT = {
   +formName: string,
   +seededRelationships: ?$ReadOnlyArray<SeededRelationshipT>,
+  +source?: CoreEntityT,
 };
 
 export function* getInitialRelationshipUpdates(
@@ -173,7 +174,7 @@ export function createInitialState(
 ): RelationshipEditorStateT {
   const {seededRelationships} = args;
 
-  const source = getSourceEntityDataForRelationshipEditor();
+  const source = args.source ?? getSourceEntityDataForRelationshipEditor();
 
   invariant(
     source.entityType !== 'release',

--- a/root/static/scripts/relationship-editor/utility/comparators.js
+++ b/root/static/scripts/relationship-editor/utility/comparators.js
@@ -7,8 +7,10 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import {compare} from '../../common/i18n.js';
 import {compareStrings} from '../../common/utility/compare.js';
 import type {
+  MediumWorkStateT,
   RelationshipSourceGroupT,
 } from '../types.js';
 
@@ -34,5 +36,12 @@ export function compareSourceWithSourceGroup(
 }
 
 export function compareWorks(a: WorkT, b: WorkT): number {
-  return a.id - b.id;
+  return compare(a.name, b.name) || (a.id - b.id);
+}
+
+export function compareWorkStates(
+  a: MediumWorkStateT,
+  b: MediumWorkStateT,
+): number {
+  return compareWorks(a.work, b.work);
 }

--- a/root/static/scripts/relationship-editor/utility/updateReleaseRelationships.js
+++ b/root/static/scripts/relationship-editor/utility/updateReleaseRelationships.js
@@ -14,7 +14,11 @@ import type {
   ReleaseRelationshipEditorStateT,
 } from '../types.js';
 
-import {compareRecordings, compareWorks} from './comparators.js';
+import {
+  compareRecordings,
+  compareWorks,
+  compareWorkStates,
+} from './comparators.js';
 import {
   findTargetTypeGroups,
   iterateTargetEntitiesOfType,
@@ -28,13 +32,6 @@ import {
 
 export const ADD_RELATIONSHIP: 1 = 1;
 export const REMOVE_RELATIONSHIP: 2 = 2;
-
-function compareWorkStates(
-  a: MediumWorkStateT,
-  b: MediumWorkStateT,
-): number {
-  return a.work.id - b.work.id;
-}
 
 function workHasNoRecordings(
   writableRootState: ReleaseRelationshipEditorStateT,

--- a/root/static/scripts/relationship-editor/utility/updateWorkStates.js
+++ b/root/static/scripts/relationship-editor/utility/updateWorkStates.js
@@ -12,7 +12,6 @@ import {
   onNotFoundDoNothing,
 } from 'weight-balanced-tree/update';
 
-import {compare} from '../../common/i18n.js';
 import type {
   MediumWorkStateT,
   ReleaseRelationshipEditorStateT,
@@ -32,10 +31,7 @@ export function compareWorkWithWorkState(
   work: WorkT,
   workState: MediumWorkStateT,
 ): number {
-  return (
-    compare(work.name, workState.work.name) ||
-    (work.id - workState.work.id)
-  );
+  return compareWorks(work, workState.work);
 }
 
 export function* findWorkRecordings(

--- a/root/static/scripts/release/components/ReleaseRelationshipEditor.js
+++ b/root/static/scripts/release/components/ReleaseRelationshipEditor.js
@@ -186,8 +186,11 @@ function compareMediumStateTuples(
   return a[0].position - b[0].position;
 }
 
-export function createInitialState(): ReleaseRelationshipEditorStateT {
+export function createInitialState(
+  source?: ?ReleaseWithMediumsAndReleaseGroupT,
+): ReleaseRelationshipEditorStateT {
   const release: ReleaseWithMediumsAndReleaseGroupT =
+    source ??
     // $FlowIgnore[unclear-type]
     (getSourceEntityDataForRelationshipEditor(): any);
 
@@ -840,7 +843,10 @@ function setWorksAsSelected(
   );
 }
 
-const reducer = reducerWithErrorHandling<
+export const reducer: ((
+  ReleaseRelationshipEditorStateT,
+  ReleaseRelationshipEditorActionT,
+) => ReleaseRelationshipEditorStateT) = reducerWithErrorHandling<
   ReleaseRelationshipEditorStateT,
   ReleaseRelationshipEditorActionT,
 >(function (

--- a/root/static/scripts/tests/relationship-editor.js
+++ b/root/static/scripts/tests/relationship-editor.js
@@ -712,7 +712,7 @@ test('MBS-12937: Changing credits for other relationships without modifying the 
   state = reducer(
     state,
     {
-      batchSelectionCount: 0,
+      batchSelectionCount: undefined,
       creditsToChangeForSource: '',
       creditsToChangeForTarget: 'all',
       newRelationshipState: relationship1,
@@ -757,7 +757,7 @@ function addRelationship(
   return reducer(
     rootState,
     {
-      batchSelectionCount: 0,
+      batchSelectionCount: undefined,
       creditsToChangeForSource: '',
       creditsToChangeForTarget: '',
       newRelationshipState: relationship,

--- a/root/static/scripts/tests/relationship-editor/constants.js
+++ b/root/static/scripts/tests/relationship-editor/constants.js
@@ -11,11 +11,14 @@ import {
   createArtistObject,
   createEventObject,
   createRecordingObject,
+  createReleaseGroupObject,
   createReleaseObject,
 } from '../../common/entity2.js';
+import {uniqueNegativeId} from '../../common/utility/numbers.js';
 import {REL_STATUS_ADD} from '../../relationship-editor/constants.js';
 import type {
   RelationshipStateT,
+  ReleaseWithMediumsAndReleaseGroupT,
 } from '../../relationship-editor/types.js';
 
 export const artist: ArtistT = createArtistObject({
@@ -33,6 +36,56 @@ export const recording: RecordingT = createRecordingObject({
 export const release: ReleaseT = createReleaseObject({
   name: 'Release',
 });
+
+const mediumId = uniqueNegativeId();
+
+const track: TrackWithRecordingT = {
+  artist: '',
+  artistCredit: {
+    names: [
+      {
+        artist,
+        joinPhrase: '',
+        name: 'Artist',
+      },
+    ],
+  },
+  editsPending: false,
+  entityType: 'track',
+  gid: 'c8f65672-e007-453d-8ecc-4a0bd9cb4dc6',
+  id: uniqueNegativeId(),
+  isDataTrack: false,
+  last_updated: null,
+  length: 10000,
+  medium_id: mediumId,
+  medium: null,
+  name: 'Track',
+  number: '1',
+  position: 1,
+  recording,
+};
+
+export const releaseWithMediumsAndReleaseGroup:
+  ReleaseWithMediumsAndReleaseGroupT = {
+    ...release,
+    releaseGroup: createReleaseGroupObject(),
+    mediums: [
+      {
+        cdtocs: [],
+        editsPending: false,
+        entityType: 'medium',
+        format_id: null,
+        format: null,
+        id: mediumId,
+        last_updated: null,
+        name: '',
+        position: 1,
+        release_id: release.id,
+        track_count: null,
+        tracks: [track],
+      },
+    ],
+  };
 
 export const emptyRelationship: RelationshipStateT = {
   _lineage: [],

--- a/root/types/medium.js
+++ b/root/types/medium.js
@@ -45,7 +45,7 @@ declare type MediumT = $ReadOnly<{
   +cdtocs: $ReadOnlyArray<string>,
   +editsPending: boolean,
   +format: MediumFormatT | null,
-  +format_id: number,
+  +format_id: number | null,
   +name: string,
   +position: number,
   +release_id: number,

--- a/root/types/medium.js
+++ b/root/types/medium.js
@@ -39,7 +39,7 @@ declare type MediumFormatT = {
 
 // MusicBrainz::Server::Entity::Medium::TO_JSON
 declare type MediumT = $ReadOnly<{
-  ...EntityRoleT<'track'>,
+  ...EntityRoleT<'medium'>,
   ...LastUpdateRoleT,
   +cdtoc_tracks?: $ReadOnlyArray<TrackT>,
   +cdtocs: $ReadOnlyArray<string>,


### PR DESCRIPTION
# Fix MBS-12976

## Problem

See the steps in MBS-12976, though you may not always be able to reproduce it: it depends on the relative sort orders of the names and IDs of the works you choose.

## Solution

This was caused by d95b3d3769dc2f494df2751988b8e3bee2c5fcf1. There were other comparators used for updating the `relatedWorks` entries besides that one. I've tried to make them call each other here to avoid other issues in the future.

## Testing

Added a unit test which reproduced the duplication issue.