### PR TITLE
MBS-12990: Don't pad the legend relationship editor fieldset

### DIFF
--- a/root/static/scripts/relationship-editor/components/RelationshipEditor.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipEditor.js
@@ -626,27 +626,30 @@ const RelationshipEditor = (
 
   return (
     <fieldset id="relationship-editor">
-      {error ? (
-        <ErrorMessage error={error.stack} />
-      ) : null}
-
       <legend>
         {l('Relationships')}
       </legend>
 
-      <RelationshipSourceGroupsContext.Provider value={sourceGroupsContext}>
-        <RelationshipTargetTypeGroups
-          dialogLocation={state.dialogLocation}
-          dispatch={dispatch}
-          releaseHasUnloadedTracks={false}
-          source={state.entity}
-          targetTypeGroups={findTargetTypeGroups(
-            state.relationshipsBySource,
-            state.entity,
-          )}
-          track={null}
-        />
-      </RelationshipSourceGroupsContext.Provider>
+      <div className="relationship-editor-fieldset-content">
+        {error ? (
+          <ErrorMessage error={error.stack} />
+        ) : null}
+
+
+        <RelationshipSourceGroupsContext.Provider value={sourceGroupsContext}>
+          <RelationshipTargetTypeGroups
+            dialogLocation={state.dialogLocation}
+            dispatch={dispatch}
+            releaseHasUnloadedTracks={false}
+            source={state.entity}
+            targetTypeGroups={findTargetTypeGroups(
+              state.relationshipsBySource,
+              state.entity,
+            )}
+            track={null}
+          />
+        </RelationshipSourceGroupsContext.Provider>
+      </div>
     </fieldset>
   );
 };

--- a/root/static/styles/relationship-editor.less
+++ b/root/static/styles/relationship-editor.less
@@ -13,7 +13,7 @@
 #content.rel-editor div.ars {padding: 0; margin: 0.5em 0; margin-left: 1.5em;}
 #content.rel-editor #release-rels {margin-top: 1em;}
 
-fieldset#relationship-editor {
+fieldset#relationship-editor .relationship-editor-fieldset-content {
     padding: @form-margin;
 }
 


### PR DESCRIPTION
### Fix MBS-12990


# Problem
The "Relationships" heading when editing an entity is indented further right than all other `fieldset` legends.

# Solution
These legends are all supposed to be aligned, but the `padding` being applied to the whole `fieldset` was moving this one further right. I was planning to just add `padding` to the `table` inside, but I guess it would also make sense to keep errors padded, so I added an extra `div` for it.

# Testing
Manually, just making sure the alignment is correct.