### PR TITLE
MBS-12956: Allow searching for edits with votes by beginners

### DIFF
--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -274,6 +274,7 @@
                  [ 'not_me', l('is not me') ]
                  [ 'subscribed', l('is in my subscriptions') ]
                  [ 'not_subscribed', l('is not in my subscriptions') ]
+                 [ 'limited', l('is a beginner') ]
                ], field_contents) %]
 
   <span class="arg autocomplete editor">

--- a/root/static/scripts/common/MB/edit_search.js
+++ b/root/static/scripts/common/MB/edit_search.js
@@ -30,6 +30,7 @@ $(function () {
       'not_me': 0,
       'subscribed': 0,
       'not_subscribed': 0,
+      'limited': 0,
     },
     subscription: {
       '=': 1, '!=': 1, 'subscribed': 0, 'not_subscribed': 0,


### PR DESCRIPTION
### Implement MBS-12956

# Problem
Beginner editors can now vote, but there's no way to search for edits where they've voted. This is useful because a surprising amount of voting beginners have turned out to be sockpuppets, but also in general to be able to double-check beginners' votes since it's expected they're still learning.

# Solution
This adds a "limited" option for Voter in the same way we have it for editor (based on the query from https://github.com/metabrainz/musicbrainz-server/pull/2808). This can already be useful since it's mostly relevant for the last few days of edits, but it times out quite easily for bigger searches - we should consider materializing the concept of "beginner" properly in the database with triggers, especially since we're using it in many places.

# Testing
Manually, limiting the edits to the last 10 days to make sure it did not time out.