### PR TITLE
MBS-13007: Fix a regressive ISE on broken WikiLink

### DIFF
--- a/lib/MusicBrainz/Server/Data/WikiDoc.pm
+++ b/lib/MusicBrainz/Server/Data/WikiDoc.pm
@@ -34,7 +34,7 @@ sub _fix_html_links
     if ($href =~ m,^(?:https?:)?//$wiki_server/(File|Image):, || $class =~ m/new/)
     {
         my $child = $node->getFirstChild();
-        if (defined $child && $child->tag eq 'img' && ($child->attr('class') // '') eq 'zoomable')
+        if (defined $child && ref($child) eq 'HTML::Element' && $child->tag eq 'img' && ($child->attr('class') // '') eq 'zoomable')
         {
             # Transform link on "zoomable" image to point directly to the original image
             my $href = $child->attr('src') || '';


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem MBS-13007
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

When a wiki page contains a WikiLink to a page that doesn’t exist yet, such as `Category:Relationship_Type` in the page `Terminology`, the class `new` is set for this link which contains text only.

I overlooked this case in commit 45288c8b merged with pull request #2894 to address MBS-12984, leading to ISE on `tag` method not found.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This patch fixes that by checking that the content is an element first.


# Testing

After flushing the cache, tested by opening the reported page `/doc/Terminology` and the 172 currently transcluded pages to check that nothing wrong would show up in browser and in server logs.

<details>
<summary>See the full list of transcluded pages</summary>

 * `/doc/About`
 * `/doc/About/Data_License`
 * `/doc/About/History`
 * `/doc/About/Logos`
 * `/doc/About/Press`
 * `/doc/About/Privacy_Policy`
 * `/doc/About/Team`
 * `/doc/Account_FAQ`
 * `/doc/AcoustID`
 * `/doc/Aliases`
 * `/doc/Annotation`
 * `/doc/Area`
 * `/doc/Artist`
 * `/doc/AudioRanger`
 * `/doc/Auto-Editor_Election`
 * `/doc/BBC_Landing_Page`
 * `/doc/Beginners_Guide`
 * `/doc/Bug_Tracker`
 * `/doc/Canonical_MusicBrainz_data`
 * `/doc/Code_of_Conduct`
 * `/doc/Code_of_Conduct/Bots`
 * `/doc/Communication/IRC`
 * `/doc/Contact_Us`
 * `/doc/Copyright_Violation_Notice`
 * `/doc/Cover_Art_Archive`
 * `/doc/Cover_Art_Archive/API`
 * `/doc/Cover_Art/Types`
 * `/doc/Data_Removal_Policy`
 * `/doc/Developer_Resources`
 * `/doc/Development`
 * `/doc/Development_Chat`
 * `/doc/Development/OAuth2`
 * `/doc/Development/Search_Architecture`
 * `/doc/Disambiguation_Comment`
 * `/doc/Disc_ID_Calculation`
 * `/doc/Edit`
 * `/doc/Editing_FAQ`
 * `/doc/Edit_Note`
 * `/doc/Editor`
 * `/doc/Edit_Type/Add_cover_art`
 * `/doc/Event`
 * `/doc/Frequently_Asked_Questions`
 * `/doc/General_FAQ`
 * `/doc/Guess_Case`
 * `/doc/Help_Wanted`
 * `/doc/How_Editing_Works`
 * `/doc/How_to_Add_Disc_IDs`
 * `/doc/How_to_Identify_Labels`
 * `/doc/How_to_Tag_Files_With_Picard`
 * `/doc/How_to_Use_the_Edit_Search`
 * `/doc/How_to_Write_Edit_Notes`
 * `/doc/Indexed_Search_Syntax`
 * `/doc/Instrument`
 * `/doc/Introduction_to_Voting`
 * `/doc/jspf`
 * `/doc/Label`
 * `/doc/Label/Country`
 * `/doc/Label/FAQ`
 * `/doc/Label/Label_Code`
 * `/doc/Label/Type`
 * `/doc/libcoverart`
 * `/doc/libdiscid`
 * `/doc/libmusicbrainz`
 * `/doc/Live_Data_Feed`
 * `/doc/Merge_Rather_Than_Delete`
 * `/doc/Mp3tag`
 * `/doc/MusicBrainz_API`
 * `/doc/MusicBrainz_API/Examples`
 * `/doc/MusicBrainz_API/Rate_Limiting`
 * `/doc/MusicBrainz_API/Search`
 * `/doc/MusicBrainz_Batch_Edits`
 * `/doc/MusicBrainz_Database`
 * `/doc/MusicBrainz_Database/Download`
 * `/doc/MusicBrainz_Database/Schema`
 * `/doc/MusicBrainz_Documentation`
 * `/doc/MusicBrainz_for_Android`
 * `/doc/MusicBrainz_Identifier`
 * `/doc/MusicBrainz_Projects`
 * `/doc/MusicBrainz_Server`
 * `/doc/MusicBrainz_Server/Setup`
 * `/doc/Other_Databases_Relationship_Type/Whitelist`
 * `/doc/Place`
 * `/doc/Products`
 * `/doc/python-musicbrainz2`
 * `/doc/Recording`
 * `/doc/Relationships`
 * `/doc/Release`
 * `/doc/Release/Catalog_Number`
 * `/doc/Release/Date`
 * `/doc/Release_Group`
 * `/doc/Release_Group/Type`
 * `/doc/Search_Server`
 * `/doc/Series`
 * `/doc/Social_Contract`
 * `/doc/Style`
 * `/doc/Style/Aliases`
 * `/doc/Style/Artist`
 * `/doc/Style/Artist_Credits`
 * `/doc/Style/Artist/Sort_Name`
 * `/doc/Style/Classical`
 * `/doc/Style/Classical/Language/English`
 * `/doc/Style/Classical/Language/Estonian`
 * `/doc/Style/Classical/Language/Spanish`
 * `/doc/Style/Classical/Recording_Artist`
 * `/doc/Style/Classical/Release_Artist`
 * `/doc/Style/Classical/Release_Title`
 * `/doc/Style/Classical/Track_Artist`
 * `/doc/Style/Classical/Track_Title`
 * `/doc/Style/Classical/Works`
 * `/doc/Style/Event`
 * `/doc/Style/Language/Catalan`
 * `/doc/Style/Language/Chinese`
 * `/doc/Style/Language/Czech`
 * `/doc/Style/Language/Danish`
 * `/doc/Style/Language/Dutch`
 * `/doc/Style/Language/English`
 * `/doc/Style/Language/Estonian`
 * `/doc/Style/Language/Finnish`
 * `/doc/Style/Language/French`
 * `/doc/Style/Language/German`
 * `/doc/Style/Language/Greek`
 * `/doc/Style/Language/Hebrew`
 * `/doc/Style/Language/Hungarian`
 * `/doc/Style/Language/Italian`
 * `/doc/Style/Language/Japanese`
 * `/doc/Style/Language/Latin`
 * `/doc/Style/Language/Latvian`
 * `/doc/Style/Language/Lithuanian`
 * `/doc/Style/Language/Norwegian`
 * `/doc/Style/Language/Polish`
 * `/doc/Style/Language/Portuguese`
 * `/doc/Style/Language/Romanian`
 * `/doc/Style/Language/Russian`
 * `/doc/Style/Language/Slovak`
 * `/doc/Style/Language/Spanish`
 * `/doc/Style/Language/Swedish`
 * `/doc/Style/Language/Transliterations`
 * `/doc/Style/Language/Turkish`
 * `/doc/Style/Language/Vietnamese`
 * `/doc/Style/Language/Yiddish`
 * `/doc/Style/Miscellaneous`
 * `/doc/Style/Old_style_practices`
 * `/doc/Style/Place`
 * `/doc/Style/Principle`
 * `/doc/Style/Principle/Error_correction_and_artist_intent`
 * `/doc/Style/Recording`
 * `/doc/Style/Relationships`
 * `/doc/Style/Relationships/URLs`
 * `/doc/Style/Relationships/URLs/Lyrics_whitelist`
 * `/doc/Style/Release`
 * `/doc/Style/Release_Group`
 * `/doc/Style/Series`
 * `/doc/Style/Specific_types_of_releases`
 * `/doc/Style/Specific_types_of_releases/Audiobook`
 * `/doc/Style/Specific_types_of_releases/Broadcast_programs`
 * `/doc/Style/Specific_types_of_releases/Live_bootlegs`
 * `/doc/Style/Specific_types_of_releases/Pseudo-Releases`
 * `/doc/Style/Specific_types_of_releases/Remixes_and_mashups`
 * `/doc/Style/Specific_types_of_releases/Soundtrack`
 * `/doc/Style/Specific_types_of_releases/Theatre`
 * `/doc/Style/Titles`
 * `/doc/Style/Titles/OC_ReMix_series`
 * `/doc/Style/Unknown_and_untitled`
 * `/doc/Style/Unknown_and_untitled/Special_purpose_artist`
 * `/doc/Style/Unknown_and_untitled/Special_purpose_label`
 * `/doc/Style/Unknown_and_untitled/Special_purpose_track_title`
 * `/doc/Style/Work`
 * `/doc/Tagger_Affiliate_Program`
 * `/doc/Track`
 * `/doc/Web_Service`
 * `/doc/WikiDocs`
 * `/doc/Yate_Music_Tagger`

</details>


# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

After deployment, the cache for wikidoc must be reset:
```sh
redis-cli --scan --pattern 'MB:wikidoc:*' | xargs redis-cli DEL
```
(which works fine because those keys don’t contain special characters)