### PR TITLE
MBS-13011: Block short links: spotify.link

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4442,7 +4442,7 @@ const CLEANUPS: CleanupEntries = {
   },
   'spotify': {
     match: [new RegExp(
-      '^(https?://)?([^/]+\\.)?(spotify\\.com)/(?!user)',
+      '^(https?://)?([^/]+\\.)?(spotify\\.(?:com|link))/(?!user)',
       'i',
     )],
     restrict: [LINK_TYPES.streamingfree],
@@ -4452,6 +4452,23 @@ const CLEANUPS: CleanupEntries = {
       return url;
     },
     validate: function (url, id) {
+      if (/spotify\.link\//i.test(url)) {
+        return {
+          error: exp.l(
+            `This is a redirect link. Please follow {redirect_url|your link}
+             and add the link it redirects to instead.`,
+            {
+              redirect_url: {
+                href: url,
+                rel: 'noopener noreferrer',
+                target: '_blank',
+              },
+            },
+          ),
+          result: false,
+          target: ERROR_TARGETS.URL,
+        };
+      }
       const m = /^https:\/\/open\.spotify\.com\/([a-z]+)\/(?:[a-zA-Z0-9_-]+)$/.exec(url);
       if (m) {
         const prefix = m[1];

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4599,6 +4599,17 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://open.spotify.com/user/1254688529',
        only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
   },
+  {
+                     input_url: 'https://spotify.link/auVCkcbzoyb',
+             input_entity_type: 'artist',
+    expected_relationship_type: undefined,
+       input_relationship_type: 'streamingfree',
+       only_valid_entity_types: [],
+                expected_error: {
+                                  error: 'is a redirect link',
+                                  target: 'url',
+                                },
+  },
   // Target
   {
                      input_url: 'https://www.target.com/b/universal-music-group/-/N-l4bvw',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -6,6 +6,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import * as ReactDOMServer from 'react-dom/server';
 import test from 'tape';
 
 import {arraysEqual} from '../../common/utility/arrays.js';
@@ -5871,9 +5872,13 @@ function testErrorObject(subtest, relationshipType, st) {
       'Default error message will be used as expected',
     );
   } else {
+    let error = validationResult.error;
+    // Some errors are React elements rather than pure strings
+    if (typeof error === 'object' && error !== null) {
+      error = ReactDOMServer.renderToString(error);
+    }
     st.ok(
-      validationResult.error &&
-        validationResult.error.includes(subtest.expected_error.error),
+      error && error.includes(subtest.expected_error.error),
       'Error message contains expected string',
     );
   }


### PR DESCRIPTION
### Implement MBS-13011

# Problem
`spotify.link` links are just shortened redirects to a specific Spotify page, so we should do the same with them as we do with all other redirect shorteners like Amazon's and Apple's: block, and ask the user to follow the redirect.

# Solution
As above :) 

# Testing
Added a test - I also had to fix the error checking code to support React errors.