### PR TITLE
MBS-13041: Fix broken Utaten favicon

### DIFF
--- a/root/static/styles/favicons.less
+++ b/root/static/styles/favicons.less
@@ -169,7 +169,7 @@
 .favicon("utaitedb");
 .favicon("utamap");
 .favicon("utanet");
-.favicon("utaten");
+.favicon("utaten", 32);
 .favicon("vgmdb");
 .favicon("viaf", 32);
 .favicon("vimeo", 32);


### PR DESCRIPTION
### Fix MBS-13041

# Problem
Utaten favicons are broken.

# Solution
We had a 32 px link but we had not specified 32 on favicons.less, so we were trying to link to a -16.png file. This just specifies that.

# Testing
Manually by checking the favicon now appears when adding a random link to https://utaten.com/lyric/mi23041713/ to a work in sample data.