### PR TITLE
MBS-13047: Do not assume every wiki image has /thumb

### DIFF
--- a/lib/MusicBrainz/Server/Data/WikiDoc.pm
+++ b/lib/MusicBrainz/Server/Data/WikiDoc.pm
@@ -38,8 +38,8 @@ sub _fix_html_links
         {
             # Transform link on "zoomable" image to point directly to the original image
             my $href = $child->attr('src') || '';
-            $href =~ s,^$WIKI_IMAGE_PREFIX/thumb,//$wiki_server$WIKI_IMAGE_PREFIX,;
-            $href =~ s,/[0-9]+px-[^/]*$,,;
+            $href =~ s,^$WIKI_IMAGE_PREFIX,//$wiki_server$WIKI_IMAGE_PREFIX,;
+            $href =~ s,^(//$wiki_server$WIKI_IMAGE_PREFIX)/thumb(.*)/[0-9]+px-[^/]*$,$1$2,;
             $node->attr('href', $href);
             $node->attr('title', 'Open in a new tab');
             $node->attr('target', '_blank');


### PR DESCRIPTION
### Fix MBS-13047

# Problem
The doc images in https://musicbrainz.org/doc/Release/Packaging are split between Commons-hosted ones and MeB Wiki-hosted ones. The zoomable thing to be able to see the images properly (added with https://github.com/metabrainz/musicbrainz-server/pull/2894) is working great with Commons images, but the MeB ones are being sent to links like `https://musicbrainz.org/-/images/a/a5/Packaging-Book2CD.jpg` rather than the wiki.

# Solution
We fix up the image links to point to the wiki as part of the wikidoc process (`sub _fix_html_links`). A regex there was assuming `/thumb` would be in all wiki image URLs, but at least the ones in `/doc/Release/Packaging` did not have it. It might be an SVG only thing? In any case, given we want to link to the full image, we can just keep removing it if there and ignore it otherwise AFAICT, so I made the regex just take `/thumb` as optional


# Testing
Manually, by running `redis-cli --scan --pattern 'MB:wikidoc:*' | xargs redis-cli DEL` to flush the appropriate cache and make the transformation happen again (thanks @yvanzo). I checked both `/doc/MusicBrainz_Database/Schema` (to ensure the currently working images still work) and `/doc/Release/Packaging` (to ensure the broken links now work).