### PR TITLE
MBS-13048: Add Uta-Net composer & lyricist links to artist

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5107,16 +5107,16 @@ const CLEANUPS: CleanupEntries = {
     match: [new RegExp('^(https?://)?([^/]+\\.)?uta-net\\.com/', 'i')],
     restrict: [LINK_TYPES.lyrics],
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?uta-net\.com\/(artist|song)\/(\d+).*$/, 'https://www.uta-net.com/$1/$2/');
+      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?uta-net\.com\/(artist|composer|lyricist|song)\/(\d+).*$/, 'https://www.uta-net.com/$1/$2/');
     },
     validate: function (url, id) {
-      const m = /^https:\/\/www\.uta-net\.com\/(artist|song)\/\d+\/$/.exec(url);
+      const m = /^https:\/\/www\.uta-net\.com\/(artist|composer|lyricist|song)\/\d+\/$/.exec(url);
       if (m) {
         const prefix = m[1];
         switch (id) {
           case LINK_TYPES.lyrics.artist:
             return {
-              result: prefix === 'artist',
+              result: /^(artist|composer|lyricist)$/.test(prefix),
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.lyrics.work:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5160,6 +5160,20 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist'],
   },
   {
+                     input_url: 'https://www.uta-net.com/composer/30/7/',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'lyrics',
+            expected_clean_url: 'https://www.uta-net.com/composer/30/',
+       only_valid_entity_types: ['artist'],
+  },
+  {
+                     input_url: 'https://www.uta-net.com/lyricist/21/5/',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'lyrics',
+            expected_clean_url: 'https://www.uta-net.com/lyricist/21/',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'www.uta-net.com/song/188300/',
              input_entity_type: 'work',
     expected_relationship_type: 'lyrics',


### PR DESCRIPTION
### Implement MBS-13048

# Issue
Uta-Net has `/composer` and `/lyricist` pages that are separate from `/artist`, but they should probably still be linkable to MB artist pages.

# Testing
Added two tests to the handling tests suite.