### PR TITLE
MBS-13049: Add Uta-Ten songWriter links to artist

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5134,16 +5134,16 @@ const CLEANUPS: CleanupEntries = {
     match: [new RegExp('^(https?://)?([^/]+\\.)?utaten\\.com/', 'i')],
     restrict: [LINK_TYPES.lyrics],
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?utaten\.com\/(artist|lyric\/.+)\/([^\/?#]+).*$/, 'https://utaten.com/$1/$2');
+      return url.replace(/^(?:https?:\/\/)?utaten\.com\/(artist|songWriter|lyric\/.+)\/([^\/?#]+).*$/, 'https://utaten.com/$1/$2');
     },
     validate: function (url, id) {
-      const m = /^https:\/\/utaten\.com\/(artist|lyric)\/.+$/.exec(url);
+      const m = /^https:\/\/utaten\.com\/(artist|songWriter|lyric)\/.+$/.exec(url);
       if (m) {
         const prefix = m[1];
         switch (id) {
           case LINK_TYPES.lyrics.artist:
             return {
-              result: prefix === 'artist',
+              result: prefix === 'artist' || prefix === 'songWriter',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.lyrics.work:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5175,6 +5175,13 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist'],
   },
   {
+                     input_url: 'https://utaten.com/songWriter/10350/?sort=release_date_desc&pageType=lyricist',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'lyrics',
+            expected_clean_url: 'https://utaten.com/songWriter/10350',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'http://utaten.com/lyric/fripSide/prominence#sort=popular_sort_asc',
              input_entity_type: 'work',
     expected_relationship_type: 'lyrics',


### PR DESCRIPTION
### Implement MBS-13049

# Issue
Uta-Ten has `/songWriter` pages that are separate from `/artist`, but they should probably still be linkable to MB artist pages.

# Testing
Added a test to the handling tests suite.