### PR TITLE
MBS-12948 / MBS-13051: Wrap more long stuff in release pages

### DIFF
--- a/root/components/GroupedTrackRelationships.js
+++ b/root/components/GroupedTrackRelationships.js
@@ -69,7 +69,12 @@ const renderWorkRelationship = (relationship: RelationshipT) => {
     <React.Fragment key={relationship.id}>
       <dt>{addColon(title)}</dt>
       <dd>
-        <EntityLink content={targetCredit} entity={work} showIcon />
+        <EntityLink
+          className="wrap-anywhere"
+          content={targetCredit}
+          entity={work}
+          showIcon
+        />
         {' '}
         {bracketedText(relationshipDateText(
           relationship,

--- a/root/components/RelationshipTargetLinks.js
+++ b/root/components/RelationshipTargetLinks.js
@@ -74,6 +74,7 @@ const RelationshipTargetLinks = ({
   } else {
     link = (
       <DescriptiveLink
+        className="wrap-anywhere"
         content={targetCredit}
         disableLink={disableLink}
         entity={target}

--- a/root/medium/MediumTracklist.js
+++ b/root/medium/MediumTracklist.js
@@ -73,7 +73,7 @@ const MediumTracklist = ({
           </span>
           {track.number}
         </td>
-        <td>
+        <td className="wrap-anywhere">
           {recording ? (
             <EntityLink
               allowNew={allowNew}
@@ -88,7 +88,7 @@ const MediumTracklist = ({
           )}
         </td>
         {showArtists ? (
-          <td>
+          <td className="wrap-anywhere">
             <ArtistCreditLink artistCredit={track.artistCredit} />
           </td>
         ) : null}

--- a/root/static/scripts/common/components/AreaWithContainmentLink.js
+++ b/root/static/scripts/common/components/AreaWithContainmentLink.js
@@ -14,6 +14,7 @@ import EntityLink from './EntityLink.js';
 type Props = {
   +allowNew?: boolean,
   +area: AreaT,
+  +className?: string,
   +content?: Expand2ReactOutput,
   +deletedCaption?: string,
   +disableLink?: boolean,

--- a/root/static/scripts/common/components/DescriptiveLink.js
+++ b/root/static/scripts/common/components/DescriptiveLink.js
@@ -15,6 +15,7 @@ import EntityLink from './EntityLink.js';
 
 type DescriptiveLinkProps = {
   +allowNew?: boolean,
+  +className?: string,
   +content?: Expand2ReactOutput,
   +customArtistCredit?: ArtistCreditT,
   +deletedCaption?: string,
@@ -30,6 +31,7 @@ type DescriptiveLinkProps = {
 
 const DescriptiveLink = ({
   allowNew,
+  className,
   content,
   customArtistCredit,
   deletedCaption,
@@ -51,6 +53,7 @@ const DescriptiveLink = ({
 
   const props = {
     allowNew,
+    className,
     content,
     deletedCaption,
     disableLink,

--- a/root/static/scripts/relationship-editor/components/DialogPreview.js
+++ b/root/static/scripts/relationship-editor/components/DialogPreview.js
@@ -98,6 +98,7 @@ const DialogPreview = (React.memo<PropsT>(({
   ) => (
     <EntityLink
       allowNew
+      className="wrap-anywhere"
       content={
         nonEmpty(content)
           ? content

--- a/root/static/scripts/relationship-editor/components/DialogSourceEntity.js
+++ b/root/static/scripts/relationship-editor/components/DialogSourceEntity.js
@@ -113,6 +113,7 @@ const DialogSourceEntity = (React.memo<PropsT>(({
           <>
             <EntityLink
               allowNew
+              className="wrap-anywhere"
               content={source.name || l('[unknown]')}
               entity={source}
               target="_blank"

--- a/root/static/scripts/relationship-editor/components/NewWorkLink.js
+++ b/root/static/scripts/relationship-editor/components/NewWorkLink.js
@@ -19,7 +19,7 @@ const NewWorkLink = ({
   <a href={'#new-work-' + String(work.id)}>
     <DeletedLink
       allowNew
-      className="rel-add"
+      className="rel-add wrap-anywhere"
       name={work.name}
     />
   </a>

--- a/root/static/scripts/relationship-editor/components/RelationshipItem.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipItem.js
@@ -99,6 +99,7 @@ const RelationshipItem = (React.memo<PropsT>(({
   } else if (target.gid) {
     targetDisplay = (
       <DescriptiveLink
+        className="wrap-anywhere"
         content={targetCredit}
         entity={target}
         showDisambiguation

--- a/root/static/scripts/release/components/MediumTrackRow.js
+++ b/root/static/scripts/release/components/MediumTrackRow.js
@@ -46,7 +46,7 @@ const MediumTrackRow = (React.memo<PropsT>(({
         <a href={'/track/' + track.gid}>{track.number}</a>
       </td>
 
-      <td className="title">
+      <td className="title wrap-anywhere">
         <EntityLink
           content={track.name}
           entity={track.recording}
@@ -75,7 +75,7 @@ const MediumTrackRow = (React.memo<PropsT>(({
       </td>
 
       {showArtists ? (
-        <td>
+        <td className="wrap-anywhere">
           <ArtistCreditLink artistCredit={track.artistCredit} />
         </td>
       ) : null}

--- a/root/static/scripts/release/components/TrackRelationshipEditor.js
+++ b/root/static/scripts/release/components/TrackRelationshipEditor.js
@@ -56,6 +56,7 @@ const TrackLink = React.memo<TrackLinkPropsT>(({
   if (showArtists) {
     trackLink = (
       <DescriptiveLink
+        className="wrap-anywhere"
         content={track.name}
         customArtistCredit={track.artistCredit}
         entity={track.recording}
@@ -66,6 +67,7 @@ const TrackLink = React.memo<TrackLinkPropsT>(({
   } else {
     trackLink = (
       <EntityLink
+        className="wrap-anywhere"
         content={track.name}
         entity={track.recording}
         showDisambiguation={false}

--- a/root/static/scripts/release/components/TrackRelationshipEditor.js
+++ b/root/static/scripts/release/components/TrackRelationshipEditor.js
@@ -89,7 +89,12 @@ type WorkLinkPropsT = {
 const WorkLink = React.memo<WorkLinkPropsT>(({
   work,
 }) => (
-  <EntityLink allowNew entity={work} target="_blank" />
+  <EntityLink
+    allowNew
+    className="wrap-anywhere"
+    entity={work}
+    target="_blank"
+  />
 ));
 
 type RelatedWorkHeadingPropsT = {


### PR DESCRIPTION
### Implement MBS-12948 / MBS-13051

# Problem
There's a ton of places in the release display page and release relationship editor where long names fail to wrap and cause scroll / escape their dialog (see commits for details on each).

# Solution
Use class `wrap-anywhere` (as introduced by https://github.com/metabrainz/musicbrainz-server/pull/2782) in these places.

# Testing
Added a release, track/recording and work all called "fdjfdjjgjkfdgjdfjkghfjkgfhgjkfhgkfjghdkfldkflskfjsfkdjflfĺksaĺkslkdlaskdĺsadlskaldksḱdĺaskdlksaldksaldkskdlśakdñḱasĺdkaskdaskdĺkksaḱśkldksldklskdksdksaḱdśkdsldksld" and saw what happened before/after. That includes using the batch-add works option to test `NewWorkLink`, adding and displaying relationships (including recording-work). Also tested adding a recording relationship to an artist and using the same string as the artist relationship credit.