### PR TITLE
MBS-13052: Support intl-XX/ path segment in Spotify URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4524,13 +4524,14 @@ const CLEANUPS: CleanupEntries = {
   },
   'spotify': {
     match: [new RegExp(
-      '^(https?://)?([^/]+\\.)?(spotify\\.(?:com|link))/(?!user)',
+      '^(https?://)?([^/]+\\.)?(spotify\\.(?:com|link))/' +
+      '(?!(?:intl-[a-z]+/)?user)',
       'i',
     )],
     restrict: [LINK_TYPES.streamingfree],
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?embed\.spotify\.com\/\?uri=spotify:([a-z]+):([a-zA-Z0-9_-]+)$/, 'https://open.spotify.com/$1/$2');
-      url = url.replace(/^(?:https?:\/\/)?(?:play|open)\.spotify\.com\/([a-z]+)\/([a-zA-Z0-9_-]+)(?:[/?#].*)?$/, 'https://open.spotify.com/$1/$2');
+      url = url.replace(/^(?:https?:\/\/)?(?:play|open)\.spotify\.com\/(?:intl-[a-z]+\/)?([a-z]+)\/([a-zA-Z0-9_-]+)(?:[/?#].*)?$/, 'https://open.spotify.com/$1/$2');
       return url;
     },
     validate: function (url, id) {
@@ -4577,10 +4578,13 @@ const CLEANUPS: CleanupEntries = {
     },
   },
   'spotifyuseraccount': {
-    match: [new RegExp('^(https?://)?([^/]+\\.)?(spotify\\.com)/user', 'i')],
+    match: [new RegExp(
+      '^(https?://)?([^/]+\\.)?(spotify\\.com)/(?:intl-[a-z]+\/)?user',
+      'i',
+    )],
     restrict: [LINK_TYPES.socialnetwork],
     clean: function (url) {
-      url = url.replace(/^(?:https?:\/\/)?(?:play|open)\.spotify\.com\/user\/([^\/?#]+)\/?(?:[?#].*)?$/, 'https://open.spotify.com/user/$1');
+      url = url.replace(/^(?:https?:\/\/)?(?:play|open)\.spotify\.com\/(?:intl-[a-z]+\/)?user\/([^\/?#]+)\/?(?:[?#].*)?$/, 'https://open.spotify.com/user/$1');
       return url;
     },
     validate: function (url) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4593,6 +4593,13 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist'],
   },
   {
+                     input_url: 'https://open.spotify.com/intl-it/artist/1cfvECgeNkitPfAecXtcVX',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'streamingfree',
+            expected_clean_url: 'https://open.spotify.com/artist/1cfvECgeNkitPfAecXtcVX',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'open.spotify.com/album/0tabKG66W34Ms0SsovkP6Q/6yVKnHVFGkg4OQ8IrgQVpZ',
              input_entity_type: 'release',
     expected_relationship_type: 'streamingfree',
@@ -4619,7 +4626,7 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
   },
   {
-                     input_url: 'https://open.spotify.com/user/hitradio%C3%B63',
+                     input_url: 'https://open.spotify.com/intl-de/user/hitradio%C3%B63',
              input_entity_type: 'label',
     expected_relationship_type: 'socialnetwork',
             expected_clean_url: 'https://open.spotify.com/user/hitradio%C3%B63',


### PR DESCRIPTION
### Implement MBS-13052

# Problem
Apparently some languages are now adding a segment like intl-de or intl-it to the Spotify URLs. These redirect to the basic URL if the site is set to English, and the basic URL to them if not. As such, the easiest way to deal with them seems to be to just drop them in cleanup.

# Solution
This just drops the new path segments in cleanup, We need to also support them when checking whether a URL is `spotify` or `spotifyuseraccount`, of course.

# Testing
Added / modified a test for `spotify` and one for `spotifyuseraccount`.