### PR TITLE
MBS-9396: Properly parse seeded release group URLs

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -179,8 +179,11 @@ export class _ExternalLinksEditor
           }
         }
       } else {
+        const seededSourceType = sourceType === 'release_group'
+          ? 'release-group'
+          : sourceType;
         const seededLinkRegex = new RegExp(
-          '(?:\\?|&)edit-' + sourceType +
+          '(?:\\?|&)edit-' + seededSourceType +
             '\\.url\\.([0-9]+)\\.(text|link_type_id)=([^&]+)',
           'g',
         );

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Create.pm
@@ -1,0 +1,106 @@
+package t::MusicBrainz::Server::Controller::ReleaseGroup::Create;
+use strict;
+use warnings;
+
+use HTTP::Request::Common qw( POST );
+use Test::Routine;
+use Test::More;
+use MusicBrainz::Server::Test qw( capture_edits html_ok );
+
+with 't::Mechanize', 't::Context';
+
+=head2 Test description
+
+This test checks whether basic release group creation works.
+
+=cut
+
+test 'Adding a new release group' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c);
+
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
+
+    $mech->get_ok(
+        '/release-group/create',
+        'Fetched the release group creation page',
+    );
+    html_ok($mech->content);
+
+    my @edits = capture_edits {
+        my $req = POST $mech->uri, [
+            'edit-release-group.name' => 'controller release group',
+            'edit-release-group.primary_type_id' => 2,
+            'edit-release-group.secondary_type_ids' => [ 1 ],
+            'edit-release-group.comment' => 'release group created in controller_releasegroup.t',
+            'edit-release-group.artist_credit.names.0.name' => 'Foo',
+            'edit-release-group.artist_credit.names.0.artist.name' => 'Bar',
+            'edit-release-group.artist_credit.names.0.artist.id' => '3',
+        ];
+        $mech->request($req);
+        ok($mech->success, 'The form returned a 2xx response code');
+    } $test->c;
+
+    ok(
+        $mech->uri =~ qr{/release-group/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})},
+        'The user is redirected to the release group page after entering the edit',
+    );
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::ReleaseGroup::Create');
+
+    is_deeply(
+        $edit->data,
+        {
+            name => 'controller release group',
+            type_id => 2,
+            secondary_type_ids => [ 1 ],
+            comment => 'release group created in controller_releasegroup.t',
+            artist_credit => {
+                names => [ {
+                    artist => { id => 3, name => 'Bar' },
+                    name => 'Foo',
+                    join_phrase => '',
+                } ],
+            },
+        },
+        'The edit contains the right data',
+    );
+
+
+    # Test display of edit data
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched the edit page');
+    html_ok($mech->content);
+    $mech->text_contains(
+        'controller release group',
+        'The edit page contains the release group name',
+    );
+    $mech->text_contains(
+        'Single',
+        'The edit page contains the release group primary type',
+    );
+    $mech->text_contains(
+        'Compilation',
+        'The edit page contains the release group secondary type',
+    );
+    $mech->text_contains(
+        'release group created in controller_releasegroup.t',
+        'The edit page contains the disambiguation',
+    );
+    $mech->text_contains('Foo', 'The edit page lists the artist');
+    $mech->content_contains(
+        '/artist/745c079d-374e-4436-9448-da92dedef3ce',
+        'The edit page contains a link to the artist',
+    );
+};
+
+1;

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -639,6 +639,7 @@ const seleniumTests = [
   {name: 'MBS-5387.json5', login: true},
   {name: 'MBS-7456.json5', login: true},
   {name: 'MBS-8952.json5', login: true},
+  {name: 'MBS-9396.json5', login: true},
   {name: 'MBS-9548.json5'},
   {name: 'MBS-9669.json5'},
   {name: 'MBS-9941.json5', login: true},

--- a/t/selenium/MBS-9396.json5
+++ b/t/selenium/MBS-9396.json5
@@ -1,0 +1,20 @@
+{
+  title: "Seeding release group form including URL (MBS-9396)",
+  commands: [
+    {
+      command: 'open',
+      target: '/release-group/create?edit-release-group.name=Testy Test&edit-release-group.url.0.text=http://www.example.com/',
+      value: '',
+    },
+    {
+      command: 'assertValue',
+      target: 'id=id-edit-release-group.name',
+      value: 'Testy Test',
+    },
+    {
+      command: 'assertValue',
+      target: 'css=#external-link-0 td:nth-child(3) input',
+      value: 'http://www.example.com/',
+    },
+  ],
+}


### PR DESCRIPTION
### Fix MBS-9396

# Problem
Seeding URLs for the release group editor was not working at all - no error, nothing, just ignored completely. This has apparently been broken since at least 2017.

# Solution
I figured out that the seeded links for RGs were not getting parsed at all right now because of the wrong sourceType string expectation. This is yet another victim of the "release_group" vs "release-group" clash, where we need to special-case everything. Sigh. I added such special-casing now.

# Testing
Manually, by comparing `/release-group/create?edit-release-group.url.0.text=http://www.example.com/&edit-release-group.url.0.link_type_id=1` with `/artist/create?edit-artist.url.0.text=http://www.example.com/&edit-artist.url.0.link_type_id=1` and checking the seeding result is the same for both now.

Added a basic RG creation test to match other entity types (but that does not allow testing URL seeding) plus a tiny Selenium test to test URL seeding.

# Comments
This is very much not the first time this kind of thing has bitten us in the ass. Is there a real reason why we have to use `release_group` in some places and `release-group` in others? (and, IIRC, `rg` in yet some others, also special-cased).