### PR TITLE
MBS-13060: Display attribute MBIDs on attribute tables

### DIFF
--- a/root/admin/attributes/Attribute.js
+++ b/root/admin/attributes/Attribute.js
@@ -78,6 +78,7 @@ const Attribute = ({
           <th>{l('ID')}</th>
           <th>{l('Name')}</th>
           <th>{l('Description')}</th>
+          <th>{l('MBID')}</th>
           <th>{l('Child order')}</th>
           <th>{l('Parent ID')}</th>
           {renderAttributesHeaderAccordingToModel(model)}
@@ -92,6 +93,7 @@ const Attribute = ({
               <td>{attribute.id}</td>
               <td>{attribute.name}</td>
               <td>{expand2react(attribute.description)}</td>
+              <td>{attribute.gid}</td>
               <td>{attribute.child_order}</td>
               <td>{attribute.parent_id}</td>
               {renderAttributes(attribute)}


### PR DESCRIPTION
### Implement MBS-13060

# Problem
We have MBIDs in the DB for all attributes under `/admin/attributes` except for language and script, but we do not  currently display them anywhere on the website (we do use them in the API). It is weird to hide these, and it recently made me have to query for the MBIDs from the DB when I wanted to update some tests with real data.

# Solution
Added an MBID column to the attribute tables.

These Attribute pages are also going to be made public (without the admin bits) at some point with MBS-11178 (https://github.com/metabrainz/musicbrainz-server/pull/2480), and then it would make sense to make it so that `mbid/$attribute_mbid` would redirect to the appropriate attributes page (MBS-13067).

# Testing
Manually, checking that all attribute types in the list now show MBIDs except for language and script (which as mentioned do not have MBIDs in their tables).