### PR TITLE
MBS-7385: Use EntityLink over release name in medium append UI

### DIFF
--- a/root/static/scripts/edit/components/ReleaseMergeStrategy.js
+++ b/root/static/scripts/edit/components/ReleaseMergeStrategy.js
@@ -129,7 +129,11 @@ const ReleaseMergeStrategy = ({
                           {
                             name: medium.name,
                             position: medium.position,
-                            release: releases[medium.release_id].name,
+                            release: (
+                              <EntityLink
+                                entity={releases[medium.release_id]}
+                              />
+                            ),
                           },
                         )
                       ) : (
@@ -137,7 +141,11 @@ const ReleaseMergeStrategy = ({
                           '(was medium {position} on release {release})',
                           {
                             position: medium.position,
-                            release: releases[medium.release_id].name,
+                            release: (
+                              <EntityLink
+                                entity={releases[medium.release_id]}
+                              />
+                            ),
                           },
                         )
                       )}


### PR DESCRIPTION
### Implement MBS-7385

# Problem
We were just printing "`was medium 1 on release Whatever`" on the UI for picking medium positions and titles when merging releases and appending mediums. This means release disambiguations were not shown here, even though they can be useful when merging different releases of the same or a similar title.

# Solution
This patch changes the text name to an `EntityLink` for the release, which both shows disambiguations and provides
an actual link to the release itself in case the user wants to reopen it to check something.

# Testing
Manually, to make sure the disambiguation now appears (compare below).

Old:
![Screenshot from 2023-05-05 11-57-53](https://user-images.githubusercontent.com/1069224/236422583-74ccf27d-5353-4319-89ca-7d0ebe4d943b.png)

New:
![image_2023-05-05_122653983](https://user-images.githubusercontent.com/1069224/236422638-3f673c3d-fb5f-46e2-89da-653c213fa2c6.png)
