### PR TITLE
MBS-8774: Show containment for selected area in area bubble

### DIFF
--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -281,7 +281,7 @@ import MB from './MB.js';
       return ReactDOMServer.renderToStaticMarkup(
         exp.l(
           'You selected {area}.',
-          {area: this.reactElement({target: '_blank'})},
+          {area: <DescriptiveLink entity={this} target="_blank" />},
         ),
       );
     }


### PR DESCRIPTION
### Implement MBS-8774

# Problem
To make sure you didn't pick the wrong area of the same name, it'd be very helpful to actually have the containment shown in the "You selected AreaName" bubble. Right now, it only shows the name as a link, so you still need to open the link to actually check whether it's the area you wanted.

# Solution
I just used `DescriptiveLink` here, which we already do for release group bubbles and seems by far like the simplest option. I made sure to keep the `target="_blank"` we already had.

# Testing
Manually, by just selecting an area with containment:

![image_2023-05-05_124423770](https://user-images.githubusercontent.com/1069224/236426141-228fa67d-f03d-4122-95c6-3f7996a84d78.png)
