### PR TITLE
MBS-10759: Explain release data quality in editor

### DIFF
--- a/root/release/ChangeQuality.js
+++ b/root/release/ChangeQuality.js
@@ -46,6 +46,20 @@ const ChangeQuality = ({
   return (
     <ReleaseLayout entity={release} fullWidth title={title}>
       <h2>{title}</h2>
+      <p>
+        {exp.l(
+          `{data_quality_doc|Data quality} indicates how good the data
+           for a release is. It is not a mark of how good or bad the music
+           itself is - for that, use {ratings_doc|ratings}.`,
+          {
+            data_quality_doc: {
+              href: '/doc/Release#Data_quality',
+              target: '_blank',
+            },
+            ratings_doc: {href: '/doc/Rating_System', target: '_blank'},
+          },
+        )}
+      </p>
       <form method="post">
         <FormRowSelect
           field={form.field.quality}

--- a/root/release/ChangeQuality.js
+++ b/root/release/ChangeQuality.js
@@ -50,7 +50,7 @@ const ChangeQuality = ({
         {exp.l(
           `{data_quality_doc|Data quality} indicates how good the data
            for a release is. It is not a mark of how good or bad the music
-           itself is - for that, use {ratings_doc|ratings}.`,
+           itself is — for that, use {ratings_doc|ratings}.`,
           {
             data_quality_doc: {
               href: '/doc/Release#Data_quality',


### PR DESCRIPTION
### Implement MBS-10759

# Problem
Right now there's no explanation when editing of what data quality means. This contributes to users relatively often still confusing this with the quality of the music itself (especially artists who often like to set this to High for their music). Changing the name from "quality" to "data quality" helped, but hopefully adding an actual explanation would help more.

# Solution
This takes the first line from [Release#Data quality](https://musicbrainz.org/doc/Release#Data_quality) and adds it to the change date quality edit page. Rather than hardcoding the definition of each quality level here, those are kept on the doc page where they can easily be improved later.

# Testing
Manually (links work).