### PR TITLE
MBS-13075: Indicate the number of items in a series

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -178,6 +178,7 @@ sub show : Chained('load') PathPart('') {
     } elsif ($entity_type eq 'series') {
         $c->model('SeriesType')->load(@$entities);
         $c->model('SeriesOrderingType')->load(@$entities);
+        $c->model('Series')->load_entity_count(@$entities);
     }
 
     my %props = (

--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -193,6 +193,7 @@ sub direct : Private
     elsif ($type eq 'series') {
         $c->model('SeriesType')->load(@entities);
         $c->model('SeriesOrderingType')->load(@entities);
+        $c->model('Series')->load_entity_count(@entities);
     }
     elsif ($type eq 'event') {
         $c->model('Event')->load_meta(@entities);

--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -49,6 +49,7 @@ after load => sub {
     $c->model('Series')->load_aliases($series);
     $c->model('SeriesType')->load($series);
     $c->model('SeriesOrderingType')->load($series);
+    $c->model('Series')->load_entity_count($series);
 
     if ($c->user_exists) {
         $c->stash->{subscribed} = $c->model('Series')

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -971,6 +971,13 @@ sub external_search
             $self->c->model('ReleaseGroup')->load_has_cover_art(@entities);
         }
 
+        if ($type eq 'series')
+        {
+            my @entities = map { $_->entity } @results;
+            $self->c->model('Series')->load_ids(@entities);
+            $self->c->model('Series')->load_entity_count(@entities);
+        }
+
         my $pager = Data::Page->new;
         $pager->current_page($page);
         $pager->entries_per_page($limit);

--- a/lib/MusicBrainz/Server/Entity/Series.pm
+++ b/lib/MusicBrainz/Server/Entity/Series.pm
@@ -23,6 +23,12 @@ has ordering_type => (
     isa => 'SeriesOrderingType',
 );
 
+has entity_count => (
+    is => 'rw',
+    isa => 'Int',
+    predicate => 'loaded_entity_count',
+);
+
 around TO_JSON => sub {
     my ($orig, $self) = @_;
 
@@ -39,6 +45,10 @@ around TO_JSON => sub {
 
     if ($self->type) {
         $json->{type} = $self->type->TO_JSON;
+    }
+
+    if ($self->loaded_entity_count) {
+        $json->{entity_count} = $self->entity_count;
     }
 
     return $json;

--- a/root/components/list/SeriesList.js
+++ b/root/components/list/SeriesList.js
@@ -13,6 +13,7 @@ import {CatalystContext} from '../../context.mjs';
 import useTable from '../../hooks/useTable.js';
 import {
   defineCheckboxColumn,
+  defineCountColumn,
   defineNameColumn,
   defineTypeColumn,
   removeFromMergeColumn,
@@ -43,12 +44,18 @@ component SeriesList(
         sortable,
         typeContext: 'series_type',
       });
+      const sizeColumn = defineCountColumn<SeriesT>({
+        columnName: 'size',
+        getCount: series => series.entity_count,
+        title: l('Number of entities'),
+      });
 
       return [
         ...(checkboxColumn ? [checkboxColumn] : []),
         nameColumn,
         typeColumn,
         seriesOrderingTypeColumn,
+        sizeColumn,
         ...(mergeForm && series.length > 2 ? [removeFromMergeColumn] : []),
       ];
     },

--- a/root/layout/components/sidebar/SeriesSidebar.js
+++ b/root/layout/components/sidebar/SeriesSidebar.js
@@ -14,6 +14,7 @@ import CommonsImage
   from '../../../static/scripts/common/components/CommonsImage.js';
 import linkedEntities
   from '../../../static/scripts/common/linkedEntities.mjs';
+import {formatCount} from '../../../statistics/utilities.js';
 import ExternalLinks from '../ExternalLinks.js';
 
 import AnnotationLinks from './AnnotationLinks.js';
@@ -52,6 +53,13 @@ component SeriesSidebar(series: SeriesT) {
             linkedEntities.series_ordering_type[series.orderingTypeID].name,
             'series_ordering_type',
           )}
+        </SidebarProperty>
+
+        <SidebarProperty
+          className=""
+          label={addColonText(l('Number of entities'))}
+        >
+          {formatCount($c, series.entity_count)}
         </SidebarProperty>
       </SidebarProperties>
 

--- a/root/search/components/SeriesResults.js
+++ b/root/search/components/SeriesResults.js
@@ -36,6 +36,9 @@ function buildResult(
           ? lp_attributes(series.typeName, 'series_type')
           : null}
       </td>
+      <td>
+        {series.entity_count}
+      </td>
     </tr>
   );
 }
@@ -56,6 +59,7 @@ component SeriesResults(...{
           <>
             <th>{l('Name')}</th>
             <th>{l('Type')}</th>
+            <th>{l('Number of entities')}</th>
           </>
         }
         pager={pager}

--- a/root/types/series.js
+++ b/root/types/series.js
@@ -23,6 +23,7 @@ declare type SeriesT = $ReadOnly<{
   ...CommentRoleT,
   ...RelatableEntityRoleT<'series'>,
   ...TypeRoleT<SeriesTypeT>,
+  +entity_count?: number,
   +orderingTypeID: number,
   +primaryAlias?: string | null,
   +type?: SeriesTypeT,

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -239,10 +239,10 @@ export function defineCountColumn<D>(
   props: {
     ...OrderableProps,
     +columnName: string,
-    +getCount: (D) => number,
+    +getCount: (D) => ?number,
     +title: string,
   },
-): ColumnOptions<D, number> {
+): ColumnOptions<D, ?number> {
   const sortable = props.sortable ?? false;
 
   return {

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/Show.pm
@@ -23,6 +23,7 @@ test all => sub {
     $mech->content_like(qr/test comment 1/, 'disambiguation comments');
     $mech->content_like(qr/Recording series/, 'has series type');
     $mech->content_like(qr/Automatic/, 'has ordering type');
+    $mech->text_contains('Number of entities:2', 'lists number of entities');
 
     # Check recordings
     $mech->content_like(qr/Dancing Queen/, 'has recording title');

--- a/t/lib/t/MusicBrainz/Server/Data/Search.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Search.pm
@@ -93,6 +93,7 @@ test all => sub {
     is($artist->comment, 'folk-rock/psychedelic band');
     is($artist->gid, '34ec9a8d-c65b-48fd-bcdd-aad2f72fdb47');
     is($artist->type->name, 'Group');
+    is($artist->type->gid, 'e431f5f6-b5d2-343d-8b36-72607fffb74b');
 
     # release_group search
     $data = load_data('release_group', $test->c, <<~'EOF');
@@ -516,6 +517,7 @@ test all => sub {
     is($label->comment, 'Finnish label');
     is($label->gid, 'e24ca2f9-416e-42bd-a223-bed20fa409d0');
     is($label->type->name, 'Production');
+    is($label->type->gid, 'a2426aab-2dd4-339c-b47d-b4923a241678');
 
     # annotation search
     $data = load_data('annotation', $test->c, <<~"EOF");


### PR DESCRIPTION
### MBS-13075

# Problem
Right now there's no good way of knowing how many items are in a series, other than just counting them by hand. This can be quite annoying for any series with more than a few entries. This is useful for a general idea of how big a series is (in a search for example it helps see what are popular/large series), and for a specific series of known real world size (such as a catalogue) it also can give a general idea of how much content is still missing from the MB entry.

# Solution
This reuses the general idea of `entity_count` we already had for collections. The `entity_count` for a series is calculated based on the `${entity_type}_series` views. See additional details on the commit messages.

# Testing
Manually, by checking series sidebars, creating a small series collection and making sure the counts appear, and doing both a direct and an indexed series search for "apple" and making sure the counts are there. None of these seemed particularly slow.