### PR TITLE
MBS-13079: Add statistics for release groups with no type set

### DIFF
--- a/lib/MusicBrainz/Server/Data/Statistics.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics.pm
@@ -1117,12 +1117,13 @@ my %stats = (
         CALC => sub {
             my ($self, $sql) = @_;
 
-            my $data = $sql->select_list_of_lists(
-                'SELECT type.id, COUNT(rg.id) AS count
-                 FROM release_group_primary_type type
-                 LEFT JOIN release_group rg ON rg.type = type.id
-                 GROUP BY type.id',
-            );
+            my $data = $sql->select_list_of_lists(<<~'SQL');
+                         SELECT COALESCE(type.id::text, 'null'),
+                                COUNT(rg.id) AS count
+                           FROM release_group_primary_type type
+                FULL OUTER JOIN release_group rg ON rg.type = type.id
+                       GROUP BY type.id
+                SQL
 
             my %dist = map { @$_ } @$data;
 
@@ -1138,14 +1139,16 @@ my %stats = (
         CALC => sub {
             my ($self, $sql) = @_;
 
-            my $data = $sql->select_list_of_lists(
-                'SELECT type.id, COUNT(rg.id) AS count
-                 FROM release_group_secondary_type type
-                 LEFT JOIN release_group_secondary_type_join type_join
-                     ON type.id = type_join.secondary_type
-                 JOIN release_group rg ON rg.id = type_join.release_group
-                 GROUP BY type.id',
-            );
+            my $data = $sql->select_list_of_lists(<<~'SQL');
+                         SELECT COALESCE(type.id::text, 'null'),
+                                COUNT(rg.id) AS count
+                           FROM release_group_secondary_type type
+                      LEFT JOIN release_group_secondary_type_join type_join
+                             ON type.id = type_join.secondary_type
+                FULL OUTER JOIN release_group rg
+                             ON rg.id = type_join.release_group
+                       GROUP BY type.id
+                SQL
 
             my %dist = map { @$_ } @$data;
 

--- a/root/statistics/Index.js
+++ b/root/statistics/Index.js
@@ -638,6 +638,12 @@ const Index = ({
               </td>
             </tr>
           ))}
+          <tr>
+            <th />
+            <th>{l('None')}</th>
+            <td>{fc('releasegroup.primary_type.null')}</td>
+            <td>{fp('releasegroup.primary_type.null', 'releasegroup')}</td>
+          </tr>
           <tr className="thead">
             <th colSpan="4">{l('Secondary Types')}</th>
           </tr>
@@ -664,6 +670,12 @@ const Index = ({
               </td>
             </tr>
           ))}
+          <tr>
+            <th />
+            <th>{l('None')}</th>
+            <td>{fc('releasegroup.secondary_type.null')}</td>
+            <td>{fp('releasegroup.secondary_type.null', 'releasegroup')}</td>
+          </tr>
         </tbody>
       </table>
 

--- a/root/statistics/stats.js
+++ b/root/statistics/stats.js
@@ -753,6 +753,16 @@ const stats = {
     color: '#ff0000',
     label: l('Release groups with user-selected cover art'),
   },
+  'count.releasegroup.primary_type.null': {
+    category: 'release-group-types',
+    color: '#ff0000',
+    label: l('Release groups with no primary type set'),
+  },
+  'count.releasegroup.secondary_type.null': {
+    category: 'release-group-types',
+    color: '#ff0000',
+    label: l('Release groups with no secondary type set'),
+  },
   'count.series': {
     category: 'core-entities',
     color: '#1a6756',


### PR DESCRIPTION
### Implement MBS-13079

# Problem
For some reason, while we were calculating no-type stats for other types we were not doing it for RG primary nor secondary types.

# Solution
This just follows the general style we use for other entity types (more specifically, I based it on area_type).

# Testing
Generated stats locally. For secondary types, where the query is less obvious, I made sure the "None" result in a sample db matched the result of:

```
SELECT count(*) FROM release_group rg WHERE NOT EXISTS (
    SELECT 1 FROM release_group_secondary_type_join rgj WHERE rgj.release_group = rg.id
)
```