### PR TITLE
MBS-12107: Enable replication with dbmirror2 by default

### DIFF
--- a/admin/InitDb.pl
+++ b/admin/InitDb.pl
@@ -17,7 +17,7 @@ my $REPTYPE = DBDefs->REPLICATION_TYPE;
 my $psql = 'psql';
 my $path_to_pending_so;
 my $databaseName = 'MAINTENANCE';
-my $dbmirror2 = 0;
+my $dbmirror2 = 1;
 my $fFixUTF8 = 0;
 my $fCreateDB;
 my $fInstallExtension;
@@ -426,7 +426,8 @@ sub SanityCheck
     {
         (defined($path_to_pending_so) || $dbmirror2) or die <<EOF;
 Error: this is a master replication server, but you did not specify
-the path to "pending.so" (i.e. --with-pending=PATH) or pass --dbmirror2.
+the path to "pending.so" (i.e. --with-pending=PATH) while specifying
+--nodbmirror2.
 EOF
 
         return if $dbmirror2;

--- a/admin/replication/ImportReplicationChanges
+++ b/admin/replication/ImportReplicationChanges
@@ -16,7 +16,7 @@ use Sql;
 my ($fHelp, $fIgnoreErrors);
 my $tmpdir = '/tmp';
 my $database = 'READWRITE';
-my $dbmirror2 = 0;
+my $dbmirror2 = 1;
 
 GetOptions(
     'help|h'            => \$fHelp,

--- a/admin/replication/LoadReplicationChanges
+++ b/admin/replication/LoadReplicationChanges
@@ -320,7 +320,7 @@ for my $f (@pending_files)
 print localtime() . " : Importing the pending data files\n";
 system "$FindBin::Bin/ImportReplicationChanges",
     '--database', $database,
-    ($dbmirror2 ? '--dbmirror2' : ()),
+    ($dbmirror2 ? '--dbmirror2' : '--nodbmirror2'),
     '--tmp-dir', $tmpdir,
     '--',
     @pending_file_paths;
@@ -335,7 +335,7 @@ rmtree($mydir);
 APPLY_CHANGES:
 # Apply the changes (ProcessReplicationChanges)
 system "$FindBin::Bin/ProcessReplicationChanges", @process_opts,
-    ($dbmirror2 ? '--dbmirror2' : ());
+    ($dbmirror2 ? '--dbmirror2' : '--nodbmirror2');
 exit $CHILD_ERROR if $CHILD_ERROR;
 
 if (-x "$FindBin::Bin/hooks/post-process") {

--- a/admin/replication/ProcessReplicationChanges
+++ b/admin/replication/ProcessReplicationChanges
@@ -20,7 +20,7 @@ use Types::Serialiser;
 
 my $long_sql = 0;
 my $short_sql = 0;
-my $dbmirror2 = 0;
+my $dbmirror2 = 1;
 my $debug_xact = 0;
 my $skip_seqid;
 my $limit = 10000;

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -50,9 +50,9 @@ sub REPLICATION_TYPE { RT_STANDALONE }
 sub REPLICATION_ACCESS_TOKEN { '' }
 
 # On RT_MASTER, setting this to 1 generates '-v2' packets from dbmirror2
-# (in addition to normal dbmirror packets). On RT_SLAVE, downloads the v2
-# packets when running replication.
-sub REPLICATION_USE_DBMIRROR2 { 0 }
+# (in addition to the old "v1" dbmirror packets). On RT_MIRROR, downloads the
+# v2 packets when running replication.
+sub REPLICATION_USE_DBMIRROR2 { 1 }
 
 ################################################################################
 # GPG Signature

--- a/t/script/dbmirror2.t
+++ b/t/script/dbmirror2.t
@@ -59,7 +59,6 @@ test all => sub {
         File::Spec->catfile($root, 'admin/InitDb.pl'),
         '--createdb',
         '--database', 'TEST_DBMIRROR2_MASTER',
-        '--dbmirror2',
         '--clean',
         '--reptype', '1',
     );
@@ -68,7 +67,6 @@ test all => sub {
         File::Spec->catfile($root, 'admin/InitDb.pl'),
         '--createdb',
         '--database', 'TEST_DBMIRROR2_SLAVE',
-        '--dbmirror2',
         '--clean',
         '--reptype', '2',
     );
@@ -156,7 +154,6 @@ test all => sub {
             File::Spec->catfile($root, 'admin/replication/LoadReplicationChanges'),
             '--base-uri', 'file://' . $output_dir,
             '--database', 'TEST_DBMIRROR2_SLAVE',
-            '--dbmirror2',
             '--lockfile', '/tmp/.mb-LoadReplicationChanges-TEST_DBMIRROR2_SLAVE',
         );
     };


### PR DESCRIPTION
 * `REPLICATION_USE_DBMIRROR2` has been flipped to `1` in lib/DBDefs/Default.pm, which (1) enables dumping of v2 packets by default in ExportAllTables, and (2) enables the downloading of v2 packets by default in LoadReplicationChanges.

 * Scripts that accept a `--dbmirror2` flag (ImportReplicationChanges, InitDb.pl, ProcessReplicationChanges) now have that flag default to true. `--nodbmirror2` can be specified where it needs to be disabled. (Currently the JSON dumps and sitemaps generation still use the old packets.)