### PR TITLE
LoadReplicationChanges: Exit code for schema sequence mismatch

### DIFF
--- a/admin/replication/LoadReplicationChanges
+++ b/admin/replication/LoadReplicationChanges
@@ -244,7 +244,7 @@ unless ($SCHEMA_SEQUENCE == $iSchemaSequence)
         $iSchemaSequence,
         ;
     print localtime() . " : You must upgrade your database in order to apply this replication packet\n";
-    exit 1;
+    exit 3;
 }
 
 # Read REPLICATION_SEQUENCE.  Check that it matches the one we thought we'd

--- a/lib/MusicBrainz/Script/JSONDump/Incremental.pm
+++ b/lib/MusicBrainz/Script/JSONDump/Incremental.pm
@@ -192,8 +192,17 @@ sub run_impl {
                     @replicate_args = (qw( carton exec -- ), @replicate_args);
                 }
 
-                system(@replicate_args) == 0
-                    or die "Replication failed (exit code $CHILD_ERROR)";
+                system(@replicate_args);
+                my $exit_code = $CHILD_ERROR >> 8;
+                # An exit code of 3 indicates a schema sequence mismatch, i.e.
+                # that a schema upgrade is required. We should not die in this
+                # case: it's not an error, and would prevent any parent script
+                # (e.g. admin/RunIncrementalJSONDump) from syncing the
+                # incremental dumps it produced for the final replication
+                # packets of the current schema sequence.
+                if ($exit_code != 0 && $exit_code != 3) {
+                    die "Replication failed (exit code $exit_code)";
+                }
 
                 $current_replication_sequence = $c->sql->select_single_value(
                     'SELECT current_replication_sequence FROM replication_control');


### PR DESCRIPTION
# Problem

After LoadReplicationChanges reaches the first packet of the next schema sequence, it outputs "You must upgrade your database in order to apply this replication packet" and exits with exit code 1. This in turn causes the incremental JSON dump scripts to fail, with admin/RunIncrementalJSONDump not rsyncing any dumps created prior to the failure.

# Solution

To avoid this, I'm using a different exit code (3) to indicate a schema sequence mismatch, and then ignoring this code in `JSONDump::Incremental`.

# Testing

I didn't test the changes at all because it's hard to reproduce without another schema-27 JSON dumps setup.  So hopefully they are straightforward.