### PR TITLE
MBS-13085: Clarify "share email" report checkbox 

### DIFF
--- a/root/user/ReportUser.js
+++ b/root/user/ReportUser.js
@@ -164,7 +164,7 @@ const ReportUser = ({
                 )}
               </p>
             }
-            label={l('Reveal my email address')}
+            label={l('Receive email updates about this report')}
             uncontrolled
           />
 


### PR DESCRIPTION
### Implement MBS-13085

# Problem
We have a "Reveal your email" checkbox when reporting users, but the people who get this report have access to your email anyway, so this is misleading.

# Solution
Improved the wording as suggested by @Aerozol.

# Testing
Manually (trivial change).