### PR TITLE
Refactor ProcessReplicationChanges

### DIFF
--- a/admin/replication/ProcessReplicationChanges
+++ b/admin/replication/ProcessReplicationChanges
@@ -72,7 +72,7 @@ my $sql = Sql->new($c->conn);
 
 # Connection wrapper used only for looping, through a cursor, over each
 # pending_data change for the transaction (X) ID obtained from the above.
-my $sql2 = Sql->new($c->conn);
+my $fetching_change_sql = Sql->new($c->conn);
 
 # Connection wrapper used only for applying all of the changes obtained from the
 # above in a single but separate transaction for each transaction (X) ID.
@@ -169,16 +169,16 @@ if (my $totalrows = $sql->select($query))
         $mirror->begin;
         $mirror->do('SET CONSTRAINTS ALL DEFERRED');
 
-        $sql2->do("DECLARE csr NO SCROLL CURSOR FOR $query", $XID);
+        $fetching_change_sql->do("DECLARE csr NO SCROLL CURSOR FOR $query", $XID);
 
         my @row2;
         my $pull = sub {
-            $sql2->finish;
-            $sql2->select("FETCH FORWARD $limit FROM csr");
+            $fetching_change_sql->finish;
+            $fetching_change_sql->select("FETCH FORWARD $limit FROM csr");
         };
         while ($pull->())
         {
-            while (@row2 = $sql2->next_row)
+            while (@row2 = $fetching_change_sql->next_row)
             {
                 # TODO: Figure out how to handle errors here
                 if ($dbmirror2) {
@@ -186,16 +186,16 @@ if (my $totalrows = $sql->select($query))
                         die "Mirror command failed.\n";
                     }
                 }
-                elsif (!mirrorCommand($row2[2], $sql2, $mirror, \@row2, $XID, $pull))
+                elsif (!mirrorCommand($row2[2], $fetching_change_sql, $mirror, \@row2, $XID, $pull))
                 {
                     die "Mirror command failed.\n";
                 }
                 ++$strows;
             }
         }
-        $sql2->finish;
+        $fetching_change_sql->finish;
 
-        $sql2->do('CLOSE csr');
+        $fetching_change_sql->do('CLOSE csr');
         $mirror->do(
             $dbmirror2
                 ? 'DELETE FROM dbmirror2.pending_data WHERE xid = ?'

--- a/admin/replication/ProcessReplicationChanges
+++ b/admin/replication/ProcessReplicationChanges
@@ -76,7 +76,7 @@ my $fetching_change_sql = Sql->new($c->conn);
 
 # Connection wrapper used only for applying all of the changes obtained from the
 # above in a single but separate transaction for each transaction (X) ID.
-my $mirror = Sql->new($c->conn);
+my $applying_change_sql = Sql->new($c->conn);
 
 $sql->auto_commit;
 $sql->do('SET search_path = musicbrainz, public');
@@ -166,8 +166,8 @@ if (my $totalrows = $sql->select($query))
                 SQL
         }
 
-        $mirror->begin;
-        $mirror->do('SET CONSTRAINTS ALL DEFERRED');
+        $applying_change_sql->begin;
+        $applying_change_sql->do('SET CONSTRAINTS ALL DEFERRED');
 
         $fetching_change_sql->do("DECLARE csr NO SCROLL CURSOR FOR $query", $XID);
 
@@ -182,11 +182,11 @@ if (my $totalrows = $sql->select($query))
             {
                 # TODO: Figure out how to handle errors here
                 if ($dbmirror2) {
-                    if (!dbmirror2_command($mirror, \@row2)) {
+                    if (!dbmirror2_command($applying_change_sql, \@row2)) {
                         die "Mirror command failed.\n";
                     }
                 }
-                elsif (!mirrorCommand($row2[2], $fetching_change_sql, $mirror, \@row2, $XID, $pull))
+                elsif (!mirrorCommand($row2[2], $fetching_change_sql, $applying_change_sql, \@row2, $XID, $pull))
                 {
                     die "Mirror command failed.\n";
                 }
@@ -196,7 +196,7 @@ if (my $totalrows = $sql->select($query))
         $fetching_change_sql->finish;
 
         $fetching_change_sql->do('CLOSE csr');
-        $mirror->do(
+        $applying_change_sql->do(
             $dbmirror2
                 ? 'DELETE FROM dbmirror2.pending_data WHERE xid = ?'
                 : 'DELETE FROM dbmirror_pending WHERE XID = ?',
@@ -204,7 +204,7 @@ if (my $totalrows = $sql->select($query))
         );
 
         print localtime() . " : COMMIT XID #$XID\n" if $debug_xact;
-        $mirror->commit;
+        $applying_change_sql->commit;
 
         ++$rows;
         unless ($rows & 0x1F and time() == $lasttime)
@@ -266,7 +266,7 @@ exit;
 
 sub mirrorCommand
 {
-    my ($op, $result, $mirror, $row, $transId, $pull)  = @_;
+    my ($op, $result, $applying_change_sql, $row, $transId, $pull)  = @_;
 
     my $table = $row->[1];
     $table =~ s/^"public"\.//;
@@ -277,25 +277,25 @@ sub mirrorCommand
     {
         ++$ins;
         ++$t->[0];
-        return mirrorInsert($result, $mirror, $row, $transId);
+        return mirrorInsert($result, $applying_change_sql, $row, $transId);
     }
     elsif ($op eq 'd')
     {
         ++$del;
         ++$t->[2];
-        return mirrorDelete($result, $mirror, $row, $transId);
+        return mirrorDelete($result, $applying_change_sql, $row, $transId);
     }
     elsif ($op eq 'u')
     {
         ++$upd;
         ++$t->[1];
-        return mirrorUpdate($result, $mirror, $row, $transId, $pull);
+        return mirrorUpdate($result, $applying_change_sql, $row, $transId, $pull);
     }
     return 0;
 }
 
 sub dbmirror2_command {
-    my ($mirror, $row)  = @_;
+    my ($applying_change_sql, $row)  = @_;
 
     my ($seqid, $table, $op, $olddata, $newdata, $keys) = @{$row};
 
@@ -319,11 +319,11 @@ sub dbmirror2_command {
                 "Primary keys for $table were not found in the " .
                 "pending_keys file. Fetching them from the database."
             );
-            my ($schema_part, $table_part) = @{ $mirror->select_single_value(
+            my ($schema_part, $table_part) = @{ $applying_change_sql->select_single_value(
                 'SELECT parse_ident(?)',
                 $table,
             ) };
-            $keys = [get_primary_keys($mirror, $schema_part, $table_part)];
+            $keys = [get_primary_keys($applying_change_sql, $schema_part, $table_part)];
             $fetched_keys->{$table} = $keys;
         }
     }
@@ -333,15 +333,15 @@ sub dbmirror2_command {
     if ($op eq 'i') {
         ++$ins;
         ++$t->[0];
-        return dbmirror2_insert($mirror, $table, $newdata);
+        return dbmirror2_insert($applying_change_sql, $table, $newdata);
     } elsif ($op eq 'd') {
         ++$del;
         ++$t->[2];
-        return dbmirror2_delete($mirror, $table, $olddata, $keys);
+        return dbmirror2_delete($applying_change_sql, $table, $olddata, $keys);
     } elsif ($op eq 'u') {
         ++$upd;
         ++$t->[1];
-        return dbmirror2_update($mirror, $table, $olddata, $newdata, $keys);
+        return dbmirror2_update($applying_change_sql, $table, $olddata, $newdata, $keys);
     }
     return 0;
 }
@@ -350,7 +350,7 @@ use MusicBrainz::Server::dbmirror;
 
 sub mirrorInsert
 {
-    my ($result, $mirror, $row, $transId)  = @_;
+    my ($result, $applying_change_sql, $row, $transId)  = @_;
     my $seqId = $row->[0];
     my $tableName = $row->[1];
 
@@ -361,17 +361,17 @@ sub mirrorInsert
 
     print localtime() . " : INSERT INTO $tableName\n" if $short_sql;
     show_long_sql($statement, $args) if $long_sql;
-    $mirror->do($statement, @$args);
+    $applying_change_sql->do($statement, @$args);
 
     return 1;
 }
 
 sub get_bind_value {
-    my ($mirror, $table, $column, $value) = @_;
+    my ($applying_change_sql, $table, $column, $value) = @_;
 
     return undef unless defined $value;
 
-    my $type_name = $mirror->get_column_type_name($table, $column);
+    my $type_name = $applying_change_sql->get_column_type_name($table, $column);
 
     # Most likely not needed, as we set `boolean_values` to (0, 1)
     # on the Perl JSON decoder.
@@ -410,14 +410,14 @@ sub get_bind_value {
 }
 
 sub get_sorted_columns_and_values {
-    my ($mirror, $table, $data) = @_;
+    my ($applying_change_sql, $table, $data) = @_;
 
     return unless defined $data;
 
     my @columns = sort { $a cmp $b } keys %{$data};
 
     my @values = map {
-        get_bind_value($mirror, $table, $_, $data->{$_})
+        get_bind_value($applying_change_sql, $table, $_, $data->{$_})
     } @columns;
 
     return (\@columns, \@values);
@@ -448,9 +448,9 @@ sub column_values_differ {
 }
 
 sub warn_if_existing_data_differs {
-    my ($mirror, $table, $olddata, $keys, $conditions, $key_data) = @_;
+    my ($applying_change_sql, $table, $olddata, $keys, $conditions, $key_data) = @_;
 
-    my $row = $mirror->select_single_row_hash(
+    my $row = $applying_change_sql->select_single_row_hash(
         "SELECT * FROM $table WHERE $conditions",
         @$key_data,
     );
@@ -458,17 +458,17 @@ sub warn_if_existing_data_differs {
     my %key_map = zip @$keys, @$key_data;
 
     my $key_string = join q( ), map {
-        $_ . '=' . $mirror->dbh->quote($key_map{$_})
+        $_ . '=' . $applying_change_sql->dbh->quote($key_map{$_})
     } @$keys;
 
     if (defined $row) {
         for my $col (keys %{$row}) {
             next if exists $key_map{$col};
 
-            my $packet_value = get_bind_value($mirror, $table, $col, $olddata->{$col});
+            my $packet_value = get_bind_value($applying_change_sql, $table, $col, $olddata->{$col});
             my $actual_value = $row->{$col};
 
-            my $type_name = $mirror->get_column_type_name($table, $col);
+            my $type_name = $applying_change_sql->get_column_type_name($table, $col);
             # postgres has no equality operator for json, only jsonb
             $type_name =~ s/json(?!b)/jsonb/;
             my $comparison_query;
@@ -481,7 +481,7 @@ sub warn_if_existing_data_differs {
                     "SELECT ?::$type_name IS DISTINCT FROM ?::$type_name";
             }
             if (
-                $mirror->select_single_value(
+                $applying_change_sql->select_single_value(
                     $comparison_query,
                     $packet_value,
                     $actual_value,
@@ -502,9 +502,9 @@ sub warn_if_existing_data_differs {
 }
 
 sub dbmirror2_insert {
-    my ($mirror, $table, $newdata)  = @_;
+    my ($applying_change_sql, $table, $newdata)  = @_;
 
-    my ($columns, $values) = get_sorted_columns_and_values($mirror, $table, $newdata);
+    my ($columns, $values) = get_sorted_columns_and_values($applying_change_sql, $table, $newdata);
     my $columns_string = join q(, ), map { valid_identifer($_) } @$columns;
     my $placholders = join q(, ), (('?') x @$columns);
     my $statement = "INSERT INTO $table ($columns_string) VALUES ($placholders)";
@@ -512,14 +512,14 @@ sub dbmirror2_insert {
     print localtime() . " : INSERT INTO $table\n" if $short_sql;
     show_long_sql($statement, $values) if $long_sql;
 
-    $mirror->do($statement, @$values);
+    $applying_change_sql->do($statement, @$values);
 
     return 1;
 }
 
 sub mirrorDelete
 {
-    my ($result, $mirror, $row, $transId) = @_;
+    my ($result, $applying_change_sql, $row, $transId) = @_;
     my $seqId = $row->[0];
     my $tableName = $row->[1];
 
@@ -530,23 +530,23 @@ sub mirrorDelete
 
     print localtime() . " : DELETE FROM $tableName\n" if $short_sql;
     show_long_sql($statement, $args) if $long_sql;
-    $mirror->do($statement, @$args);
+    $applying_change_sql->do($statement, @$args);
 
     return 1;
 }
 
 sub dbmirror2_delete {
-    my ($mirror, $table, $olddata, $keys)  = @_;
+    my ($applying_change_sql, $table, $olddata, $keys)  = @_;
 
     my $conditions = join ' AND ',
         map { valid_identifer($_) . ' = ?' }
         @$keys;
     my @key_data = map {
-        get_bind_value($mirror, $table, $_, $olddata->{$_})
+        get_bind_value($applying_change_sql, $table, $_, $olddata->{$_})
     } @$keys;
 
     warn_if_existing_data_differs(
-        $mirror, $table, $olddata,
+        $applying_change_sql, $table, $olddata,
         $keys, $conditions, \@key_data,
     );
 
@@ -555,14 +555,14 @@ sub dbmirror2_delete {
     print localtime() . " : DELETE FROM $table\n" if $short_sql;
     show_long_sql($statement, \@key_data) if $long_sql;
 
-    $mirror->do($statement, @key_data);
+    $applying_change_sql->do($statement, @key_data);
 
     return 1;
 }
 
 sub mirrorUpdate
 {
-    my ($result, $mirror, $row, $transId, $pull) = @_;
+    my ($result, $applying_change_sql, $row, $transId, $pull) = @_;
     my $seqId = $row->[0];
     my $tableName = $row->[1];
 
@@ -581,31 +581,31 @@ sub mirrorUpdate
 
     print localtime() . " : UPDATE $tableName\n" if $short_sql;
     show_long_sql($statement, $args) if $long_sql;
-    $mirror->do($statement, @$args);
+    $applying_change_sql->do($statement, @$args);
 
     return 1;
 }
 
 sub dbmirror2_update {
-    my ($mirror, $table, $olddata, $newdata, $keys)  = @_;
+    my ($applying_change_sql, $table, $olddata, $newdata, $keys)  = @_;
 
     my $conditions = join ' AND ',
         map { valid_identifer($_) . ' = ?' }
         @$keys;
     my @key_data = map {
-        get_bind_value($mirror, $table, $_, $olddata->{$_})
+        get_bind_value($applying_change_sql, $table, $_, $olddata->{$_})
     } @$keys;
 
     warn_if_existing_data_differs(
-        $mirror, $table, $olddata,
+        $applying_change_sql, $table, $olddata,
         $keys, $conditions, \@key_data,
     );
 
     my (@changed_columns, @changed_values);
 
     for my $column (sort keys %{$newdata}) {
-        my $old_value = get_bind_value($mirror, $table, $column, $olddata->{$column});
-        my $new_value = get_bind_value($mirror, $table, $column, $newdata->{$column});
+        my $old_value = get_bind_value($applying_change_sql, $table, $column, $olddata->{$column});
+        my $new_value = get_bind_value($applying_change_sql, $table, $column, $newdata->{$column});
         if (column_values_differ($old_value, $new_value)) {
             push @changed_columns, $column;
             push @changed_values, $new_value;
@@ -623,7 +623,7 @@ sub dbmirror2_update {
     print localtime() . " : UPDATE $table\n" if $short_sql;
     show_long_sql($statement, \@key_data) if $long_sql;
 
-    $mirror->do($statement, @changed_values, @key_data);
+    $applying_change_sql->do($statement, @changed_values, @key_data);
 
     return 1;
 }

--- a/admin/replication/ProcessReplicationChanges
+++ b/admin/replication/ProcessReplicationChanges
@@ -18,8 +18,8 @@ use MusicBrainz::Server::Context;
 use Sql;
 use Types::Serialiser;
 
-my $long_sql = 0;
-my $short_sql = 0;
+my $show_long_sql = 0;
+my $show_short_sql = 0;
 my $dbmirror2 = 1;
 my $debug_xact = 0;
 my $skip_seqid;
@@ -44,8 +44,8 @@ Options are:
 EOF
 
 GetOptions(
-    'short-sql'         => \$short_sql,
-    'long-sql'          => \$long_sql,
+    'short-sql'         => \$show_short_sql,
+    'long-sql'          => \$show_long_sql,
     'dbmirror2!'        => \$dbmirror2,
     'debug-xact'        => \$debug_xact,
     'skip-seqid|s=i'    => \$skip_seqid,
@@ -126,7 +126,7 @@ if (my $totalrows = $sql->select($query))
     };
 
     $p = sub { $lasttime = time }
-        if $short_sql or $long_sql or $debug_xact;
+        if $show_short_sql or $show_long_sql or $debug_xact;
 
         $p->('', '');
 
@@ -359,8 +359,8 @@ sub mirrorInsert
 
     my ($statement, $args) = MusicBrainz::Server::dbmirror::prepare_insert($tableName, $valuepairs);
 
-    print localtime() . " : INSERT INTO $tableName\n" if $short_sql;
-    show_long_sql($statement, $args) if $long_sql;
+    print localtime() . " : INSERT INTO $tableName\n" if $show_short_sql;
+    show_long_sql($statement, $args) if $show_long_sql;
     $applying_change_sql->do($statement, @$args);
 
     return 1;
@@ -509,8 +509,8 @@ sub dbmirror2_insert {
     my $placholders = join q(, ), (('?') x @$columns);
     my $statement = "INSERT INTO $table ($columns_string) VALUES ($placholders)";
 
-    print localtime() . " : INSERT INTO $table\n" if $short_sql;
-    show_long_sql($statement, $values) if $long_sql;
+    print localtime() . " : INSERT INTO $table\n" if $show_short_sql;
+    show_long_sql($statement, $values) if $show_long_sql;
 
     $applying_change_sql->do($statement, @$values);
 
@@ -528,8 +528,8 @@ sub mirrorDelete
 
     my ($statement, $args) = MusicBrainz::Server::dbmirror::prepare_delete($tableName, $keypairs);
 
-    print localtime() . " : DELETE FROM $tableName\n" if $short_sql;
-    show_long_sql($statement, $args) if $long_sql;
+    print localtime() . " : DELETE FROM $tableName\n" if $show_short_sql;
+    show_long_sql($statement, $args) if $show_long_sql;
     $applying_change_sql->do($statement, @$args);
 
     return 1;
@@ -552,8 +552,8 @@ sub dbmirror2_delete {
 
     my $statement = "DELETE FROM $table WHERE $conditions";
 
-    print localtime() . " : DELETE FROM $table\n" if $short_sql;
-    show_long_sql($statement, \@key_data) if $long_sql;
+    print localtime() . " : DELETE FROM $table\n" if $show_short_sql;
+    show_long_sql($statement, \@key_data) if $show_long_sql;
 
     $applying_change_sql->do($statement, @key_data);
 
@@ -579,8 +579,8 @@ sub mirrorUpdate
 
     my ($statement, $args) = MusicBrainz::Server::dbmirror::prepare_update($tableName, $valuepairs, $keypairs);
 
-    print localtime() . " : UPDATE $tableName\n" if $short_sql;
-    show_long_sql($statement, $args) if $long_sql;
+    print localtime() . " : UPDATE $tableName\n" if $show_short_sql;
+    show_long_sql($statement, $args) if $show_long_sql;
     $applying_change_sql->do($statement, @$args);
 
     return 1;
@@ -620,8 +620,8 @@ sub dbmirror2_update {
 
     my $statement = "UPDATE $table SET $updates WHERE $conditions";
 
-    print localtime() . " : UPDATE $table\n" if $short_sql;
-    show_long_sql($statement, \@key_data) if $long_sql;
+    print localtime() . " : UPDATE $table\n" if $show_short_sql;
+    show_long_sql($statement, \@key_data) if $show_long_sql;
 
     $applying_change_sql->do($statement, @changed_values, @key_data);
 

--- a/admin/replication/ProcessReplicationChanges
+++ b/admin/replication/ProcessReplicationChanges
@@ -66,8 +66,16 @@ my $c = MusicBrainz::Server::Context->create_script_context(database => $databas
 my $json = JSON::XS->new;
 $json->boolean_values(0, 1)->pretty(0);
 
+# Main connection wrapper used for looping over all of the ordered transaction (X) IDs,
+# and also any other miscellaneous queries at the beginning/ending of the script.
 my $sql = Sql->new($c->conn);
+
+# Connection wrapper used only for looping, through a cursor, over each
+# pending_data change for the transaction (X) ID obtained from the above.
 my $sql2 = Sql->new($c->conn);
+
+# Connection wrapper used only for applying all of the changes obtained from the
+# above in a single but separate transaction for each transaction (X) ID.
 my $mirror = Sql->new($c->conn);
 
 $sql->auto_commit;


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Some variable names are not really telling much about this piece of code, leading sometimes to confusion. For example, see https://github.com/metabrainz/musicbrainz-server/pull/2919#discussion_r1183566776.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

In [`ProcessReplicationChanges`](https://github.com/metabrainz/musicbrainz-server/blob/v-2023-05-15-schema-change/admin/replication/ProcessReplicationChanges), rename the variables:
* [x] `$short_sql` into `$show_short_sql` (to avoid the confusion with any SQL connection)
* [x] `$long_sql` into `$show_long_sql` (to avoid the confusion with any SQL connection)
* [x] keep `$sql` (since it is used as a generic connection as usual)
* [x] `$sql2` into `$fetching_change_sql`
* [x] `$mirror` into `applying_change_sql`