### PR TITLE
MBS-13088: Standardize series type bubble

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -168,16 +168,14 @@ with 'MusicBrainz::Server::Controller::Role::Edit' => {
 before qw( edit create ) => sub {
     my ($self, $c) = @_;
 
-    my $series_types = {
-        map { $_->id => $_->TO_JSON } $c->model('SeriesType')->get_all
-    };
+    my %series_types = map {$_->id => $_} $c->model('SeriesType')->get_all();
 
     my $series_ordering_types = {
         map { $_->id => $_->TO_JSON } $c->model('SeriesOrderingType')->get_all
     };
 
     $c->stash(
-        series_types => $series_types,
+        series_types => \%series_types,
         series_ordering_types => $series_ordering_types,
     );
 };

--- a/root/series/edit_form.tt
+++ b/root/series/edit_form.tt
@@ -33,9 +33,7 @@
   </div>
 
   <div class="documentation">
-    <div class="bubble" id="series-type-bubble" data-bind="bubble: typeBubble">
-      <p data-bind="text: target() &amp;&amp; target().type() ? target().type().description : ''"></p>
-    </div>
+    [%- type_bubble(form.field('type_id'), series_types) -%]
 
     <div class="bubble" id="ordering-type-bubble" data-bind="bubble: orderingTypeBubble">
       <p data-bind="text: target() ? target().orderingTypeDescription() : ''"></p>

--- a/root/static/scripts/series/edit.js
+++ b/root/static/scripts/series/edit.js
@@ -7,20 +7,13 @@ import './components/SeriesRelationshipEditor.js';
 import MB from '../common/MB.js';
 import initializeDuplicateChecker from '../edit/check-duplicates.js';
 import {createExternalLinksEditorForHtmlForm} from '../edit/externalLinks.js';
+import typeBubble from '../edit/typeBubble.js';
 
 $(function () {
-  var $type = $('#id-edit-series\\.type_id');
   var $orderingType = $('#id-edit-series\\.ordering_type_id');
 
   const series = MB.getSourceEntityInstance();
   series.orderingTypeID($orderingType.val());
-  series.typeID($type.val());
-
-  series.typeBubble = new MB.Control.BubbleDoc();
-
-  series.typeBubble.canBeShown = function () {
-    return nonEmpty($type.val());
-  };
 
   series.orderingTypeBubble = new MB.Control.BubbleDoc();
 
@@ -31,17 +24,11 @@ $(function () {
     );
   });
 
-  ko.applyBindingsToNode($type[0], {
-    value: series.typeID,
-    controlsBubble: series.typeBubble,
-  }, series);
-
   ko.applyBindingsToNode($orderingType[0], {
     value: series.orderingTypeID,
     controlsBubble: series.orderingTypeBubble,
   }, series);
 
-  ko.applyBindings(series, $('#series-type-bubble')[0]);
   ko.applyBindings(series, $('#ordering-type-bubble')[0]);
 
   MB.Control.initializeGuessCase('series', 'id-edit-series');
@@ -54,3 +41,6 @@ $(function () {
 
   createExternalLinksEditorForHtmlForm('edit-series');
 });
+
+const typeIdField = 'select[name=edit-series\\.type_id]';
+typeBubble(typeIdField);


### PR DESCRIPTION
### Fix MBS-13088


# Problem
The bubble for series types doesn't even appear at first as it should, and eventually appears empty.

# Solution
Rather than fidgeting with the non-standard implementation we had for series, I just changed it to match the other type bubbles (based it on `place`).

# Testing
Manually, by going to `/series/create` and checking the type docs appear.