### PR TITLE
MBS-13089: Properly enclose $used_in_relationship in parens

### DIFF
--- a/lib/MusicBrainz/Server/Data/Event.pm
+++ b/lib/MusicBrainz/Server/Data/Event.pm
@@ -159,7 +159,7 @@ sub is_empty {
         SELECT TRUE
         FROM event event_row
         WHERE id = ?
-        AND NOT $used_in_relationship
+        AND NOT ($used_in_relationship)
         SQL
 }
 

--- a/lib/MusicBrainz/Server/Data/Place.pm
+++ b/lib/MusicBrainz/Server/Data/Place.pm
@@ -167,7 +167,7 @@ sub is_empty {
         SELECT TRUE
         FROM place place_row
         WHERE id = ?
-        AND NOT $used_in_relationship
+        AND NOT ($used_in_relationship)
         SQL
 }
 

--- a/lib/MusicBrainz/Server/Data/Work.pm
+++ b/lib/MusicBrainz/Server/Data/Work.pm
@@ -477,7 +477,7 @@ sub is_empty {
         SELECT TRUE
         FROM work work_row
         WHERE id = ?
-        AND NOT $used_in_relationship
+        AND NOT ($used_in_relationship)
         SQL
 }
 


### PR DESCRIPTION
### Fix MBS-13089

# Problem
A place with a URL relationship gets detected as empty.

# Solution
I enclosed `$used_in_relationship` in parens when used alone. `$used_in_relationship` is actually a bunch of clauses like: `EXISTS (...) OR EXISTS (...)` - without this being enclosed in parens, it's actually doing `AND NOT EXISTS (first set) OR EXISTS (second set)` and returning `is_empty` as `true` if any relationships exists for all but the first clause.

# Testing
Manually, checking the place for which the bug was reported now shows properly.