### PR TITLE
Avoid area bubble crashing on missing iso_3166_1_codes

### DIFF
--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -273,7 +273,12 @@ import MB from './MB.js';
     toJSON() {
       return Object.assign(
         super.toJSON(),
-        {iso_3166_1_codes: this.iso_3166_1_codes || []},
+        {
+          containment: this.containment || [],
+          iso_3166_1_codes: this.iso_3166_1_codes || [],
+          iso_3166_2_codes: this.iso_3166_2_codes || [],
+          iso_3166_3_codes: this.iso_3166_3_codes || [],
+        },
       );
     }
 
@@ -281,7 +286,7 @@ import MB from './MB.js';
       return ReactDOMServer.renderToStaticMarkup(
         exp.l(
           'You selected {area}.',
-          {area: <DescriptiveLink entity={this} target="_blank" />},
+          {area: <DescriptiveLink entity={this.toJSON()} target="_blank" />},
         ),
       );
     }


### PR DESCRIPTION
# Problem
Area bubbles for artists (and I assume label too) are crashing when trying to fill them using the area data stored in the form since that is missing `iso_3166_1_codes`.

# Solution
Using `{this}` rather than `{this.toJSON()}` meant we were hitting the issue why we originally added the `iso_3166_1_codes` assignment to `toJSON`, so use `this.toJSON()` instead. In order to be able to display containment with `toJSON` we need to actively set it in `toJSON` as well.

# Testing
Manually with [the case reported by CatQuest](https://tickets.metabrainz.org/browse/MBS-8774?focusedCommentId=68134&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-68134) plus making sure the rest of areas (e.g. when searching) still worked fine.