### PR TITLE
MBS-12211: Avoid crash when URL has been removed

### DIFF
--- a/root/report/components/ArtistUrlList.js
+++ b/root/report/components/ArtistUrlList.js
@@ -12,6 +12,8 @@ import EntityLink from '../../static/scripts/common/components/EntityLink.js';
 import bracketed from '../../static/scripts/common/utility/bracketed.js';
 import type {ReportArtistUrlT} from '../types.js';
 
+import RemovedUrlRow from './RemovedUrlRow.js';
+
 type Props = {
   +items: $ReadOnlyArray<ReportArtistUrlT>,
   +pager: PagerT,
@@ -34,7 +36,10 @@ const ArtistUrlList = ({
           </tr>
         </thead>
         <tbody>
-          {items.map((item) => {
+          {items.map((item, index) => {
+            if (!item.url) {
+              return <RemovedUrlRow colSpan="2" index={index} />;
+            }
             lastGID = currentGID;
             currentGID = item.url.gid;
 

--- a/root/report/components/LabelUrlList.js
+++ b/root/report/components/LabelUrlList.js
@@ -12,6 +12,8 @@ import EntityLink from '../../static/scripts/common/components/EntityLink.js';
 import bracketed from '../../static/scripts/common/utility/bracketed.js';
 import type {ReportLabelUrlT} from '../types.js';
 
+import RemovedUrlRow from './RemovedUrlRow.js';
+
 type Props = {
   +items: $ReadOnlyArray<ReportLabelUrlT>,
   +pager: PagerT,
@@ -34,7 +36,11 @@ const LabelUrlList = ({
           </tr>
         </thead>
         <tbody>
-          {items.map((item) => {
+          {items.map((item, index) => {
+            if (!item.url) {
+              return <RemovedUrlRow colSpan="2" index={index} />;
+            }
+
             lastGID = currentGID;
             currentGID = item.url.gid;
 

--- a/root/report/components/ReleaseGroupUrlList.js
+++ b/root/report/components/ReleaseGroupUrlList.js
@@ -14,6 +14,8 @@ import EntityLink from '../../static/scripts/common/components/EntityLink.js';
 import bracketed from '../../static/scripts/common/utility/bracketed.js';
 import type {ReportReleaseGroupUrlT} from '../types.js';
 
+import RemovedUrlRow from './RemovedUrlRow.js';
+
 type Props = {
   +items: $ReadOnlyArray<ReportReleaseGroupUrlT>,
   +pager: PagerT,
@@ -37,7 +39,11 @@ const ReleaseGroupUrlList = ({
           </tr>
         </thead>
         <tbody>
-          {items.map((item) => {
+          {items.map((item, index) => {
+            if (!item.url) {
+              return <RemovedUrlRow colSpan="3" index={index} />;
+            }
+
             lastGID = currentGID;
             currentGID = item.url.gid;
 

--- a/root/report/components/ReleaseUrlList.js
+++ b/root/report/components/ReleaseUrlList.js
@@ -14,6 +14,8 @@ import EntityLink from '../../static/scripts/common/components/EntityLink.js';
 import bracketed from '../../static/scripts/common/utility/bracketed.js';
 import type {ReportReleaseUrlT} from '../types.js';
 
+import RemovedUrlRow from './RemovedUrlRow.js';
+
 type Props = {
   +items: $ReadOnlyArray<ReportReleaseUrlT>,
   +pager: PagerT,
@@ -37,7 +39,11 @@ const ReleaseUrlList = ({
           </tr>
         </thead>
         <tbody>
-          {items.map((item) => {
+          {items.map((item, index) => {
+            if (!item.url) {
+              return <RemovedUrlRow colSpan="3" index={index} />;
+            }
+
             lastGID = currentGID;
             currentGID = item.url.gid;
 

--- a/root/report/components/RemovedUrlRow.js
+++ b/root/report/components/RemovedUrlRow.js
@@ -1,0 +1,21 @@
+/*
+ * @flow strict
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+const RemovedUrlRow = ({
+  colSpan,
+  index,
+}: {colSpan: string, index: number}): React$Element<'tr'> => (
+  <tr className="even" key={index}>
+    <td colSpan={colSpan}>
+      {l('This URL no longer exists.')}
+    </td>
+  </tr>
+);
+
+export default RemovedUrlRow;


### PR DESCRIPTION
### Fix MBS-12211

# Problem
`UrlList` reports were working as expected when the non-URL entity was gone, but were crashing when the URL itself was gone. 

# Solution
For a case where there's no URL, there's no point on showing the entity grouping at all, so this just returns the new `RemovedUrlRow` component in those cases.

# Testing
Manually, ensuring the reported `/report/DiscogsLinksWithMultipleArtists?filter=0&page=2` page now loads:
![image_2023-05-19_152835349](https://github.com/metabrainz/musicbrainz-server/assets/1069224/3a59acfe-1169-4620-b926-f157a812b78d)
