### PR TITLE
MBS-12552 (pre): Nail last "core" Flow.js types

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -391,8 +391,7 @@
                 "extra_fks": {
                     "release_label": "label"
                 }
-            },
-            "manual": true
+            }
         },
         "report_filter": true,
         "reviews": true,

--- a/entities.mjs
+++ b/entities.mjs
@@ -418,7 +418,6 @@ const ENTITIES = {
           release_label: 'label',
         },
       },
-      manual: true,
     },
     report_filter: true,
     reviews: true,

--- a/root/components/EntityDeletionHelp.js
+++ b/root/components/EntityDeletionHelp.js
@@ -11,7 +11,7 @@ import EntityLink from '../static/scripts/common/components/EntityLink.js';
 
 type Props = {
   +children?: React$Node,
-  +entity: CoreEntityT,
+  +entity: ManuallyRemovableEntityT,
 };
 
 const EntityDeletionHelp = ({

--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -144,6 +144,7 @@ import MB from './MB.js';
   // Used by MB.entity() above to cache everything with a GID.
   MB.entityCache = {};
 
+  // This base class is actually used for relatable entity types and editor
   class CoreEntity extends Entity {
     constructor(data) {
       super(data);

--- a/root/types/area.js
+++ b/root/types/area.js
@@ -11,7 +11,7 @@
 declare type AreaT = $ReadOnly<{
   ...AnnotationRoleT,
   ...CommentRoleT,
-  ...CoreEntityRoleT<'area'>,
+  ...RelatableEntityRoleT<'area'>,
   ...DatePeriodRoleT,
   ...TypeRoleT<AreaTypeT>,
   +containment: $ReadOnlyArray<AreaT> | null,

--- a/root/types/artist.js
+++ b/root/types/artist.js
@@ -11,7 +11,7 @@
 declare type ArtistT = $ReadOnly<{
   ...AnnotationRoleT,
   ...CommentRoleT,
-  ...CoreEntityRoleT<'artist'>,
+  ...RelatableEntityRoleT<'artist'>,
   ...DatePeriodRoleT,
   ...IpiCodesRoleT,
   ...IsniCodesRoleT,

--- a/root/types/entity.js
+++ b/root/types/entity.js
@@ -60,7 +60,7 @@ declare type CommentRoleT = {
   +comment: string,
 };
 
-declare type CoreEntityRoleT<+T> = {
+declare type RelatableEntityRoleT<+T> = {
   ...EntityRoleT<T>,
   ...LastUpdateRoleT,
   +gid: string,

--- a/root/types/entity.js
+++ b/root/types/entity.js
@@ -97,42 +97,6 @@ declare type CollectableEntityTypeT =
   | 'series'
   | 'work';
 
-declare type NonUrlCoreEntityT =
-  | AreaT
-  | ArtistT
-  | EventT
-  | GenreT
-  | InstrumentT
-  | LabelT
-  | PlaceT
-  | RecordingT
-  | ReleaseGroupT
-  | ReleaseT
-  | SeriesT
-  | WorkT;
-
-declare type CoreEntityT =
-  | NonUrlCoreEntityT
-  | UrlT;
-
-declare type NonUrlCoreEntityTypeT =
-  | 'area'
-  | 'artist'
-  | 'event'
-  | 'genre'
-  | 'instrument'
-  | 'label'
-  | 'place'
-  | 'recording'
-  | 'release_group'
-  | 'release'
-  | 'series'
-  | 'work';
-
-declare type CoreEntityTypeT =
-  | NonUrlCoreEntityTypeT
-  | 'url';
-
 declare type EditableEntityT =
   | AreaT
   | ArtistT

--- a/root/types/entity.js
+++ b/root/types/entity.js
@@ -175,6 +175,14 @@ declare type DatePeriodRoleT = {
   +ended: boolean,
 };
 
+declare type ManuallyRemovableEntityT =
+  | AreaT
+  | GenreT
+  | InstrumentT
+  | LabelT
+  | RecordingT
+  | ReleaseT;
+
 declare type MergeableEntityT =
   | AreaT
   | ArtistT

--- a/root/types/entity.js
+++ b/root/types/entity.js
@@ -143,7 +143,6 @@ declare type ManuallyRemovableEntityT =
   | AreaT
   | GenreT
   | InstrumentT
-  | LabelT
   | RecordingT
   | ReleaseT;
 

--- a/root/types/event.js
+++ b/root/types/event.js
@@ -11,7 +11,7 @@
 declare type EventT = $ReadOnly<{
   ...AnnotationRoleT,
   ...CommentRoleT,
-  ...CoreEntityRoleT<'event'>,
+  ...RelatableEntityRoleT<'event'>,
   ...DatePeriodRoleT,
   ...RatableRoleT,
   ...ReviewableRoleT,

--- a/root/types/genre.js
+++ b/root/types/genre.js
@@ -11,6 +11,6 @@
 declare type GenreT = $ReadOnly<{
   ...AnnotationRoleT,
   ...CommentRoleT,
-  ...CoreEntityRoleT<'genre'>,
+  ...RelatableEntityRoleT<'genre'>,
   +primaryAlias?: string | null,
 }>;

--- a/root/types/instrument.js
+++ b/root/types/instrument.js
@@ -17,7 +17,7 @@ declare type InstrumentCreditsAndRelTypesRoleT = {
 declare type InstrumentT = $ReadOnly<{
   ...AnnotationRoleT,
   ...CommentRoleT,
-  ...CoreEntityRoleT<'instrument'>,
+  ...RelatableEntityRoleT<'instrument'>,
   ...TypeRoleT<InstrumentTypeT>,
   +description: string,
   +primaryAlias?: string | null,

--- a/root/types/label.js
+++ b/root/types/label.js
@@ -11,7 +11,7 @@
 declare type LabelT = $ReadOnly<{
   ...AnnotationRoleT,
   ...CommentRoleT,
-  ...CoreEntityRoleT<'label'>,
+  ...RelatableEntityRoleT<'label'>,
   ...DatePeriodRoleT,
   ...IpiCodesRoleT,
   ...IsniCodesRoleT,

--- a/root/types/place.js
+++ b/root/types/place.js
@@ -17,7 +17,7 @@ declare type CoordinatesT = {
 declare type PlaceT = $ReadOnly<{
   ...AnnotationRoleT,
   ...CommentRoleT,
-  ...CoreEntityRoleT<'place'>,
+  ...RelatableEntityRoleT<'place'>,
   ...DatePeriodRoleT,
   ...RatableRoleT,
   ...ReviewableRoleT,

--- a/root/types/recording.js
+++ b/root/types/recording.js
@@ -11,7 +11,7 @@
 declare type RecordingT = $ReadOnly<{
   ...AnnotationRoleT,
   ...CommentRoleT,
-  ...CoreEntityRoleT<'recording'>,
+  ...RelatableEntityRoleT<'recording'>,
   ...RatableRoleT,
   ...ReviewableRoleT,
   +appearsOn?: AppearancesT<{gid: string, name: string}>,

--- a/root/types/release.js
+++ b/root/types/release.js
@@ -29,7 +29,7 @@ declare type ReleaseT = $ReadOnly<{
   ...AnnotationRoleT,
   ...ArtistCreditRoleT,
   ...CommentRoleT,
-  ...CoreEntityRoleT<'release'>,
+  ...RelatableEntityRoleT<'release'>,
   +barcode: string | null,
   +combined_format_name?: string,
   +combined_track_count?: string,

--- a/root/types/releasegroup.js
+++ b/root/types/releasegroup.js
@@ -15,7 +15,7 @@ declare type ReleaseGroupT = $ReadOnly<{
   ...AnnotationRoleT,
   ...ArtistCreditRoleT,
   ...CommentRoleT,
-  ...CoreEntityRoleT<'release_group'>,
+  ...RelatableEntityRoleT<'release_group'>,
   ...RatableRoleT,
   ...ReviewableRoleT,
   ...TypeRoleT<ReleaseGroupTypeT>,

--- a/root/types/series.js
+++ b/root/types/series.js
@@ -19,7 +19,7 @@ declare type SeriesEntityTypeT =
 declare type SeriesT = $ReadOnly<{
   ...AnnotationRoleT,
   ...CommentRoleT,
-  ...CoreEntityRoleT<'series'>,
+  ...RelatableEntityRoleT<'series'>,
   ...TypeRoleT<SeriesTypeT>,
   +orderingTypeID: number,
   +primaryAlias?: string | null,

--- a/root/types/url.js
+++ b/root/types/url.js
@@ -9,7 +9,7 @@
 
 // MusicBrainz::Server::Entity::URL::TO_JSON
 declare type UrlT = {
-  ...CoreEntityRoleT<'url'>,
+  ...RelatableEntityRoleT<'url'>,
   ...PendingEditsRoleT,
   +decoded: string,
   +href_url: string,

--- a/root/types/work.js
+++ b/root/types/work.js
@@ -11,7 +11,7 @@
 declare type WorkT = $ReadOnly<{
   ...AnnotationRoleT,
   ...CommentRoleT,
-  ...CoreEntityRoleT<'work'>,
+  ...RelatableEntityRoleT<'work'>,
   ...RatableRoleT,
   ...ReviewableRoleT,
   ...TypeRoleT<WorkTypeT>,


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

In preparation for MBS-12552, a few occurrences of the generic types `Core*T` still remain.


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Finally drop these after being discussed at yesterday’s team meeting.

Also add a note to the JS class `CoreEntity` which will disappear along with knockout.js.

# Testing

Rely on CI Flow tests only.