### PR TITLE
MBS-13113: Show in attribute page if it supports free text

### DIFF
--- a/root/relationship/linkattributetype/RelationshipAttributeTypeIndex.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypeIndex.js
@@ -140,6 +140,18 @@ const RelationshipAttributeTypeIndex = ({
           ) : null}
         </p>
 
+        {attribute.creditable ? (
+          <p>
+            {l('This attribute supports free text credits')}
+          </p>
+        ) : null}
+
+        {attribute.free_text ? (
+          <p>
+            {l('This attribute uses free text values')}
+          </p>
+        ) : null}
+
         {childrenAttrs.length ? (
           <>
             <h2>{l('Possible values')}</h2>


### PR DESCRIPTION
### Implement MBS-13113


# Problem
When editing a relationship attribute such as https://musicbrainz.org/relationship-attribute/a40b43ed-2722-4b4a-98a5-478283cdf8df a relationship editor can modify two checkboxes: "This attribute supports free text credits" and "This attribute uses free text values". The value of these is not actually shown in any way in the main attribute page though AFAICT, meaning non-admins have no way of telling from the docs whether a specific attribute supports free text in any way.

# Solution
This adds lines at the bottom of the attribute description section if the attribute supports free text, with the same strings as the checkboxes themselves.

# Testing
Manually, by visiting pages for attributes with different settings: neither (`/relationship-attribute/4485dfdb-6000-4602-8b18-5f84e34d8aed`), text values (`/relationship-attribute/1fb983fb-d6c2-4fe5-b67a-d6216a3a78dd`), text credits (`http://reolappy:5000/relationship-attribute/d92884b7-ee0c-46d5-96f3-918196ba8c5b`). Not sure if there's anything that uses both at once, but the two are not dependent on each other so it should work fine anyway.

# Comment
The strings here are reused from the checkboxes and have no ending period. We might want to add a period to them even if it requires "retranslation" - if so, we should do the same on the form strings in https://github.com/metabrainz/musicbrainz-server/pull/2775 if not yet merged by then.