### PR TITLE
MBS-13105 / MBS-13106: Fix ISEs on attribute deletion pages

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Admin/Attributes.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin/Attributes.pm
@@ -1,6 +1,8 @@
 package MusicBrainz::Server::Controller::Admin::Attributes;
 use Moose;
 use namespace::autoclean;
+use utf8;
+
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
 use MusicBrainz::Server::Translation qw( l );
@@ -117,7 +119,11 @@ sub edit : Chained('attribute_base') Args(1) RequireAuth(account_admin) SecureFo
 sub delete : Chained('attribute_base') Args(1) RequireAuth(account_admin) SecureForm {
     my ($self, $c, $id) = @_;
     my $model = $c->stash->{model};
-    my $attr = $c->model($model)->get_by_id($id);
+    my $attr = $c->model($model)->get_by_id($id)
+        or $c->detach(
+            '/error_404',
+            [ "Found no attribute of type “$model” with ID “$id”." ],
+        );
     my $form = $c->form(form => 'SecureConfirm');
     $c->stash->{attribute} = $attr;
 

--- a/lib/MusicBrainz/Server/Data/Language.pm
+++ b/lib/MusicBrainz/Server/Data/Language.pm
@@ -68,7 +68,7 @@ sub find_by_code
 sub in_use {
     my ($self, $id) = @_;
     return $self->sql->select_single_value(
-        'SELECT 1 FROM release WHERE language = ? UNION SELECT 1 FROM work WHERE language = ? UNION SELECT 1 FROM editor_language WHERE language = ? LIMIT 1',
+        'SELECT 1 FROM release WHERE language = ? UNION SELECT 1 FROM work_language WHERE language = ? UNION SELECT 1 FROM editor_language WHERE language = ? LIMIT 1',
         $id, $id, $id);
 }
 

--- a/lib/MusicBrainz/Server/Data/Language.pm
+++ b/lib/MusicBrainz/Server/Data/Language.pm
@@ -72,6 +72,8 @@ sub in_use {
         $id, $id, $id);
 }
 
+sub has_children { 0 }
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/lib/MusicBrainz/Server/Data/Script.pm
+++ b/lib/MusicBrainz/Server/Data/Script.pm
@@ -57,6 +57,8 @@ sub in_use {
         $id);
 }
 
+sub has_children { 0 }
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Admin/Attributes/Delete.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Admin/Attributes/Delete.pm
@@ -1,0 +1,186 @@
+package t::MusicBrainz::Server::Controller::Admin::Attributes::Delete;
+use strict;
+use warnings;
+
+use Test::Routine;
+use Test::More;
+use MusicBrainz::Server::Test qw( html_ok );
+
+with 't::Mechanize', 't::Context';
+
+test 'Delete standard attribute (series type)' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+attributes');
+
+    $test->mech->get('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'editor', password => 'password' },
+    );
+
+    $mech->get('/admin/attributes/SeriesType/delete/1');
+    is(
+        $mech->status,
+        403,
+        'Normal user cannot access the remove script page',
+    );
+
+    $test->mech->get('/logout');
+    $test->mech->get('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'admin', password => 'password' },
+    );
+
+    $mech->get('/admin/attributes/SeriesType/delete/1');
+    html_ok($mech->content);
+    $mech->text_contains(
+      'because it is the parent of other attributes.',
+      'Series type with children attributes cannot be deleted',
+    );
+
+    $mech->get('/admin/attributes/SeriesType/delete/2');
+    html_ok($mech->content);
+    $mech->text_contains(
+      'You cannot remove the attribute "Release series" because it is still in use.',
+      'Series type in use on a series cannot be deleted',
+    );
+
+    $mech->get_ok('/admin/attributes/SeriesType/delete/47');
+    html_ok($mech->content);
+    $mech->text_contains(
+      'Are you sure you wish to remove the Release group award attribute?',
+      'The delete series type message is shown when type not in use',
+    );
+
+    note('We actually delete the type');
+    $mech->form_with_fields('confirm.submit');
+    $mech->click('confirm.submit');
+
+    $mech->get_ok('/admin/attributes/SeriesType');
+    $mech->text_lacks(
+      'Release group award',
+      'The series type has been deleted (no longer shows on the types list)',
+    );
+
+    $mech->get('/admin/attributes/SeriesType/delete/1');
+    html_ok($mech->content);
+    $mech->text_contains(
+      'Are you sure you wish to remove the Release group series attribute?',
+      'Series type which had child can be deleted now child is deleted',
+    );
+};
+
+test 'Delete language' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+attributes');
+
+    $test->mech->get('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'editor', password => 'password' },
+    );
+
+    $mech->get('/admin/attributes/Language/delete/120');
+    is(
+        $mech->status,
+        403,
+        'Normal user cannot access the remove language page',
+    );
+
+    $test->mech->get('/logout');
+    $test->mech->get('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'admin', password => 'password' },
+    );
+
+    $mech->get_ok('/admin/attributes/Language/delete/120');
+    html_ok($mech->content);
+    $mech->text_contains(
+      'You cannot remove the attribute "English" because it is still in use.',
+      'Language in use on a release cannot be deleted',
+    );
+
+    $mech->get_ok('/admin/attributes/Language/delete/27');
+    html_ok($mech->content);
+    $mech->text_contains(
+      'You cannot remove the attribute "Asturian" because it is still in use.',
+      'Language in use on a work cannot be deleted',
+    );
+
+    $mech->get_ok('/admin/attributes/Language/delete/123');
+    html_ok($mech->content);
+    $mech->text_contains(
+      'You cannot remove the attribute "Estonian" because it is still in use.',
+      'Language in use on an editor cannot be deleted',
+    );
+
+    $mech->get_ok('/admin/attributes/Language/delete/113');
+    html_ok($mech->content);
+    $mech->text_contains(
+      'Are you sure you wish to remove the Dutch attribute?',
+      'The delete language message is shown when language not in use',
+    );
+
+    note('We actually delete the language');
+    $mech->form_with_fields('confirm.submit');
+    $mech->click('confirm.submit');
+
+    $mech->get_ok('/admin/attributes/Language');
+    $mech->text_lacks(
+      'Dutch',
+      'The language has been deleted (no longer shows on the languages list)',
+    );
+};
+
+test 'Delete script' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+attributes');
+
+    $test->mech->get('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'editor', password => 'password' },
+    );
+
+    $mech->get('/admin/attributes/Script/delete/28');
+    is(
+        $mech->status,
+        403,
+        'Normal user cannot access the remove script page',
+    );
+
+    $test->mech->get('/logout');
+    $test->mech->get('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'admin', password => 'password' },
+    );
+
+    $mech->get_ok('/admin/attributes/Script/delete/28');
+    html_ok($mech->content);
+    $mech->text_contains(
+      'You cannot remove the attribute "Latin" because it is still in use.',
+      'Script in use on a release cannot be deleted',
+    );
+
+    $mech->get_ok('/admin/attributes/Script/delete/85');
+    html_ok($mech->content);
+    $mech->text_contains(
+      'Are you sure you wish to remove the Japanese attribute?',
+      'The delete script message is shown when script not in use',
+    );
+
+    note('We actually delete the script');
+    $mech->form_with_fields('confirm.submit');
+    $mech->click('confirm.submit');
+
+    $mech->get_ok('/admin/attributes/Script');
+    $mech->text_lacks(
+      'Japanese',
+      'The script has been deleted (no longer shows on the scripts list)',
+    );
+};
+
+1;

--- a/t/sql/attributes.sql
+++ b/t/sql/attributes.sql
@@ -1,0 +1,90 @@
+SET client_min_messages TO 'warning';
+
+INSERT INTO editor (
+  id, name, password, ha1,
+  email, email_confirm_date)
+VALUES (
+  1, 'editor', '{CLEARTEXT}password', '3a115bc4f05ea9856bd4611b75c80bca',
+  'foo@example.com', now());
+
+INSERT INTO editor (
+  id, name, password, ha1,
+  email, email_confirm_date, privs)
+VALUES (
+  2, 'admin', '{CLEARTEXT}password', '3a115bc4f05ea9856bd4611b75c80bca',
+  'foo@example.com', now(), 128);
+
+-- Release for language and script usage
+INSERT INTO artist (
+  begin_date_day, begin_date_month, begin_date_year, comment, area,
+  edits_pending, end_date_day, end_date_month, end_date_year, ended,
+  gender, gid, id, last_updated, name, sort_name,
+  type, begin_area, end_area
+)
+VALUES (
+  NULL, NULL, NULL, '', NULL,
+  0, NULL, NULL, NULL, '0',
+  NULL, '3088b672-fba9-4b4b-8ae0-dce13babfbb4', 11545, NULL, 'Plone', 'Plone',
+  2, NULL, NULL
+);
+
+INSERT INTO artist_credit (
+  id, artist_count, created, name,
+  ref_count, gid
+)
+VALUES (
+  11545, 1, '2011-01-18 16:24:02.551922+00', 'Plone',
+  115, '68734848-cbfb-3d65-9e0c-d4e2870650bf'
+);
+
+INSERT INTO artist_credit_name (
+  artist, artist_credit, join_phrase, name, position
+)
+VALUES (
+  11545, 11545, '', 'Plone', 0
+);
+
+INSERT INTO release_group (
+  artist_credit, comment, edits_pending, gid, id,
+  last_updated, name, type
+)
+VALUES (
+  11545, '', 0, '202cad78-a2e1-3fa7-b8bc-77c1f737e3da', 155364,
+  '2009-05-24 20:47:00.490177+00', 'For Beginner Piano', 1
+);
+
+INSERT INTO release (
+  status, release_group, edits_pending, packaging, id, quality, last_updated,
+  script, language, name, artist_credit, barcode, comment,
+  gid
+)
+VALUES (
+  1, 155364, 0, NULL, 654729, -1, '2010-02-22 02:01:29.413661+00',
+  28, 120, 'For Beginner Piano', 11545, '', '',
+  'dd66bfdd-6097-32e3-91b6-67f47ba25d4c'
+);
+
+-- Work for language usage
+INSERT INTO work (
+  id, gid, name, type, edits_pending, comment
+)
+VALUES (
+  1, '559be0c1-2c87-45d6-ba43-1b1feb8f831e', 'Danza la Xarra', 1, 0, ''
+);
+
+INSERT INTO work_language (work, language)
+VALUES (1, 27);
+
+-- Editor language usage
+INSERT INTO editor_language (editor, language, fluency)
+VALUES (1, 123, 'native');
+
+-- Series for series type usage
+INSERT INTO series (
+  id, gid, name, comment,
+  type, ordering_type, last_updated
+)
+VALUES (
+  1, 'a8749d0c-4a5a-4403-97c5-f6cd018f8e6d', 'Test Release Series', '',
+  2, 1, '2002-02-20'
+);


### PR DESCRIPTION
### Fix MBS-13105 / MBS-13106

# Problem
Trying to delete any language caused an ISE, because it was trying to check the no longer existing `language` column of the `work` table. Trying to delete any script not in use caused a different ISE (this ISE also applied to languages but was hidden there by the first one) since the code expected a non-existing `has_children` method.

# Solution
Fix the language `in_use` query to actually look at the `work_language` table. Add dummy `has_children` methods for language and script (which always return false).

# Testing
Manually, plus I added reasonably exhaustive tests for all three cases of language, script and standard attribute (the latter had no ISEs right now, but we might as well).