### PR TITLE
MBS-13111 / MBS-13116: Hide list of autoeditor election voters during vote

### DIFF
--- a/root/elections/ElectionDetails.js
+++ b/root/elections/ElectionDetails.js
@@ -22,6 +22,8 @@ type PropsT = {
 
 const ElectionDetails = ({election}: PropsT): React$MixedElement => {
   const $c = React.useContext(CatalystContext);
+  const voteCount = election.votes.length;
+  const abstainCount = voteCount - (election.yes_votes + election.no_votes);
   return (
     <>
       <h2>{l('Details')}</h2>
@@ -54,12 +56,20 @@ const ElectionDetails = ({election}: PropsT): React$MixedElement => {
           ? (
             <>
               <tr>
+                <th>{addColonText(l('Total votes'))}</th>
+                <td>{voteCount}</td>
+              </tr>
+              <tr>
                 <th>{l('Votes for:')}</th>
                 <td>{election.yes_votes}</td>
               </tr>
               <tr>
                 <th>{l('Votes against:')}</th>
                 <td>{election.no_votes}</td>
+              </tr>
+              <tr>
+                <th>{addColonText(l('Abstentions'))}</th>
+                <td>{abstainCount}</td>
               </tr>
             </>
           ) : (

--- a/root/elections/ElectionVoting.js
+++ b/root/elections/ElectionVoting.js
@@ -22,11 +22,14 @@ type PropsT = {
 
 const ElectionVoting = ({election}: PropsT): React$MixedElement => {
   const $c = React.useContext(CatalystContext);
+
   let message = exp.l(
     'To find out if you can vote for this candidate, please {url|log in}.',
     {url: '/login'},
   );
+
   const user = $c.user;
+
   if (user) {
     if (!isAutoEditor(user)) {
       message = l(
@@ -50,6 +53,11 @@ const ElectionVoting = ({election}: PropsT): React$MixedElement => {
       message = l('Voting is closed.');
     }
   }
+
+  const userVote = election.votes.find(vote => (
+    vote.voter.id === user?.id
+  ));
+
   return (
     <>
       {canSecond(election, user) ? (
@@ -65,19 +73,29 @@ const ElectionVoting = ({election}: PropsT): React$MixedElement => {
       ) : null}
       <p>
         {canVote(election, user) ? (
-          <form action={`/election/${election.id}/vote`} method="post">
-            <span className="buttons">
-              <button name="vote.vote" type="submit" value="1">
-                {l('Vote YES')}
-              </button>
-              <button name="vote.vote" type="submit" value="-1">
-                {l('Vote NO')}
-              </button>
-              <button name="vote.vote" type="submit" value="0">
-                {l('Abstain')}
-              </button>
-            </span>
-          </form>
+          <>
+            {userVote ? (
+              <p>
+                {texp.l(
+                  'Your current vote: {vote}',
+                  {vote: lp(userVote.vote_name, 'vote')},
+                )}
+              </p>
+            ) : null}
+            <form action={`/election/${election.id}/vote`} method="post">
+              <span className="buttons">
+                <button name="vote.vote" type="submit" value="1">
+                  {l('Vote YES')}
+                </button>
+                <button name="vote.vote" type="submit" value="-1">
+                  {l('Vote NO')}
+                </button>
+                <button name="vote.vote" type="submit" value="0">
+                  {l('Abstain')}
+                </button>
+              </span>
+            </form>
+          </>
         ) : message}
       </p>
       {canCancel(election, user) ? (

--- a/root/elections/Show.js
+++ b/root/elections/Show.js
@@ -32,7 +32,12 @@ const Show = ({election}: Props): React$Element<typeof Layout> | null => {
       <h2>{l('Voting')}</h2>
       <ElectionVoting election={election} />
       <h2>{l('Votes cast')}</h2>
-      <ElectionVotes election={election} />
+      {election.is_closed ? <ElectionVotes election={election} /> : (
+        <p>
+          {l(`The list of voters will only be shown
+              when the election is complete.`)}
+        </p>
+      )}
     </Layout>
   );
 };


### PR DESCRIPTION
### Fix MBS-13111 / Implement MBS-13116

# Problem
The list of who has voted and when (even if with votes marked as "Private") being shown during the voting period has no actual benefit, and the drawback of allowing people who can see the vote tally (proposer, seconders and candidate) to figure out who voted what by comparing the vote tally with the vote list repeatedly upon changes (there's 4 Yes votes, then on refresh there's 4 Yes and 1 No, clearly the latest voter voted No).

The only real usefulness I can see in showing the voter list during the election period is that it allows voters to see what they have voted in case they want to change it, so that needs to be kept somehow.

Edit: another useful point was brought up in a ticket comment: since we don't show the total number of voters nor the number of abstentions in the tally, the voter list is the only way to know the amount of Abstain votes during the vote itself.

# Solution
This hides the voters list during the election period and indicates the current vote if any of the page visitor with a line above the voting buttons.

![image_2023-06-01_141125826](https://github.com/metabrainz/musicbrainz-server/assets/1069224/946e4297-75e4-45e3-8cf9-23fd13daef90)

The second commit adds "Total votes" and "Abstentions" to the tally, which allows people with tally viewing privs to still know the number of abstentions during the vote, and makes it so people don't need to do math in general to find out those numbers:

![image_2023-06-01_151831048](https://github.com/metabrainz/musicbrainz-server/assets/1069224/08fc7d3a-16e3-4c29-8ea7-7f514062e3ad)


# Testing
Manually, by creating an election in sample data and voting on it.