### PR TITLE
MBS-13119: Readd anchor link to CDTocReleaseList

### DIFF
--- a/root/report/components/CDTocReleaseList.js
+++ b/root/report/components/CDTocReleaseList.js
@@ -40,6 +40,7 @@ const CDTocReleaseList = ({
   const columns = React.useMemo(
     () => {
       const cdTocColumn = defineCDTocColumn<ReportCDTocReleaseT>({
+        getAnchor: result => result.release?.gid ?? '',
         getCDToc: result => result.cdtoc ?? null,
       });
       const releaseColumn = defineEntityColumn<ReportCDTocReleaseT>({

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -174,6 +174,7 @@ export function defineBeginDateColumn(
 export function defineCDTocColumn<D>(
   props: {
     ...OrderableProps,
+    +getAnchor?: (D) => string,
     +getCDToc: (D) => CDTocT | null,
   },
 ): ColumnOptions<D, string> {
@@ -183,7 +184,13 @@ export function defineCDTocColumn<D>(
     Cell: ({row: {original}}) => {
       const cdToc = props.getCDToc(original);
       return (cdToc ? (
-        <CDTocLink cdToc={cdToc} />
+        <CDTocLink
+          anchorPath={
+            typeof props.getAnchor === 'function'
+              ? props.getAnchor(original)
+              : ''}
+          cdToc={cdToc}
+        />
       ) : null);
     },
     Header: (sortable


### PR DESCRIPTION
### Fix MBS-13119

# Problem
When [converting the `CDTocReleaseList` file to react-table](https://github.com/metabrainz/musicbrainz-server/commit/3b774087d2fd041c8b2ff0bb72f38a1aa4ff632b#diff-f01992fd268330fa3a22c46f93677e325f1f1e98a5a7a53742f3c41fc8966530), it seems I accidentally missed the part where it sent the `anchorPath` parameter to indicate the exact release in the disc ID page, so it currently just links to the disc ID page without any specific anchors. The anchor link was meant to help users figure out which release is the unapplied one in `/report/CDTOCNotApplied` when there's more than one.

# Solution
This re-adds the anchor link, by adding an optional `getAnchor` function that can be passed to `defineCDTocColumn`.

# Testing
Tested the anchor is now shown in the `/report/CDTOCNotApplied` page, and that the cdtoc links still work fine in the `/report/CDTOCDubiousLength` (which does not pass a `getAnchor` function to `defineCDTocColumn`).