### PR TITLE
Add static.metabrainz.org to CSP header

### DIFF
--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -692,13 +692,15 @@ sub set_csp_headers {
         'script-src',
         q('self'),
         qq('nonce-$globals_script_nonce'),
-        'staticbrainz.org'
+        'staticbrainz.org',
+        'static.metabrainz.org',
     );
 
     my @csp_style_src = (
         'style-src',
         q('self'),
         'staticbrainz.org',
+        'static.metabrainz.org',
     );
 
     my @csp_img_src = (
@@ -706,6 +708,7 @@ sub set_csp_headers {
         q('self'),
         'data:',
         'staticbrainz.org',
+        'static.metabrainz.org',
     );
 
     my @csp_frame_src = ('frame-src', q('self'));

--- a/t/lib/t/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/OAuth2.pm
@@ -91,9 +91,9 @@ sub csp_headers_ok {
     my $csp_pattern =
         q(default-src 'self'; ) .
         q(frame-ancestors 'none'; ) .
-        q(script-src 'self' 'nonce-[0-9A-Za-z\+/]{43}=' staticbrainz\.org; ) .
-        q(style-src 'self' staticbrainz\.org; ) .
-        q(img-src 'self' data: staticbrainz\.org; ) .
+        q(script-src 'self' 'nonce-[0-9A-Za-z\+/]{43}=' staticbrainz\.org static\.metabrainz\.org; ) .
+        q(style-src 'self' staticbrainz\.org static\.metabrainz\.org; ) .
+        q(img-src 'self' data: staticbrainz\.org static\.metabrainz\.org; ) .
         q(frame-src 'self');
     like($response->header('Content-Security-Policy'), qr{^$csp_pattern$});
 }


### PR DESCRIPTION
staticbrainz.org now redirects to static.metabrainz.org, which breaks CSP on "secure" forms (e.g. the login page). A side effect of that is that CSS, JS, and images can't load on these pages without fixing the header.

This doesn't adjust any irombook code for now.  As part of merging this, we should also update docker-server-configs to use `static.metabrainz.org` for `STATIC_RESOURCES_LOCATION`; but for now both domains are whitelisted in the header so that either case works while the configuration is being updated.