### PR TITLE
MBS-13100: Readd beginner voting restrictions

### DIFF
--- a/lib/MusicBrainz/Server/Data/Vote.pm
+++ b/lib/MusicBrainz/Server/Data/Vote.pm
@@ -51,7 +51,7 @@ sub enter_votes
     Sql::run_in_transaction(sub {
         $self->sql->do('LOCK vote IN SHARE ROW EXCLUSIVE MODE');
 
-        # Deal with votes on closed or own edits, by blocked users, etc.
+        # Deal with votes on closed or own edits, by blocked/beginner users, etc.
         my @edit_ids = map { $_->{edit_id} } @votes;
         my $edits = $self->c->model('Edit')->get_by_ids(@edit_ids);
         @votes = grep { defined $edits->{ $_->{edit_id} } } @votes;

--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -108,6 +108,7 @@ sub may_vote {
     my $self = shift;
 
     return $self->has_confirmed_email_address &&
+           !$self->is_limited &&
            !$self->is_bot &&
            $self->is_editing_enabled;
 }

--- a/root/utility/edit.js
+++ b/root/utility/edit.js
@@ -187,6 +187,7 @@ export function editorMayVote(
 ): boolean {
   return (
     !!editor &&
+    !editor.is_limited &&
     nonEmpty(editor.email_confirmation_date) &&
     !isBot(editor) &&
     isEditingEnabled(editor)

--- a/t/lib/t/MusicBrainz/Server/Controller/Edit/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Edit/Show.pm
@@ -108,6 +108,33 @@ test 'Check edit page differences for editor without confirmed email' => sub {
     );
 };
 
+test 'Check edit page differences for beginner editor' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $edit = prepare($test);
+
+    $mech->get_ok('/login');
+    $mech->submit_form( with_fields => {
+        username => 'editor6',
+        password => 'pass',
+    } );
+
+    $mech->get_ok(
+        '/edit/' . $edit->id,
+        'Fetched edit page as a beginner editor other than the edit author',
+    );
+    html_ok($mech->content);
+
+    $mech->content_contains(
+        'Submit note',
+        'The edit page contains the button to add an edit note',
+    );
+    $mech->content_contains(
+        'You are not currently able to vote on this edit',
+        'The message about not being able to vote is present',
+    );
+};
+
 test 'Check edit page differences when logged out' => sub {
     my $test = shift;
     my $mech = $test->mech;

--- a/t/lib/t/MusicBrainz/Server/Data/EditNote.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/EditNote.pm
@@ -60,7 +60,6 @@ test 'Loading existing notes' => sub {
         ),
     );
 
-
     note('Check edit that should have one note');
     $edit = $c->model('Edit')->get_by_id(2);
     $c->model('EditNote')->load_for_edits($edit);

--- a/t/lib/t/MusicBrainz/Server/Data/EditNote.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/EditNote.pm
@@ -89,16 +89,17 @@ test 'Adding edit notes works and sends emails' => sub {
     my $editor2 = $c->model('Editor')->get_by_id(2);
 
     my $edit = $c->model('Edit')->get_by_id(3);
+    my $edit_id = $edit->id;
 
     # We make editor2 vote so they will receive mail too on an edit note
     $c->model('Vote')->enter_votes(
         $editor2,
-        [{ edit_id => $edit->id, vote => 1 }],
+        [{ edit_id => $edit_id, vote => 1 }],
     );
 
     note('editor3 enters a note');
     $c->model('EditNote')->add_note(
-        $edit->id,
+        $edit_id,
         { text => 'This is my note!', editor_id => 3 },
     );
 
@@ -124,7 +125,7 @@ test 'Adding edit notes works and sends emails' => sub {
     note('Checking email sent to editor1 (edit creator)');
     is(
         $email->get_header('Subject'),
-        'Note added to your edit #' . $edit->id,
+        'Note added to your edit #' . $edit_id,
         'Subject explains a note was added to edit',
     );
     is(
@@ -135,7 +136,7 @@ test 'Adding edit notes works and sends emails' => sub {
     my $email_body = $email->object->body_str;
     like(
         $email_body,
-        qr{$server/edit/${\ $edit->id }},
+        qr{$server/edit/$edit_id},
         'Email body contains edit url',
     );
     like(
@@ -145,7 +146,7 @@ test 'Adding edit notes works and sends emails' => sub {
     );
     like(
         $email_body,
-        qr{to your edit #${\ $edit->id }},
+        qr{to your edit #$edit_id},
         'Email body mentions "your edit #"',
     );
     like(
@@ -157,7 +158,7 @@ test 'Adding edit notes works and sends emails' => sub {
     note('Checking email sent to editor2 (voter)');
     is(
         $email2->get_header('Subject'),
-        'Note added to edit #' . $edit->id,
+        'Note added to edit #' . $edit_id,
         'Subject explains a note was added to edit',
     );
     is(
@@ -168,7 +169,7 @@ test 'Adding edit notes works and sends emails' => sub {
     my $email2_body = $email2->object->body_str;
     like(
         $email2_body,
-        qr{$server/edit/${\ $edit->id }},
+        qr{$server/edit/$edit_id},
         'Email body contains edit url',
     );
     like(
@@ -178,7 +179,7 @@ test 'Adding edit notes works and sends emails' => sub {
     );
     like(
         $email2_body,
-        qr{to edit #${\ $edit->id }},
+        qr{to edit #$edit_id},
         'Email body mentions "edit #" (not "your edit")',
     );
     like(

--- a/t/lib/t/MusicBrainz/Server/Data/EditNote.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/EditNote.pm
@@ -15,6 +15,8 @@ use MusicBrainz::Server::Data::EditNote;
 use MusicBrainz::Server::Email;
 use MusicBrainz::Server::Test;
 
+with 't::Context';
+
 BEGIN {
     package MockEdit;
     use Moose;
@@ -24,102 +26,126 @@ BEGIN {
     sub edit_name { 'mock edit' }
 };
 
-with 't::Context';
-
-test all => sub {
-
-my $test = shift;
-MusicBrainz::Server::Test->prepare_test_database($test->c, '+edit_note');
-
 use MusicBrainz::Server::EditRegistry;
 MusicBrainz::Server::EditRegistry->register_type('MockEdit');
 
-my $edit_data = MusicBrainz::Server::Data::Edit->new(c => $test->c);
-my $en_data = MusicBrainz::Server::Data::EditNote->new(c => $test->c);
-my $editor_data = MusicBrainz::Server::Data::Editor->new(c => $test->c);
+test 'Loading existing notes' => sub {
+    my $test = shift;
+    my $c = $test->c;
 
-my $editor2 = $editor_data->get_by_id(2);
+    MusicBrainz::Server::Test->prepare_test_database($c, '+edit_note');
 
-# Multiple edit edit_notes
-my $edit = $edit_data->get_by_id(1);
-$en_data->load_for_edits($edit);
-is(@{ $edit->edit_notes }, 2, 'Edit has two edit notes');
-check_note($edit->edit_notes->[0], 'MusicBrainz::Server::Entity::EditNote',
-       editor_id => 1,
-       edit_id => 1,
-       text => 'This is a note');
+    my $edit_data = MusicBrainz::Server::Data::Edit->new(c => $test->c);
+    my $en_data = MusicBrainz::Server::Data::EditNote->new(c => $test->c);
+    my $editor_data = MusicBrainz::Server::Data::Editor->new(c => $test->c);
 
-check_note($edit->edit_notes->[1], 'MusicBrainz::Server::Entity::EditNote',
-       editor_id => 2,
-       edit_id => 1,
-       text => 'This is a later note');
+    note('Check edit that should have two notes');
+    my $edit = $edit_data->get_by_id(1);
+    $en_data->load_for_edits($edit);
+    is(@{ $edit->edit_notes }, 2, 'Edit has two edit notes');
+    check_note(
+        $edit->edit_notes->[0],
+        'MusicBrainz::Server::Entity::EditNote',
+        (
+            editor_id => 1,
+            edit_id => 1,
+            text => 'This is a note',
+        ),
+    );
 
-
-# Single edit note
-$edit = $edit_data->get_by_id(2);
-$en_data->load_for_edits($edit);
-is(@{ $edit->edit_notes }, 1, 'Edit has one edit note');
-check_note($edit->edit_notes->[0], 'MusicBrainz::Server::Entity::EditNote',
-       editor_id => 1,
-       edit_id => 2,
-       text => 'Another edit note');
-
-# No edit edit_notes
-$edit = $edit_data->get_by_id(3);
-$en_data->load_for_edits($edit);
-is(@{ $edit->edit_notes }, 0, 'Edit has no edit notes');
-
-# Insert a new edit note
-$en_data->insert($edit->id, {
-        editor_id => 3,
-        text => 'This is a new edit note',
-    });
+    check_note(
+        $edit->edit_notes->[1],
+        'MusicBrainz::Server::Entity::EditNote',
+        (
+            editor_id => 2,
+            edit_id => 1,
+            text => 'This is a later note',
+        ),
+    );
 
 
-$en_data->load_for_edits($edit);
-is(@{ $edit->edit_notes }, 1, 'Edit has one edit note');
-check_note($edit->edit_notes->[0], 'MusicBrainz::Server::Entity::EditNote',
-        editor_id => 3,
-        edit_id => 3,
-        text => 'This is a new edit note');
+    note('Check edit that should have one note');
+    $edit = $edit_data->get_by_id(2);
+    $en_data->load_for_edits($edit);
+    is(@{ $edit->edit_notes }, 1, 'Edit has one edit note');
+    check_note(
+        $edit->edit_notes->[0],
+        'MusicBrainz::Server::Entity::EditNote',
+        (
+            editor_id => 1,
+            edit_id => 2,
+            text => 'Another edit note',
+        ),
+    );
 
-# Make sure we can insert edit notes while already in a transaction
-$test->c->sql->begin;
-lives_ok {
+    note('Check edit that should have zero notes');
+    $edit = $edit_data->get_by_id(3);
+    $en_data->load_for_edits($edit);
+    is(@{ $edit->edit_notes }, 0, 'Edit has no edit notes');
+};
+
+test 'Adding edit notes' => sub {
+    my $test = shift;
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+edit_note');
+
+    my $edit_data = MusicBrainz::Server::Data::Edit->new(c => $test->c);
+    my $en_data = MusicBrainz::Server::Data::EditNote->new(c => $test->c);
+    my $editor_data = MusicBrainz::Server::Data::Editor->new(c => $test->c);
+
+    my $editor2 = $editor_data->get_by_id(2);
+
+    my $edit = $edit_data->get_by_id(3);
+
+    # Insert a new edit note
     $en_data->insert($edit->id, {
             editor_id => 3,
-            text => 'Note' })
-} q(Edit notes don't die while in a transaction already);
-$test->c->sql->commit;
+            text => 'This is a new edit note',
+        });
 
-# Test adding edit notes with email sending
-$test->c->model('Vote')->enter_votes($editor2, [{ edit_id => $edit->id, vote => 1 }]);
 
-$en_data->add_note($edit->id, { text => 'This is my note!', editor_id => 3 });
+    $en_data->load_for_edits($edit);
+    is(@{ $edit->edit_notes }, 1, 'Edit has one edit note');
+    check_note($edit->edit_notes->[0], 'MusicBrainz::Server::Entity::EditNote',
+            editor_id => 3,
+            edit_id => 3,
+            text => 'This is a new edit note');
 
-my $server = 'https://' . DBDefs->WEB_SERVER_USED_IN_EMAIL;
-my $email_transport = MusicBrainz::Server::Email->get_test_transport;
-is($email_transport->delivery_count, 2, 'Exactly two emails sent');
+    # Make sure we can insert edit notes while already in a transaction
+    $test->c->sql->begin;
+    lives_ok {
+        $en_data->insert($edit->id, {
+                editor_id => 3,
+                text => 'Note' })
+    } q(Edit notes don't die while in a transaction already);
+    $test->c->sql->commit;
 
-my $email2 = $email_transport->shift_deliveries->{email};
-my $email = $email_transport->shift_deliveries->{email};
+    # Test adding edit notes with email sending
+    $test->c->model('Vote')->enter_votes($editor2, [{ edit_id => $edit->id, vote => 1 }]);
 
-is($email->get_header('Subject'), 'Note added to your edit #' . $edit->id, 'Subject explains a note was added to edit');
-is($email->get_header('To'), '"editor1" <editor1@example.com>', 'Email is addressed to editor1');
-my $email_body = $email->object->body_str;
-like($email_body, qr{$server/edit/${\ $edit->id }}, 'Email body contains edit url');
-like($email_body, qr{'editor3' has added}, 'Email body mentions editor3');
-like($email_body, qr{to your edit #${\ $edit->id }}, 'Email body mentions "your edit #"');
-like($email_body, qr{This is my note!}, 'Email body has correct edit note text');
+    $en_data->add_note($edit->id, { text => 'This is my note!', editor_id => 3 });
 
-is($email2->get_header('Subject'), 'Note added to edit #' . $edit->id, 'Subject explains a note was added to edit');
-is($email2->get_header('To'), '"editor2" <editor2@example.com>', 'Email is addressed to editor2');
-my $email2_body = $email2->object->body_str;
-like($email2_body, qr{$server/edit/${\ $edit->id }}, 'Email body contains edit url');
-like($email2_body, qr{'editor3' has added}, 'Email body mentions editor3');
-like($email2_body, qr{to edit #${\ $edit->id }}, 'Email body mentions "edit #"');
-like($email2_body, qr{This is my note!}, 'Email body has correct edit note text');
+    my $server = 'https://' . DBDefs->WEB_SERVER_USED_IN_EMAIL;
+    my $email_transport = MusicBrainz::Server::Email->get_test_transport;
+    is($email_transport->delivery_count, 2, 'Exactly two emails sent');
 
+    my $email2 = $email_transport->shift_deliveries->{email};
+    my $email = $email_transport->shift_deliveries->{email};
+
+    is($email->get_header('Subject'), 'Note added to your edit #' . $edit->id, 'Subject explains a note was added to edit');
+    is($email->get_header('To'), '"editor1" <editor1@example.com>', 'Email is addressed to editor1');
+    my $email_body = $email->object->body_str;
+    like($email_body, qr{$server/edit/${\ $edit->id }}, 'Email body contains edit url');
+    like($email_body, qr{'editor3' has added}, 'Email body mentions editor3');
+    like($email_body, qr{to your edit #${\ $edit->id }}, 'Email body mentions "your edit #"');
+    like($email_body, qr{This is my note!}, 'Email body has correct edit note text');
+
+    is($email2->get_header('Subject'), 'Note added to edit #' . $edit->id, 'Subject explains a note was added to edit');
+    is($email2->get_header('To'), '"editor2" <editor2@example.com>', 'Email is addressed to editor2');
+    my $email2_body = $email2->object->body_str;
+    like($email2_body, qr{$server/edit/${\ $edit->id }}, 'Email body contains edit url');
+    like($email2_body, qr{'editor3' has added}, 'Email body mentions editor3');
+    like($email2_body, qr{to edit #${\ $edit->id }}, 'Email body mentions "edit #"');
+    like($email2_body, qr{This is my note!}, 'Email body has correct edit note text');
 };
 
 test 'delete_content' => sub {

--- a/t/lib/t/MusicBrainz/Server/Data/Vote.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Vote.pm
@@ -125,25 +125,25 @@ test 'Email on first no vote' => sub {
         $editor2,
         [{ edit_id => $edit_id, vote => $VOTE_YES }],
     );
-    is($email_transport->delivery_count, 0, 'yes vote sends no email');
+    is($email_transport->delivery_count, 0, 'Yes vote sends no email');
 
     $c->model('Vote')->enter_votes(
         $editor2,
         [{ edit_id => $edit_id, vote => $VOTE_NO }],
     );
-    is($email_transport->delivery_count, 1, 'first no vote sends email');
+    is($email_transport->delivery_count, 1, 'First No vote sends email');
 
     $c->model('Vote')->enter_votes(
         $editor3,
         [{ edit_id => $edit_id, vote => $VOTE_NO }],
     );
-    is($email_transport->delivery_count, 1, 'second no vote sends no email');
+    is($email_transport->delivery_count, 1, 'Second No vote sends no email');
 
     $c->model('Vote')->enter_votes(
         $editor2,
         [{ edit_id => $edit_id, vote => $VOTE_YES }],
     );
-    is($email_transport->delivery_count, 1, 'yes vote sends no email');
+    is($email_transport->delivery_count, 1, 'Second Yes vote sends no email');
     $c->model('Vote')->enter_votes(
         $editor3,
         [{ edit_id => $edit_id, vote => $VOTE_YES }],
@@ -151,7 +151,7 @@ test 'Email on first no vote' => sub {
     is(
         $email_transport->delivery_count,
         1,
-        'changing no vote to yes vote sends no email',
+        'Changing No vote to Yes vote sends no email',
     );
 
     $c->model('Vote')->enter_votes(
@@ -161,24 +161,24 @@ test 'Email on first no vote' => sub {
     is(
         $email_transport->delivery_count,
         2,
-        'new no vote bringing count from 0 to 1 sends an email',
+        'New No vote bringing count from 0 to 1 sends an email',
     );
 
     my $email = $email_transport->shift_deliveries->{email};
     is(
         $email->get_header('Subject'),
         "Someone has voted against your edit #$edit_id",
-        'Subject explains someone has voted against your edit',
+        'Email subject explains someone has voted against your edit',
     );
     is(
         $email->get_header('References'),
         sprintf('<edit-%d@%s>', $edit_id, DBDefs->WEB_SERVER_USED_IN_EMAIL),
-        'References header contains edit id',
+        'Email’s References header contains edit id',
     );
     is(
         $email->get_header('To'),
         '"editor1" <editor1@example.com>',
-        'To header contains editor email',
+        'Email’s To header contains editor email',
     );
 
     my $server = DBDefs->WEB_SERVER_USED_IN_EMAIL;
@@ -186,9 +186,9 @@ test 'Email on first no vote' => sub {
     like(
         $email_body,
         qr{https://$server/edit/${\ $edit_id }},
-        'body contains link to edit',
+        'Email body contains link to edit',
     );
-    like($email_body, qr{'editor2'}, 'body mentions editor2');
+    like($email_body, qr{'editor2'}, 'Email body mentions editor2');
 };
 
 test 'Extend expiration on first no vote' => sub {

--- a/t/lib/t/MusicBrainz/Server/Data/Vote.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Vote.pm
@@ -37,26 +37,27 @@ test 'Email on first no vote' => sub {
         edit_type => 4242,
         foo => 'bar',
     );
+    my $edit_id = $edit->id;
 
     my $email_transport = MusicBrainz::Server::Email->get_test_transport;
     my $editor2 = $c->model('Editor')->get_by_id(2);
     my $editor3 = $c->model('Editor')->get_by_id(3);
 
-    $c->model('Vote')->enter_votes($editor2, [{ edit_id => $edit->id, vote => $VOTE_YES }]);
+    $c->model('Vote')->enter_votes($editor2, [{ edit_id => $edit_id, vote => $VOTE_YES }]);
     is($email_transport->delivery_count, 0, 'yes vote sends no email');
 
-    $c->model('Vote')->enter_votes($editor2, [{ edit_id => $edit->id, vote => $VOTE_NO }]);
+    $c->model('Vote')->enter_votes($editor2, [{ edit_id => $edit_id, vote => $VOTE_NO }]);
     is($email_transport->delivery_count, 1, 'first no vote sends email');
 
-    $c->model('Vote')->enter_votes($editor3, [{ edit_id => $edit->id, vote => $VOTE_NO }]);
+    $c->model('Vote')->enter_votes($editor3, [{ edit_id => $edit_id, vote => $VOTE_NO }]);
     is($email_transport->delivery_count, 1, 'second no vote sends no email');
 
-    $c->model('Vote')->enter_votes($editor2, [{ edit_id => $edit->id, vote => $VOTE_YES }]);
+    $c->model('Vote')->enter_votes($editor2, [{ edit_id => $edit_id, vote => $VOTE_YES }]);
     is($email_transport->delivery_count, 1, 'yes vote sends no email');
-    $c->model('Vote')->enter_votes($editor3, [{ edit_id => $edit->id, vote => $VOTE_YES }]);
+    $c->model('Vote')->enter_votes($editor3, [{ edit_id => $edit_id, vote => $VOTE_YES }]);
     is($email_transport->delivery_count, 1, 'yes vote sends no email');
 
-    $c->model('Vote')->enter_votes($editor2, [{ edit_id => $edit->id, vote => $VOTE_NO }]);
+    $c->model('Vote')->enter_votes($editor2, [{ edit_id => $edit_id, vote => $VOTE_NO }]);
     is($email_transport->delivery_count, 2, 'new no vote bringing count from 0 to 1 sends an email');
 };
 
@@ -71,25 +72,26 @@ test 'Extend expiration on first no vote' => sub {
         edit_type => 4242,
         foo => 'bar',
     );
+    my $edit_id = $edit->id;
 
     $c->sql->do(
         q(UPDATE edit SET expire_time = NOW() + interval '20 hours' WHERE id = ?),
-        $edit->id
+        $edit_id
     );
 
     my $expected_expire_time = DateTime::Format::Pg->parse_datetime(
         $c->sql->select_single_value(q(SELECT NOW() + interval '72 hours';)));
     my $expire_time = DateTime::Format::Pg->parse_datetime(
-        $c->sql->select_single_value('SELECT expire_time FROM edit WHERE id = ?', $edit->id));
+        $c->sql->select_single_value('SELECT expire_time FROM edit WHERE id = ?', $edit_id));
     is(DateTime->compare($expire_time, $expected_expire_time), -1,
                          q(edit's expiration time is less than 72 hours));
 
     my $editor2 = $c->model('Editor')->get_by_id(2);
 
-    $c->model('Vote')->enter_votes($editor2, [{ edit_id => $edit->id, vote => $VOTE_NO }]);
+    $c->model('Vote')->enter_votes($editor2, [{ edit_id => $edit_id, vote => $VOTE_NO }]);
 
     $expire_time = DateTime::Format::Pg->parse_datetime(
-        $c->sql->select_single_value('SELECT expire_time FROM edit WHERE id = ?', $edit->id));
+        $c->sql->select_single_value('SELECT expire_time FROM edit WHERE id = ?', $edit_id));
     is($expire_time, $expected_expire_time, q(edit's expiration was extended by the no vote));
 };
 
@@ -107,32 +109,32 @@ my $edit = $c->model('Edit')->create(
     edit_type => 4242,
     foo => 'bar',
 );
+my $edit_id = $edit->id;
 
 my $editor1 = $c->model('Editor')->get_by_id(1);
 my $editor2 = $c->model('Editor')->get_by_id(2);
 my $editor3 = $c->model('Editor')->get_by_id(3);
 
 # Test voting on an edit
-$vote_data->enter_votes($editor2, [{ edit_id => $edit->id, vote => $VOTE_NO }]);
-$vote_data->enter_votes($editor2, [{ edit_id => $edit->id, vote => $VOTE_YES }]);
-$vote_data->enter_votes($editor2, [{ edit_id => $edit->id, vote => $VOTE_ABSTAIN }]);
-$vote_data->enter_votes($editor2, [{ edit_id => $edit->id, vote => $VOTE_YES }]);
+$vote_data->enter_votes($editor2, [{ edit_id => $edit_id, vote => $VOTE_NO }]);
+$vote_data->enter_votes($editor2, [{ edit_id => $edit_id, vote => $VOTE_YES }]);
+$vote_data->enter_votes($editor2, [{ edit_id => $edit_id, vote => $VOTE_ABSTAIN }]);
+$vote_data->enter_votes($editor2, [{ edit_id => $edit_id, vote => $VOTE_YES }]);
 
 my $email_transport = MusicBrainz::Server::Email->get_test_transport;
 is($email_transport->delivery_count, 1);
 
-my $edit_id = $edit->id;
 my $email = $email_transport->shift_deliveries->{email};
 is($email->get_header('Subject'), "Someone has voted against your edit #$edit_id", 'Subject explains someone has voted against your edit');
-is($email->get_header('References'), sprintf('<edit-%d@%s>', $edit->id, DBDefs->WEB_SERVER_USED_IN_EMAIL), 'References header contains edit id');
+is($email->get_header('References'), sprintf('<edit-%d@%s>', $edit_id, DBDefs->WEB_SERVER_USED_IN_EMAIL), 'References header contains edit id');
 is($email->get_header('To'), '"editor1" <editor1@example.com>', 'To header contains editor email');
 
 my $server = DBDefs->WEB_SERVER_USED_IN_EMAIL;
 my $email_body = $email->object->body_str;
-like($email_body, qr{https://$server/edit/${\ $edit->id }}, 'body contains link to edit');
+like($email_body, qr{https://$server/edit/$edit_id}, 'body contains link to edit');
 like($email_body, qr{'editor2'}, 'body mentions editor2');
 
-$edit = $c->model('Edit')->get_by_id($edit->id);
+$edit = $c->model('Edit')->get_by_id($edit_id);
 $vote_data->load_for_edits($edit);
 
 is(scalar @{ $edit->votes }, 4);
@@ -146,8 +148,8 @@ is($edit->votes->[3]->superseded, 0);
 is($edit->votes->[$_]->editor_id, 2) for 0..3;
 
 # Make sure the person who created an edit cannot vote
-$vote_data->enter_votes($editor1, [{ edit_id => $edit->id, vote => $VOTE_NO }]);
-$edit = $c->model('Edit')->get_by_id($edit->id);
+$vote_data->enter_votes($editor1, [{ edit_id => $edit_id, vote => $VOTE_NO }]);
+$edit = $c->model('Edit')->get_by_id($edit_id);
 $vote_data->load_for_edits($edit);
 is($email_transport->delivery_count, 0);
 
@@ -155,28 +157,28 @@ is(scalar @{ $edit->votes }, 4);
 is($edit->votes->[$_]->editor_id, 2) for 0..3;
 
 # Check the vote counts
-$edit = $c->model('Edit')->get_by_id($edit->id);
+$edit = $c->model('Edit')->get_by_id($edit_id);
 $vote_data->load_for_edits($edit);
 is($edit->yes_votes, 1);
 is($edit->no_votes, 0);
 
-$vote_data->enter_votes($editor2, [{ edit_id => $edit->id, vote => $VOTE_ABSTAIN }]);
-$edit = $c->model('Edit')->get_by_id($edit->id);
+$vote_data->enter_votes($editor2, [{ edit_id => $edit_id, vote => $VOTE_ABSTAIN }]);
+$edit = $c->model('Edit')->get_by_id($edit_id);
 is($edit->yes_votes, 0);
 is($edit->no_votes, 0);
 
 # Make sure *new* no-votes against result in an email being sent
-$vote_data->enter_votes($editor2, [{ edit_id => $edit->id, vote => $VOTE_NO }]);
+$vote_data->enter_votes($editor2, [{ edit_id => $edit_id, vote => $VOTE_NO }]);
 is($email_transport->delivery_count, 1, 'no-vote count 0-1 results in email');
 
 # but that ones that just add extra no-votes don't send any
-$vote_data->enter_votes($editor3, [{ edit_id => $edit->id, vote => $VOTE_NO }]);
+$vote_data->enter_votes($editor3, [{ edit_id => $edit_id, vote => $VOTE_NO }]);
 is($email_transport->delivery_count, 1, 'no-vote count 1-2 does not result in additional email');
 
 # Entering invalid votes doesn't do anything
 $vote_data->load_for_edits($edit);
 my $old_count = @{ $edit->votes };
-$vote_data->enter_votes($editor2, [{ edit_id => $edit->id, vote => 123 }]);
+$vote_data->enter_votes($editor2, [{ edit_id => $edit_id, vote => 123 }]);
 is(@{ $edit->votes }, $old_count, 'vote count should not have changed');
 };
 

--- a/t/lib/t/MusicBrainz/Server/Data/Vote.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Vote.pm
@@ -30,9 +30,9 @@ test 'Email on first no vote' => sub {
     my $test = shift;
     my $c = $test->c;
 
-    MusicBrainz::Server::Test->prepare_test_database($test->c, '+vote');
+    MusicBrainz::Server::Test->prepare_test_database($c, '+vote');
 
-    my $edit = $test->c->model('Edit')->create(
+    my $edit = $c->model('Edit')->create(
         editor_id => 1,
         edit_type => 4242,
         foo => 'bar',
@@ -64,9 +64,9 @@ test 'Extend expiration on first no vote' => sub {
     my $test = shift;
     my $c = $test->c;
 
-    MusicBrainz::Server::Test->prepare_test_database($test->c, '+vote');
+    MusicBrainz::Server::Test->prepare_test_database($c, '+vote');
 
-    my $edit = $test->c->model('Edit')->create(
+    my $edit = $c->model('Edit')->create(
         editor_id => 1,
         edit_type => 4242,
         foo => 'bar',
@@ -96,19 +96,21 @@ test 'Extend expiration on first no vote' => sub {
 test all => sub {
 
 my $test = shift;
-MusicBrainz::Server::Test->prepare_test_database($test->c, '+vote');
+my $c = $test->c;
 
-my $vote_data = $test->c->model('Vote');
+MusicBrainz::Server::Test->prepare_test_database($c, '+vote');
 
-my $edit = $test->c->model('Edit')->create(
+my $vote_data = $c->model('Vote');
+
+my $edit = $c->model('Edit')->create(
     editor_id => 1,
     edit_type => 4242,
     foo => 'bar',
 );
 
-my $editor1 = $test->c->model('Editor')->get_by_id(1);
-my $editor2 = $test->c->model('Editor')->get_by_id(2);
-my $editor3 = $test->c->model('Editor')->get_by_id(3);
+my $editor1 = $c->model('Editor')->get_by_id(1);
+my $editor2 = $c->model('Editor')->get_by_id(2);
+my $editor3 = $c->model('Editor')->get_by_id(3);
 
 # Test voting on an edit
 $vote_data->enter_votes($editor2, [{ edit_id => $edit->id, vote => $VOTE_NO }]);
@@ -130,7 +132,7 @@ my $email_body = $email->object->body_str;
 like($email_body, qr{https://$server/edit/${\ $edit->id }}, 'body contains link to edit');
 like($email_body, qr{'editor2'}, 'body mentions editor2');
 
-$edit = $test->c->model('Edit')->get_by_id($edit->id);
+$edit = $c->model('Edit')->get_by_id($edit->id);
 $vote_data->load_for_edits($edit);
 
 is(scalar @{ $edit->votes }, 4);
@@ -145,7 +147,7 @@ is($edit->votes->[$_]->editor_id, 2) for 0..3;
 
 # Make sure the person who created an edit cannot vote
 $vote_data->enter_votes($editor1, [{ edit_id => $edit->id, vote => $VOTE_NO }]);
-$edit = $test->c->model('Edit')->get_by_id($edit->id);
+$edit = $c->model('Edit')->get_by_id($edit->id);
 $vote_data->load_for_edits($edit);
 is($email_transport->delivery_count, 0);
 
@@ -153,13 +155,13 @@ is(scalar @{ $edit->votes }, 4);
 is($edit->votes->[$_]->editor_id, 2) for 0..3;
 
 # Check the vote counts
-$edit = $test->c->model('Edit')->get_by_id($edit->id);
+$edit = $c->model('Edit')->get_by_id($edit->id);
 $vote_data->load_for_edits($edit);
 is($edit->yes_votes, 1);
 is($edit->no_votes, 0);
 
 $vote_data->enter_votes($editor2, [{ edit_id => $edit->id, vote => $VOTE_ABSTAIN }]);
-$edit = $test->c->model('Edit')->get_by_id($edit->id);
+$edit = $c->model('Edit')->get_by_id($edit->id);
 is($edit->yes_votes, 0);
 is($edit->no_votes, 0);
 

--- a/t/lib/t/MusicBrainz/Server/Data/Vote.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Vote.pm
@@ -33,8 +33,6 @@ test 'Basic voting behaviour' => sub {
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+vote');
 
-    my $vote_data = $c->model('Vote');
-
     my $edit = $c->model('Edit')->create(
         editor_id => 1,
         edit_type => 4242,
@@ -45,25 +43,25 @@ test 'Basic voting behaviour' => sub {
     my $editor2 = $c->model('Editor')->get_by_id(2);
 
     note('editor2 enters 4 votes: No -> Yes -> Abstain -> Yes');
-    $vote_data->enter_votes(
+    $c->model('Vote')->enter_votes(
         $editor2,
         [{ edit_id => $edit_id, vote => $VOTE_NO }],
     );
-    $vote_data->enter_votes(
+    $c->model('Vote')->enter_votes(
         $editor2,
         [{ edit_id => $edit_id, vote => $VOTE_YES }],
     );
-    $vote_data->enter_votes(
+    $c->model('Vote')->enter_votes(
         $editor2,
         [{ edit_id => $edit_id, vote => $VOTE_ABSTAIN }],
     );
-    $vote_data->enter_votes(
+    $c->model('Vote')->enter_votes(
         $editor2,
         [{ edit_id => $edit_id, vote => $VOTE_YES }],
     );
 
     $edit = $c->model('Edit')->get_by_id($edit_id);
-    $vote_data->load_for_edits($edit);
+    $c->model('Vote')->load_for_edits($edit);
 
     is(scalar @{ $edit->votes }, 4, 'There are 4 votes on the edit');
     is($edit->votes->[0]->vote, $VOTE_NO, 'Vote 1 is a No');
@@ -90,12 +88,12 @@ test 'Basic voting behaviour' => sub {
 
     # Check the vote counts
     $edit = $c->model('Edit')->get_by_id($edit_id);
-    $vote_data->load_for_edits($edit);
+    $c->model('Vote')->load_for_edits($edit);
     is($edit->yes_votes, 1, 'There is 1 Yes vote');
     is($edit->no_votes, 0, 'There are 0 No votes');
 
     note('editor2 now abstains again');
-    $vote_data->enter_votes(
+    $c->model('Vote')->enter_votes(
         $editor2,
         [{ edit_id => $edit_id, vote => $VOTE_ABSTAIN }],
     );

--- a/t/sql/edit_note.sql
+++ b/t/sql/edit_note.sql
@@ -3,7 +3,10 @@ SET client_min_messages TO 'warning';
 INSERT INTO editor (id, name, password, email, ha1, email_confirm_date, member_since) VALUES
 (1, 'editor1', '{CLEARTEXT}pass', 'editor1@example.com', '16a4862191803cb596ee4b16802bb7ee', now(), '2014-12-03'),
 (2, 'editor2', '{CLEARTEXT}pass', 'editor2@example.com', 'ba025a52cc5ff57d5d10f31874a83de6', now(), '2014-12-04'),
-(3, 'editor3', '{CLEARTEXT}pass', 'editor3@example.com', 'c096994132d53f3e1cde757943b10e7d', now(), '2014-12-05');
+(3, 'editor3', '{CLEARTEXT}pass', 'editor3@example.com', 'c096994132d53f3e1cde757943b10e7d', now(), '2014-12-05'),
+-- Reminder: Editor #4 is ModBot
+-- Beginner editor
+(6, 'editor6', '{CLEARTEXT}pass', 'editor6@example.com', '01de7bc91330d78a6d0a84033e293f11', now(), '2014-12-03');
 
 -- Test multiple edit_notes
 INSERT INTO edit (id, editor, type, status, expire_time)

--- a/t/sql/vote.sql
+++ b/t/sql/vote.sql
@@ -8,7 +8,11 @@ INSERT INTO editor (id, name, password, email, ha1, email_confirm_date, member_s
     (2, 'editor2', '{CLEARTEXT}pass', 'editor2@example.com', 'ba025a52cc5ff57d5d10f31874a83de6', now(), '2014-12-01'),
     (3, 'editor3', '{CLEARTEXT}pass', 'editor3@example.com', 'c096994132d53f3e1cde757943b10e7d', now(), '2014-12-02'),
     -- Reminder: Editor #4 is ModBot
-    (5, 'editor5', '{CLEARTEXT}pass', null, '01de7bc91330d78a6d0a84033e293f15', null, '2014-12-03');
+    -- Non-verified editor
+    (5, 'editor5', '{CLEARTEXT}pass', null, '01de7bc91330d78a6d0a84033e293f15', null, '2014-12-03'),
+    -- Beginner editor
+    (6, 'editor6', '{CLEARTEXT}pass', 'editor6@example.com', '01de7bc91330d78a6d0a84033e293f11', now(), '2014-12-03');
+
 
 -- Dummy edits to allow voting
 INSERT INTO edit (id, editor, type, status, expire_time)

--- a/t/sql/vote_stats.sql
+++ b/t/sql/vote_stats.sql
@@ -1,5 +1,8 @@
 SET client_min_messages TO 'warning';
 
+INSERT INTO editor (id, name, password, email, ha1, email_confirm_date, member_since) VALUES
+    (1, 'editor1', '{CLEARTEXT}pass', 'editor1@example.com', '16a4862191803cb596ee4b16802bb7ee', now(), now());
+ 
 INSERT INTO edit (id, type, editor, status, expire_time) VALUES (666, 1, 1, 1, NOW());
 INSERT INTO edit_data (edit, data) VALUES (666, '{}');
 INSERT INTO vote (editor, vote, vote_time, edit)


### PR DESCRIPTION
### Implement MBS-13100

# Problem
There's been too many sockpuppets created just for voting since we removed the requirement. We need to have some way to discourage this.

# Solution
We might want to adapt how beginner editorship works later on (one idea I have is MBS-13132), but for now this just blocks voting again for beginner editors, since that's the easiest fix.

# Testing
Added back a test testing beginner editors cannot vote, but the test now checks they can indeed post a note since we haven't removed that permission.