### PR TITLE
MBS-13131: Move staticbrainz to static.metabrainz for instruments

### DIFF
--- a/lib/MusicBrainz/Server/Report/InstrumentsWithoutAnImage.pm
+++ b/lib/MusicBrainz/Server/Report/InstrumentsWithoutAnImage.pm
@@ -20,7 +20,7 @@ sub query
             JOIN url ON liu.entity1 = url.id
             WHERE liu.entity0 = i.id
             AND lt.gid = 'f64eacbd-1ea1-381e-9886-2cfb552b7d90' --image
-            AND url.url LIKE '%staticbrainz.org/irombook%'
+            AND url.url LIKE '%static.metabrainz.org/irombook%'
         )
     };
 }

--- a/root/static/scripts/common/components/IrombookImage.js
+++ b/root/static/scripts/common/components/IrombookImage.js
@@ -12,7 +12,7 @@ type Props = {
 };
 
 function isIrombookImage(url: UrlT): boolean {
-  return /https:\/\/staticbrainz\.org\/irombook\//.test(url.href_url);
+  return /https:\/\/static\.metabrainz\.org\/irombook\//.test(url.href_url);
 }
 
 const IrombookImage = ({entity}: Props): React$Element<'div'> | null => {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2682,7 +2682,7 @@ const CLEANUPS: CleanupEntries = {
     },
   },
   'irombook': {
-    match: [new RegExp('^https://staticbrainz\\.org/irombook/')],
+    match: [new RegExp('^https://static\\.metabrainz\\.org/irombook/')],
     restrict: [LINK_TYPES.image],
     validate: function (url, id) {
       return {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2612,7 +2612,7 @@ limited_link_type_combinations: [
   },
   // IROMBOOK images (StaticBrainz)
   {
-                     input_url: 'https://staticbrainz.org/irombook/sitar/sitar.png',
+                     input_url: 'https://static.metabrainz.org/irombook/sitar/sitar.png',
              input_entity_type: 'instrument',
     expected_relationship_type: 'image',
        only_valid_entity_types: ['instrument'],


### PR DESCRIPTION
### Implement MBS-13131

# Description
We've changed the way the static resources work, so we need to update the expected URLs. The already existing URLs will be updated separately with a one-off bot run (MBBE-80).

# Testing
Just the basic (updated) URL test.