### PR TITLE
admin/run: fix log path and automatically create it

### DIFF
--- a/admin/run
+++ b/admin/run
@@ -50,28 +50,27 @@ command_full_path=$(which "$1")
 command_verbatim=$1
 shift
 
-pre_command='carton exec --'
-username="$(id -u -n)"
-if id -u 'musicbrainz' &>/dev/null && [[ "$username" != 'musicbrainz' ]]
-then
-  pre_command="sudo --preserve-env --set-home -u musicbrainz -- $pre_command"
-  username='musicbrainz'
-fi
-
 if [[ $command_full_path =~ admin/cron/.*\.sh$ ]]
 then
   log_dir_name=$(echo "$command_full_path" | sed 's_^.*admin/cron/\(.*\)\.sh$_\1_')
 else
   log_dir_name='occasionally'
 fi
-
-log_dir_path="$(eval echo ~"$username/log/$log_dir_name")"
-$pre_command mkdir -p "$log_dir_path"
-
+log_dir_path="$HOME/log/$log_dir_name"
+if ! [[ -d "$log_dir_path" ]]
+then
+  echo >&2 "$SCRIPT_NAME: '$log_dir_path' doesn't exist"
+  echo >&2 "Make sure to run in the appropriate container."
+  exit 73 # EX_CANTCREAT
+fi
 log_timestamp=$(date --utc +%FT%TZ)
 log_file_path="$log_dir_path/$log_timestamp.log"
-# ensure log is owned by $username
-$pre_command touch "$log_file_path"
+
+pre_command='carton exec --'
+if id -u 'musicbrainz' &>/dev/null && [[ "$(id -u -n)" != 'musicbrainz' ]]
+then
+  pre_command="sudo --preserve-env --set-home -u musicbrainz -- $pre_command"
+fi
 
 echo "Running '$command_verbatim $*' and logging at '$log_file_path'..."
 if [[ -t 1 ]]

--- a/admin/run
+++ b/admin/run
@@ -65,6 +65,7 @@ fi
 
 if [[ $command_full_path =~ admin/cron/.*\.sh$ ]]
 then
+  # shellcheck disable=SC2001,SC2016
   log_dir_name=$(echo "$command_full_path" | sed 's_^.*admin/cron/\(.*\)\.sh$_\1_')
 else
   log_dir_name='occasionally'

--- a/admin/run
+++ b/admin/run
@@ -57,6 +57,12 @@ command_full_path=$(which "$1")
 command_verbatim=$1
 shift
 
+if [[ "$(id -u -n)" != 'musicbrainz' ]]
+then
+  exec sudo --preserve-env --set-home -u musicbrainz -- \
+    "${BASH_SOURCE[0]}" "$command_verbatim" "$@"
+fi
+
 if [[ $command_full_path =~ admin/cron/.*\.sh$ ]]
 then
   log_dir_name=$(echo "$command_full_path" | sed 's_^.*admin/cron/\(.*\)\.sh$_\1_')
@@ -74,11 +80,6 @@ log_timestamp=$(date --utc +%FT%TZ)
 log_file_path="$log_dir_path/$log_timestamp.log"
 
 pre_command='carton exec --'
-if [[ "$(id -u -n)" != 'musicbrainz' ]]
-then
-  pre_command="sudo --preserve-env --set-home -u musicbrainz -- $pre_command"
-fi
-
 echo "Running '$command_verbatim $*' and logging at '$log_file_path'..."
 if [[ -t 1 ]]
 then

--- a/admin/run
+++ b/admin/run
@@ -56,7 +56,7 @@ then
 else
   log_dir_name='occasionally'
 fi
-log_dir_path="$HOME/log/$log_dir_name"
+log_dir_path="/home/musicbrainz/log/$log_dir_name"
 if ! [[ -d "$log_dir_path" ]]
 then
   echo >&2 "$SCRIPT_NAME: '$log_dir_path' doesn't exist"

--- a/admin/run
+++ b/admin/run
@@ -43,6 +43,13 @@ then
   exit 64 # EX_USAGE
 fi
 
+if ! id -u 'musicbrainz' &>/dev/null
+then
+  echo >&2 "$SCRIPT_NAME: user 'musicbrainz' doesn't exist"
+  echo >&2 "Make sure to run in a production container."
+  exit 67 # EX_NOUSER
+fi
+
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 export PERL_CARTON_PATH=/home/musicbrainz/carton-local
 
@@ -67,7 +74,7 @@ log_timestamp=$(date --utc +%FT%TZ)
 log_file_path="$log_dir_path/$log_timestamp.log"
 
 pre_command='carton exec --'
-if id -u 'musicbrainz' &>/dev/null && [[ "$(id -u -n)" != 'musicbrainz' ]]
+if [[ "$(id -u -n)" != 'musicbrainz' ]]
 then
   pre_command="sudo --preserve-env --set-home -u musicbrainz -- $pre_command"
 fi

--- a/admin/run
+++ b/admin/run
@@ -50,27 +50,28 @@ command_full_path=$(which "$1")
 command_verbatim=$1
 shift
 
+pre_command='carton exec --'
+username="$(id -u -n)"
+if id -u 'musicbrainz' &>/dev/null && [[ "$username" != 'musicbrainz' ]]
+then
+  pre_command="sudo --preserve-env --set-home -u musicbrainz -- $pre_command"
+  username='musicbrainz'
+fi
+
 if [[ $command_full_path =~ admin/cron/.*\.sh$ ]]
 then
   log_dir_name=$(echo "$command_full_path" | sed 's_^.*admin/cron/\(.*\)\.sh$_\1_')
 else
   log_dir_name='occasionally'
 fi
-log_dir_path="$HOME/log/$log_dir_name"
-if ! [[ -d "$log_dir_path" ]]
-then
-  echo >&2 "$SCRIPT_NAME: '$log_dir_path' doesn't exist"
-  echo >&2 "Make sure to run in the appropriate container."
-  exit 73 # EX_CANTCREAT
-fi
+
+log_dir_path="$(eval echo ~"$username/log/$log_dir_name")"
+$pre_command mkdir -p "$log_dir_path"
+
 log_timestamp=$(date --utc +%FT%TZ)
 log_file_path="$log_dir_path/$log_timestamp.log"
-
-pre_command='carton exec --'
-if id -u 'musicbrainz' &>/dev/null && [[ "$(id -u -n)" != 'musicbrainz' ]]
-then
-  pre_command="sudo --preserve-env --set-home -u musicbrainz -- $pre_command"
-fi
+# ensure log is owned by $username
+$pre_command touch "$log_file_path"
 
 echo "Running '$command_verbatim $*' and logging at '$log_file_path'..."
 if [[ -t 1 ]]

--- a/docker/scripts/create_log_directories.sh
+++ b/docker/scripts/create_log_directories.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -e -u
+
+SCRIPT_NAME=$(basename "$0")
+
+if ((BASH_VERSINFO[0] < 4))
+then
+  echo >&2 "$SCRIPT_NAME: at least version 4 of bash is required"
+  echo >&2 "Make sure this version of bash comes first in \$PATH"
+  exit 69 # EX_UNAVAILABLE
+fi
+
+declare -rA log_directories_by_container_type=(
+  ['production-cron']='daily hourly monthly occasionally'
+  ['json-dump']='daily-json-dump hourly-json-dump occasionally'
+  ['search-indexes-dump']='daily-search-indexes-dump hourly-search-indexes-dump occasionally'
+  ['sitemaps']='daily-sitemaps hourly-sitemaps occasionally'
+)
+
+HELP=$(cat <<EOH
+Usage: $SCRIPT_NAME
+
+This script is meant to be used in production only, to create the
+directories for log files when starting up a container of the type
+indicated by the environment variable MB_CONTAINER_TYPE among:
+${!log_directories_by_container_type[@]}
+
+EOH
+)
+
+if [[ $# -ne 0 && $1 =~ ^-*h(elp)?$ ]]
+then
+  echo "$HELP"
+  exit 0 # EX_OK
+elif [[ $# -ne 0 ]]
+then
+  echo >&2 "$SCRIPT_NAME takes no argument."
+  echo >&2 "Try '$SCRIPT_NAME help' for usage."
+  exit 64 # EX_USAGE
+fi
+
+# shellcheck disable=SC2076
+if [[ ! " ${!log_directories_by_container_type[*]} " =~ " $MB_CONTAINER_TYPE " ]]
+then
+  echo >&2 "$SCRIPT_NAME: unrecognized value of MB_CONTAINER_TYPE: $MB_CONTAINER_TYPE"
+  echo >&2 "Try '$SCRIPT_NAME help' for usage."
+  exit 64 # EX_USAGE
+fi
+
+MB_LOG_ROOT=/home/musicbrainz/log
+
+for directory in ${log_directories_by_container_type[$MB_CONTAINER_TYPE]}
+do
+  sudo -u musicbrainz -- mkdir -p "$MB_LOG_ROOT/$directory"
+done
+
+# vi: set et sts=2 sw=2 ts=2 :

--- a/docker/templates/Dockerfile.json-dump.m4
+++ b/docker/templates/Dockerfile.json-dump.m4
@@ -13,6 +13,12 @@ COPY docker/musicbrainz-json-dump/crontab /var/spool/cron/crontabs/musicbrainz
 RUN chown musicbrainz:musicbrainz /var/spool/cron/crontabs/musicbrainz && \
     chmod 600 /var/spool/cron/crontabs/musicbrainz
 
+ENV MB_CONTAINER_TYPE json-dump
+
+COPY \
+    docker/scripts/create_log_directories.sh \
+    /etc/my_init.d/90_create_log_directories.sh
+
 COPY docker/scripts/start_musicbrainz_server.sh /usr/local/bin/
 
 git_info

--- a/docker/templates/Dockerfile.production-cron.m4
+++ b/docker/templates/Dockerfile.production-cron.m4
@@ -14,4 +14,10 @@ COPY \
 RUN chown musicbrainz:musicbrainz /var/spool/cron/crontabs/musicbrainz && \
     chmod 600 /var/spool/cron/crontabs/musicbrainz
 
+ENV MB_CONTAINER_TYPE production-cron
+
+COPY \
+    docker/scripts/create_log_directories.sh \
+    /etc/my_init.d/90_create_log_directories.sh
+
 git_info

--- a/docker/templates/Dockerfile.search-indexes-dump.m4
+++ b/docker/templates/Dockerfile.search-indexes-dump.m4
@@ -12,4 +12,10 @@ COPY docker/musicbrainz-search-indexes-dump/crontab /var/spool/cron/crontabs/mus
 RUN chown musicbrainz:musicbrainz /var/spool/cron/crontabs/musicbrainz && \
     chmod 600 /var/spool/cron/crontabs/musicbrainz
 
+ENV MB_CONTAINER_TYPE search-indexes-dump
+
+COPY \
+    docker/scripts/create_log_directories.sh \
+    /etc/my_init.d/90_create_log_directories.sh
+
 git_info

--- a/docker/templates/Dockerfile.sitemaps.m4
+++ b/docker/templates/Dockerfile.sitemaps.m4
@@ -13,6 +13,12 @@ COPY docker/musicbrainz-sitemaps/crontab /var/spool/cron/crontabs/musicbrainz
 RUN chown musicbrainz:musicbrainz /var/spool/cron/crontabs/musicbrainz && \
     chmod 600 /var/spool/cron/crontabs/musicbrainz
 
+ENV MB_CONTAINER_TYPE sitemaps
+
+COPY \
+    docker/scripts/create_log_directories.sh \
+    /etc/my_init.d/90_create_log_directories.sh
+
 COPY docker/scripts/start_musicbrainz_server.sh /usr/local/bin/
 
 RUN chown_mb(`/home/musicbrainz/log MBS_ROOT/root/static/sitemaps')


### PR DESCRIPTION
# Problem

sitemaps cron has not been running for quite some time.  I'm not sure for how long, but at some point the logs volume was cleared, which breaks admin/run.

To check what was failing, I ran this inside the container:

```sh
root@0ca0886613a0:/home/musicbrainz/musicbrainz-server# ./admin/run admin/cron/daily-sitemaps.sh
run: '/root/log/daily-sitemaps' doesn't exist
Make sure to run in the appropriate container.
```

This is odd to me because the script is supposed to `sudo` as the musicbrainz user if it exists.  In that case it should also use /home/musicbrainz as the log path, since that's the user it's invoking the passed-in script as.

Next, I tried the same command as the musicbrainz user:

```sh
root@0ca0886613a0:/home/musicbrainz/musicbrainz-server# su musicbrainz
musicbrainz@0ca0886613a0:~/musicbrainz-server$ ./admin/run admin/cron/daily-sitemaps.sh
run: '/home/musicbrainz/log/daily-sitemaps' doesn't exist
Make sure to run in the appropriate container.
```

Since the log volume was cleared at some point, these directories don't exist, and the script fails.  This was never an issue before, because our old crontab automatically created the log path:

```
-10 0 * * * . /etc/container_environment.sh; mkdir -p $HOME/log/daily-sitemaps && cd $HOME/musicbrainz-server && carton exec -- admin/cron/daily-sitemaps.sh > $HOME/log/daily-sitemaps/$(date --utc +\%FT\%TZ).log 2>&1
```

It appears that the intent of the script is to error in case you're running the command inside the wrong container, but I think that rarely happens in practice.  What is clear is that we don't actively monitor the sitemaps cron logs for failures, so I'd much prefer the script be made more resilient.

# Solution

<del>
I've made the following changes to resolve these issues:

 * Storing the username we're invoking the command as in `$username` and putting logs in `~$username`.
 * Creating `$log_dir_path` instead of erroring.
 * Ensuring the created log path and file are owned by `$username`.
</del>

Address the case of missing log directories:

 * Creating the log directories when starting the container with an init script.
   (Keep erroring if any log directory is missing)

Address the case of running as `root`:

 * Exit with error if there is no `musicbrainz` user.
 * Run everything as `musicbrainz` user, including redirects and piped commands.
 * Use the HOME directory of `musicbrainz` user specifically.

# Testing

<del>
I've copied the changes into the musicbrainz-sitemaps container and checked that invoking `./admin/run admin/cron/daily-sitemaps.sh` works. (Only tested as the root user.)
</del>

See below comment https://github.com/metabrainz/musicbrainz-server/pull/2968#pullrequestreview-1613034283