### PR TITLE
Block notes on add note

### DIFF
--- a/lib/MusicBrainz/Server/Data/Edit.pm
+++ b/lib/MusicBrainz/Server/Data/Edit.pm
@@ -893,11 +893,8 @@ sub insert_votes_and_notes {
     Sql::run_in_transaction(sub {
         $self->c->model('Vote')->enter_votes($editor, \@votes);
 
-        my $edits = $self->get_by_ids(map { $_->{edit_id} } @notes);
         for my $note (@notes) {
             my $edit_id = $note->{edit_id};
-            my $edit = $edits->{$edit_id};
-            next unless defined $edit && $edit->editor_may_add_note($editor);
             $self->c->model('EditNote')->add_note(
                 $edit_id,
                 {

--- a/t/sql/edit_note.sql
+++ b/t/sql/edit_note.sql
@@ -5,6 +5,8 @@ INSERT INTO editor (id, name, password, email, ha1, email_confirm_date, member_s
 (2, 'editor2', '{CLEARTEXT}pass', 'editor2@example.com', 'ba025a52cc5ff57d5d10f31874a83de6', now(), '2014-12-04'),
 (3, 'editor3', '{CLEARTEXT}pass', 'editor3@example.com', 'c096994132d53f3e1cde757943b10e7d', now(), '2014-12-05'),
 -- Reminder: Editor #4 is ModBot
+-- Non-verified editor
+(5, 'editor5', '{CLEARTEXT}pass', null, '01de7bc91330d78a6d0a84033e293f15', null, '2014-12-03'),
 -- Beginner editor
 (6, 'editor6', '{CLEARTEXT}pass', 'editor6@example.com', '01de7bc91330d78a6d0a84033e293f11', now(), '2014-12-03');
 


### PR DESCRIPTION
# Description
Whether notes can be added was being checked only at the `insert_votes_and_notes` level, but the equivalent `enter_votes` checks at a lower level, which seems a lot safer (we have plenty of calls for `add_note` outside of that method). Just in case ModBot is not otherwise considered able to add notes for whatever reason, this gives ModBot free pass (since we very often call `add_note` for ModBot directly).

# Testing
Added a test for add_note specifically, made sure other tests still pass.

On top of https://github.com/metabrainz/musicbrainz-server/pull/2966 since that significantly changes the relevant test file.