### PR TITLE
MBS-13094: Allow admins to browse edit note changes

### DIFF
--- a/lib/MusicBrainz/Server/Data/EditNoteChange.pm
+++ b/lib/MusicBrainz/Server/Data/EditNoteChange.pm
@@ -14,7 +14,7 @@ sub _table
 sub _columns
 {
     return 'id, edit_note AS edit_note_id, change_editor AS editor_id, ' .
-        'change_time, status, reason';
+        'change_time, status, reason, old_note, new_note';
 }
 
 sub _entity_class
@@ -44,6 +44,16 @@ sub load_latest
         my $edit_note_change = $changes{ $edit_note->id } or next;
         $edit_note->latest_change($edit_note_change);
     }
+}
+
+sub get_history
+{
+    my ($self, $id, $limit, $offset) = @_;
+    my $query = 'SELECT ' . $self->_columns .
+                ' FROM ' . $self->_table .
+                ' WHERE edit_note = ?' .
+                ' ORDER BY change_time DESC';
+    $self->query_to_list_limited($query, [$id], $limit, $offset);
 }
 
 no Moose;

--- a/lib/MusicBrainz/Server/Entity/EditNoteChange.pm
+++ b/lib/MusicBrainz/Server/Entity/EditNoteChange.pm
@@ -48,14 +48,32 @@ has 'status' => (
     is  => 'rw',
 );
 
+has 'new_note' => (
+    isa => 'Str',
+    is => 'rw',
+);
+
+has 'old_note' => (
+    isa => 'Str',
+    is => 'rw',
+);
+
 around TO_JSON => sub {
     my ($orig, $self) = @_;
 
     my $json = $self->$orig;
     $json->{change_editor_id} = $self->editor_id + 0;
     $json->{change_time} = datetime_to_iso8601($self->change_time);
+    $json->{edit_note_id} = $self->edit_note_id + 0;
+    $json->{id} = $self->id + 0;
+    $json->{new_note} = $self->new_note;
+    $json->{old_note} = $self->old_note;
     $json->{reason} = $self->reason;
     $json->{status} = $self->status;
+
+    if (my $editor = $self->editor) {
+        $self->link_entity('editor', $self->editor_id, $editor);
+    }
 
     return $json;
 };

--- a/root/edit/components/EditNote.js
+++ b/root/edit/components/EditNote.js
@@ -17,6 +17,7 @@ import {
 } from '../../constants.js';
 import {CatalystContext} from '../../context.mjs';
 import EditorLink from '../../static/scripts/common/components/EditorLink.js';
+import bracketed from '../../static/scripts/common/utility/bracketed.js';
 import {isAccountAdmin, isAddingNotesDisabled}
   from '../../static/scripts/common/utility/privileges.js';
 import getVoteName from '../../static/scripts/edit/utility/getVoteName.js';
@@ -116,11 +117,12 @@ const EditNote = ({
   const isRecent = Boolean(
     noteDate && (new Date().getTime() - noteDate.getTime()) < twentyFourHours,
   );
+  const isAdmin = isAccountAdmin(user);
   const canBeChangedByOwner = isCurrentEditor && !hasReply &&
                               isRecent && !isDeleted &&
                               !isAddingNotesDisabled(user);
   const canShowEditControls = showEditControls &&
-                              (canBeChangedByOwner || isAccountAdmin(user));
+                              (canBeChangedByOwner || isAdmin);
 
   return (
     <div className="edit-note" id={anchor}>
@@ -158,30 +160,42 @@ const EditNote = ({
         </a>
       </h3>
       {isDeleted ? (
-        <div className="edit-note-text deleted-note">
-          {changedBySelf ? (
-            nonEmpty(changeReason) ? (
-              texp.l(
-                `This edit note was removed by its author.
-                 Reason given: “{reason}”.`,
-                {reason: changeReason},
+        <div className="edit-note-text">
+          <span className="deleted-note">
+            {changedBySelf ? (
+              nonEmpty(changeReason) ? (
+                texp.l(
+                  `This edit note was removed by its author.
+                   Reason given: “{reason}”.`,
+                  {reason: changeReason},
+                )
+              ) : (
+                l(`This edit note was removed by its author.
+                   No reason was provided.`)
               )
             ) : (
-              l(`This edit note was removed by its author.
-                 No reason was provided.`)
-            )
-          ) : (
-            nonEmpty(changeReason) ? (
-              texp.l(
-                `This edit note was removed by an admin.
-                 Reason given: “{reason}”.`,
-                {reason: changeReason},
+              nonEmpty(changeReason) ? (
+                texp.l(
+                  `This edit note was removed by an admin.
+                   Reason given: “{reason}”.`,
+                  {reason: changeReason},
+                )
+              ) : (
+                l(`This edit note was removed by an admin.
+                   No reason was provided.`)
               )
-            ) : (
-              l(`This edit note was removed by an admin.
-                 No reason was provided.`)
-            )
-          )}
+            )}
+          </span>
+          {isAdmin ? (
+            <span className="small">
+              {' '}
+              {bracketed(
+                <a href={`/edit-note/${editNote.id}/changes`}>
+                  {lp('see all changes', 'edit note')}
+                </a>,
+              )}
+            </span>
+          ) : null}
         </div>
       ) : (
         <>
@@ -228,6 +242,16 @@ const EditNote = ({
                   )
                 )
               )}
+              {isAdmin ? (
+                <>
+                  {' '}
+                  {bracketed(
+                    <a href={`/edit-note/${editNote.id}/changes`}>
+                      {lp('see all changes', 'edit note')}
+                    </a>,
+                  )}
+                </>
+              ) : null}
             </div>
           ) : null}
         </>

--- a/root/edit_note/EditNoteChange.js
+++ b/root/edit_note/EditNoteChange.js
@@ -1,0 +1,76 @@
+/*
+ * @flow strict
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import Layout from '../layout/index.js';
+import EditorLink from '../static/scripts/common/components/EditorLink.js';
+import linkedEntities from '../static/scripts/common/linkedEntities.mjs';
+import nonEmpty from '../static/scripts/common/utility/nonEmpty.js';
+import DiffSide from '../static/scripts/edit/components/edit/DiffSide.js';
+import {DELETE, INSERT} from '../static/scripts/edit/utility/editDiff.js';
+
+type EditNoteChangeProps = {
+  +change: EditNoteChangeT,
+  +noteUrl: string,
+};
+
+const EditNoteChange = ({
+  change,
+  noteUrl,
+}: EditNoteChangeProps): React$MixedElement => {
+  const editor = linkedEntities.editor[change.change_editor_id];
+
+  return (
+    <Layout fullWidth title="Edit note change">
+      <h2>{'Edit note change'}</h2>
+      <h3>{'Changing editor'}</h3>
+      <EditorLink editor={editor} />
+      <h3>{'Type'}</h3>
+      <p>{change.status}</p>
+      <div className="note-diff">
+        <h3>{'Old note'}</h3>
+        <p>
+          <DiffSide
+            filter={DELETE}
+            newText={change.new_note ?? ''}
+            oldText={change.old_note ?? ''}
+            split="\s+"
+          />
+        </p>
+        <h3>{'New note'}</h3>
+        {change.status === 'deleted' ? (
+          <p className="small">{'This note was deleted.'}</p>
+        ) : (
+          <p>
+            <DiffSide
+              filter={INSERT}
+              newText={change.new_note ?? ''}
+              oldText={change.old_note ?? ''}
+              split="\s+"
+            />
+          </p>
+        )}
+      </div>
+      <h3>{'Change reason'}</h3>
+      {nonEmpty(change.reason)
+        ? <p>{change.reason}</p>
+        : <p className="small">{'No reason entered.'}</p>}
+      <p className="small">
+        <a href={`/edit-note/${change.edit_note_id}/changes`}>
+          {'See all changes for this edit note'}
+        </a>
+        {' / '}
+        <a href={noteUrl}>
+          {'Go to the edit note'}
+        </a>
+      </p>
+    </Layout>
+  );
+};
+
+export default EditNoteChange;

--- a/root/edit_note/EditNoteHistory.js
+++ b/root/edit_note/EditNoteHistory.js
@@ -1,0 +1,104 @@
+/*
+ * @flow strict
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import PaginatedResults from '../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../context.mjs';
+import Layout from '../layout/index.js';
+import EditorLink from '../static/scripts/common/components/EditorLink.js';
+import expand2react from '../static/scripts/common/i18n/expand2react.js';
+import linkedEntities from '../static/scripts/common/linkedEntities.mjs';
+import bracketed from '../static/scripts/common/utility/bracketed.js';
+import formatUserDate from '../utility/formatUserDate.js';
+
+type EditNoteHistoryTableProps = {
+  +changes: $ReadOnlyArray<EditNoteChangeT>,
+};
+
+type EditNoteHistoryProps = {
+  +changes: $ReadOnlyArray<EditNoteChangeT>,
+  +noteUrl: string,
+  +pager: PagerT,
+};
+
+const EditNoteHistoryTable = ({
+  changes,
+}: EditNoteHistoryTableProps): React$Element<'table'> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+
+  return (
+    <table className="tbl">
+      <thead>
+        <tr>
+          <th>{'Editor'}</th>
+          <th>{'Status'}</th>
+          <th>{'Date'}</th>
+          <th>{'Version History'}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {changes.map(change => {
+          const editor = linkedEntities.editor[change.change_editor_id];
+          return (
+            <tr key={change.id}>
+              <td>
+                <EditorLink editor={editor} />
+              </td>
+              <td>{change.status}</td>
+              <td>
+                {formatUserDate($c, change.change_time)}
+              </td>
+              <td>
+                <a
+                  href={
+                    `/edit-note/${change.edit_note_id}/change/${change.id}`
+                  }
+                >
+                  {'View this change'}
+                </a>
+                {' '}
+                {bracketed(
+                  change.reason ||
+                  expand2react('<em>no reason specified</em>'),
+                )}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};
+
+const EditNoteHistory = ({
+  changes,
+  noteUrl,
+  pager,
+}: EditNoteHistoryProps): React$MixedElement => (
+  <Layout fullWidth title="Edit note change history">
+    <h2>{'Edit note change history'}</h2>
+    {changes.length ? (
+      <PaginatedResults pager={pager}>
+        <EditNoteHistoryTable changes={changes} />
+      </PaginatedResults>
+    ) : (
+      <p>
+        {'This edit note has no change history.'}
+      </p>
+    )}
+    <p className="small">
+      <a href={noteUrl}>
+        {'Go to the edit note'}
+      </a>
+    </p>
+  </Layout>
+);
+
+export default EditNoteHistory;

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -113,6 +113,8 @@ export default {
   'edit/OpenEdits': (): Promise<mixed> => import('../edit/OpenEdits.js'),
   'edit/SubscribedEditorEdits': (): Promise<mixed> => import('../edit/SubscribedEditorEdits.js'),
   'edit/SubscribedEdits': (): Promise<mixed> => import('../edit/SubscribedEdits.js'),
+  'edit_note/EditNoteChange': (): Promise<mixed> => import('../edit_note/EditNoteChange.js'),
+  'edit_note/EditNoteHistory': (): Promise<mixed> => import('../edit_note/EditNoteHistory.js'),
   'elections/Index': (): Promise<mixed> => import('../elections/Index.js'),
   'elections/Nominate': (): Promise<mixed> => import('../elections/Nominate.js'),
   'elections/Show': (): Promise<mixed> => import('../elections/Show.js'),

--- a/root/static/styles/entity.less
+++ b/root/static/styles/entity.less
@@ -105,7 +105,7 @@ p.subheader {
     margin-top: 1em;
 }
 
-.annotation-diff {
+.annotation-diff, .note-diff {
     margin: 1em 0;
 }
 

--- a/root/types/edit.js
+++ b/root/types/edit.js
@@ -34,6 +34,10 @@ declare type EditWithIdT = $ReadOnly<{...EditT, +id: number}>;
 declare type EditNoteChangeT = {
   +change_editor_id: number,
   +change_time: string,
+  +edit_note_id: number,
+  +id: number,
+  +new_note: string,
+  +old_note: string,
   +reason: string,
   +status: 'edited' | 'deleted',
 };

--- a/t/lib/t/MusicBrainz/Server/Controller/EditNote/ChangeNote.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/EditNote/ChangeNote.pm
@@ -1,4 +1,4 @@
-package t::MusicBrainz::Server::Controller::Edit::ChangeNote;
+package t::MusicBrainz::Server::Controller::EditNote::ChangeNote;
 use strict;
 use warnings;
 

--- a/t/lib/t/MusicBrainz/Server/Controller/EditNote/NoteHistory.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/EditNote/NoteHistory.pm
@@ -1,0 +1,319 @@
+package t::MusicBrainz::Server::Controller::EditNote::NoteHistory;
+use strict;
+use warnings;
+
+use DateTime;
+use Test::Routine;
+use Test::More;
+use utf8;
+
+use MusicBrainz::Server::Test qw( html_ok test_xpath_html );
+
+with 't::Context', 't::Mechanize';
+
+=head1 DESCRIPTION
+
+This checks that edit note history pages are shown correctly,
+and that they can be viewed by admins and only by admins.
+
+=cut
+
+test 'History page links' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database(
+        $test->c,
+        '+edit_note_history',
+    );
+
+    # Test as normal editor
+    $mech->get_ok('/login');
+    $mech->submit_form(
+        with_fields => {username => 'editor1', password => 'pass'}
+    );
+
+    note('We get the edit with modified notes as a normal editor');
+    $mech->get_ok('/edit/1');
+    html_ok($mech->content);
+
+    my @history_link_matches = $mech->content =~ /see all changes/g;
+    is(
+        scalar @history_link_matches,
+        0,
+        'No history page links are shown to normal editor',
+    );
+
+    $mech->get('/logout');
+
+    # Test as admin
+    $mech->get_ok('/login');
+    $mech->submit_form(
+        with_fields => {username => 'admin3', password => 'pass'}
+    );
+
+    note('We get the edit with modified notes as an admin');
+    $mech->get_ok('/edit/1');
+    html_ok($mech->content);
+
+    @history_link_matches = $mech->content =~ /see all changes/g;
+    is(
+        scalar @history_link_matches,
+        2,
+        '2 history page links are shown to admin (one per note with changes)',
+    );
+};
+
+test 'History page display' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database(
+        $test->c,
+        '+edit_note_history',
+    );
+
+    # Test as admin
+    $mech->get_ok('/login');
+    $mech->submit_form(
+        with_fields => {username => 'admin3', password => 'pass'}
+    );
+
+    note('We get the history for a note with two modifications');
+    $mech->get_ok('/edit-note/1/changes');
+    html_ok($mech->content);
+
+    my $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '2',
+        'There are two entries in the changes table',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[3]',
+        '2014-12-07 00:00 UTC',
+        'The latest change is shown first',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[1]',
+        'editor1',
+        'The latest change is by editor1',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[2]',
+        'edited',
+        'The latest change is a modification',
+    );
+    $tx->like(
+        '//table[@class="tbl"]/tbody/tr[1]/td[4]',
+        qr/no reason specified/,
+        'The latest change has no reason given',
+    );
+
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[2]/td[3]',
+        '2014-12-06 00:00 UTC',
+        'The oldest change is shown last',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[2]/td[1]',
+        'editor1',
+        'The oldest change is by editor1',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[2]/td[2]',
+        'edited',
+        'The oldest change is a modification',
+    );
+    $tx->like(
+        '//table[@class="tbl"]/tbody/tr[2]/td[4]',
+        qr/typo/,
+        'The oldest change reason is listed',
+    );
+
+    note('We get the history for a note with no changes');
+    $mech->get_ok('/edit-note/2/changes');
+    html_ok($mech->content);
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '0',
+        'There are no entries in the changes table',
+    );
+
+    note('We get the history for a note with one deletion');
+    $mech->get_ok('/edit-note/3/changes');
+    html_ok($mech->content);
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '1',
+        'There is one entry in the changes table',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[3]',
+        '2016-12-05 00:00 UTC',
+        'The date is correct',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[1]',
+        'admin3',
+        'The change is by admin3',
+    );
+        $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[2]',
+        'deleted',
+        'The latest change is a removal',
+    );
+    $tx->like(
+        '//table[@class="tbl"]/tbody/tr[1]/td[4]',
+        qr/Unhelpful/,
+        'The change reason is listed',
+    );
+};
+
+test 'Change page display' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database(
+        $test->c,
+        '+edit_note_history',
+    );
+
+    # Test as admin
+    $mech->get_ok('/login');
+    $mech->submit_form(
+        with_fields => {username => 'admin3', password => 'pass'}
+    );
+
+    note('We get the first change in the first note');
+    $mech->get_ok('/edit-note/1/change/1');
+    html_ok($mech->content);
+    $mech->text_contains(
+        'edited',
+        'The change status is present',
+    );
+    $mech->text_contains(
+        'editor1',
+        'The changing editor is present',
+    );
+    $mech->text_contains(
+        'This is a messy ntoe',
+        'The old note content is present',
+    );
+    $mech->text_contains(
+        'This is a messy note',
+        'The new note content is present',
+    );
+    $mech->text_contains(
+        'typo',
+        'The change reason is present',
+    );
+
+    note('We get the second change in the first note');
+    $mech->get_ok('/edit-note/1/change/2');
+    html_ok($mech->content);
+    $mech->text_contains(
+        'edited',
+        'The change status is present',
+    );
+    $mech->text_contains(
+        'editor1',
+        'The changing editor is present',
+    );
+    $mech->text_contains(
+        'This is a messy note',
+        'The old note content is present',
+    );
+    $mech->text_contains(
+        'This is a fixed note',
+        'The new note content is present',
+    );
+    $mech->text_contains(
+        'No reason entered',
+        'The "No reason entered" message is present',
+    );
+
+    note('We try to get the third change from the first note');
+    $mech->get('/edit-note/1/change/3');
+    is(
+        $mech->status,
+        400,
+        'Trying to get a change from the wrong note gives a 400 Bad Request error',
+    );
+    $mech->text_contains(
+        'is not associated with this note',
+        'The error message saying this is the wrong note is displayed',
+    );
+
+    note('We get the only change in the third note');
+    $mech->get_ok('/edit-note/3/change/3');
+    html_ok($mech->content);
+    $mech->text_contains(
+        'Typedeleted', # To test it ignoring "was deleted" below
+        'The change status is present',
+    );
+    $mech->text_contains(
+        'Changing editoradmin3', # To test it ignoring the header link
+        'The changing editor is present',
+    );
+    $mech->text_contains(
+        'I HATE YOU ALL',
+        'The old note content is present',
+    );
+    $mech->text_contains(
+        'This note was deleted',
+        'The deleted note message is present',
+    );
+    $mech->text_contains(
+        'Unhelpful',
+        'The change reason is present',
+    );
+};
+
+test 'Pages are blocked for non-admins' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database(
+        $test->c,
+        '+edit_note_history',
+    );
+
+    $mech->get('/edit-note/1/changes');
+    $mech->text_contains(
+        'You need to be logged in to view this page',
+        'Trying to view the history page requires login',
+    );
+
+    $mech->get('/edit-note/1/change/1');
+    $mech->text_contains(
+        'You need to be logged in to view this page',
+        'Trying to view a specific change page requires login',
+    );
+
+    # Test as normal editor
+    $mech->get_ok('/login');
+    $mech->submit_form(
+        with_fields => {username => 'editor1', password => 'pass'}
+    );
+
+    $mech->get('/edit-note/1/changes');
+    is(
+        $mech->status,
+        403,
+        'Trying to get the history page as a non-admin gives a 403 Forbidden error',
+    );
+
+    $mech->get('/edit-note/1/change/1');
+    is(
+        $mech->status,
+        403,
+        'Trying to get a specific change page as a non-admin gives a 403 Forbidden error',
+    );
+};
+
+1;

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -166,6 +166,8 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   'Controller::Edit::subscribed_editors',
   'Controller::EditNote::base',
   'Controller::EditNote::delete',
+  'Controller::EditNote::edit_note_change',
+  'Controller::EditNote::edit_note_history',
   'Controller::EditNote::modify',
   'Controller::Event::alias',
   'Controller::Event::aliases',

--- a/t/sql/edit_note_history.sql
+++ b/t/sql/edit_note_history.sql
@@ -1,0 +1,25 @@
+SET client_min_messages TO 'warning';
+
+INSERT INTO editor (id, name, password, privs, email, ha1, email_confirm_date, member_since) VALUES
+(1, 'editor1', '{CLEARTEXT}pass', 0, 'editor1@example.com', '16a4862191803cb596ee4b16802bb7ee', now(), '2014-12-03'),
+(2, 'editor2', '{CLEARTEXT}pass', 0, 'editor2@example.com', 'ba025a52cc5ff57d5d10f31874a83de6', now(), '2014-12-04'),
+(3, 'admin3', '{CLEARTEXT}pass', 128, 'editor3@example.com', 'c096994132d53f3e1cde757943b10e7d', now(), '2014-12-05');
+
+INSERT INTO artist (id, gid, name, sort_name)
+    VALUES (1, 'a9d99e40-72d7-11de-8a39-0800200c9a66', 'Name', 'Name');
+INSERT INTO edit (id, editor, type, status, expire_time)
+    VALUES (1, 1, 32, 1, NOW());
+INSERT INTO edit_data (edit, data)
+    VALUES (1, '{"entity":{"name":"Name","id":1},"new":{"name":"NewName"},"old":{"name":"Name"}}');
+INSERT INTO edit_artist (edit, artist)
+    VALUES (1, 1);
+
+INSERT INTO edit_note (id, editor, edit, post_time, text)
+    VALUES (1, 1, 1, '2014-12-05', 'This is a fixed note'),
+           (2, 2, 1, '2014-12-05', 'This is an untouched answer'),
+           (3, 1, 1, '2014-12-05', '');
+
+INSERT INTO edit_note_change (id, status, edit_note, change_editor, change_time, old_note, new_note, reason)
+     VALUES (1, 'edited', 1, 1, '2014-12-06', 'This is a messy ntoe', 'This is a messy note', 'typo'),
+            (2, 'edited', 1, 1, '2014-12-07', 'This is a messy note', 'This is a fixed note', ''),
+            (3, 'deleted', 3, 3, '2016-12-05', 'I HATE YOU ALL', '', 'Unhelpful');


### PR DESCRIPTION
### Implement MBS-13094

# Problem
Admins should be able to see the edit history for any edit, since otherwise a user could, for example, insult another and then edit the note so that the email is sent but others don't see.

# Solution
This mostly follows what we do for annotations, but most of it does not support translated strings since it's admin-only. Translations are added for stuff that will show in otherwise translated pages.

### Edit view
![image_2023-06-26_162838967](https://github.com/metabrainz/musicbrainz-server/assets/1069224/169b7909-2052-45fd-a903-42e7f6f23f80)

### History page
![Screenshot from 2023-06-26 16-26-34](https://github.com/metabrainz/musicbrainz-server/assets/1069224/ce38c69f-befa-4075-a0bd-34587f1a3e60)

### Change page
![Screenshot from 2023-06-26 16-26-53](https://github.com/metabrainz/musicbrainz-server/assets/1069224/084c2a22-d147-4115-baf1-4f55ca4070e4)

# Checklist for author
* [x] Add tests for these pages

# Testing
Manually navigating around after changes, plus added a test file checking that the pages are blocked for non-admins and show the expected data for admins.