### PR TITLE
Special purpose language: No linguistic content (zxx)

### DIFF
--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -117,7 +117,7 @@ test 'previewing/creating/editing a release group and release' => sub {
     like($html, qr/Vision Creation Newsun/, 'preview has release name');
     like($html, qr/limited edition/, 'preview has release comment');
     like($html, qr/4943674011582/, 'preview has barcode');
-    like($html, qr/No linguistic content/, 'preview has language');
+    like($html, qr/\[No linguistic content\]/, 'preview has language');
     like($html, qr/Symbols/, 'preview has script');
     like($html, qr/Official/, 'preview has release status');
     like($html, qr/1999-10-27/, 'preview has release date');

--- a/t/sql/initial.sql
+++ b/t/sql/initial.sql
@@ -109,7 +109,7 @@ INSERT INTO language VALUES (198, 'jpn', 'jpn', 'ja', 'Japanese', 2, 'jpn');
 INSERT INTO language VALUES (284, 'mul', 'mul', '', '[Multiple languages]', 2, 'mul');
 INSERT INTO language VALUES (393, 'spa', 'spa', 'es', 'Spanish', 2, 'spa');
 INSERT INTO language VALUES (455, 'cym', 'wel', 'cy', 'Welsh', 1, 'cym');
-INSERT INTO language VALUES (486, 'zxx', 'zxx', NULL, 'No linguistic content', 1, 'zxx');
+INSERT INTO language VALUES (486, 'zxx', 'zxx', NULL, '[No linguistic content]', 1, 'zxx');
 
 INSERT INTO link_attribute_type VALUES (1, NULL, 1, 0, '0a5341f8-3b1d-4f99-a0c6-26b7f4e42c7f', 'additional', 'This attribute describes if a particular role was considered normal or additional.', '2014-03-30 09:53:32.715353+00');
 INSERT INTO link_attribute_type VALUES (2, NULL, 2, 0, '5b66c85d-6963-4d4b-86e5-18d2caccb349', 'minor', 'This attribute describes if a particular collaboration was considered equal or minor.', '2011-09-28 20:29:34.86135+00');


### PR DESCRIPTION
- Like `[Artificial (Other)]` (`qaa`)
- Like `[Multiple languages]` (`mul`)
- Like `[No lyrics]` (same `zxx`)

`No linguistic language` (`zxx`) should be renamed to `[No linguistic language]` (`zxx`) and should thus appear in release language list (select combo) after ~~`[Multiple languages]` (Frequently used)~~ `[Artificial (Other)]`, instead of between `Niuean` and `Nogai`.

I guess it also requires a Database edit of the stored label in languages table.

Maybe I am missing some files.