### PR TITLE
MBS-13149 / MBS-13153 / MBS-13156 / MBS-13157: More guess case changes

### DIFF
--- a/root/static/scripts/guess-case/modes.js
+++ b/root/static/scripts/guess-case/modes.js
@@ -65,6 +65,7 @@ const PREPROCESS_FIXLIST = [
    */
   [/(\b|^)a\s?c+ap+el+a(\b)/i, 'a_cappella'], // A Capella preprocess
   [/(\b|^)oc\sremix(\b)/i,     'oc_remix'],   // OC ReMix preprocess
+  [/(\b|^)re-edit(\b)/ig,      're_edit'],    // re-edit preprocess
   [/(\b|^)a\/k\/a(\b)/ig,      'a_k_a_'],     // a.k.a. preprocess
   [/(\b|^)a\.k\.a\.(\s)/ig,    'a_k_a_'],
 ];
@@ -74,7 +75,8 @@ const POSTPROCESS_FIXLIST = [
   [/(\b|^)a_cappella(\b)/, 'a cappella'], // a_cappella inside brackets
   [/(\b|^)A_cappella(\b)/, 'A Cappella'], // a_cappella outside brackets
   [/(\b|^)oc_remix(\b)/i,  'OC ReMix'],   // oc_remix
-  [/(\b|^)Re_edit(\b)/,    're-edit'],    // re_edit inside brackets
+  [/(\b|^)re_edit(\b)/g,   're-edit'],    // re_edit inside brackets
+  [/(\b|^)Re_edit(\b)/g,   'Re-Edit'],    // re_edit outside brackets
   [/(\b|^)a_k_a_(\b|$)/ig, 'a.k.a.'],     // a.k.a. lowercase
   [/(\b|^)aka(\b|$)/ig,    'aka'],        // aka lowercase
 

--- a/root/static/scripts/guess-case/modes.js
+++ b/root/static/scripts/guess-case/modes.js
@@ -63,22 +63,22 @@ const PREPROCESS_FIXLIST = [
    * combined word hacks, e.g. replace spaces with underscores ("a cappella"
    * -> a_capella), such that it can be handled correctly in post-processing.
    */
-  [/(\b|^)a\s?c+ap+el+a(\b)/i, 'a_cappella'], // A Capella preprocess
-  [/(\b|^)oc\sremix(\b)/i,     'oc_remix'],   // OC ReMix preprocess
-  [/(\b|^)re-edit(\b)/ig,      're_edit'],    // re-edit preprocess
-  [/(\b|^)a\/k\/a(\b)/ig,      'a_k_a_'],     // a.k.a. preprocess
-  [/(\b|^)a\.k\.a\.(\s)/ig,    'a_k_a_'],
+  [/(\b|^)a\s?c+ap+el+a(\b)/ig, 'a_cappella'], // A Capella preprocess
+  [/(\b|^)oc\sremix(\b)/ig,     'oc_remix'],   // OC ReMix preprocess
+  [/(\b|^)re-edit(\b)/ig,       're_edit'],    // re-edit preprocess
+  [/(\b|^)a\/k\/a(\b)/ig,       'a_k_a_'],     // a.k.a. preprocess
+  [/(\b|^)a\.k\.a\.(\s)/ig,     'a_k_a_'],
 ];
 
 // see combined words hack in preProcessTitles
 const POSTPROCESS_FIXLIST = [
-  [/(\b|^)a_cappella(\b)/, 'a cappella'], // a_cappella inside brackets
-  [/(\b|^)A_cappella(\b)/, 'A Cappella'], // a_cappella outside brackets
-  [/(\b|^)oc_remix(\b)/i,  'OC ReMix'],   // oc_remix
-  [/(\b|^)re_edit(\b)/g,   're-edit'],    // re_edit inside brackets
-  [/(\b|^)Re_edit(\b)/g,   'Re-Edit'],    // re_edit outside brackets
-  [/(\b|^)a_k_a_(\b|$)/ig, 'a.k.a.'],     // a.k.a. lowercase
-  [/(\b|^)aka(\b|$)/ig,    'aka'],        // aka lowercase
+  [/(\b|^)a_cappella(\b)/g, 'a cappella'], // a_cappella inside brackets
+  [/(\b|^)A_cappella(\b)/g, 'A Cappella'], // a_cappella outside brackets
+  [/(\b|^)oc_remix(\b)/ig,  'OC ReMix'],   // oc_remix
+  [/(\b|^)re_edit(\b)/g,    're-edit'],    // re_edit inside brackets
+  [/(\b|^)Re_edit(\b)/g,    'Re-Edit'],    // re_edit outside brackets
+  [/(\b|^)a_k_a_(\b|$)/ig,  'a.k.a.'],     // a.k.a. lowercase
+  [/(\b|^)aka(\b|$)/ig,     'aka'],        // aka lowercase
 
   /*
    * "fe" is considered a lowercase word, but "Santa Fe" is very common in

--- a/root/static/scripts/guess-case/utils.js
+++ b/root/static/scripts/guess-case/utils.js
@@ -116,6 +116,8 @@ const lowerCaseBracketWordsList = [
   're_edit',
   'reinterpreted',
   'remake',
+  'remaster',
+  'remastered',
   'remix',
   'rmx',
   'reprise',

--- a/root/static/scripts/guess-case/utils.js
+++ b/root/static/scripts/guess-case/utils.js
@@ -113,6 +113,7 @@ const lowerCaseBracketWordsList = [
   'outtakes',
   'quadraphonic',
   'reedit',
+  're_edit',
   'reinterpreted',
   'remake',
   'remix',

--- a/root/static/scripts/guess-case/utils.js
+++ b/root/static/scripts/guess-case/utils.js
@@ -114,6 +114,7 @@ const lowerCaseBracketWordsList = [
   'quadraphonic',
   'reedit',
   're_edit',
+  'refix',
   'reinterpreted',
   'remake',
   'remaster',

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -413,7 +413,7 @@ test('Work', function (t) {
 });
 
 test('BugFixes', function (t) {
-  t.plan(39);
+  t.plan(40);
 
   const tests = [
     {
@@ -648,6 +648,12 @@ test('BugFixes', function (t) {
       input: 'The Best Remaster',
       expected: 'The Best (remaster)',
       bug: 'MBS-13156',
+      mode: 'English',
+    },
+    {
+      input: 'The Best Refix',
+      expected: 'The Best (refix)',
+      bug: 'MBS-13149',
       mode: 'English',
     },
     /*

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -413,7 +413,7 @@ test('Work', function (t) {
 });
 
 test('BugFixes', function (t) {
-  t.plan(38);
+  t.plan(39);
 
   const tests = [
     {
@@ -642,6 +642,12 @@ test('BugFixes', function (t) {
       input: 'The Best Re-Edit',
       expected: 'The Best (re-edit)',
       bug: 'MBS-13153',
+      mode: 'English',
+    },
+    {
+      input: 'The Best Remaster',
+      expected: 'The Best (remaster)',
+      bug: 'MBS-13156',
       mode: 'English',
     },
     /*

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -413,7 +413,7 @@ test('Work', function (t) {
 });
 
 test('BugFixes', function (t) {
-  t.plan(40);
+  t.plan(42);
 
   const tests = [
     {
@@ -653,6 +653,18 @@ test('BugFixes', function (t) {
     {
       input: 'The Best Refix',
       expected: 'The Best (refix)',
+      bug: 'MBS-13149',
+      mode: 'English',
+    },
+    {
+      input: 'The Best OC Remix Song (OC Remix By Stan)',
+      expected: 'The Best OC ReMix Song (OC ReMix by Stan)',
+      bug: 'MBS-13149',
+      mode: 'English',
+    },
+    {
+      input: 'An A Cappella Festival (A Cappella Version)',
+      expected: 'An A Cappella Festival (a cappella version)',
       bug: 'MBS-13149',
       mode: 'English',
     },

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -413,7 +413,7 @@ test('Work', function (t) {
 });
 
 test('BugFixes', function (t) {
-  t.plan(36);
+  t.plan(38);
 
   const tests = [
     {
@@ -630,6 +630,18 @@ test('BugFixes', function (t) {
       input: 'The Best Song (8-Bit Loop Version)',
       expected: 'The Best Song (8-bit loop version)',
       bug: 'MBS-12779',
+      mode: 'English',
+    },
+    {
+      input: 'The Best Re-Edit (Someone Famous Re-Edit)',
+      expected: 'The Best Re-Edit (Someone Famous re-edit)',
+      bug: 'MBS-13153',
+      mode: 'English',
+    },
+    {
+      input: 'The Best Re-Edit',
+      expected: 'The Best (re-edit)',
+      bug: 'MBS-13153',
       mode: 'English',
     },
     /*


### PR DESCRIPTION
### Fix MBS-13153 and MBS-13157, implement MBS-13149 and MBS-13156

# Problem
The words "remaster" ("remastered") and "refix" are pretty much always ETI and should be treated as such by guess case. Same for "re-edit", which we already try to cover, but buggily.
While looking into these I also noticed we don't use global regexes enough, causing issues if the same word appears twice (uncommon, but not impossible).

# Solution
I added all of the new words to the list of words which are put into parens if seen at the end of the title, and lowercased if in parens.
I fixed the re-edit check and made it behave differently inside and outside parens.
I made the a cappella and OC ReMix checks global so that it checks more than once per title.

# Testing
Added a basic test for each case.