### PR TITLE
MBS-13092: Support Apple Music song links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -826,9 +826,11 @@ const CLEANUPS: CleanupEntries = {
       multiple(LINK_TYPES.downloadpurchase, LINK_TYPES.streamingpaid),
     ],
     clean: function (url) {
-      url = url.replace(/^https?:\/\/(?:(?:beta|geo)\.)?music\.apple\.com\/([a-z]{2}\/)?(artist|album|author|label|music-video)\/(?:[^?#\/]+\/)?(?:id)?([0-9]+)(?:\?.*)?$/, 'https://music.apple.com/$1$2/$3');
+      url = url.replace(/^https?:\/\/(?:(?:beta|geo)\.)?music\.apple\.com\//, 'https://music.apple.com/');
       // US page is the default, add its country-code to clarify (MBS-10623)
       url = url.replace(/^(https:\/\/music\.apple\.com)\/([a-z-]{3,})\//, '$1/us/$2/');
+      url = url.replace(/^(https:\/\/music\.apple\.com\/[a-z]{2})\/album\/[^?#\/]+\/[0-9]+\?i=([0-9]+)$/, '$1/song/$2');
+      url = url.replace(/^(https:\/\/music\.apple\.com\/[a-z]{2})\/(artist|album|author|label|music-video|song)\/(?:[^?#\/]+\/)?(?:id)?([0-9]+)(?:\?.*)?$/, '$1/$2/$3');
       return url;
     },
     validate: function (url, id) {
@@ -875,7 +877,7 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.downloadpurchase.recording:
           case LINK_TYPES.streamingpaid.recording:
             return {
-              result: prefix === 'music-video',
+              result: prefix === 'music-video' || prefix === 'song',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.downloadpurchase.release:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -598,6 +598,26 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://music.apple.com/ee/music-video/539886832',
   },
   {
+                     input_url: 'https://music.apple.com/song/low-frequency-response-test/1435928320',
+             input_entity_type: 'recording',
+limited_link_type_combinations: [
+                                  'downloadpurchase',
+                                  'streamingpaid',
+                                  ['downloadpurchase', 'streamingpaid'],
+                                ],
+            expected_clean_url: 'https://music.apple.com/us/song/1435928320',
+  },
+  {
+                     input_url: 'https://music.apple.com/us/album/low-frequency-response-test/1435928305?i=1435928320',
+             input_entity_type: 'recording',
+limited_link_type_combinations: [
+                                  'downloadpurchase',
+                                  'streamingpaid',
+                                  ['downloadpurchase', 'streamingpaid'],
+                                ],
+            expected_clean_url: 'https://music.apple.com/us/song/1435928320',
+  },
+  {
                      input_url: 'https://music.apple.com/jp/album/uchiagehanabi-single/1263790414',
              input_entity_type: 'release',
 limited_link_type_combinations: [


### PR DESCRIPTION
### Implement MBS-13092

# Problem
We were blocking song links for Apple Music, but I can't see any real reasons to. There's two kinds of song links - one that selects the track on an album (kind of like our track links in MB) and one that goes to a /song page for the track itself.

# Solution
This allows entering `/song` links on recordings, and converts `/album/albumid?i=trackid` links to /song ones, since there's no reason not to convert them and allow them, as far as I can tell.
I split the regexes a bit more for clarity.

# Testing
URL tests added.