### PR TITLE
MBS-13115: Move annotation preview button to the left of Enter

### DIFF
--- a/root/annotation/EditAnnotation.js
+++ b/root/annotation/EditAnnotation.js
@@ -84,7 +84,7 @@ const EditAnnotation = ({
 
         <EnterEditNote field={form.field.edit_note} />
 
-        <EnterEdit form={form}>
+        <EnterEdit childrenFirst form={form}>
           <button
             name={form.field.preview.html_name}
             type="submit"

--- a/root/static/scripts/edit/components/EnterEdit.js
+++ b/root/static/scripts/edit/components/EnterEdit.js
@@ -9,6 +9,7 @@
 
 type CommonProps = {
   +children?: React$Node,
+  +childrenFirst?: boolean,
   +disabled?: boolean,
   +form: ReadOnlyFormT<{
     +make_votable: ReadOnlyFieldT<boolean>,
@@ -29,6 +30,7 @@ type Props =
 
 const EnterEdit = ({
   children,
+  childrenFirst = false,
   disabled = false,
   form,
   ...otherProps
@@ -63,6 +65,7 @@ const EnterEdit = ({
         </div>
       </div>
       <div className="row no-label buttons">
+        {childrenFirst ? children : null}
         <button
           className="submit positive"
           disabled={disabled}
@@ -70,7 +73,7 @@ const EnterEdit = ({
         >
           {l('Enter edit')}
         </button>
-        {children}
+        {childrenFirst ? null : children}
       </div>
     </>
   );


### PR DESCRIPTION
### Implement MBS-13115

# Reasoning
Having the preview button go first is more likely to encourage people to use it (and make sure the annotation looks right) before submitting. Ran this through @Aerozol to confirm it seemed good.

Implemented by just having a boolean to say whether children buttons for `EnterEdit` should be before or after the submit button (we have Cancel buttons to the right when present, and we haven't had any talk of moving those).

# Testing
Manually