### PR TITLE
MBS-13098: Process cover art params for seeding

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -361,7 +361,7 @@ sub add_cover_art : Chained('load') PathPart('add-cover-art') Edit {
         }
     } elsif ($c->form_posted) {
         $c->response->status(500);
-    } elsif (!$c->form_posted && %{ $c->req->query_params }) {
+    } elsif (%{ $c->req->query_params }) {
         # Process query parameters to support seeding fields.
         my $merged = { ( %{$form->fif}, %{$c->req->query_params} ) };
         $form->process( params => $merged );

--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -361,6 +361,11 @@ sub add_cover_art : Chained('load') PathPart('add-cover-art') Edit {
         }
     } elsif ($c->form_posted) {
         $c->response->status(500);
+    } elsif (!$c->form_posted && %{ $c->req->query_params }) {
+        # Process query parameters to support seeding fields.
+        my $merged = { ( %{$form->fif}, %{$c->req->query_params} ) };
+        $form->process( params => $merged );
+        $form->clear_errors;
     }
 
     if ($returning_json) {

--- a/root/release/add_cover_art.tt
+++ b/root/release/add_cover_art.tt
@@ -18,7 +18,9 @@
     }).fail(function () { $(".caa-warning").parent().toggle(); });
   </script>
 
-  <form id="add-cover-art" class="cover-art" action="[% c.req.uri %]" method="post" >
+  [%# Remove query params used to seed fields to avoid a "field must contain a single
+      value" error due to submitting duplicate parameters via the body later. %]
+  <form id="add-cover-art" class="cover-art" action="[% c.req.uri.replace('\?.*', '') %]" method="post" >
     [%- USE r = FormRenderer(form) -%]
 
     <div class="add-files row">

--- a/root/release/add_cover_art.tt
+++ b/root/release/add_cover_art.tt
@@ -20,7 +20,7 @@
 
   [%# Remove query params used to seed fields to avoid a "field must contain a single
       value" error due to submitting duplicate parameters via the body later. %]
-  <form id="add-cover-art" class="cover-art" action="[% c.req.uri.replace('\?.*', '') %]" method="post" >
+  <form id="add-cover-art" class="cover-art" action="[% c.req.uri.path %]" method="post">
     [%- USE r = FormRenderer(form) -%]
 
     <div class="add-files row">

--- a/t/selenium/CAA.json5
+++ b/t/selenium/CAA.json5
@@ -3,7 +3,8 @@
   commands: [
     {
       command: 'open',
-      target: '/release/dd245091-b21e-48a3-b59a-f9b8ed8a0469/add-cover-art',
+      // Seed the edit note field via a query parameter.
+      target: '/release/dd245091-b21e-48a3-b59a-f9b8ed8a0469/add-cover-art?add-cover-art.edit_note=seeded+note',
       value: '',
     },
     {
@@ -17,6 +18,11 @@
       command: 'check',
       target: "xpath=((//ul[contains(@class, 'checkboxes')])[1]//input[contains(@type, 'checkbox')][contains(@class, 'type')])[1]",
       value: '',
+    },
+    {
+      command: 'check',
+      target: "id=id-add-cover-art.edit_note",
+      value: 'seeded note',
     },
     {
       command: 'sendKeys',
@@ -102,6 +108,17 @@
       command: 'assertText',
       target: "xpath=((//div[contains(@class, 'artwork-cont mp')])[2]/p)[2]",
       value: 'back',
+    },
+    // Verify that the seeded edit note was used.
+    {
+      command: 'open',
+      target: '/edit/1',
+      value: '',
+    },
+    {
+      command: 'assertText',
+      target: "xpath=//div[contains(@class, 'edit-note-text')]",
+      value: 'seeded note',
     },
     // Wait for the artwork-indexer to catch up.
     {


### PR DESCRIPTION
Update MusicBrainz::Server::Controller::Release's add_cover_art() method to pass query parameters to the form's process() method when handling GET requests so that the edit note textarea and make-votable checkbox can be seeded via add-cover-art.edit_note and add-cover-art.make_votable, respectively.

This matches what MusicBrainz::Server::Controller's edit_action() method does for other forms that are seedable via query params.

Also update add_cover_art.tt to remove query parameters from the form's "action" URL so that they won't be double submitted in the query string and the request body.

---

This was definitely at the upper end of the time-spent-to-lines-of-code ratio. 😬 I haven't written any Perl in a long time and haven't used Catalyst/HTML::FormHandler/etc. before, so it took me a lot of time to figure out what was different between the add-cover-art form and other forms that support seeding (like adding artists). Hopefully I'm not doing anything wrong.

I didn't see anything in the musicbrainz-docker repo about emulating the CAA, and I couldn't get the instructions in `HACKING-CAA.md` working under mb-docker, so I ended up just hacking `lib/MusicBrainz/Server/Controller/WS/js.pm` and `root/static/scripts/edit/MB/CoverArt.js` locally to skip uploading. This change works for me as expected after doing that.

I also wasn't sure what to do with regard to tests. One option might be to make `t/lib/t/MusicBrainz/Server/Controller/Release/EditCoverArt.pm` pass a query string and check that the resulting page contains the seeded value. Another option might be updating `t/selenium/CAA.json5`. Should I be looking into adding either of those changes to this? I haven't tried running tests yet and I'm not sure how they work with musicbrainz-docker (if at all).