### PR TITLE
Beta: Fix log flood regression since #2902

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Medium.pm
+++ b/lib/MusicBrainz/Server/Entity/Medium.pm
@@ -172,14 +172,16 @@ around TO_JSON => sub {
 
     my $track_count = $self->track_count;
     my $format_id = $self->format_id;
+    my $position = $self->position;
+    my $release_id = $self->release_id;
 
     my $data = {
         %{ $self->$orig },
         cdtocs      => [map { $_->cdtoc->toc } $self->all_cdtocs],
         format      => $self->format ? $self->format->TO_JSON : undef,
         format_id   => defined $format_id ? (0 + $format_id) : undef,
-        position    => (0 + $self->position),
-        release_id  => (0 + $self->release_id),
+        position    => defined $position ? (0 + $position) : undef,
+        release_id  => defined $release_id ? (0 + $release_id) : undef,
         track_count => defined $track_count ? (0 + $track_count) : undef,
     };
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Since the commit e38d8e95e6ab06888c956df668a4cb5617a3b4ea (pull request #2902) is in prod (`v-2023-06-07`), search queries are triggering two warnings for each result in logs, that is up to 200 log lines for each query, resulting in needless GBs of logs.


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This patch simply checks if defined before enforcing integer conversion, that is the same approach for `position` and `release_id` as for `format_id` and `track_count`, thus stopping the log flood.

However by doing so, it partly reverts the commit e38d8e95e6ab06888c956df668a4cb5617a3b4ea as it unsyncs the Flow type `MediumT` for its `position` and `release_id` properties. It is unclear whether these should be nullable or if a new type should be used instead since these are null only for search results. Beyond Flow types, the property `mediums_loaded` in Perl is misleading too. A larger refactoring might be needed to sanitize the code.

# Testing

Manually tested by:
* visiting http://localhost:5000/taglookup?artist=Tracy%20Chapman&release=Tracy%20Chapman&track=&tracknum=&duration=&filename=&tport=8000 and checking server logs,
* trying to reproduce MBS-12976

Note: We don’t have CI tests for these warnings in logs.

# Draft progress
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Further check code to determine if undefined `position` is legitimate.
* [x] Further check code to determine if undefined `release_id` is legitimate.
* [x] Further trace code to find out potential implications of this patch.