### PR TITLE
MBS-13160: Rename "legal name" on artist page to "performance name of"

### DIFF
--- a/root/artist/ArtistIndex.js
+++ b/root/artist/ArtistIndex.js
@@ -46,6 +46,8 @@ type FooterSwitchProps = {
 type Props = {
   +ajaxFilterFormUrl: string,
   +artist: ArtistT,
+  +baseName: ?ArtistT,
+  +baseNameLegalNameAliases: ?$ReadOnlyArray<string>,
   +eligibleForCleanup: boolean,
   +filterForm: ?FilterFormT,
   +hasDefault: boolean,
@@ -54,9 +56,7 @@ type Props = {
   +hasVariousArtists: boolean,
   +hasVariousArtistsExtra: boolean,
   +includingAllStatuses: boolean,
-  +legalName: ?ArtistT,
   +legalNameAliases: ?$ReadOnlyArray<string>,
-  +legalNameArtistAliases: ?$ReadOnlyArray<string>,
   +numberOfRevisions: number,
   +otherIdentities: $ReadOnlyArray<ArtistT>,
   +pager: PagerT,
@@ -197,6 +197,8 @@ const FooterSwitch = ({
 const ArtistIndex = ({
   ajaxFilterFormUrl,
   artist,
+  baseName,
+  baseNameLegalNameAliases,
   eligibleForCleanup,
   filterForm,
   hasDefault,
@@ -205,9 +207,7 @@ const ArtistIndex = ({
   hasVariousArtists,
   hasVariousArtistsExtra,
   includingAllStatuses,
-  legalName,
   legalNameAliases,
-  legalNameArtistAliases,
   numberOfRevisions,
   otherIdentities,
   pager,
@@ -235,11 +235,11 @@ const ArtistIndex = ({
         numberOfRevisions={numberOfRevisions}
       />
 
-      {legalName ? (
-        <RelatedEntitiesDisplay title={l('Legal name')}>
-          <DescriptiveLink entity={legalName} />
-          {legalNameArtistAliases
-            ? ' ' + bracketedText(commaOnlyListText(legalNameArtistAliases))
+      {baseName ? (
+        <RelatedEntitiesDisplay title={l('Performance name of')}>
+          <DescriptiveLink entity={baseName} />
+          {baseNameLegalNameAliases
+            ? ' ' + bracketedText(commaOnlyListText(baseNameLegalNameAliases))
             : null}
         </RelatedEntitiesDisplay>
 


### PR DESCRIPTION
### Implement MBS-13160

# Problem
We renamed the relationship text for "performs as" with STYLE-2328 but the display on the artist overview page was still hardcoded to "Legal name".

# Solution
This renames the hardcoded text to "Performance name of" (as in the relationship) in the case where we follow this relationship (which no longer mandates it must be a legal name). "Legal name" is kept for actual legal name alias display.

I wasn't sure what'd be a good name for the no-longer-`legalName`, ended up going with `baseName` since it's the base of the grouping of names for the artist.

# Testing
Manually, on the artist from the ticket.