### PR TITLE
MBS-13167: Show last granted token date for auth applications

### DIFF
--- a/lib/MusicBrainz/Server/Data/EditorOAuthToken.pm
+++ b/lib/MusicBrainz/Server/Data/EditorOAuthToken.pm
@@ -21,7 +21,7 @@ sub _columns
 {
     return 'id, editor, application, authorization_code, ' .
            'access_token, refresh_token, expire_time, scope, ' .
-           'code_challenge, code_challenge_method';
+           'code_challenge, code_challenge_method, granted';
 }
 
 sub _column_mapping
@@ -37,6 +37,7 @@ sub _column_mapping
         refresh_token => 'refresh_token',
         expire_time => 'expire_time',
         scope => 'scope',
+        granted => 'granted',
     };
 }
 
@@ -69,7 +70,7 @@ sub get_by_refresh_token
 sub find_granted_by_editor
 {
     my ($self, $editor_id, $limit, $offset) = @_;
-    my $query = 'SELECT application, scope, max(refresh_token) AS refresh_token
+    my $query = 'SELECT application, scope, max(granted) as granted
                  FROM ' . $self->_table . '
                  WHERE
                     editor = ? AND

--- a/root/account/applications/Index.js
+++ b/root/account/applications/Index.js
@@ -7,12 +7,16 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import * as React from 'react';
+
 import PaginatedResults from '../../components/PaginatedResults.js';
 import {ACCESS_SCOPE_PERMISSIONS} from '../../constants.js';
+import {SanitizedCatalystContext} from '../../context.mjs';
 import Layout from '../../layout/index.js';
 import {compare} from '../../static/scripts/common/i18n.js';
 import {commaOnlyListText}
   from '../../static/scripts/common/i18n/commaOnlyList.js';
+import formatUserDate from '../../utility/formatUserDate.js';
 import loopParity from '../../utility/loopParity.js';
 
 type Props = {
@@ -44,10 +48,15 @@ const buildApplicationRow = (application: ApplicationT, index: number) => (
   </tr>
 );
 
-const buildTokenRow = (token: EditorOAuthTokenT, index: number) => (
+const buildTokenRow = (
+  token: EditorOAuthTokenT,
+  index: number,
+  $c: SanitizedCatalystContextT,
+) => (
   <tr className={loopParity(index)} key={token.id}>
     <td>{token.application.name}</td>
     <td>{formatScopes(token)}</td>
+    <td>{formatUserDate($c, token.granted)}</td>
     <td>
       <a
         href={'/account/applications/revoke-access/' +
@@ -78,80 +87,87 @@ const Index = ({
   appsPager,
   tokens,
   tokensPager,
-}: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Applications')}>
-    <h1>{l('Applications')}</h1>
+}: Props): React$Element<typeof Layout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
 
-    <h2>{l('Authorized Applications')}</h2>
+  return (
+    <Layout fullWidth title={l('Applications')}>
+      <h1>{l('Applications')}</h1>
 
-    <p>
-      {l(
-        `Some applications and websites support accessing private data from
-         or submitting data to MusicBrainz but require your permission to
-         access your account. These are the applications that you have
-         authorized to access your MusicBrainz account. If you no longer use
-         some of the applications, you can revoke their access.`,
-      )}
-    </p>
+      <h2>{l('Authorized Applications')}</h2>
 
-    {tokens.length
-      ? (
-        <PaginatedResults pageVar="tokens_page" pager={tokensPager}>
-          <table className="tbl">
-            <thead>
-              <tr>
-                <th>{l('Application')}</th>
-                <th>{l('Access')}</th>
-                <th>{l('Actions')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {tokens.map(buildTokenRow)}
-            </tbody>
-          </table>
-        </PaginatedResults>
-      ) : (
-        <p>{l('You have not authorized any applications.')}</p>
-      )}
+      <p>
+        {l(
+          `Some applications and websites support accessing private data from
+          or submitting data to MusicBrainz but require your permission to
+          access your account. These are the applications that you have
+          authorized to access your MusicBrainz account. If you no longer use
+          some of the applications, you can revoke their access.`,
+        )}
+      </p>
 
-    <h2>{l('Developer Applications')}</h2>
+      {tokens.length
+        ? (
+          <PaginatedResults pageVar="tokens_page" pager={tokensPager}>
+            <table className="tbl">
+              <thead>
+                <tr>
+                  <th>{l('Application')}</th>
+                  <th>{l('Access')}</th>
+                  <th>{l('Last granted token')}</th>
+                  <th>{l('Actions')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tokens.map(
+                  (token, index) => buildTokenRow(token, index, $c),
+                )}
+              </tbody>
+            </table>
+          </PaginatedResults>
+        ) : (
+          <p>{l('You have not authorized any applications.')}</p>
+        )}
 
-    <p>
-      {exp.l(
-        `Do you want to develop an application that uses the
-         {mb_api_doc_url|MusicBrainz API}? 
-         {register_url|Register an application} to generate OAuth tokens.
-         See our {oauth2_doc_url|OAuth documentation} for more details.`,
-        {
-          mb_api_doc_url: '/doc/MusicBrainz_API',
-          oauth2_doc_url: '/doc/Development/OAuth2',
-          register_url: '/account/applications/register',
-        },
-      )}
-    </p>
+      <h2>{l('Developer Applications')}</h2>
 
-    {applications.length
-      ? (
-        <PaginatedResults pageVar="apps_page" pager={appsPager}>
-          <table className="tbl">
-            <thead>
-              <tr>
-                <th>{l('Application')}</th>
-                <th>{l('Type')}</th>
-                <th>{l('OAuth Client ID')}</th>
-                <th>{l('OAuth Client Secret')}</th>
-                <th>{l('Actions')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {applications.map(buildApplicationRow)}
-            </tbody>
-          </table>
-        </PaginatedResults>
-      ) : (
-        <p>{l('You do not have any registered applications.')}</p>
-      )}
-  </Layout>
-);
+      <p>
+        {exp.l(
+          `Do you want to develop an application that uses the
+          {mb_api_doc_url|MusicBrainz API}? 
+          {register_url|Register an application} to generate OAuth tokens.
+          See our {oauth2_doc_url|OAuth documentation} for more details.`,
+          {
+            mb_api_doc_url: '/doc/MusicBrainz_API',
+            oauth2_doc_url: '/doc/Development/OAuth2',
+            register_url: '/account/applications/register',
+          },
+        )}
+      </p>
+
+      {applications.length
+        ? (
+          <PaginatedResults pageVar="apps_page" pager={appsPager}>
+            <table className="tbl">
+              <thead>
+                <tr>
+                  <th>{l('Application')}</th>
+                  <th>{l('Type')}</th>
+                  <th>{l('OAuth Client ID')}</th>
+                  <th>{l('OAuth Client Secret')}</th>
+                  <th>{l('Actions')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {applications.map(buildApplicationRow)}
+              </tbody>
+            </table>
+          </PaginatedResults>
+        ) : (
+          <p>{l('You do not have any registered applications.')}</p>
+        )}
+    </Layout>
+  );
+};
 
 export default Index;


### PR DESCRIPTION
### Implement MBS-13167

# Problem
It seems useful to know when was the last time a specific application / scope had a token granted; that is likely to help users revoke unneeded ones (I for example currently seem to have 7 ListenBrainz tokens, some of which were granted in 2015).

# Solution
This adds a column in the authorized applications table for the `granted` token column, which displays the last time a token was granted for this specific application + scope combo. I stopped returning the `refresh_token` here since it seems we do not use it at all.

# Testing
Manually.