### PR TITLE
MBS-13173: Also allow daily.bandcamp.com interviews

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -965,21 +965,16 @@ const CLEANUPS: CleanupEntries = {
   },
   'bandcamp': {
     match: [new RegExp(
-      '^(https?://)?([^/]+\\.)?bandcamp\\.com(?!/campaign/)',
+      '^(https?://)?(((?!daily)[^/])+\\.)?bandcamp\\.com(?!/campaign/)',
       'i',
     )],
     restrict: [{
-      ...LINK_TYPES.review,
       ...LINK_TYPES.bandcamp,
       work: LINK_TYPES.lyrics.work,
     }],
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?([^\/]+\.)?bandcamp\.com(?:\/([^?#]*))?.*$/, 'https://$1bandcamp.com/$2');
-      if (/^https:\/\/daily\.bandcamp\.com/.test(url)) {
-        url = url.replace(/^https:\/\/daily\.bandcamp\.com\/(\d+\/\d+\/\d+\/[\w-]+)(?:\/.*)?$/, 'https://daily.bandcamp.com/$1/');
-      } else {
-        url = url.replace(/^https:\/\/([^\/]+)\.bandcamp\.com\/(?:((?:album|merch|track)\/[^\/]+))?.*$/, 'https://$1.bandcamp.com/$2');
-      }
+      url = url.replace(/^https:\/\/([^\/]+)\.bandcamp\.com\/(?:((?:album|merch|track)\/[^\/]+))?.*$/, 'https://$1.bandcamp.com/$2');
       return url;
     },
     validate: function (url, id) {
@@ -1016,11 +1011,6 @@ const CLEANUPS: CleanupEntries = {
             result: /^https:\/\/[^\/]+\.bandcamp\.com\/$/.test(url),
             target: ERROR_TARGETS.ENTITY,
           };
-        case LINK_TYPES.review.release_group:
-          return {
-            result: /^https:\/\/daily\.bandcamp\.com\/\d+\/\d+\/\d+\/[\w-]+-review\/$/.test(url),
-            target: ERROR_TARGETS.ENTITY,
-          };
         case LINK_TYPES.lyrics.work:
           return {
             result: /^https:\/\/[^\/]+\.bandcamp\.com\/track\/[\w-]+$/.test(url),
@@ -1045,6 +1035,34 @@ const CLEANUPS: CleanupEntries = {
           return {result: /^https:\/\/[^\/]+\.bandcamp\.com\/campaign\/[^?#/]+$/.test(url)};
       }
       return {result: false, target: ERROR_TARGETS.ENTITY};
+    },
+  },
+  'bandcampdaily': {
+    match: [new RegExp(
+      '^(https?://)?daily\\.bandcamp\\.com',
+      'i',
+    )],
+    restrict: [{
+      ...LINK_TYPES.interview,
+      ...LINK_TYPES.review,
+    }],
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?daily\.bandcamp\.com\/((?:\d+\/\d+\/\d+|[\w-]+)\/[\w-]+)(?:\/.*)?$/, 'https://daily.bandcamp.com/$1/');
+    },
+    validate: function (url, id) {
+      switch (id) {
+        case LINK_TYPES.interview.artist:
+          return {
+            result: /^https:\/\/daily\.bandcamp\.com\/(?:\d+\/\d+\/\d+|[\w-]+)\/[\w-]+-interview\/$/.test(url),
+            target: ERROR_TARGETS.ENTITY,
+          };
+        case LINK_TYPES.review.release_group:
+          return {
+            result: /^https:\/\/daily\.bandcamp\.com\/(?:\d+\/\d+\/\d+|[\w-]+)\/[\w-]+-review\/$/.test(url),
+            target: ERROR_TARGETS.ENTITY,
+          };
+      }
+      return {result: false, target: ERROR_TARGETS.URL};
     },
   },
   'bandsintown': {
@@ -5759,6 +5777,17 @@ entitySpecificRules.recording = function (url) {
       ),
       result: false,
       target: ERROR_TARGETS.URL,
+    };
+  }
+  return {result: true};
+};
+
+// Disallow non-daily Bandcamp URLs at release group level
+entitySpecificRules.release_group = function (url) {
+  if (/^(https?:\/\/)?(((?!daily)[^/])+\.)?bandcamp\.com/.test(url)) {
+    return {
+      result: false,
+      target: ERROR_TARGETS.ENTITY,
     };
   }
   return {result: true};

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -750,6 +750,20 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['release_group'],
   },
   {
+                     input_url: 'https://daily.bandcamp.com/album-of-the-day/saloli-canyon-review',
+             input_entity_type: 'release_group',
+    expected_relationship_type: 'review',
+            expected_clean_url: 'https://daily.bandcamp.com/album-of-the-day/saloli-canyon-review/',
+       only_valid_entity_types: ['release_group'],
+  },
+  {
+                     input_url: 'http://daily.bandcamp.com/features/arif-mirbaghi-protest-the-hero-interview',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'interview',
+            expected_clean_url: 'https://daily.bandcamp.com/features/arif-mirbaghi-protest-the-hero-interview/',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'http://daily.bandcamp.com/2018/05/30/gnawa-bandcamp-list',
              input_entity_type: 'release_group',
     expected_relationship_type: 'review',


### PR DESCRIPTION
### Fix MBS-13173

# Problem
Bandcamp publishes interviews with artists seemingly quite often, but we were automatically selecting "bandcamp" for those.

# Solution
This moves `daily.bandcamp` URLs to a separate handling section, so we can deal with them more properly and select interview when appropriate.

While doing this I noticed that newer album reviews are no longer listed under the date as we expected, but under an `album-of-the-day` path. As such, I made both interview and review support these sorts of paths.

Finally, since we are no longer doing any RG-level selecting on the standard bandcamp handling, non-daily bandcamp URLs need to be blocked separately on RGs. AFAICT no non-daily bandcamp URL would be acceptable for RG (and the previous setup blocked them all) so this is a blanket ban.

# Testing
Added a test for the interviews, another for the new kind of review URLs. The RG blocking is tested by the `davidmandelberg.bandcamp.com` RG test (which broke until I reimplemented the blocking explicitly).