### PR TITLE
Update database docs diagrams to schema 28

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -334,6 +334,7 @@ Creating the database
         You can import this sample dump in the same way as the full dump above.
 
     4.  Build materialized tables (optional but recommended)
+        <a name="build-materialized-tables"></a>
 
         MusicBrainz Server makes use of materialized (or denormalized) tables in
         production to improve the performance of certain pages and features. These

--- a/docs/database_schema_diagrams/graphs/area_entity_details.dot
+++ b/docs/database_schema_diagrams/graphs/area_entity_details.dot
@@ -1,7 +1,7 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph area_entity_details {
-    tooltip = "Tables for the “area” core entity type properties"
+    tooltip = "Tables for the “area” entity type properties"
     graph [
         bgcolor = "#cb75ab:#f0976c"
         concentrate = true

--- a/docs/database_schema_diagrams/graphs/artist_entity_details.dot
+++ b/docs/database_schema_diagrams/graphs/artist_entity_details.dot
@@ -1,7 +1,7 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph artist_entity_details {
-    tooltip = "Tables for the “artist” core entity type properties"
+    tooltip = "Tables for the “artist” entity type properties"
     graph [
         bgcolor = "#cb75ab:#f0976c"
         concentrate = true

--- a/docs/database_schema_diagrams/graphs/cdstub_details.dot
+++ b/docs/database_schema_diagrams/graphs/cdstub_details.dot
@@ -1,5 +1,5 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph cdstub_details {
     tooltip = "Tables for CD stub"
     graph [

--- a/docs/database_schema_diagrams/graphs/cover_art_details.dot
+++ b/docs/database_schema_diagrams/graphs/cover_art_details.dot
@@ -1,5 +1,5 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph cover_art_details {
     tooltip = "Tables for cover art"
     graph [

--- a/docs/database_schema_diagrams/graphs/entity_network_details.dot
+++ b/docs/database_schema_diagrams/graphs/entity_network_details.dot
@@ -1,7 +1,7 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph entity_network_details {
-    tooltip = "Tables specifically related to core entities"
+    tooltip = "Tables uniquely related to primary entity types"
     graph [
         bgcolor = "#cb75ab:#f0976c"
         concentrate = true
@@ -142,7 +142,6 @@ digraph entity_network_details {
                 <tr><td bgcolor="#bbbbbb33" align="left" port="track_count"><font point-size="14">track_count</font></td></tr>
                 <tr><td bgcolor="#bbbbbb33" align="left" port="leadout_offset"><font point-size="14">leadout_offset</font></td></tr>
                 <tr><td bgcolor="#bbbbbb33" align="left" port="track_offset"><font point-size="14">track_offset</font></td></tr>
-                <tr><td bgcolor="#bbbbbb33" align="left" port="degraded"><font point-size="14">degraded</font></td></tr>
                 <tr><td bgcolor="#bbbbbb33" align="left" port="created"><font point-size="14">created</font></td></tr>
             </table>
         >

--- a/docs/database_schema_diagrams/graphs/entity_network_overview.dot
+++ b/docs/database_schema_diagrams/graphs/entity_network_overview.dot
@@ -1,7 +1,7 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph entity_network_overview {
-    tooltip = "Overview of tables connecting entities"
+    tooltip = "Overview of tables connecting primary entity types"
     graph [
         bgcolor = "#cb75ab:#f0976c"
         concentrate = true

--- a/docs/database_schema_diagrams/graphs/event_entity_details.dot
+++ b/docs/database_schema_diagrams/graphs/event_entity_details.dot
@@ -1,7 +1,7 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph event_entity_details {
-    tooltip = "Tables for the “event” core entity type properties"
+    tooltip = "Tables for the “event” entity type properties"
     graph [
         bgcolor = "#cb75ab:#f0976c"
         concentrate = true

--- a/docs/database_schema_diagrams/graphs/genre_entity_details.dot
+++ b/docs/database_schema_diagrams/graphs/genre_entity_details.dot
@@ -1,7 +1,7 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph genre_entity_details {
-    tooltip = "Tables for the “genre” core entity type properties"
+    tooltip = "Tables for the “genre” entity type properties"
     graph [
         bgcolor = "#cb75ab:#f0976c"
         concentrate = true

--- a/docs/database_schema_diagrams/graphs/instrument_entity_details.dot
+++ b/docs/database_schema_diagrams/graphs/instrument_entity_details.dot
@@ -1,7 +1,7 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph instrument_entity_details {
-    tooltip = "Tables for the “instrument” core entity type properties"
+    tooltip = "Tables for the “instrument” entity type properties"
     graph [
         bgcolor = "#cb75ab:#f0976c"
         concentrate = true

--- a/docs/database_schema_diagrams/graphs/label_entity_details.dot
+++ b/docs/database_schema_diagrams/graphs/label_entity_details.dot
@@ -1,7 +1,7 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph label_entity_details {
-    tooltip = "Tables for the “label” core entity type properties"
+    tooltip = "Tables for the “label” entity type properties"
     graph [
         bgcolor = "#cb75ab:#f0976c"
         concentrate = true

--- a/docs/database_schema_diagrams/graphs/place_entity_details.dot
+++ b/docs/database_schema_diagrams/graphs/place_entity_details.dot
@@ -1,7 +1,7 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph place_entity_details {
-    tooltip = "Tables for the “place” core entity type properties"
+    tooltip = "Tables for the “place” entity type properties"
     graph [
         bgcolor = "#cb75ab:#f0976c"
         concentrate = true

--- a/docs/database_schema_diagrams/graphs/recording_entity_details.dot
+++ b/docs/database_schema_diagrams/graphs/recording_entity_details.dot
@@ -1,7 +1,7 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph recording_entity_details {
-    tooltip = "Tables for the “recording” core entity type properties"
+    tooltip = "Tables for the “recording” entity type properties"
     graph [
         bgcolor = "#cb75ab:#f0976c"
         concentrate = true

--- a/docs/database_schema_diagrams/graphs/relationship_details.dot
+++ b/docs/database_schema_diagrams/graphs/relationship_details.dot
@@ -1,5 +1,5 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph relationship_details {
     tooltip = "Tables for relationship properties"
     graph [

--- a/docs/database_schema_diagrams/graphs/relationship_overview.dot
+++ b/docs/database_schema_diagrams/graphs/relationship_overview.dot
@@ -1,5 +1,5 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph relationship_overview {
     tooltip = "Tables for relationship connections"
     graph [

--- a/docs/database_schema_diagrams/graphs/release_entity_details.dot
+++ b/docs/database_schema_diagrams/graphs/release_entity_details.dot
@@ -1,7 +1,7 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph release_entity_details {
-    tooltip = "Tables for the “release” core entity type properties"
+    tooltip = "Tables for the “release” entity type properties"
     graph [
         bgcolor = "#cb75ab:#f0976c"
         concentrate = true

--- a/docs/database_schema_diagrams/graphs/release_group_entity_details.dot
+++ b/docs/database_schema_diagrams/graphs/release_group_entity_details.dot
@@ -1,7 +1,7 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph release_group_entity_details {
-    tooltip = "Tables for the “release_group” core entity type properties"
+    tooltip = "Tables for the “release_group” entity type properties"
     graph [
         bgcolor = "#cb75ab:#f0976c"
         concentrate = true

--- a/docs/database_schema_diagrams/graphs/series_entity_details.dot
+++ b/docs/database_schema_diagrams/graphs/series_entity_details.dot
@@ -1,7 +1,7 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph series_entity_details {
-    tooltip = "Tables for the “series” core entity type properties"
+    tooltip = "Tables for the “series” entity type properties"
     graph [
         bgcolor = "#cb75ab:#f0976c"
         concentrate = true

--- a/docs/database_schema_diagrams/graphs/url_entity_details.dot
+++ b/docs/database_schema_diagrams/graphs/url_entity_details.dot
@@ -1,7 +1,7 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph url_entity_details {
-    tooltip = "Tables for the “url” core entity type properties"
+    tooltip = "Tables for the “url” entity type properties"
     graph [
         bgcolor = "#cb75ab:#f0976c"
         concentrate = true

--- a/docs/database_schema_diagrams/graphs/work_entity_details.dot
+++ b/docs/database_schema_diagrams/graphs/work_entity_details.dot
@@ -1,7 +1,7 @@
 // Automatically generated, do not edit.
-// - Database schema sequence: 27
+// - Database schema sequence: 28
 digraph work_entity_details {
-    tooltip = "Tables for the “work” core entity properties"
+    tooltip = "Tables for the “work” entity type properties"
     graph [
         bgcolor = "#cb75ab:#f0976c"
         concentrate = true

--- a/docs/database_schema_diagrams/images/area_entity_details.svg
+++ b/docs/database_schema_diagrams/images/area_entity_details.svg
@@ -6,7 +6,7 @@
 <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" inkscape:current-layer="svg587" inkscape:cx="-505.09237" inkscape:cy="645.02308" inkscape:deskcolor="#d1d1d1" inkscape:document-units="pt" inkscape:pagecheckerboard="0" inkscape:pageopacity="0.0" inkscape:showpageshadow="2" inkscape:window-height="1034" inkscape:window-maximized="1" inkscape:window-width="1920" inkscape:window-x="-4" inkscape:window-y="-4" inkscape:zoom="0.52168676" pagecolor="#ffffff" showgrid="false"/>
 <g class="graph" transform="scale(1) translate(4 854.5)">
 <title>area_entity_details</title>
-<a xlink:title="Tables for the “area” core entity type properties">
+<a xlink:title="Tables for the “area” entity type properties">
 <defs>
 <linearGradient id="l_0" x1="30.03" x2="469.97" y1="-639.88" y2="-210.62" gradientUnits="userSpaceOnUse">
 <stop stop-color="#cb75ab" offset="0"/>

--- a/docs/database_schema_diagrams/images/artist_entity_details.svg
+++ b/docs/database_schema_diagrams/images/artist_entity_details.svg
@@ -6,7 +6,7 @@
 <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" inkscape:current-layer="svg1470" inkscape:cx="730.86111" inkscape:cy="1148.0268" inkscape:deskcolor="#d1d1d1" inkscape:document-units="pt" inkscape:pagecheckerboard="0" inkscape:pageopacity="0.0" inkscape:showpageshadow="2" inkscape:window-height="1034" inkscape:window-maximized="1" inkscape:window-width="1920" inkscape:window-x="-4" inkscape:window-y="-4" inkscape:zoom="0.30443541" pagecolor="#ffffff" showgrid="false"/>
 <g class="graph" transform="scale(1) translate(4 1467.5)">
 <title>artist_entity_details</title>
-<a xlink:title="Tables for the “artist” core entity type properties">
+<a xlink:title="Tables for the “artist” entity type properties">
 <defs>
 <linearGradient id="l_0" x1="32.58" x2="505.42" y1="-1099.6" y2="-363.87" gradientUnits="userSpaceOnUse">
 <stop stop-color="#cb75ab" offset="0"/>

--- a/docs/database_schema_diagrams/images/entity_network_details.svg
+++ b/docs/database_schema_diagrams/images/entity_network_details.svg
@@ -6,7 +6,7 @@
 <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" inkscape:current-layer="svg3894" inkscape:cx="970.70671" inkscape:cy="3174.7611" inkscape:deskcolor="#d1d1d1" inkscape:document-units="pt" inkscape:pagecheckerboard="0" inkscape:pageopacity="0.0" inkscape:showpageshadow="2" inkscape:window-height="1034" inkscape:window-maximized="1" inkscape:window-width="1920" inkscape:window-x="-4" inkscape:window-y="-4" inkscape:zoom="0.28175349" pagecolor="#ffffff" showgrid="false"/>
 <g class="graph" transform="scale(1) translate(4 3177)">
 <title>entity_network_details</title>
-<a xlink:title="Tables specifically related to core entities">
+<a xlink:title="Tables uniquely related to primary entity types">
 <defs>
 <linearGradient id="l_0" x1="120.4" x2="1728.6" y1="-2381.8" y2="-791.25" gradientUnits="userSpaceOnUse">
 <stop stop-color="#cb75ab" offset="0"/>
@@ -356,10 +356,7 @@
 <text x="697.5" y="-760.3" font-family="Times,serif" font-size="14">track_offset</text>
 <polygon points="694.5 -732.5 694.5 -753.5 800.5 -753.5 800.5 -732.5" fill="#bbb" fill-opacity=".2" stroke="transparent"/>
 <polygon points="694.5 -732.5 694.5 -753.5 800.5 -753.5 800.5 -732.5" fill="none" stroke="#000"/>
-<text x="697.5" y="-739.3" font-family="Times,serif" font-size="14">degraded</text>
-<polygon points="694.5 -711.5 694.5 -732.5 800.5 -732.5 800.5 -711.5" fill="#bbb" fill-opacity=".2" stroke="transparent"/>
-<polygon points="694.5 -711.5 694.5 -732.5 800.5 -732.5 800.5 -711.5" fill="none" stroke="#000"/>
-<text x="697.5" y="-718.3" font-family="Times,serif" font-size="14">created</text>
+<text x="697.5" y="-739.3" font-family="Times,serif" font-size="14">created</text>
 </g>
 <!-- country_area -->
 <g class="node">

--- a/docs/database_schema_diagrams/images/entity_network_overview.svg
+++ b/docs/database_schema_diagrams/images/entity_network_overview.svg
@@ -6,7 +6,7 @@
 <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" inkscape:current-layer="svg4589" inkscape:cx="487" inkscape:cy="385" inkscape:deskcolor="#d1d1d1" inkscape:document-units="pt" inkscape:pagecheckerboard="0" inkscape:pageopacity="0.0" inkscape:showpageshadow="2" inkscape:window-height="1034" inkscape:window-maximized="1" inkscape:window-width="1920" inkscape:window-x="-4" inkscape:window-y="-4" inkscape:zoom="0.5" pagecolor="#ffffff" showgrid="false"/>
 <g class="graph" transform="scale(1) translate(4 791.44)">
 <title>entity_network_overview</title>
-<a xlink:title="Overview of tables connecting entities">
+<a xlink:title="Overview of tables connecting primary entity types">
 <defs>
 <linearGradient id="l_0" x1="48.05" x2="720.95" y1="-592.58" y2="-194.86" gradientUnits="userSpaceOnUse">
 <stop stop-color="#cb75ab" offset="0"/>

--- a/docs/database_schema_diagrams/images/event_entity_details.svg
+++ b/docs/database_schema_diagrams/images/event_entity_details.svg
@@ -6,7 +6,7 @@
 <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" inkscape:current-layer="svg2059" inkscape:cx="83.764892" inkscape:cy="410.90966" inkscape:deskcolor="#d1d1d1" inkscape:document-units="pt" inkscape:pagecheckerboard="0" inkscape:pageopacity="0.0" inkscape:showpageshadow="2" inkscape:window-height="1034" inkscape:window-maximized="1" inkscape:window-width="1920" inkscape:window-x="-4" inkscape:window-y="-4" inkscape:zoom="0.75807416" pagecolor="#ffffff" showgrid="false"/>
 <g class="graph" transform="scale(1) translate(4 831.5)">
 <title>event_entity_details</title>
-<a xlink:title="Tables for the “event” core entity type properties">
+<a xlink:title="Tables for the “event” entity type properties">
 <defs>
 <linearGradient id="l_0" x1="29.16" x2="457.84" y1="-622.63" y2="-204.87" gradientUnits="userSpaceOnUse">
 <stop stop-color="#cb75ab" offset="0"/>

--- a/docs/database_schema_diagrams/images/genre_entity_details.svg
+++ b/docs/database_schema_diagrams/images/genre_entity_details.svg
@@ -6,7 +6,7 @@
 <svg width="355pt" height="529pt" viewBox="0 0 355 528.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <g class="graph" transform="scale(1) translate(4 524.5)">
 <title>genre_entity_details</title>
-<a xlink:title="Tables for the “genre” core entity type properties">
+<a xlink:title="Tables for the “genre” entity type properties">
 <defs>
 <linearGradient id="l_0" x1="19.78" x2="327.22" y1="-392.38" y2="-128.12" gradientUnits="userSpaceOnUse">
 <stop stop-color="#cb75ab" offset="0"/>

--- a/docs/database_schema_diagrams/images/instrument_entity_details.svg
+++ b/docs/database_schema_diagrams/images/instrument_entity_details.svg
@@ -6,7 +6,7 @@
 <svg width="639pt" height="721pt" viewBox="0 0 639 720.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <g class="graph" transform="scale(1) translate(4 716.5)">
 <title>instrument_entity_details</title>
-<a xlink:title="Tables for the “instrument” core entity type properties">
+<a xlink:title="Tables for the “instrument” entity type properties">
 <defs>
 <linearGradient id="l_0" x1="38.8" x2="592.2" y1="-536.38" y2="-176.12" gradientUnits="userSpaceOnUse">
 <stop stop-color="#cb75ab" offset="0"/>

--- a/docs/database_schema_diagrams/images/label_entity_details.svg
+++ b/docs/database_schema_diagrams/images/label_entity_details.svg
@@ -6,7 +6,7 @@
 <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" inkscape:current-layer="svg2750" inkscape:cx="-404.06006" inkscape:cy="1245.3581" inkscape:deskcolor="#d1d1d1" inkscape:document-units="pt" inkscape:pagecheckerboard="0" inkscape:pageopacity="0.0" inkscape:showpageshadow="2" inkscape:window-height="1034" inkscape:window-maximized="1" inkscape:window-width="1920" inkscape:window-x="-4" inkscape:window-y="-4" inkscape:zoom="0.42196697" pagecolor="#ffffff" showgrid="false"/>
 <g class="graph" transform="scale(1) translate(4 1057.5)">
 <title>label_entity_details</title>
-<a xlink:title="Tables for the “label” core entity type properties">
+<a xlink:title="Tables for the “label” entity type properties">
 <defs>
 <linearGradient id="l_0" x1="28.09" x2="442.91" y1="-792.13" y2="-261.37" gradientUnits="userSpaceOnUse">
 <stop stop-color="#cb75ab" offset="0"/>

--- a/docs/database_schema_diagrams/images/place_entity_details.svg
+++ b/docs/database_schema_diagrams/images/place_entity_details.svg
@@ -6,7 +6,7 @@
 <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" inkscape:current-layer="svg3363" inkscape:cx="471.77751" inkscape:cy="465.19763" inkscape:deskcolor="#d1d1d1" inkscape:document-units="pt" inkscape:pagecheckerboard="0" inkscape:pageopacity="0.0" inkscape:showpageshadow="2" inkscape:window-height="1034" inkscape:window-maximized="1" inkscape:window-width="1920" inkscape:window-x="-4" inkscape:window-y="-4" inkscape:zoom="0.75989209" pagecolor="#ffffff" showgrid="false"/>
 <g class="graph" transform="scale(1) translate(4 829.5)">
 <title>place_entity_details</title>
-<a xlink:title="Tables for the “place” core entity type properties">
+<a xlink:title="Tables for the “place” entity type properties">
 <defs>
 <linearGradient id="l_0" x1="29.02" x2="455.98" y1="-621.13" y2="-204.37" gradientUnits="userSpaceOnUse">
 <stop stop-color="#cb75ab" offset="0"/>

--- a/docs/database_schema_diagrams/images/recording_entity_details.svg
+++ b/docs/database_schema_diagrams/images/recording_entity_details.svg
@@ -6,7 +6,7 @@
 <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" inkscape:current-layer="svg4024" inkscape:cx="355.70651" inkscape:cy="675.76963" inkscape:deskcolor="#d1d1d1" inkscape:document-units="pt" inkscape:pagecheckerboard="0" inkscape:pageopacity="0.0" inkscape:showpageshadow="2" inkscape:window-height="1034" inkscape:window-maximized="1" inkscape:window-width="1920" inkscape:window-x="-4" inkscape:window-y="-4" inkscape:zoom="0.68736443" pagecolor="#ffffff" showgrid="false"/>
 <g class="graph" transform="scale(1) translate(4 917.5)">
 <title>recording_entity_details</title>
-<a xlink:title="Tables for the “recording” core entity type properties">
+<a xlink:title="Tables for the “recording” entity type properties">
 <defs>
 <linearGradient id="l_0" x1="40.61" x2="617.39" y1="-687.13" y2="-226.37" gradientUnits="userSpaceOnUse">
 <stop stop-color="#cb75ab" offset="0"/>

--- a/docs/database_schema_diagrams/images/release_entity_details.svg
+++ b/docs/database_schema_diagrams/images/release_entity_details.svg
@@ -6,7 +6,7 @@
 <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" inkscape:current-layer="svg5341" inkscape:cx="946.89467" inkscape:cy="1109.5345" inkscape:deskcolor="#d1d1d1" inkscape:document-units="pt" inkscape:pagecheckerboard="0" inkscape:pageopacity="0.0" inkscape:showpageshadow="2" inkscape:window-height="1034" inkscape:window-maximized="1" inkscape:window-width="1920" inkscape:window-x="-4" inkscape:window-y="-4" inkscape:zoom="0.36276474" pagecolor="#ffffff" showgrid="false"/>
 <g class="graph" transform="scale(1) translate(4 1742.5)">
 <title>release_entity_details</title>
-<a xlink:title="Tables for the “release” core entity type properties">
+<a xlink:title="Tables for the “release” entity type properties">
 <defs>
 <linearGradient id="l_0" x1="51.2" x2="764.8" y1="-1305.9" y2="-432.62" gradientUnits="userSpaceOnUse">
 <stop stop-color="#cb75ab" offset="0"/>

--- a/docs/database_schema_diagrams/images/release_group_entity_details.svg
+++ b/docs/database_schema_diagrams/images/release_group_entity_details.svg
@@ -6,7 +6,7 @@
 <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" inkscape:current-layer="svg6196" inkscape:cx="80.112821" inkscape:cy="925.13846" inkscape:deskcolor="#d1d1d1" inkscape:document-units="pt" inkscape:pagecheckerboard="0" inkscape:pageopacity="0.0" inkscape:showpageshadow="2" inkscape:window-height="1034" inkscape:window-maximized="1" inkscape:window-width="1920" inkscape:window-x="-4" inkscape:window-y="-4" inkscape:zoom="0.45560748" pagecolor="#ffffff" showgrid="false"/>
 <g class="graph" transform="scale(1) translate(4 1387)">
 <title>release_group_entity_details</title>
-<a xlink:title="Tables for the “release_group” core entity type properties">
+<a xlink:title="Tables for the “release_group” entity type properties">
 <defs>
 <linearGradient id="l_0" x1="57.7" x2="855.3" y1="-1039.2" y2="-343.75" gradientUnits="userSpaceOnUse">
 <stop stop-color="#cb75ab" offset="0"/>

--- a/docs/database_schema_diagrams/images/series_entity_details.svg
+++ b/docs/database_schema_diagrams/images/series_entity_details.svg
@@ -6,7 +6,7 @@
 <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" inkscape:current-layer="svg8683" inkscape:cx="394.20355" inkscape:cy="481.80434" inkscape:deskcolor="#d1d1d1" inkscape:document-units="pt" inkscape:pagecheckerboard="0" inkscape:pageopacity="0.0" inkscape:showpageshadow="2" inkscape:window-height="1034" inkscape:window-maximized="1" inkscape:window-width="1920" inkscape:window-x="-4" inkscape:window-y="-4" inkscape:zoom="0.87898752" pagecolor="#ffffff" showgrid="false"/>
 <g class="graph" transform="scale(1) translate(4 716.5)">
 <title>series_entity_details</title>
-<a xlink:title="Tables for the “series” core entity type properties">
+<a xlink:title="Tables for the “series” entity type properties">
 <defs>
 <linearGradient id="l_0" x1="35.52" x2="546.48" y1="-536.38" y2="-176.12" gradientUnits="userSpaceOnUse">
 <stop stop-color="#cb75ab" offset="0"/>

--- a/docs/database_schema_diagrams/images/url_entity_details.svg
+++ b/docs/database_schema_diagrams/images/url_entity_details.svg
@@ -6,7 +6,7 @@
 <svg width="295pt" height="160pt" viewBox="0 0 295 160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <g class="graph" transform="scale(1) translate(4 156)">
 <title>url_entity_details</title>
-<a xlink:title="Tables for the “url” core entity type properties">
+<a xlink:title="Tables for the “url” entity type properties">
 <defs>
 <linearGradient id="l_0" x1="15.76" x2="271.24" y1="-116" y2="-36" gradientUnits="userSpaceOnUse">
 <stop stop-color="#cb75ab" offset="0"/>

--- a/docs/database_schema_diagrams/images/work_entity_details.svg
+++ b/docs/database_schema_diagrams/images/work_entity_details.svg
@@ -6,7 +6,7 @@
 <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" inkscape:current-layer="svg6593" inkscape:cx="488.31874" inkscape:cy="705.13609" inkscape:deskcolor="#d1d1d1" inkscape:document-units="pt" inkscape:pagecheckerboard="0" inkscape:pageopacity="0.0" inkscape:showpageshadow="2" inkscape:window-height="1034" inkscape:window-maximized="1" inkscape:window-width="1920" inkscape:window-x="-4" inkscape:window-y="-4" inkscape:zoom="0.52117599" pagecolor="#ffffff" showgrid="false"/>
 <g class="graph" transform="scale(1) translate(4 1211.5)">
 <title>work_entity_details</title>
-<a xlink:title="Tables for the “work” core entity properties">
+<a xlink:title="Tables for the “work” entity type properties">
 <defs>
 <linearGradient id="l_0" x1="51.47" x2="768.53" y1="-907.63" y2="-299.87" gradientUnits="userSpaceOnUse">
 <stop stop-color="#cb75ab" offset="0"/>

--- a/docs/database_schema_diagrams/source/area_entity_details.json
+++ b/docs/database_schema_diagrams/source/area_entity_details.json
@@ -1,5 +1,5 @@
 {
-  "tooltip": "Tables for the “area” core entity type properties",
+  "tooltip": "Tables for the “area” entity type properties",
   "_comment": "It shows replicated and materialized tables used to define any area entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],

--- a/docs/database_schema_diagrams/source/area_entity_details.json
+++ b/docs/database_schema_diagrams/source/area_entity_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for the “area” core entity type properties",
-  "_comment": "Show replicated and materialized tables used to define any area entity, beyond relationships. The main table is highlighted.",
+  "_comment": "It shows replicated and materialized tables used to define any area entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],
     "area": ["highlighted"],

--- a/docs/database_schema_diagrams/source/artist_entity_details.json
+++ b/docs/database_schema_diagrams/source/artist_entity_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for the “artist” core entity type properties",
-  "_comment": "Show replicated and materialized tables used to define any artist entity, beyond relationships. The main table is highlighted.",
+  "_comment": "It shows replicated and materialized tables used to define any artist entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],
     "area": ["shortened"],

--- a/docs/database_schema_diagrams/source/artist_entity_details.json
+++ b/docs/database_schema_diagrams/source/artist_entity_details.json
@@ -1,5 +1,5 @@
 {
-  "tooltip": "Tables for the “artist” core entity type properties",
+  "tooltip": "Tables for the “artist” entity type properties",
   "_comment": "It shows replicated and materialized tables used to define any artist entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],

--- a/docs/database_schema_diagrams/source/cdstub_details.json
+++ b/docs/database_schema_diagrams/source/cdstub_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for CD stub",
-  "_comment": "It shows tables involved in representing a CD stub. Main table is highlighted.",
+  "_comment": "It shows tables involved in representing a CD stub. The main table is highlighted.",
   "tables": {
     "cdtoc_raw": [],
     "release_raw": ["highlighted"],

--- a/docs/database_schema_diagrams/source/cover_art_details.json
+++ b/docs/database_schema_diagrams/source/cover_art_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for cover art",
-  "_comment": "It shows tables used to set a cover art for releases and release groups. These two core entities are highlighted. It also shows when tables belong to the 'cover_art_archive' schema.",
+  "_comment": "It shows tables used to set a cover art for releases and release groups. The main tables for these two entity types are highlighted. It also shows when tables belong to the 'cover_art_archive' schema.",
   "tables": {
     "art_type": [],
     "cover_art": [],

--- a/docs/database_schema_diagrams/source/entity_network_details.json
+++ b/docs/database_schema_diagrams/source/entity_network_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables specifically related to core entities",
-  "_comment": "It shows tables unique to some entities, that is, beyond alias, collection, edit, link, subscription, rating, tag.",
+  "_comment": "It shows tables unique to some entities, that is, beyond alias, collection, edit, relationship, subscription, rating, tag.",
   "tables": {
     "area": ["highlighted"],
     "area_type": [],

--- a/docs/database_schema_diagrams/source/entity_network_details.json
+++ b/docs/database_schema_diagrams/source/entity_network_details.json
@@ -1,6 +1,6 @@
 {
-  "tooltip": "Tables specifically related to core entities",
-  "_comment": "It shows tables unique to some entities, that is, beyond aliases, collections, edits, relationships, subscriptions, ratings, tags.",
+  "tooltip": "Tables uniquely related to primary entities",
+  "_comment": "It shows the main tables for primary entity types and tables unique to some of these, that is, beyond aliases, collections, edits, relationships, subscriptions, ratings, tags.",
   "tables": {
     "area": ["highlighted"],
     "area_type": [],

--- a/docs/database_schema_diagrams/source/entity_network_details.json
+++ b/docs/database_schema_diagrams/source/entity_network_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables specifically related to core entities",
-  "_comment": "It shows tables unique to some entities, that is, beyond alias, collection, edit, relationship, subscription, rating, tag.",
+  "_comment": "It shows tables unique to some entities, that is, beyond aliases, collections, edits, relationships, subscriptions, ratings, tags.",
   "tables": {
     "area": ["highlighted"],
     "area_type": [],

--- a/docs/database_schema_diagrams/source/entity_network_details.json
+++ b/docs/database_schema_diagrams/source/entity_network_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables specifically related to core entities",
-  "_comment": "It shows tables unique to some entities; That is beyond alias, collection, edit, link, subscription, rating, tag.",
+  "_comment": "It shows tables unique to some entities, that is, beyond alias, collection, edit, link, subscription, rating, tag.",
   "tables": {
     "area": ["highlighted"],
     "area_type": [],

--- a/docs/database_schema_diagrams/source/entity_network_details.json
+++ b/docs/database_schema_diagrams/source/entity_network_details.json
@@ -1,5 +1,5 @@
 {
-  "tooltip": "Tables uniquely related to primary entities",
+  "tooltip": "Tables uniquely related to primary entity types",
   "_comment": "It shows the main tables for primary entity types and tables unique to some of these, that is, beyond aliases, annotations, edits, redirects, relationships, ratings, tags.",
   "tables": {
     "area": ["highlighted"],

--- a/docs/database_schema_diagrams/source/entity_network_details.json
+++ b/docs/database_schema_diagrams/source/entity_network_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables uniquely related to primary entities",
-  "_comment": "It shows the main tables for primary entity types and tables unique to some of these, that is, beyond aliases, collections, edits, relationships, subscriptions, ratings, tags.",
+  "_comment": "It shows the main tables for primary entity types and tables unique to some of these, that is, beyond aliases, annotations, edits, redirects, relationships, ratings, tags.",
   "tables": {
     "area": ["highlighted"],
     "area_type": [],

--- a/docs/database_schema_diagrams/source/entity_network_details.json
+++ b/docs/database_schema_diagrams/source/entity_network_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables specifically related to core entities",
-  "_comment": "It shows tables unique to some entities; That is beyond alias, collection, disambiguation comment, edit, link, subscription, rating, tag.",
+  "_comment": "It shows tables unique to some entities; That is beyond alias, collection, edit, link, subscription, rating, tag.",
   "tables": {
     "area": ["highlighted"],
     "area_type": [],

--- a/docs/database_schema_diagrams/source/entity_network_overview.json
+++ b/docs/database_schema_diagrams/source/entity_network_overview.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Overview of tables connecting entities",
-  "_comment": "Show core entity tables and unique tables connecting these, that is, beyond relationships. Core entities are highlighted. All tables are shortened to focus on foreign key constraints.",
+  "_comment": "It shows core entity tables and unique tables connecting these, that is, beyond relationships. Core entities are highlighted. All tables are shortened to focus on foreign key constraints.",
   "tables": {
     "area": ["highlighted","shortened"],
     "artist": ["highlighted","shortened"],

--- a/docs/database_schema_diagrams/source/entity_network_overview.json
+++ b/docs/database_schema_diagrams/source/entity_network_overview.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Overview of tables connecting entities",
-  "_comment": "It shows the main tables for primary entities and unique tables connecting these tables, that is, beyond relationships. Core entities are highlighted. All tables are shortened to focus on foreign key constraints.",
+  "_comment": "It shows the main tables for primary entities and unique tables connecting these tables, that is, beyond relationships. The main tables are highlighted. All tables are shortened to focus on foreign key constraints.",
   "tables": {
     "area": ["highlighted","shortened"],
     "artist": ["highlighted","shortened"],

--- a/docs/database_schema_diagrams/source/entity_network_overview.json
+++ b/docs/database_schema_diagrams/source/entity_network_overview.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Overview of tables connecting entities",
-  "_comment": "Show core entity tables and unique tables connecting these; That is beyond relationship. Core entities are highlighted. All tables are shortened to focus on foreign key constraints.",
+  "_comment": "Show core entity tables and unique tables connecting these, that is, beyond relationship. Core entities are highlighted. All tables are shortened to focus on foreign key constraints.",
   "tables": {
     "area": ["highlighted","shortened"],
     "artist": ["highlighted","shortened"],

--- a/docs/database_schema_diagrams/source/entity_network_overview.json
+++ b/docs/database_schema_diagrams/source/entity_network_overview.json
@@ -1,6 +1,6 @@
 {
-  "tooltip": "Overview of tables connecting entities",
-  "_comment": "It shows the main tables for primary entities and unique tables connecting these tables, that is, beyond relationships. The main tables are highlighted. All tables are shortened to focus on foreign key constraints.",
+  "tooltip": "Overview of tables connecting primary entity types",
+  "_comment": "It shows the main tables for primary entity types and unique tables connecting these tables, that is, beyond relationships. The main tables are highlighted. All tables are shortened to focus on foreign key constraints.",
   "tables": {
     "area": ["highlighted","shortened"],
     "artist": ["highlighted","shortened"],

--- a/docs/database_schema_diagrams/source/entity_network_overview.json
+++ b/docs/database_schema_diagrams/source/entity_network_overview.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Overview of tables connecting entities",
-  "_comment": "Show core entity tables and unique tables connecting these, that is, beyond relationship. Core entities are highlighted. All tables are shortened to focus on foreign key constraints.",
+  "_comment": "Show core entity tables and unique tables connecting these, that is, beyond relationships. Core entities are highlighted. All tables are shortened to focus on foreign key constraints.",
   "tables": {
     "area": ["highlighted","shortened"],
     "artist": ["highlighted","shortened"],

--- a/docs/database_schema_diagrams/source/entity_network_overview.json
+++ b/docs/database_schema_diagrams/source/entity_network_overview.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Overview of tables connecting entities",
-  "_comment": "It shows core entity tables and unique tables connecting these, that is, beyond relationships. Core entities are highlighted. All tables are shortened to focus on foreign key constraints.",
+  "_comment": "It shows the main tables for primary entities and unique tables connecting these tables, that is, beyond relationships. Core entities are highlighted. All tables are shortened to focus on foreign key constraints.",
   "tables": {
     "area": ["highlighted","shortened"],
     "artist": ["highlighted","shortened"],

--- a/docs/database_schema_diagrams/source/event_entity_details.json
+++ b/docs/database_schema_diagrams/source/event_entity_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for the “event” core entity type properties",
-  "_comment": "Show replicated tables used to define any event entity, beyond relationships. The main table is highlighted.",
+  "_comment": "It shows replicated tables used to define any event entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],
     "event": ["highlighted"],

--- a/docs/database_schema_diagrams/source/event_entity_details.json
+++ b/docs/database_schema_diagrams/source/event_entity_details.json
@@ -1,5 +1,5 @@
 {
-  "tooltip": "Tables for the “event” core entity type properties",
+  "tooltip": "Tables for the “event” entity type properties",
   "_comment": "It shows replicated tables used to define any event entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],

--- a/docs/database_schema_diagrams/source/genre_entity_details.json
+++ b/docs/database_schema_diagrams/source/genre_entity_details.json
@@ -1,5 +1,5 @@
 {
-  "tooltip": "Tables for the “genre” core entity type properties",
+  "tooltip": "Tables for the “genre” entity type properties",
   "_comment": "It shows replicated tables used to define any genre entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],

--- a/docs/database_schema_diagrams/source/genre_entity_details.json
+++ b/docs/database_schema_diagrams/source/genre_entity_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for the “genre” core entity type properties",
-  "_comment": "Show replicated tables used to define any genre entity, beyond relationships. The main table is highlighted.",
+  "_comment": "It shows replicated tables used to define any genre entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],
     "genre": ["highlighted"],

--- a/docs/database_schema_diagrams/source/instrument_entity_details.json
+++ b/docs/database_schema_diagrams/source/instrument_entity_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for the “instrument” core entity type properties",
-  "_comment": "Show replicated tables used to define any instrument entity, beyond relationships. The main table is highlighted.",
+  "_comment": "It shows replicated tables used to define any instrument entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],
     "instrument": ["highlighted"],

--- a/docs/database_schema_diagrams/source/instrument_entity_details.json
+++ b/docs/database_schema_diagrams/source/instrument_entity_details.json
@@ -1,5 +1,5 @@
 {
-  "tooltip": "Tables for the “instrument” core entity type properties",
+  "tooltip": "Tables for the “instrument” entity type properties",
   "_comment": "It shows replicated tables used to define any instrument entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],

--- a/docs/database_schema_diagrams/source/label_entity_details.json
+++ b/docs/database_schema_diagrams/source/label_entity_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for the “label” core entity type properties",
-  "_comment": "Show replicated tables used to define any label entity, beyond relationships. The main table is highlighted.",
+  "_comment": "It shows replicated tables used to define any label entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],
     "area": ["shortened"],

--- a/docs/database_schema_diagrams/source/label_entity_details.json
+++ b/docs/database_schema_diagrams/source/label_entity_details.json
@@ -1,5 +1,5 @@
 {
-  "tooltip": "Tables for the “label” core entity type properties",
+  "tooltip": "Tables for the “label” entity type properties",
   "_comment": "It shows replicated tables used to define any label entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],

--- a/docs/database_schema_diagrams/source/place_entity_details.json
+++ b/docs/database_schema_diagrams/source/place_entity_details.json
@@ -1,5 +1,5 @@
 {
-  "tooltip": "Tables for the “place” core entity type properties",
+  "tooltip": "Tables for the “place” entity type properties",
   "_comment": "It shows replicated tables used to define any place entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],

--- a/docs/database_schema_diagrams/source/place_entity_details.json
+++ b/docs/database_schema_diagrams/source/place_entity_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for the “place” core entity type properties",
-  "_comment": "Show replicated tables used to define any place entity, beyond relationships. The main table is highlighted.",
+  "_comment": "It shows replicated tables used to define any place entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],
     "area": ["shortened"],

--- a/docs/database_schema_diagrams/source/recording_entity_details.json
+++ b/docs/database_schema_diagrams/source/recording_entity_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for the “recording” core entity type properties",
-  "_comment": "Show replicated and materialized tables used to define any recording entity, beyond relationships. The main table is highlighted.",
+  "_comment": "It shows replicated and materialized tables used to define any recording entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],
     "artist": ["shortened"],

--- a/docs/database_schema_diagrams/source/recording_entity_details.json
+++ b/docs/database_schema_diagrams/source/recording_entity_details.json
@@ -1,5 +1,5 @@
 {
-  "tooltip": "Tables for the “recording” core entity type properties",
+  "tooltip": "Tables for the “recording” entity type properties",
   "_comment": "It shows replicated and materialized tables used to define any recording entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],

--- a/docs/database_schema_diagrams/source/relationship_details.json
+++ b/docs/database_schema_diagrams/source/relationship_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for relationship properties",
-  "_comment": "Show tables for the detailed representation of a link. Main tables are highlighted.",
+  "_comment": "It shows tables for the detailed representation of a link. The main tables are highlighted.",
   "tables": {
     "link": ["highlighted"],
     "link_attribute": ["highlighted"],

--- a/docs/database_schema_diagrams/source/relationship_overview.json
+++ b/docs/database_schema_diagrams/source/relationship_overview.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for relationship connections",
-  "_comment": "Show minimal foreign keys needed to define a relationship between two entities. Artist-Work is just an example of relationship type. Main table is highlighted. All other tables are shortened to focus on foreign key constraints.",
+  "_comment": "It shows minimal foreign keys needed to define a relationship between two entities. Artist-Work is just an example of relationship type. The main table is highlighted. All other tables are shortened to focus on foreign key constraints.",
   "tables": {
     "artist": ["shortened"],
     "l_artist_work": ["highlighted"],

--- a/docs/database_schema_diagrams/source/relationship_overview.json
+++ b/docs/database_schema_diagrams/source/relationship_overview.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for relationship connections",
-  "_comment": "It shows minimal foreign keys needed to define a relationship between two entities. Artist-Work is just an example of relationship type. The main table is highlighted. All other tables are shortened to focus on foreign key constraints.",
+  "_comment": "It shows minimal foreign keys needed to define a relationship between two entities. Artist-Work is just an example of a relationship type. The main table is highlighted. All other tables are shortened to focus on foreign key constraints.",
   "tables": {
     "artist": ["shortened"],
     "l_artist_work": ["highlighted"],

--- a/docs/database_schema_diagrams/source/release_entity_details.json
+++ b/docs/database_schema_diagrams/source/release_entity_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for the “release” core entity type properties",
-  "_comment": "Show replicated and materialized tables used to define any release entity, beyond relationships. The main table is highlighted.",
+  "_comment": "It shows replicated and materialized tables used to define any release entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],
     "area": ["shortened"],

--- a/docs/database_schema_diagrams/source/release_entity_details.json
+++ b/docs/database_schema_diagrams/source/release_entity_details.json
@@ -1,5 +1,5 @@
 {
-  "tooltip": "Tables for the “release” core entity type properties",
+  "tooltip": "Tables for the “release” entity type properties",
   "_comment": "It shows replicated and materialized tables used to define any release entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],

--- a/docs/database_schema_diagrams/source/release_group_entity_details.json
+++ b/docs/database_schema_diagrams/source/release_group_entity_details.json
@@ -1,5 +1,5 @@
 {
-  "tooltip": "Tables for the “release_group” core entity type properties",
+  "tooltip": "Tables for the “release_group” entity type properties",
   "_comment": "It shows replicated and materialized tables used to define any release group entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],

--- a/docs/database_schema_diagrams/source/release_group_entity_details.json
+++ b/docs/database_schema_diagrams/source/release_group_entity_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for the “release_group” core entity type properties",
-  "_comment": "Show replicated and materialized tables used to define any release group entity, beyond relationships. The main table is highlighted.",
+  "_comment": "It shows replicated and materialized tables used to define any release group entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],
     "artist": ["shortened"],

--- a/docs/database_schema_diagrams/source/series_entity_details.json
+++ b/docs/database_schema_diagrams/source/series_entity_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for the “series” core entity type properties",
-  "_comment": "Show replicated tables used to define any series entity, beyond relationships. The main table is highlighted.",
+  "_comment": "It shows replicated tables used to define any series entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],
     "tag": [],

--- a/docs/database_schema_diagrams/source/series_entity_details.json
+++ b/docs/database_schema_diagrams/source/series_entity_details.json
@@ -1,5 +1,5 @@
 {
-  "tooltip": "Tables for the “series” core entity type properties",
+  "tooltip": "Tables for the “series” entity type properties",
   "_comment": "It shows replicated tables used to define any series entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "annotation": [],

--- a/docs/database_schema_diagrams/source/url_entity_details.json
+++ b/docs/database_schema_diagrams/source/url_entity_details.json
@@ -1,5 +1,5 @@
 {
-  "tooltip": "Tables for the “url” core entity type properties",
+  "tooltip": "Tables for the “url” entity type properties",
   "_comment": "It shows replicated tables used to define any URL entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "url": ["highlighted"],

--- a/docs/database_schema_diagrams/source/url_entity_details.json
+++ b/docs/database_schema_diagrams/source/url_entity_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for the “url” core entity type properties",
-  "_comment": "Show replicated tables used to define any URL entity, beyond relationships. The main table is highlighted.",
+  "_comment": "It shows replicated tables used to define any URL entity, beyond relationships. The main table is highlighted.",
   "tables": {
     "url": ["highlighted"],
     "url_gid_redirect": []

--- a/docs/database_schema_diagrams/source/work_entity_details.json
+++ b/docs/database_schema_diagrams/source/work_entity_details.json
@@ -1,5 +1,5 @@
 {
-  "tooltip": "Tables for the “work” entity properties",
+  "tooltip": "Tables for the “work” entity type properties",
   "_comment": "It shows replicated tables used to define any work entity, beyond relationships. It can be used as an example for tables generally used to define any entity of any type. The main table is highlighted.",
   "tables": {
     "annotation": [],

--- a/docs/database_schema_diagrams/source/work_entity_details.json
+++ b/docs/database_schema_diagrams/source/work_entity_details.json
@@ -1,6 +1,6 @@
 {
   "tooltip": "Tables for the “work” core entity properties",
-  "_comment": "Show replicated tables used to define any work entity, beyond relationships. It can be used as an example for tables generally used to define any entity of any type. The core entity is highlighted.",
+  "_comment": "It shows replicated tables used to define any work entity, beyond relationships. It can be used as an example for tables generally used to define any entity of any type. The core entity is highlighted.",
   "tables": {
     "annotation": [],
     "language": [],

--- a/docs/database_schema_diagrams/source/work_entity_details.json
+++ b/docs/database_schema_diagrams/source/work_entity_details.json
@@ -1,6 +1,6 @@
 {
-  "tooltip": "Tables for the “work” core entity properties",
-  "_comment": "It shows replicated tables used to define any work entity, beyond relationships. It can be used as an example for tables generally used to define any entity of any type. The core entity is highlighted.",
+  "tooltip": "Tables for the “work” entity properties",
+  "_comment": "It shows replicated tables used to define any work entity, beyond relationships. It can be used as an example for tables generally used to define any entity of any type. The main table is highlighted.",
   "tables": {
     "annotation": [],
     "language": [],


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* Diagrams need to be updated for schema 28.
* Diagrams have to be reviewed for:
  * relevance of their descriptions and table lists
  * coverage of the documentation

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Reviewed in team meeting, made some changes in comments and tooltips.

# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Get text changes approved
* [x] Generate graphs/images again with `make`
* [x] Reapply aesthetic changes with diff but for `entity_network_details` which might require to go through `inkscape` again.
* [x] Run `make normalized` and commit


# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Upload the generated files to the wiki (as new revisions for current diagrams).
