### PR TITLE
MBS-13183: Add CORS support to Wikipedia extracts

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/WikipediaExtract.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/WikipediaExtract.pm
@@ -14,6 +14,22 @@ sub wikipedia_extract : Chained('load') PathPart('wikipedia-extract')
     my ($self, $c) = @_;
 
     my $res = $c->res;
+    $res->header('Access-Control-Allow-Origin' => '*');
+
+    my $req = $c->req;
+    if ($req->method eq 'OPTIONS') {
+        if ($req->header('Origin') && $req->header('Access-Control-Request-Method')) {
+            # CORS preflight request
+            $res->header('Access-Control-Allow-Methods' => 'GET, OPTIONS');
+            $res->header('Access-Control-Allow-Headers' => 'User-Agent');
+        } else {
+            # Non-CORS request
+            $res->header('Allow' => 'GET, OPTIONS');
+        }
+
+        $c->response->body('');
+        $c->detach;
+    }
 
     my $wp_extract = $self->_get_extract($c, 0);
 

--- a/lib/MusicBrainz/Server/Controller/Role/WikipediaExtract.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/WikipediaExtract.pm
@@ -13,11 +13,13 @@ sub wikipedia_extract : Chained('load') PathPart('wikipedia-extract')
 {
     my ($self, $c) = @_;
 
+    my $res = $c->res;
+
     my $wp_extract = $self->_get_extract($c, 0);
 
-    $c->res->headers->header('X-Robots-Tag' => 'noindex');
-    $c->res->content_type('application/json; charset=utf-8');
-    $c->res->{body} = $c->json_utf8->encode({wikipediaExtract => $wp_extract});
+    $res->headers->header('X-Robots-Tag' => 'noindex');
+    $res->content_type('application/json; charset=utf-8');
+    $res->{body} = $c->json_utf8->encode({wikipediaExtract => $wp_extract});
 }
 
 sub _get_extract

--- a/t/lib/t/MusicBrainz/Server/Controller/Role/WikipediaExtract.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Role/WikipediaExtract.pm
@@ -1,0 +1,46 @@
+package t::MusicBrainz::Server::Controller::Role::WikipediaExtract;
+use strict;
+use warnings;
+
+use Test::Routine;
+use Test::More;
+
+with 't::Mechanize', 't::Context';
+
+use utf8;
+use HTTP::Request;
+use HTTP::Status qw( :constants );
+
+test 'CORS support' => sub {
+    my $test = shift;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+mozart');
+
+    my $response;
+
+    # Check basic OPTIONS support
+    $test->mech->request(HTTP::Request->new(OPTIONS => '/artist/b972f589-fb0e-474e-b64a-803b0364fa75/wikipedia-extract'));
+    $response = $test->mech->response;
+    is($response->code, HTTP_OK, 'OK status is returned to any OPTIONS request');
+    is($response->content, '', 'No content is returned to any OPTIONS request');
+    is($response->header('access-control-allow-headers'), undef, 'Access-Control-Allow-Headers header isn’t returned to basic OPTIONS request');
+    is($response->header('access-control-allow-methods'), undef, 'Access-Control-Allow-Methods header isn’t returned to basic OPTIONS request');
+    is($response->header('access-control-allow-origin'), '*', 'Access-Control-Allow-Origin header is returned to any OPTIONS request');
+    is($response->header('allow'), 'GET, OPTIONS', 'Allow header is returned to basic OPTIONS request');
+
+    # Check CORS preflight support
+    $test->mech->request(HTTP::Request->new('OPTIONS', '/artist/b972f589-fb0e-474e-b64a-803b0364fa75/wikipedia-extract', [
+            'Access-Control-Request-Headers' => 'Content-Type, User-Agent',
+            'Access-Control-Request-Method' => 'GET',
+            'Origin' => 'https://example.com',
+        ]));
+    $response = $test->mech->response;
+    is($response->code, HTTP_OK, 'OK status is returned to any OPTIONS request');
+    is($response->content, '', 'No content is returned to any OPTIONS request');
+    is($response->header('access-control-allow-headers'), 'User-Agent', 'Access-Control-Allow-Headers header is returned to CORS preflight request');
+    is($response->header('access-control-allow-methods'), 'GET, OPTIONS', 'Access-Control-Allow-Methods header is returned to CORS preflight request');
+    is($response->header('access-control-allow-origin'), '*', 'Access-Control-Allow-Origin header is returned to any OPTIONS request');
+    is($response->header('allow'), undef, 'Allow header isn’t returned to CORS preflight request');
+};
+
+1;


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Allow ListenBrainz to easily use Wikipedia extracts retrieved by MusicBrainz server.

# Solution MBS-13183
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Supporting CORS is one way out, it doesn’t require tinkering with Redis cache.

# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Test manually using cURL
* [x] Add CI test

# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Ping LB team when available