### PR TITLE
MBS-13177: Show label events on label rels page

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/Label.pm
@@ -12,10 +12,10 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
         default => ['url'],
         subset => {
             show => ['artist', 'label', 'url'],
-            relationships => [qw( area artist event instrument label place series url )],
+            relationships => [qw( area artist instrument label place series url )],
         },
         paged_subset => {
-            relationships => [qw( recording release release_group work )],
+            relationships => [qw( event recording release release_group work )],
         },
     },
 };

--- a/root/components/RelationshipsTable.js
+++ b/root/components/RelationshipsTable.js
@@ -44,10 +44,11 @@ const pickAppearancesTypes = (entityType: RelatableEntityTypeT) => {
   switch (entityType) {
     case 'area':
     case 'artist':
-    case 'label':
     case 'place': {
       return generalTypesList;
     }
+    case 'label':
+      return [...generalTypesList, 'event'];
     case 'work': {
       return recordingOnlyTypesList;
     }


### PR DESCRIPTION
### Fix MBS-13177

# Problem
Label-Event relationships are not shown anywhere on the label page. 

# Solution
Label-Event rels were already being loaded (unpaged), but not being shown since `Relationships.js` did not use them. This was not a problem until recently because we didn't have any. Since the only one we now have is `label presents event`, which seems more akin to recording/release rels with cardinality 1:0 than the other rels we show outside the rels table, I'm moving this to load them as a paged subset and showing them in `RelationshipsTable.js` instead. 

I considered a separate events page but events are nowhere near as relevant to most labels as to artists, so I think the generic rels table is more than good enough. 

# Testing
Manually, with the label provided in the ticket (`/label/e8fb3a04-7d34-42fe-a155-bd8c51c96db8/relationships`) and `pink` data.