### PR TITLE
Fix warning after pull request #2554

### DIFF
--- a/lib/MusicBrainz/Server/Data/Role/Area.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Area.pm
@@ -16,7 +16,7 @@ sub find_by_area {
     my $table = $self->can('_find_by_area_table') ? $self->_find_by_area_table : $self->_table;
     my $columns = $self->_columns;
     my $order_by = $self->can('_find_by_area_order') ? $self->_find_by_area_order : 'name, id';
-    my $extra_conditions;
+    my $extra_conditions = '';
 
     if ($table eq 'editor') {
         $extra_conditions = " AND (editor.privs & $SPAMMER_FLAG) = 0";


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

In commit 42cd50fc0f7c17b3940fa4911ec0eb17acaf7480 (pull request #2554) the variable `extra_conditons` wasn’t initialized when used most of the time, triggering the following warning very frequently (currently ~4K times per week):

    Use of uninitialized value $extra_conditions in concatenation (.) or
    string at lib/MusicBrainz/Server/Data/Role/Area.pm line 25.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This patch just initializes this variable to the empty string.