### PR TITLE
MBS-11947: Stop hiding focus indicators on links

### DIFF
--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -32,8 +32,7 @@ a {
         text-decoration: none;
     }
 
-
-    &:active, &:focus {
+    &:active {
         outline-style: none;
     }
 


### PR DESCRIPTION
# MBS-11947

Remove the 'outline-style: none' CSS rule on a:hover to allow the UA to draw focus indicators on links. This was added by 2f155ec2 in 2010, but it impairs keyboard accessibility for the site and it's unclear why it was needed.