### PR TITLE
MBS-13207 (II): Make recording focusable when adding release

### DIFF
--- a/root/release/edit/recordings.tt
+++ b/root/release/edit/recordings.tt
@@ -163,7 +163,7 @@
         [% l('Search:') %]
         <span class="autocomplete">
           [% React.embed(c, 'static/scripts/common/components/SearchIcon') %]
-          <input type="text" class="name" data-bind="autocomplete: { entity: 'recording', currentSelection: recording, lookupHook: $root.recordingAssociation.autocompleteHook($data) }" />
+          <input type="text" class="name" data-bind="autocomplete: { entity: 'recording', currentSelection: recording, lookupHook: $root.recordingAssociation.autocompleteHook($data) }" data-keydown="keydownEvent" />
         </span>
       </p>
 

--- a/root/static/scripts/release-editor/bubbles.js
+++ b/root/static/scripts/release-editor/bubbles.js
@@ -123,6 +123,34 @@ class RecordingBubble extends MB.Control.BubbleDoc {
   moveToTrack(track, stealFocus) {
     this.show(track.bubbleControlRecording, stealFocus);
   }
+
+  keydownEvent(data, event) {
+    /*
+     * Manually advance the focus to the first recording radio button if the
+     * Tab key is pressed in the recording name text input. By default, only
+     * the currently-checked radio button (which defaults to "Add a new
+     * recording" at the end of the list when entering a new tracklist) is
+     * keyboard-focusable. See MBS-13207.
+     *
+     * TODO: This only makes it possible to select the first radio button.
+     * Consider doing something similar to support tabbing to other unchecked
+     * radio buttons.
+     */
+    const noMods = !event.altKey && !event.ctrlKey && !event.metaKey &&
+      !event.shiftKey;
+    if (event.key === 'Tab' && noMods && !event.isDefaultPrevented()) {
+      const radio = document.querySelector(
+        '#recording-assoc-bubble input[name="recording-selection"]',
+      );
+      if (radio) {
+        radio.focus();
+        return false;
+      }
+    }
+
+    // Instruct Knockout to not call preventDefault.
+    return true;
+  }
 }
 
 releaseEditor.recordingBubble = new RecordingBubble('Recording');

--- a/root/static/scripts/tests/release-editor/seeds/mbs-13207.html
+++ b/root/static/scripts/tests/release-editor/seeds/mbs-13207.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <form action="/release/add" method="POST">
+      <input type="hidden" name="name" value="MBS-13207" />
+      <input type="hidden" name="artist_credit.names.0.artist.name" value="Nine Inch Nails" />
+      <input type="hidden" name="artist_credit.names.0.mbid" value="b7ffd2af-418f-4be2-bdd1-22f8b48613da" />
+      <input type="hidden" name="mediums.0.format" value="Digital Media" />
+      <input type="hidden" name="mediums.0.track.0.name" value="Piggy" />
+      <input type="hidden" name="mediums.0.track.0.length" value="264000" />
+      <input type="hidden" name="edit_note" value="Testing MBS-13207" />
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -692,6 +692,7 @@ const seleniumTests = [
     name: 'release-editor/MBS-12077.json5',
     sql: 'vision_creation_newsun.sql',
   },
+  {name: 'release-editor/MBS-13207.json5', login: true},
   {
     name: 'Check_Duplicates.json5',
     login: true,

--- a/t/selenium/release-editor/MBS-13207.json5
+++ b/t/selenium/release-editor/MBS-13207.json5
@@ -1,0 +1,70 @@
+{
+  title: 'MBS-13207',
+  commands: [
+    {
+      command: 'open',
+      target: '/static/scripts/tests/release-editor/seeds/mbs-13207.html',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'pause',
+      target: '500',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=a[href="#recordings"]',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=button.edit-track-recording',
+      value: '',
+    },
+    {
+      command: 'pause',
+      target: '1000',
+      value: '',
+    },
+    // Check that there's a radio button for at least one existing recording
+    // in addition to the "Add a new recording" button -- if there's only one
+    // button, then we can't verify the fix.
+    {
+      command: 'assertEval',
+      target: 'document.querySelectorAll("#recording-assoc-bubble input[name=recording-selection]").length > 1',
+      value: 'true',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#recording-assoc-bubble input.name',
+      value: '${KEY_TAB}',
+    },
+    // The first recording's radio button should receive the focus.
+    // Normally, only checked radio buttons are keyboard-focusable.
+    {
+      command: 'assertEval',
+      target: 'document.activeElement === document.querySelector("#recording-assoc-bubble input[name=recording-selection]")',
+      value: 'true',
+    },
+    {
+      command: 'open',
+      target: '/',
+      value: '',
+    },
+    {
+      command: 'handleAlert',
+      target: 'accept',
+      value: '',
+    },
+    {
+      command: 'waitUntilUrlIs',
+      target: '/',
+      value: '',
+    },
+  ],
+}


### PR DESCRIPTION
# MBS-13207

Manually focus the first radio button when Tab is typed in the recording name input field at /release/add#recordings.

By default, only the currently-checked radio button is keyboard-focusable, making it impossible to use the keyboard to select an existing recording.