### PR TITLE
Fix CI tests: Replace Perl short `$!` with long `$OS_ERROR`

### DIFF
--- a/admin/functions.sh
+++ b/admin/functions.sh
@@ -16,7 +16,7 @@ make_temp_dir()
                         DIR => shift(),
                         CLEANUP => 0,
                         TMPDIR => 1,
-                ) or die $!;
+                ) or die $!; # OS_ERROR
                 print $dir;
         ' "$@"
     ` || exit $?

--- a/lib/MusicBrainz/Script/JSONDump.pm
+++ b/lib/MusicBrainz/Script/JSONDump.pm
@@ -121,7 +121,7 @@ EOF
              catdir($mbdump->output_dir, $dump_fname)) or die $OS_ERROR;
     }
 
-    unlink "$dump_fpath.lock" or die $!;
+    unlink "$dump_fpath.lock" or die $OS_ERROR;
 
     return;
 }
@@ -425,7 +425,7 @@ sub run {
     my $exit_code = $self->run_impl($c);
 
     $c->connector->disconnect;
-    rmdir($TMP_EXPORT_DIR) or die $!;
+    rmdir($TMP_EXPORT_DIR) or die $OS_ERROR;
 
     log_info { 'Done' };
     return $exit_code;


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

In Perl `$!` is a short name for `$OS_ERROR` and the linter doesn’t allow short names, breaking CI tests.

It happened because I did not rebase the pull request #2350 on `master` before merging, and the Perl linter setup changed in the meantime in `master` branch, thus the CI tests did pass for this pull request even though they would not have if rebased.


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Replace all instances of Perl `$!` with its long name `$OS_ERROR`; See https://perldoc.perl.org/perlvar#$OS_ERROR


# Notes

- `admin/functions.sh` is not tested as it is a Bash file embedding a Perl snippet; Seems worth replacing too.
- `script/reset_selenium_env.sh` uses `$!` but it is a Bash variable for the PID of last executed background task.