### PR TITLE
MBS-13207 (I): Make release recording input not steal focus

### DIFF
--- a/root/static/scripts/edit/MB/Control/Bubble.js
+++ b/root/static/scripts/edit/MB/Control/Bubble.js
@@ -120,8 +120,8 @@ BubbleBase.prototype.activeBubbles = {};
  * input to the left of it.
  */
 class BubbleDoc extends BubbleBase {
-  show(control) {
-    super.show(control);
+  show(control, stealFocus) {
+    super.show(control, stealFocus);
 
     const $bubble = this.$bubble;
     const $parent = $bubble.parent();

--- a/root/static/scripts/release-editor/bubbles.js
+++ b/root/static/scripts/release-editor/bubbles.js
@@ -106,14 +106,14 @@ class RecordingBubble extends MB.Control.BubbleDoc {
     }
   }
 
-  show(control) {
+  show(control, stealFocus) {
     var track = ko.dataFor(control);
 
     if (track && !track.hasExistingRecording()) {
       releaseEditor.recordingAssociation.findRecordingSuggestions(track);
     }
 
-    super.show(control);
+    super.show(control, stealFocus);
   }
 
   currentTrack() {


### PR DESCRIPTION
Prevent the focus from getting incorrectly reassigned to the recording name text field whenever a radio button is selected at /release/add#recordings.

The RecordingBubble was passing a stealFocus argument around internally but then ignoring it in its show() method and not passing it to its parent class BubbleDoc (which also ignored it). Make sure that the argument makes it all the way up to the BubbleBase class.