### PR TITLE
MBS-13227: Omit "music quoted in" rels in tracklists

### DIFF
--- a/root/components/GroupedTrackRelationships.js
+++ b/root/components/GroupedTrackRelationships.js
@@ -108,6 +108,8 @@ const irrelevantLinkTypes: {
     [315, false], // revisions
     [316, false], // orchestrations
     [350, false], // arrangements
+    [1046, true], // works quoting music from this
+    [1047, true], // works quoting lyrics from this
   ]),
 };
 


### PR DESCRIPTION
# MBS-13227
Avoid displaying "music quoted in" work-work relationships in tracklists. Works linked by these relationships are typically unrelated to the track in question, and other similar relationships (based on, arrangements, medleys, etc.) are already omitted.