### PR TITLE
MBS-13225: Allow skipping Confirm Form Submission page

### DIFF
--- a/root/main/ConfirmSeed.js
+++ b/root/main/ConfirmSeed.js
@@ -29,6 +29,17 @@ const ConfirmSeed = ({
 }: Props): React$Element<typeof Layout> => {
   const $c = React.useContext(SanitizedCatalystContext);
   const title = l('Confirm Form Submission');
+
+  /*
+   * Automatically submit the form if /release/add (where POST requests are
+   * used to seed fields rather than to create edits) was requested and the
+   * client indicated that they want the form to be skipped. See MBS-13225.
+   */
+  const url = new URL($c.req.uri);
+  const autoSubmit =
+    url.pathname === '/release/add' &&
+    url.searchParams.get('skip_confirmation') === '1';
+
   return (
     <Layout fullWidth title={title}>
       <h1>{title}</h1>
@@ -50,7 +61,7 @@ const ConfirmSeed = ({
       </p>
       <form method="post">
         {postParameters ? <PostParameters params={postParameters} /> : null}
-        <ConfirmSeedButtons />
+        <ConfirmSeedButtons autoSubmit={autoSubmit} />
       </form>
       {manifest.js('confirm-seed', {async: 'async'})}
     </Layout>

--- a/root/static/scripts/main/components/ConfirmSeedButtons.js
+++ b/root/static/scripts/main/components/ConfirmSeedButtons.js
@@ -7,33 +7,50 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import * as React from 'react';
+
 import DBDefs from '../../common/DBDefs-client.mjs';
 
-const ConfirmSeedButtons = (): React$MixedElement => (
-  <>
-    <button type="submit">
-      {l('Continue')}
-    </button>
-    <button
-      className="negative"
-      onClick={() => {
-        if (history.length > 1) {
-          history.back();
-        } else {
-          window.location.replace(
-            window.location.protocol + '//' +
-            DBDefs.WEB_SERVER,
-          );
-        }
-      }}
-      type="button"
-    >
-      {l('Leave')}
-    </button>
-  </>
-);
+type PropsT = {
+  +autoSubmit: boolean,
+};
+
+const ConfirmSeedButtons = ({
+  autoSubmit,
+}: PropsT): React$MixedElement => {
+  const submitRef = React.useRef<HTMLButtonElement | null>(null);
+  React.useEffect(() => {
+    if (autoSubmit) {
+      submitRef.current?.click();
+    }
+  });
+
+  return (
+    <>
+      <button ref={submitRef} type="submit">
+        {l('Continue')}
+      </button>
+      <button
+        className="negative"
+        onClick={() => {
+          if (history.length > 1) {
+            history.back();
+          } else {
+            window.location.replace(
+              window.location.protocol + '//' +
+              DBDefs.WEB_SERVER,
+            );
+          }
+        }}
+        type="button"
+      >
+        {l('Leave')}
+      </button>
+    </>
+  );
+};
 
 export default (hydrate(
   'span.buttons.confirm-seed',
   ConfirmSeedButtons,
-): React$AbstractComponent<{}, void>);
+): React$AbstractComponent<PropsT, void>);


### PR DESCRIPTION
# MBS-13225

When /release/add is being seeded via a cross-site POST request, automatically submit the "Confirm Form Submission" form if the request included a "skip_confirmation" query parameter set to "1". This allows editors to go straight to the seeded "Add Release" page without needing an extra click.

# Problem

Users need to click through an extra "Confirm Form Submission" interstitial whenever they seed a release via a POST request to `/release/add`. This page still needs to be loaded to ensure that the `session` and `remember_login` cookies are passed (due to `SameSite=strict` being used), but making the user interact with it seems unnecessary for preventing CSRF attacks since the actual edit submission happens via a different `/ws/js/edit/create` path.

# Solution

The form can automatically submit itself when it's being loaded for `/release/add`. Clients must include a `skip_confirmation` query parameter set to `1` in order to auto-submit to avoid causing regressions in user scripts or extensions that already automatically submit the form.

# Testing

I've manually tested this change's behavior locally by modifying my yambs seeder to pass `skip_confirmation=1` and verifying that the confirmation screen is skipped. (I also had to hack `set_csp_headers` in `lib/MusicBrainz/Server.pm` to bail out early to actually get scripts to run; I'm not sure if there's some issue in musicbrainz-docker that's preventing CSP hashes from getting updated when I make local changes.)

I also verified that the screen isn't skipped when I omit `skip_confirmation` for `/release/add` requests, and that `skip_confirmation` doesn't skip the confirmation screen for `/artist/create` POST requests (which would permit CSRF attacks), and that I get the login page as before when starting in a logged-out state (and that I end up at the seeded form after logging in).

I added Selenium tests for this, but then I realized that they probably won't work since the tests' seeding forms are presumably loaded from the same origin as the server, resulting in the confirmation screen never getting shown. Please let me know if I'm mistaken there.