### PR TITLE
MBS-2604: Infer link direction between people and groups

### DIFF
--- a/root/static/scripts/common/constants.js
+++ b/root/static/scripts/common/constants.js
@@ -54,6 +54,15 @@ export const VOCAL_ROOT_ID = 3;
 export const AREA_TYPE_COUNTRY = 1;
 
 export const ARTIST_TYPE_PERSON = 1;
+export const ARTIST_TYPE_GROUP = 2;
+export const ARTIST_TYPE_ORCHESTRA = 5;
+export const ARTIST_TYPE_CHOIR = 6;
+
+export const ARTIST_GROUP_TYPES: Set<number> = new Set([
+  ARTIST_TYPE_CHOIR,
+  ARTIST_TYPE_GROUP,
+  ARTIST_TYPE_ORCHESTRA,
+]);
 
 export const CONTACT_URL = 'https://metabrainz.org/contact';
 

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -635,6 +635,7 @@ async function handleCommand({command, target, value}, t) {
 /* eslint-disable sort-keys */
 const seleniumTests = [
   {name: 'Create_Account.json5'},
+  {name: 'MBS-2604.json5', login: true},
   {name: 'MBS-5387.json5', login: true},
   {name: 'MBS-7456.json5', login: true},
   {name: 'MBS-9548.json5'},

--- a/t/selenium/MBS-2604.json5
+++ b/t/selenium/MBS-2604.json5
@@ -1,0 +1,59 @@
+{
+  title: 'MBS-2604: Infer link direction between people and groups',
+  commands: [
+    // Link a person from a group's page and check that the relationship
+    // direction defaults to person being the member of the group.
+    {
+      command: 'open',
+      target: '/artist/b7ffd2af-418f-4be2-bdd1-22f8b48613da/edit',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#relationship-editor button.add-item',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-type',
+      value: 'member${KEY_ENTER}',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: '5441c29d-3602-4898-b1a1-b77fa23b8e50',
+    },
+    {
+      command: 'assertText',
+      target: 'css=#add-relationship-dialog table.preview td',
+      value: 'David Bowie is/was a member of Nine Inch Nails',
+    },
+    // Link a group from a person's page and check that the relationship
+    // still defaults to person being the member of the group.
+    {
+      command: 'open',
+      target: '/artist/5441c29d-3602-4898-b1a1-b77fa23b8e50/edit',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#relationship-editor button.add-item',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-type',
+      value: 'member${KEY_ENTER}',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: 'b7ffd2af-418f-4be2-bdd1-22f8b48613da',
+    },
+    {
+      command: 'assertText',
+      target: 'css=#add-relationship-dialog table.preview td',
+      value: 'David Bowie is/was a member of Nine Inch Nails',
+    },
+  ],
+}


### PR DESCRIPTION
# MBS-2604

Make the relationship editor automatically infer the link direction for certain artist-artist relationships between individuals and groups (including orchestras and choirs).

For example, when a "member of" relationship with a person target is added to a group artist, it is automatically reversed.

This is intended to reduce the need to click the "Change direction" button and to make errors less common. Editors are still free to manually change the link direction before saving the relationship.

# Problem

Artist-artist relationships often default to being in the wrong direction. For example, when editing a group to add a "member of" relationship with a person as the target, the link direction needs to be manually reversed. Editors frequently forget to do this, resulting in incorrect data being entered.

# Solution

This change updates `RelationshipDialogContent.js` to infer the correct link direction whenever the link type or target entity MBID is modified.

# Testing

I've manually verified that relationships are automatically reversed now in the case described above (linking a member via a band's page), and that they aren't in the opposite scenario (linking a band via a member's page). If the approach that I'm taking seems reasonable, I'll work on adding Selenium tests that exercise this code (and updating existing tests, if needed).