### PR TITLE
MBS-13237: Clean up Twitch mobile links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5582,7 +5582,7 @@ const CLEANUPS: CleanupEntries = {
     match: [new RegExp('^(https?://)?([^/]+\\.)?twitch\\.(?:com|tv)/', 'i')],
     restrict: [{...LINK_TYPES.streamingfree, ...LINK_TYPES.videochannel}],
     clean: function (url) {
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?twitch\.(?:com|tv)\/((?:videos\/)?[^\/?#]+).*$/, 'https://www.twitch.tv/$1');
+      url = url.replace(/^(?:https?:\/\/)?(?:(?:m|www)\.)?twitch\.(?:com|tv)\/((?:videos\/)?[^\/?#]+).*$/, 'https://www.twitch.tv/$1');
       return url;
     },
     validate: function (url, id) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5484,6 +5484,13 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://www.twitch.tv/pisceze',
        only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
   },
+  {
+                     input_url: 'https://m.twitch.tv/marimbamatt913',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'videochannel',
+            expected_clean_url: 'https://www.twitch.tv/marimbamatt913',
+       only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
+  },
   // Twitter
   {
                      input_url: 'http://twitter.com/miguelgrimaldo',


### PR DESCRIPTION
### Implement MBS-13237

# Problem
Twitch mobile links (such as https://m.twitch.tv/marimbamatt913) are rejected.

# Solution
These mobile links equivalent to the usual www. links (such as https://www.twitch.tv/marimbamatt913) and should just be converted into them, so this just does that.

# Testing
Added a test.
