### PR TITLE
MBS-13165: Allow X ending for IdRef IDs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2839,7 +2839,7 @@ const CLEANUPS: CleanupEntries = {
       return url;
     },
     validate: function (url, id) {
-      const m = /^https:\/\/www\.idref\.fr\/\d+?$/.exec(url);
+      const m = /^https:\/\/www\.idref\.fr\/[\dX]+?$/.exec(url);
       if (m) {
         switch (id) {
           case LINK_TYPES.otherdatabases.artist:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2696,6 +2696,13 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://www.idref.fr/172248248',
        only_valid_entity_types: ['artist', 'genre', 'instrument', 'label', 'place', 'series', 'work'],
   },
+  {
+                     input_url: 'http://idref.fr/11762442X',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.idref.fr/11762442X',
+       only_valid_entity_types: ['artist', 'genre', 'instrument', 'label', 'place', 'series', 'work'],
+  },
   // IMDb (Internet Movie Database)
   {
                      input_url: 'http://www.imdb.com/name/nm1539156/',


### PR DESCRIPTION
### Fix MBS-13165

# Problem
IdRef URLs can actually end on X, but we're expecting only digits.

# Solution
Wikidata suggests it's always 8 digits, then a digit or X: https://www.wikidata.org/wiki/Property:P269

That said, because we've been burned before when trusting WD too much, I'm just allowing any number of digits and Xs - I don't expect this has much of a chance to lead to false positives unless someone starts making up IdRef IDs for some reason.

# Testing
Added a small test with an url with X ending.