### PR TITLE
MBS-13214 / MBS-13238: Improve Open Library handling

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4334,6 +4334,39 @@ const CLEANUPS: CleanupEntries = {
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?openlibrary\.org\/publishers\/([^/?#]+).*$/, 'https://openlibrary.org/publishers/$1');
       return url;
     },
+    validate: function (url, id) {
+      let m = /^https:\/\/openlibrary\.org\/(authors|books|works)\/OL[0-9]+[AMW]\/$/.exec(url);
+      if (!m) {
+        m = /^https:\/\/openlibrary\.org\/(publishers)\/[^/?#]+$/.exec(url);
+      }
+      if (m) {
+        const prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.otherdatabases.artist:
+            return {
+              result: prefix === 'authors',
+              target: ERROR_TARGETS.ENTITY,
+            };
+          case LINK_TYPES.otherdatabases.label:
+            return {
+              result: prefix === 'publishers',
+              target: ERROR_TARGETS.ENTITY,
+            };
+          case LINK_TYPES.otherdatabases.release:
+            return {
+              result: prefix === 'books',
+              target: ERROR_TARGETS.ENTITY,
+            };
+          case LINK_TYPES.otherdatabases.work:
+            return {
+              result: prefix === 'works',
+              target: ERROR_TARGETS.ENTITY,
+            };
+        }
+        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+      }
+      return {result: false, target: ERROR_TARGETS.URL};
+    },
   },
   'operabase': {
     match: [new RegExp('^(https?://)?(www\\.)?operabase\\.com', 'i')],

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4331,6 +4331,7 @@ const CLEANUPS: CleanupEntries = {
     restrict: [LINK_TYPES.otherdatabases],
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?openlibrary\.org\/(authors|books|works)\/(OL[0-9]+[AMW]).*$/, 'https://openlibrary.org/$1/$2/');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?openlibrary\.org\/publishers\/([^/?#]+).*$/, 'https://openlibrary.org/publishers/$1');
       return url;
     },
   },

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4330,7 +4330,7 @@ const CLEANUPS: CleanupEntries = {
     match: [new RegExp('^(https?://)?(www\\.)?openlibrary\\.org', 'i')],
     restrict: [LINK_TYPES.otherdatabases],
     clean: function (url) {
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?openlibrary\.org\/(authors|books|works)\/(OL[0-9]+[AMW]\/)(.*)*$/, 'https://openlibrary.org/$1/$2');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?openlibrary\.org\/(authors|books|works)\/(OL[0-9]+[AMW]).*$/, 'https://openlibrary.org/$1/$2/');
       return url;
     },
   },

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4170,9 +4170,10 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://openlibrary.org/books/OL8993487M/',
   },
   {
-                     input_url: 'https://openlibrary.org/works/OL82592W/',
+                     input_url: 'https://openlibrary.org/works/OL20723256W?edition=',
              input_entity_type: 'work',
     expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://openlibrary.org/works/OL20723256W/',
   },
   // Operabase
   {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4162,30 +4162,35 @@ limited_link_type_combinations: [
                      input_url: 'https://openlibrary.org/authors/OL23919A/',
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',
+       only_valid_entity_types: ['artist'],
   },
   {
                      input_url: 'http://openlibrary.org/publishers/Penguin_Books,_Limited',
              input_entity_type: 'label',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://openlibrary.org/publishers/Penguin_Books,_Limited',
+       only_valid_entity_types: ['label'],
   },
   {
-                     input_url: 'https://www.openlibrary.org/publishers/McGraw-Hill',
+                     input_url: 'https://openlibrary.org/publishers/McGraw-Hill',
              input_entity_type: 'label',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://openlibrary.org/publishers/McGraw-Hill',
+       only_valid_entity_types: ['label'],
   },
   {
                      input_url: 'http://openlibrary.org/books/OL8993487M/Harry_Potter_and_the_Philosopher\'s_Stone',
              input_entity_type: 'release',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://openlibrary.org/books/OL8993487M/',
+       only_valid_entity_types: ['release'],
   },
   {
                      input_url: 'https://openlibrary.org/works/OL20723256W?edition=',
              input_entity_type: 'work',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://openlibrary.org/works/OL20723256W/',
+       only_valid_entity_types: ['work'],
   },
   // Operabase
   {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4164,6 +4164,18 @@ limited_link_type_combinations: [
     expected_relationship_type: 'otherdatabases',
   },
   {
+                     input_url: 'http://openlibrary.org/publishers/Penguin_Books,_Limited',
+             input_entity_type: 'label',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://openlibrary.org/publishers/Penguin_Books,_Limited',
+  },
+  {
+                     input_url: 'https://www.openlibrary.org/publishers/McGraw-Hill',
+             input_entity_type: 'label',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://openlibrary.org/publishers/McGraw-Hill',
+  },
+  {
                      input_url: 'http://openlibrary.org/books/OL8993487M/Harry_Potter_and_the_Philosopher\'s_Stone',
              input_entity_type: 'release',
     expected_relationship_type: 'otherdatabases',


### PR DESCRIPTION
### Fix MBS-13214 / Implement MBS-13238

# Problem
A link without an ending slug, such as `https://openlibrary.org/works/OL20723256W?edition=`, does not get cleaned up. Same for any `/publishers` link (valid for labels, for example publishing audiobooks).

No validation happens at all for any of these links either.

# Solution
The first ticket here makes it so that cleanup does not depend on whether a slash appears after the OL ID, since that does not seem relevant to anything really (in fact, it seems some places, like the IA site, specifically link to pages without an ending slash and that might be a slightly preferable permalink).

The second ticket also allows cleaning up publisher links. Those don't use OL IDs for some reason, just plain text slugs, but they can certainly still be useful (some audiobook publishers have hundreds of entries).

The third ticket adds validation, limiting `/authors` links to artists, `/publishers` links to labels, `/books` links to releases (for audiobooks) and `/works` links to works. The only other links in the DB right now are 4 links to `/subjects` which seems to be for stuff books are *about* and I think it doesn't really make sense to link to anyway.

# Testing
Expanded the existing tests to also check validation, and added `/publishers` tests (including one with a comma and one with a hyphen to make sure we can deal with those fine).