### PR TITLE
MBS-13225: Add deps to useEffect call in ConfirmSeedButtons.

### DIFF
--- a/root/static/scripts/main/components/ConfirmSeedButtons.js
+++ b/root/static/scripts/main/components/ConfirmSeedButtons.js
@@ -23,7 +23,7 @@ const ConfirmSeedButtons = ({
     if (autoSubmit) {
       submitRef.current?.click();
     }
-  });
+  }, [autoSubmit, submitRef]);
 
   return (
     <>


### PR DESCRIPTION
I'm not sure if it has any effect in practice, but fix an oversight from 6f0b967e3d2f.

---

It looks like I forgot to amend my commit to include a change suggested by @mwiencek, namely passing a dependency list to the `React.useEffect()` call that clicks the submit button. I'm including the original ticket in the commit title, although I'm not sure if it's necessary (or desirable). I had already manually tested this locally.