### PR TITLE
MBS-13241: Prevent recording bubble from shifting.

### DIFF
--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -233,10 +233,16 @@ div.changes div.warning { margin: 1em auto; }
 }
 
 #recording-assoc-bubble {
+    tr { vertical-align: top; }
+
     td.suggested-recording { padding: 1em; }
     td.appears-on { padding-bottom: 1em; }
 
     span.autocomplete input { width: 22em; }
+}
+
+#track-recording-assignation {
+    tr { vertical-align: top; }
 }
 
 /* __________________________________


### PR DESCRIPTION
# MBS-13241

Set "vertical-align: top" on the tracklist table rows at /release/add#recordings to prevent the "Edit" button from shifting vertically depending on the height of the track and recording titles, which was causing the bubble that contains the recordings list also shift vertically.

Also set "vertical-align: top" on the recording rows since it looks odd when the artist name and duration aren't aligned with the top of a multiline recording title and disambiguation.

# Problem

The bubble that lists recordings often moves vertically when a recording is clicked, which can be disorienting. This happens because the bubble is aligned with the "Edit" button, which is vertically centered within its row, and the row's height can increase when the selected recording has a long title or disambiguation.

The vertical alignment of text within the tracklist and recordings list also looks a bit strange due to each cell being vertically centered.

# Solution

Add CSS to ensure that each cell's contents are vertically aligned with the top of the row.

**Before**:
![before](https://github.com/metabrainz/musicbrainz-server/assets/40385/ba777567-ba58-43d1-acd1-6d373ecea794)

**After**:
![after](https://github.com/metabrainz/musicbrainz-server/assets/40385/80baa25b-d041-4cab-94f7-ce2d71f63f5d)

# Testing

I've been opening `/release/add?release-group=0da580f2-6768-498f-af9d-2becaddf15e0` and adding a single "Fight Fire With Fire" track with length 4:45. There are plenty of recordings to select, some of which have long disambiguations. Without this change, the bubble moves vertically when clicking between recording without a disambiguation and one with a disambiguation. With the change, it (usually) doesn't move.

As described on the ticket, I've noticed that the bubble sometimes still shifts when I click a recording while scrolled all the way to the bottom of the page. I haven't been able to find any JS that's responsible for this and suspect that it may be builtin behavior in Chrome. I haven't had a chance to test whether the same thing happens in Firefox or not.

I won't be able to test this PR locally until next week, so I've just been using DevTools in Chrome 115 and Firefox ESR to apply these rules to the beta site and verify that they work as expected.