### PR TITLE
Add top padding to track/recording position and buttons.

### DIFF
--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -197,7 +197,7 @@ div.changes div.warning { margin: 1em auto; }
         td {
             &.position {
                 text-align: right;
-                padding: 0 0.5em;
+                padding: 0.5em 0.5em 0 0.5em;
                 font-size: @extremely-large-text;
                 width: 1em;
             }
@@ -212,6 +212,7 @@ div.changes div.warning { margin: 1em auto; }
             }
 
             &.buttons {
+                padding-top: 1em;
                 width: 7em;
                 button { width: 6em; }
             }


### PR DESCRIPTION
Update the release editor CSS to make the recording page's track positions and buttons line up with the track and recording titles. These cells were vertically centered within their rows before, but 128764ab3dd made them top-aligned.

See discussion on #3021.