### PR TITLE
MBS-13250: Don't crash on missing text content on setlist

### DIFF
--- a/root/static/scripts/common/utility/formatSetlist.js
+++ b/root/static/scripts/common/utility/formatSetlist.js
@@ -36,7 +36,10 @@ const linkRegExp =
  * all equivalent syntaxes are supported and documented for convenience.
  * https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references
  */
-function decodeSomeHTMLEntities(content: string) {
+function decodeSomeHTMLEntities(content: ?string) {
+  if (content == null) {
+    return '';
+  }
   return content
     .replace(/&#91;|&#x5b;|&lsqb;|&lbrack;/gi, '[')
     .replace(/&#93;|&#x5d;|&rsqb;|&rbrack;/gi, ']')

--- a/root/static/scripts/tests/utility/formatSetlist.js
+++ b/root/static/scripts/tests/utility/formatSetlist.js
@@ -19,6 +19,7 @@ test('formatSetlist', function (t) {
     '@ pre-text [e1af2f0d-c685-4e83-a27d-b27e79787aab|artist 1] mid-text ' +
       '[0eda70b7-c77b-4775-b1db-5b0e5a3ca4c1|artist 2 (:v&#93;&#x5d;&rsqb;&rbrack;] post-text\n\r\n' +
     '* e [b831b5a4-e1a9-4516-bb50-b6eed446fc9b|work 1] [not a link]\r' +
+    '* e [b831b5a4-e1a9-4516-bb50-b6eed446fc9c]\r' +
     '@ plain text artist &lbrack;&lsqb;&#x5b;&#91;v:)\n' +
     '# comment [b831b5a4-e1a9-4516-bb50-b6eed446fc9b|not a link]\r\n' +
     '# comment <a href="#">also not a link</a> &#38;amp; &amp;rsqb;\r\n' +
@@ -38,6 +39,7 @@ test('formatSetlist', function (t) {
     '</strong> post-text<br/><br/>' +
     'e <a href="/work/b831b5a4-e1a9-4516-bb50-b6eed446fc9b">work 1</a> ' +
       '[not a link]<br/>' +
+    'e <a href="/work/b831b5a4-e1a9-4516-bb50-b6eed446fc9c">work:b831b5a4-e1a9-4516-bb50-b6eed446fc9c</a><br/>' +
     '<strong>Artist: ' +
     'plain text artist [[[[v:)' +
     '</strong><br/>' +


### PR DESCRIPTION
### Fix MBS-13250

# Problem
After a setlist was added to an event, it started crashing with an error about trying to run `replace` on `undefined`.

# Solution
I found that this was caused by the setlist linking to works without work titles like this:
` * [58b51a5a-279b-476d-b27e-f44402faa675]`

We do explicitly support empty content, so this was just a bug - this just makes it so we don't try to run `replace` on `undefined` content.

# Testing
Added one row like this to the test setlist in our `formatSetlist` test.