### PR TITLE
MBS-3629: Add check/uncheck all option to subscription pages

### DIFF
--- a/root/user/UserSubscriptions.js
+++ b/root/user/UserSubscriptions.js
@@ -40,7 +40,11 @@ const UserSubscriptionsTable = ({
   <table className="tbl">
     <thead>
       <tr>
-        {viewingOwnProfile ? <th style={{width: '1em'}} /> : null}
+        {viewingOwnProfile ? (
+          <th className="checkbox-cell">
+            <input type="checkbox" />
+          </th>
+        ) : null}
         <th>{l('Name')}</th>
       </tr>
     </thead>


### PR DESCRIPTION
### Implement MBS-3629

# Problem
Unlike most other tables with selectable checkboxes on the site, the ones to select and unsubscribe from subscriptions do not currently have a "select all" checkbox on the table header.

# Solution
There seems to be no good reason why we do not have this (shift-clicking works, but we offer both options in other places). Just following the same pattern as elsewhere including `className` over the previous `style` object.

# Testing
Manually with my test data, including that selecting all and then clicking unsubscribe works, and that selecting all, then unselecting all, then clicking unsubscribe does nothing as expected.