### PR TITLE
MBS-13260: Upgrade Node.js to v18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,12 @@ version: 2.1
 executors:
   musicbrainz-tests:
     docker:
+      - image: metabrainz/musicbrainz-tests:v-2023-08
+        user: root
+    working_directory: /home/musicbrainz/musicbrainz-server
+
+  musicbrainz-tests-node-v16:
+    docker:
       - image: metabrainz/musicbrainz-tests:v-2022-10
         user: root
     working_directory: /home/musicbrainz/musicbrainz-server
@@ -87,8 +93,88 @@ jobs:
       - store_test_results:
           path: ./junit_output
 
+  js-perl-and-pgtap-node-v16:
+    executor: musicbrainz-tests-node-v16
+    steps:
+      - restore_cache:
+          keys:
+            - v1-source-{{ .Branch }}-{{ .Revision }}
+            - v1-source-{{ .Branch }}-
+            - v1-source-
+      - checkout
+      - run: |
+          chown -R musicbrainz:musicbrainz .
+          # The checkout step configures git to skip gc, so we run it
+          # here to reduce .git's size before saving it to cache.
+          sudo -E -H -u musicbrainz git gc
+      - save_cache:
+          key: v1-source-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ".git"
+
+      - restore_cache:
+          keys:
+            - v2-node-v16-{{ checksum "yarn.lock" }}
+            - v2-node-v16-
+      - run: |
+          chown -R musicbrainz:musicbrainz .
+          sudo -E -H -u musicbrainz yarn
+      - save_cache:
+          key: v2-node-v16-{{ checksum "yarn.lock" }}
+          paths:
+            - "node_modules"
+
+      - run: |
+          sudo -E -H -u musicbrainz mkdir -p junit_output
+          sudo -E -H -u musicbrainz cp docker/musicbrainz-tests/DBDefs.pm lib/
+          rm /etc/service/{postgresql,redis}/down && sv start postgresql redis
+          sudo -E -H -u musicbrainz carton exec -- ./script/create_test_db.sh
+          sudo -E -H -u musicbrainz make -C po all_quiet deploy
+          MUSICBRAINZ_RUNNING_TESTS=1 NODE_ENV=test WEBPACK_MODE=development NO_PROGRESS=1 sudo -E -H -u musicbrainz carton exec -- \
+              ./script/compile_resources.sh client server web-tests
+          sudo -E -H -u musicbrainz ./node_modules/.bin/flow --quiet
+          sudo -E -H -u musicbrainz ./node_modules/.bin/eslint --max-warnings 0 .
+          rm /etc/service/chrome/down && sv start chrome
+          sudo -E -H -u musicbrainz carton exec -- node \
+              t/web.js \
+              | tee >(./node_modules/.bin/tap-junit > ./junit_output/js_web.xml) \
+              | ./node_modules/.bin/tap-difflet
+          sv kill chrome
+          ./docker/musicbrainz-tests/add_mbtest_alias.sh
+          sudo -u postgres createdb -O musicbrainz -T musicbrainz_test -U postgres musicbrainz_test_json_dump
+          sudo -u postgres createdb -O musicbrainz -T musicbrainz_test -U postgres musicbrainz_test_full_export
+          sudo -u postgres createdb -O musicbrainz -T musicbrainz_test -U postgres musicbrainz_test_sitemaps
+          rm /etc/service/{template-renderer,vnu,website}/down && sv start template-renderer vnu website
+          export MMD_SCHEMA_ROOT=/home/musicbrainz/mb-solr/mmd-schema
+          export JUNIT_OUTPUT_FILE=junit_output/perl_and_pgtap.xml
+          sudo -E -H -u musicbrainz carton exec -- prove \
+              --pgtap-option dbname=musicbrainz_test \
+              --pgtap-option host=localhost \
+              --pgtap-option port=5432 \
+              --pgtap-option username=musicbrainz \
+              --source pgTAP \
+              --source Perl \
+              -I lib \
+              t/author/* \
+              t/critic.t \
+              t/hydration_i18n.t \
+              t/pgtap/* \
+              t/pgtap/unused-tags/* \
+              t/script/MergeDuplicateArtistCredits.t \
+              t/script/BuildSitemaps.t \
+              t/script/DumpJSON.t \
+              t/script/ExportAllTables.t \
+              t/script/dbmirror2.t \
+              t/tests.t \
+              --harness=TAP::Harness::JUnit \
+              -v
+
+      - store_test_results:
+          path: ./junit_output
+
 workflows:
   version: 2.1
   build-and-test:
     jobs:
       - js-perl-and-pgtap
+      - js-perl-and-pgtap-node-v16

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,7 +74,7 @@ Prerequisites
     If you plan on accessing musicbrainz-server inside a web browser, you should
     install Node and the package manager Yarn.
 
-    We currently run Node.js v16.16.0 in production.  While we try to support
+    We currently run Node.js v18.17.1 in production.  While we try to support
     all 16.x versions of Node, it's recommended to install one greater than or
     equal to v16.13.0, as this is when the LTS line started and better matches
     what we use and know works.  If your release of Ubuntu doesn't have such a

--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -21,14 +21,14 @@ RUN apt-get update && \
     echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     curl -sLO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
-    curl -sLO https://deb.nodesource.com/node_16.x/pool/main/n/nodejs/nodejs_16.16.0-deb-1nodesource1_amd64.deb && \
+    curl -sLO https://deb.nodesource.com/node_18.x/pool/main/n/nodejs/nodejs_18.17.1-deb-1nodesource1_amd64.deb && \
     apt-get update && \
     apt-get install \
         --no-install-recommends \
         --no-install-suggests \
         -y \
         ./google-chrome-stable_current_amd64.deb \
-        ./nodejs_16.16.0-deb-1nodesource1_amd64.deb \
+        ./nodejs_18.17.1-deb-1nodesource1_amd64.deb \
         build-essential \
         bzip2 \
         gcc \
@@ -95,7 +95,7 @@ RUN apt-get update && \
         python3.9-venv && \
     rm -rf /var/lib/apt/lists/* && \
     rm google-chrome-stable_current_amd64.deb && \
-    rm nodejs_16.16.0-deb-1nodesource1_amd64.deb && \
+    rm nodejs_18.17.1-deb-1nodesource1_amd64.deb && \
     update-java-alternatives -s java-1.8.0-openjdk-amd64 && \
     systemctl disable rabbitmq-server
 

--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -168,10 +168,11 @@ RUN sudo -E -H -u musicbrainz git clone https://github.com/metabrainz/artwork-re
     sudo -E -H -u musicbrainz sh -c 'python3.9 -m venv venv; . venv/bin/activate; pip install -r requirements.txt' && \
     cd /home/musicbrainz
 
-RUN curl -sLO https://chromedriver.storage.googleapis.com/106.0.5249.61/chromedriver_linux64.zip && \
-    unzip chromedriver_linux64.zip -d /usr/local/bin && \
+RUN curl -sLO https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/linux64/chromedriver-linux64.zip && \
+    unzip chromedriver-linux64.zip -d /tmp && \
+    mv /tmp/chromedriver-linux64/chromedriver /usr/local/bin/ && \
     chmod +x /usr/local/bin/chromedriver && \
-    rm chromedriver_linux64.zip
+    rm -r chromedriver-linux64.zip /tmp/chromedriver-linux64
 
 RUN curl -sLO https://github.com/validator/validator/releases/download/18.11.5/vnu.jar_18.11.5.zip && \
     unzip -d vnu -j vnu.jar_18.11.5.zip && \

--- a/docker/musicbrainz-tests/chrome.service
+++ b/docker/musicbrainz-tests/chrome.service
@@ -5,4 +5,5 @@ exec sudo -E -H -u musicbrainz google-chrome-stable \
     --disable-dev-shm-usage \
     --disable-gpu \
     --no-sandbox \
-    --remote-debugging-port=9222
+    --remote-debugging-port=9222 \
+    'about:blank'

--- a/docker/templates/macros.m4
+++ b/docker/templates/macros.m4
@@ -13,7 +13,7 @@ m4_define(`apt_purge', `apt-get purge --auto-remove -y $1')
 
 m4_define(`sudo_mb', `sudo -E -H -u musicbrainz $1')
 
-m4_define(`NODEJS_DEB', `nodejs_16.16.0-deb-1nodesource1_amd64.deb')
+m4_define(`NODEJS_DEB', `nodejs_18.17.1-deb-1nodesource1_amd64.deb')
 
 m4_define(
     `install_javascript',
@@ -25,7 +25,7 @@ RUN apt-key add /tmp/yarn_pubkey.txt && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt_install(``git python3-minimal yarn'') && \
     cd /tmp && \
-    curl -sLO https://deb.nodesource.com/node_16.x/pool/main/n/nodejs/NODEJS_DEB && \
+    curl -sLO https://deb.nodesource.com/node_18.x/pool/main/n/nodejs/NODEJS_DEB && \
     dpkg -i NODEJS_DEB && \
     cd - && \
     sudo_mb(``yarn install$1'')

--- a/lib/MusicBrainz/Server/Data/Collection.pm
+++ b/lib/MusicBrainz/Server/Data/Collection.pm
@@ -374,10 +374,10 @@ sub delete {
     $self->remove_gid_redirects(@collection_ids);
 
     # Remove all entities associated with the collection(s)
-    map {
+    for (entities_with('collections')) {
         $self->sql->do("DELETE FROM editor_collection_$_
             WHERE collection IN (" . placeholders(@collection_ids) . ')', @collection_ids);
-    } entities_with('collections');
+    }
 
     # Remove all collaborators associated with the collection(s)
     $self->sql->do('DELETE FROM editor_collection_collaborator

--- a/lib/MusicBrainz/Server/Edit/Release/ReorderMediums.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/ReorderMediums.pm
@@ -75,9 +75,9 @@ sub foreign_keys {
 
     my %fk = ( Release => { $self->data->{release}{id} => [ ] } );
 
-    map {
-        $fk{Medium}->{ $_->{medium_id} } = []
-    } @{ $self->data->{medium_positions} };
+    for (@{ $self->data->{medium_positions} }) {
+        $fk{Medium}->{ $_->{medium_id} } = [];
+    }
 
     return \%fk;
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@babel/eslint-parser": "7.19.1",
     "babel-plugin-istanbul": "5.2.0",
     "buffer": "6.0.3",
-    "chrome-remote-interface": "0.27.0",
+    "chrome-remote-interface": "0.33.0",
     "eslint": "7.9.0",
     "eslint-plugin-fb-flow": "0.0.2",
     "eslint-plugin-flowtype": "5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1543,11 +1543,6 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
-async-limiter@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
-  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
-
 babel-loader@9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-9.1.0.tgz#839e9ae88aea930864ef9ec0f356dfca96ecf238"
@@ -1768,13 +1763,13 @@ chokidar@^3.4.0, chokidar@^3.5.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chrome-remote-interface@0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.27.0.tgz#83a3ecc1f9e4da395aec81fe33963104676726b4"
-  integrity sha512-K7x1L0Wlxor6uj6ejRbERbIxp5FCRtxZiFZGmOP6mcQm6C5e0AyPa2oayR82pQkfdKaxaoiu72AeuA89WYR3AA==
+chrome-remote-interface@0.33.0:
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.33.0.tgz#9140b5612ee5cdc39212cd0296d3b61ea881c47a"
+  integrity sha512-tv/SgeBfShXk43fwFpQ9wnS7mOCPzETnzDXTNxCb6TqKOiOeIfbrJz+2NAp8GmzwizpKa058wnU1Te7apONaYg==
   dependencies:
     commander "2.11.x"
-    ws "^6.1.0"
+    ws "^7.2.0"
 
 chrome-trace-event@^1.0.2:
   version "1.0.3"
@@ -5320,12 +5315,10 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^6.1.0:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e"
-  integrity sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==
-  dependencies:
-    async-limiter "~1.0.0"
+ws@^7.2.0:
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
+  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
 xgettext-js@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
# MBS-13260: Upgrade Node.js to v18

From the ticket: "MusicBrainz Server depends on Node.js 16 which is currently still an LTS in maintenance phase. Its EOL is the 11th September 2023. So it should be replaced with the next active LTS which is Node.js 18."

Since we plan to require v20 when that reaches LTS, and given the short notice, I haven't updated the requirements in INSTALL.md yet (though I've noted that we run v18 in production); I've also modified the CircleCI config to run tests against the previous musicbrainz-tests image which contains Node.js v16 in order to avoid any breakage in the meantime.