### PR TITLE
MBS-13224: Show edit/note restrictions from user profile

### DIFF
--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -282,7 +282,7 @@ const UserProfileInformation = ({
 
         {/* Only relevant to logged in users, avoid more public shame */}
         {viewingUser && restrictions.length ? (
-          <UserProfileProperty name={l(addColonText('Active restrictions'))}>
+          <UserProfileProperty name={l(addColonText('Restrictions'))}>
             {commaOnlyListText(restrictions)}
           </UserProfileProperty>
         ) : null}

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Show.pm
@@ -70,7 +70,7 @@ test 'User restrictions display' => sub {
 
     $mech->get('/user/Alice');
     $mech->text_lacks(
-        'Active restrictions',
+        'Restrictions',
         'No restriction info shown if none applies',
     );
 
@@ -83,7 +83,7 @@ test 'User restrictions display' => sub {
 
     $mech->get('/user/Alice');
     $mech->text_contains(
-        'Active restrictions:Edit notes disabled',
+        'Restrictions:Edit notes disabled',
         'Restriction info shown when logged in as other (but not Untrusted)',
     );
 
@@ -91,7 +91,7 @@ test 'User restrictions display' => sub {
 
     $mech->get('/user/Alice');
     $mech->text_lacks(
-        'Active restrictions',
+        'Restrictions',
         'No restriction info shown when logged out',
     );
 
@@ -102,7 +102,7 @@ test 'User restrictions display' => sub {
 
     $mech->get('/user/Alice');
     $mech->text_contains(
-        'Active restrictions:Edit notes disabled',
+        'Restrictions:Edit notes disabled',
         'Restriction info shown when logged in as self (but not Untrusted)',
     );
 
@@ -120,7 +120,7 @@ test 'User restrictions display' => sub {
 
     $mech->get('/user/Alice');
     $mech->text_contains(
-        'Active restrictions:Edit notes disabled, Untrusted',
+        'Restrictions:Edit notes disabled, Untrusted',
         'Restriction info including Untrusted shown when logged in as admin',
     );
 };


### PR DESCRIPTION
### Implement MBS-13224

# Problem
We have for a long time chosen not to show whether a user was blocked from editing or leaving edit notes publicly in order to avoid publicly shaming editors.
Sadly, this means already banned editors get reported again, kind of wasting the time of both re-reporters and admins.
Additionally, it's unfair to the user *not* to display this info, since other editors can demand the user react to their edit notes without knowing they cannot.

# Solution
This shows active editing/voting an edit note restrictions for the user to other logged in users only and only when they visit their profile, which is the least shaming way of doing it but still visible if someone is thinking of re-reporting.

The "Untrusted" restriction is explicitly not shown to other users. "Untrusted" is usually set as a "hidden" "minor" restriction for users who just need an extra eye on their edits, and we don't even notify the restricted user of it, so it wouldn't make sense to notify others.

# Testing
Manually, plus added a test for this (and while at it turned another pointless test for this page into one that does something, on a separate commit).