### PR TITLE
MBS-13268: Stop cleaning up CDBaby links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1889,38 +1889,12 @@ const CLEANUPS: CleanupEntries = {
       return {result: false, target: ERROR_TARGETS.URL};
     },
   },
-  'cdbaby': {
-    match: [new RegExp(
-      '^(https?://)?([^/]+\\.)?cdbaby\\.(com|name)/(?!Artist/)',
-      'i',
-    )],
-    clean: function (url) {
-      const m = url.match(/(?:https?:\/\/)?(?:(?:store|www)\.)?cdbaby\.com\/cd\/([^\/]+)(\/(from\/[^\/]+)?)?/);
-      if (m) {
-        url = 'https://store.cdbaby.com/cd/' + m[1].toLowerCase();
-      }
-      url = url.replace(/(?:https?:\/\/)?(?:(?:store|www)\.)?cdbaby\.com\/Images\/Album\/([\w%]+)(?:_small)?\.jpg/, 'https://store.cdbaby.com/cd/$1');
-      return url.replace(/(?:https?:\/\/)?(?:images\.)?cdbaby\.name\/.\/.\/([\w%]+)(?:_small)?\.jpg/, 'https://store.cdbaby.com/cd/$1');
-    },
-  },
   'cdbaby_artist': {
     match: [new RegExp(
       '^(https?://)?((store|www)\\.)?cdbaby\\.(com|name)/Artist/',
       'i',
     )],
     restrict: [LINK_TYPES.cdbaby],
-    clean: function (url) {
-      return url.replace(/(?:https?:\/\/)?(?:(?:store|www)\.)?cdbaby\.(?:com|name)\/Artist\/([\w%]+).*$/i, 'https://store.cdbaby.com/Artist/$1');
-    },
-    validate: function (url, id) {
-      if (/^https:\/\/store.cdbaby\.com\/Artist\/[\w%]+$/.test(url)) {
-        if (id === LINK_TYPES.cdbaby.artist) {
-          return {result: true};
-        }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
-      }
-      return {result: false, target: ERROR_TARGETS.URL};
-    },
   },
   'cdjapan': {
     match: [new RegExp(

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1539,14 +1539,6 @@ limited_link_type_combinations: [
                      input_url: 'www.cdbaby.name/artist/Johnn%c3%afDoe1#',
              input_entity_type: 'artist',
     expected_relationship_type: 'cdbaby',
-            expected_clean_url: 'https://store.cdbaby.com/Artist/Johnn%c3%afDoe1',
-       only_valid_entity_types: ['artist'],
-  },
-  {
-                     input_url: 'http://cdbaby.com/cd/Johnn%c3%af003',
-             input_entity_type: 'release',
-    expected_relationship_type: undefined,
-            expected_clean_url: 'https://store.cdbaby.com/cd/johnn%c3%af003',
   },
   // CB (Cape Breton) Fiddle Recordings
   {


### PR DESCRIPTION
### Implement MBS-13268


# Problem
CD Baby is gone anyway, so added URLs nowadays will be from old data. As mentioned in our forum
(https://community.metabrainz.org/t/cd-baby-store-closes-on-31-march/467757/12) we often could benefit from not cleaning those since the cleanup can make it harder to find archived versions of the data, and the "cleaned" URL is also broken by now anyway.

# Solution
This removes cleanup/validation, but keeps the autoselection of the cdbaby reltype for artists.

# Testing
None, other than keeping the cdbaby artist test but only with autoselection testing.