### PR TITLE
MBS-13195: More useful sort for applications list

### DIFF
--- a/lib/MusicBrainz/Server/Data/EditorOAuthToken.pm
+++ b/lib/MusicBrainz/Server/Data/EditorOAuthToken.pm
@@ -70,13 +70,16 @@ sub get_by_refresh_token
 sub find_granted_by_editor
 {
     my ($self, $editor_id, $limit, $offset) = @_;
-    my $query = 'SELECT application, scope, max(granted) as granted
-                 FROM ' . $self->_table . '
+    my $query = 'SELECT token.application,
+                        token.scope,
+                        max(token.granted) as granted
+                 FROM ' . $self->_table . ' token
+                 JOIN application ON token.application = application.id
                  WHERE
-                    editor = ? AND
-                    access_token IS NOT NULL
-                 GROUP BY application, scope
-                 ORDER BY application, scope';
+                    token.editor = ? AND
+                    token.access_token IS NOT NULL
+                 GROUP BY application.name, token.application, token.scope
+                 ORDER BY application.name, granted DESC, token.scope';
     $self->query_to_list_limited($query, [$editor_id], $limit, $offset);
 }
 


### PR DESCRIPTION
### Implement MBS-13195


# Problem
The current sort of the authorized applications list (by application ID) means nothing to users, so it feels effectively random. 

# Solution
The two best options seemed to be granted token time (does not require extra joins, but keeps similar applications separate) or application name (groups similar applications; needs one extra join).

It feels to me that the benefit of name is worth the join on this table since it shouldn't add a significant delay (application is relatively small). I'm doing a second level of sorting on token date (newest first) since it seems to also make the table nicer when there's several entries for a name.

# Testing
Manually with my own authorized apps (which include duplicate app names)