### PR TITLE
MBS-13072: Notify on subsecond recording edit lengths

### DIFF
--- a/root/edit/details/EditRecording.js
+++ b/root/edit/details/EditRecording.js
@@ -28,6 +28,8 @@ const EditRecording = ({edit}: Props): React$Element<'table'> => {
   const name = display.name;
   const comment = display.comment;
   const length = display.length;
+  const areLengthsAlmostSame = Boolean(length &&
+    formatTrackLength(length.new) === formatTrackLength(length.old));
   const video = display.video;
   const artistCredit = display.artist_credit;
   return (
@@ -54,11 +56,21 @@ const EditRecording = ({edit}: Props): React$Element<'table'> => {
           />
         ) : null}
         {length ? (
-          <Diff
-            label={addColonText(l('Length'))}
-            newText={formatTrackLength(length.new)}
-            oldText={formatTrackLength(length.old)}
-          />
+          areLengthsAlmostSame ? (
+            <tr>
+              <th>{addColonText(l('Length'))}</th>
+              <td colSpan="2">
+                {l(`This edit makes subsecond changes
+                    to the recording length`)}
+              </td>
+            </tr>
+          ) : (
+            <Diff
+              label={addColonText(l('Length'))}
+              newText={formatTrackLength(length.new)}
+              oldText={formatTrackLength(length.old)}
+            />
+          )
         ) : null}
         {video ? (
           <FullChangeDiff


### PR DESCRIPTION
### Fix MBS-13072

# Problem
If an edit such as `/edit/99374885` only makes subsecond changes to a recording's length, nothing at all is shown in the edit, since we diff on seconds and as such the diff is empty. That means it's entirely unclear what the edit even tries to do.

# Solution
This shows an informative message equivalent to the one in `edit/details/SetTrackLengths`, since we seem to consider subsecond changes not worth displaying.

# Testing
Manually, on the given edit.