### PR TITLE
MBS-12423: Block VGMdb links from release groups

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -6509,6 +6509,12 @@ entitySpecificRules.release_group = function (url) {
       target: ERROR_TARGETS.ENTITY,
     };
   }
+  if (/^(https?:\/\/)?vgmdb\.(?:net|com)/.test(url)) {
+    return {
+      result: false,
+      target: ERROR_TARGETS.ENTITY,
+    };
+  }
   return {result: true};
 };
 

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5872,6 +5872,13 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://vgmdb.net/product/8301',
        only_valid_entity_types: ['work'],
   },
+  {
+                     input_url: 'https://vgmdb.net/product/8302/',
+             input_entity_type: 'release_group',
+    expected_relationship_type: undefined,
+       input_relationship_type: 'review',
+       only_valid_entity_types: [],
+  },
   // VIAF (Virtual International Authority File)
   {
                      input_url: 'http://viaf.org/viaf/109231256',


### PR DESCRIPTION
### Implement MBS-12423

# Problem
Apparently people keep insisting on adding VGMdb links to RGs as either standalone sites or reviews, but VGMdb doesn't actually have anything that matches our RG level and these should never be added to RGs.

# Solution
Just block VGMdb links on RGs entirely like we already did with Bandcamp links.

I also deleted the 9 still existing RG links by hand - they were all seemingly already present at the release level as well anyway. 

# Testing
Added one basic test.