### PR TITLE
MBS-13145: Also show collection tab to logged out viewers

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Collection.pm
@@ -29,7 +29,7 @@ role
 
     $extra{consumer}->name->config(
         action => {
-            $method_name => { Chained => 'load', RequireAuth => undef }
+            $method_name => { Chained => 'load' }
         }
     );
 
@@ -49,7 +49,7 @@ role
         my ($collections) = $c->model('Collection')->find_by({
             entity_id => $c->stash->{$entity_name}->id,
             entity_type => $entity_type,
-            show_private_only => $c->user_exists ? $c->user->id : undef,
+            show_private_only => $c->user_exists ? $c->user->id : 'none',
         });
         $collections;
     };

--- a/lib/MusicBrainz/Server/Controller/Role/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Collection.pm
@@ -44,14 +44,14 @@ role
         $collections;
     };
 
-    method _all_non_visible_collections => sub {
+    method _non_visible_collection_count => sub {
         my ($self, $c) = @_;
-        my ($collections) = $c->model('Collection')->find_by({
+        my $count = $c->model('Collection')->get_hidden_collection_count({
             entity_id => $c->stash->{$entity_name}->id,
             entity_type => $entity_type,
-            show_private_only => $c->user_exists ? $c->user->id : 'none',
+            editor_id => $c->user_exists ? $c->user->id : undef,
         });
-        $collections;
+        $count;
     };
 
     # Stuff that has the side bar and thus needs to display collection information
@@ -65,7 +65,7 @@ role
         my %entity_collections_map = map { $_->id => 1 } @$entity_collections;
 
         my $number_of_visible_collections = @$entity_collections;
-        my $number_of_non_visible_collections = @{$self->_all_non_visible_collections($c)};
+        my $number_of_non_visible_collections = $self->_non_visible_collection_count($c);
 
         if ($c->user_exists) {
             # Make a list of collections and whether this entity is contained in them
@@ -105,8 +105,7 @@ View a list of collections that this work has been added to.
         my ($self, $c) = @_;
 
         my @public_collections = @{$self->_all_visible_collections($c)};
-        # For private collections we just want the number, so we just read the results in scalar context
-        my $private_collections = @{$self->_all_non_visible_collections($c)};
+        my $private_collections = $self->_non_visible_collection_count($c);
 
         $c->model('Editor')->load(@public_collections);
 

--- a/lib/MusicBrainz/Server/Data/Collection.pm
+++ b/lib/MusicBrainz/Server/Data/Collection.pm
@@ -274,10 +274,13 @@ sub find_by {
         push @args, $editor_id, $editor_id;
     } elsif ($editor_id = $opts->{show_private_only}) {
         push @conditions, 'editor_collection.public = false';
-        push @conditions, 'editor_collection.editor != ?';
-        push @conditions, 'NOT EXISTS (SELECT 1 FROM editor_collection_collaborator ecc
-                            WHERE ecc.collection = editor_collection.id AND ecc.editor = ?)';
-        push @args, $editor_id, $editor_id;
+        # We skip this if there's no logged in editor
+        unless ($editor_id eq 'none') {
+            push @conditions, 'editor_collection.editor != ?';
+            push @conditions, 'NOT EXISTS (SELECT 1 FROM editor_collection_collaborator ecc
+                                WHERE ecc.collection = editor_collection.id AND ecc.editor = ?)';
+            push @args, $editor_id, $editor_id;
+        }
     } else {
         push @conditions, 'editor_collection.public = true';
     }

--- a/lib/MusicBrainz/Server/Data/Collection.pm
+++ b/lib/MusicBrainz/Server/Data/Collection.pm
@@ -272,15 +272,6 @@ sub find_by {
                             EXISTS (SELECT 1 FROM editor_collection_collaborator ecc
                             WHERE ecc.collection = editor_collection.id AND ecc.editor = ?))';
         push @args, $editor_id, $editor_id;
-    } elsif ($editor_id = $opts->{show_private_only}) {
-        push @conditions, 'editor_collection.public = false';
-        # We skip this if there's no logged in editor
-        unless ($editor_id eq 'none') {
-            push @conditions, 'editor_collection.editor != ?';
-            push @conditions, 'NOT EXISTS (SELECT 1 FROM editor_collection_collaborator ecc
-                                WHERE ecc.collection = editor_collection.id AND ecc.editor = ?)';
-            push @args, $editor_id, $editor_id;
-        }
     } else {
         push @conditions, 'editor_collection.public = true';
     }
@@ -297,6 +288,56 @@ sub find_by {
         my @result = $self->query_to_list($query, \@args);
         return (\@result, scalar @result);
     }
+}
+
+sub get_hidden_collection_count {
+    my ($self, $opts) = @_;
+
+    my (@conditions, @args);
+
+    push @conditions, 'editor_collection.public = false';
+    my $entity_type = $opts->{entity_type};
+    push @conditions, <<~'SQL';
+        EXISTS (
+                SELECT 1
+                  FROM editor_collection_type ct
+                 WHERE ct.id = editor_collection.type
+                   AND ct.entity_type = ?
+               )
+        SQL
+    push @args, $entity_type;
+
+    my $entity_id = $opts->{entity_id};
+    push @conditions, <<~"SQL";
+        EXISTS (
+                SELECT 1
+                  FROM editor_collection_$entity_type ce
+                 WHERE editor_collection.id = ce.collection
+                   AND ce.$entity_type = ?
+               )
+        SQL
+    push @args, $entity_id;
+
+    if (my $editor_id = $opts->{editor_id}) {
+        push @conditions, 'editor_collection.editor != ?';
+        push @conditions, <<~'SQL';
+            NOT EXISTS (
+                        SELECT 1
+                          FROM editor_collection_collaborator ecc
+                         WHERE ecc.collection = editor_collection.id
+                           AND ecc.editor = ?
+                       )
+            SQL
+        push @args, $editor_id, $editor_id;
+    }
+
+    my $query =
+        'SELECT count(*) ' .
+        '  FROM ' . $self->_table . ' ' .
+        ' WHERE ' . join(' AND ', @conditions);
+
+    return $self->sql->select_single_value($query, @args);
+
 }
 
 sub load {

--- a/root/layout/components/sidebar/CollectionLinks.js
+++ b/root/layout/components/sidebar/CollectionLinks.js
@@ -38,9 +38,7 @@ const CollectionLinks = ({
 }: Props): React$Element<typeof CollectionList> | null => {
   const $c = React.useContext(CatalystContext);
   const numberOfCollections = $c.stash.number_of_collections || 0;
-  if (!$c.user) {
-    return null;
-  }
+  const userExists = Boolean($c.user);
   return (
     <CollectionList
       addCollectionText={l('Add to a new collection')}
@@ -52,6 +50,7 @@ const CollectionLinks = ({
       ownCollectionsHeader={l('My collections')}
       ownCollectionsNoneText={noCollectionsStrings[entity.entityType]()}
       sectionClass="collections"
+      userExists={userExists}
       usersLink={
         <EntityLink
           content={texp.ln(

--- a/root/layout/components/sidebar/CollectionList.js
+++ b/root/layout/components/sidebar/CollectionList.js
@@ -65,6 +65,7 @@ type CollectionListProps = {
   +ownCollectionsHeader: string,
   +ownCollectionsNoneText: string,
   +sectionClass: string,
+  +userExists: boolean,
   +usersLink: React$Element<EntityLink>,
   +usersLinkHeader: string,
 };
@@ -141,6 +142,7 @@ const CollectionList = ({
   ownCollectionsHeader,
   ownCollectionsNoneText,
   sectionClass,
+  userExists,
   usersLink,
   usersLinkHeader,
 }: CollectionListProps): React$MixedElement => (
@@ -148,29 +150,33 @@ const CollectionList = ({
     <h2 className={sectionClass}>
       {header}
     </h2>
-    <h3>
-      {ownCollectionsHeader}
-    </h3>
-    <OwnCollectionList
-      addText={addCollectionText}
-      collections={ownCollections}
-      entity={entity}
-      noneText={ownCollectionsNoneText}
-    />
-    {collaborativeCollections?.length ? (
+    {userExists ? (
       <>
         <h3>
-          {collaborativeCollectionsHeader}
+          {ownCollectionsHeader}
         </h3>
-        <CollaborativeCollectionList
-          collections={collaborativeCollections}
+        <OwnCollectionList
+          addText={addCollectionText}
+          collections={ownCollections}
           entity={entity}
+          noneText={ownCollectionsNoneText}
         />
+        {collaborativeCollections?.length ? (
+          <>
+            <h3>
+              {collaborativeCollectionsHeader}
+            </h3>
+            <CollaborativeCollectionList
+              collections={collaborativeCollections}
+              entity={entity}
+            />
+          </>
+        ) : null}
+        <h3>
+          {usersLinkHeader}
+        </h3>
       </>
     ) : null}
-    <h3>
-      {usersLinkHeader}
-    </h3>
     <ul className="links">
       <li>{usersLink}</li>
     </ul>


### PR DESCRIPTION
### Implement MBS-13145

# Problem
We currently require login to see any data about collections for a specific entity, even when the entity is in a public collection that can otherwise be seen when logged out.
I don't think this is really intentional, but more of a side effect of the way the collections page / sidebar got implemented. I asked @Aerozol and he also suggested that this data should be shown to everyone, since it's interesting to showcase.

# Solution

This shows only the "in X collections" link on the sidebar for logged out users (all others seem irrelevant). It also allows them to see the `/collections` page for the entity, showing only public collections.
We still want to pass `show_private_only` for `_all_non_visible_collections` when there's no user, since otherwise it will not restrict it to non-visible collections, but we don't have an editor ID to pass; I chose to just pass `'none'` as a string, then make it skip the ID-related conditions if that is passed.

# Testing
Manually, by navigating to an entity in one of my public collections, seeing the sidebar shows it's in one collection, clicking through to the collections page and seeing it correctly links to my collection. Also checked the page is linked but empty when an entity is in 0 collections.