### PR TITLE
MBS-13192: Redirect to profile post report rather than detach

### DIFF
--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -811,7 +811,11 @@ sub report : Chained('load') RequireAuth HiddenOnMirrors SecureForm {
             $c->flash->{message} = l('Your report has been sent.');
         }
 
-        $c->detach('/user/profile', [$reported_user->name]);
+        $c->response->redirect($c->uri_for_action(
+            '/user/profile',
+            [ $reported_user->name ],
+        ));
+        $c->detach;
     }
 }
 


### PR DESCRIPTION
### Fix MBS-13192


# Problem
After a report is sent the user profile is loaded, but the URL stays as `/user/X/report` (and for some reason the report link moves on the page as described by the ticket).

# Solution
Doing just `detach` here was causing the issues. I don't think that was intentional in any way, and we generally use `response->redirect` elsewhere, so I do that here too, which also stops the link moving.

# Testing
Manually, by reporting a user.