### PR TITLE
MBS-13252: Report: Show notes links on non-Broadcast releases

### DIFF
--- a/lib/MusicBrainz/Server/Report/ShowNotesButNotBroadcast.pm
+++ b/lib/MusicBrainz/Server/Report/ShowNotesButNotBroadcast.pm
@@ -1,0 +1,36 @@
+package MusicBrainz::Server::Report::ShowNotesButNotBroadcast;
+use Moose;
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+
+sub query {<<~'SQL'}
+        SELECT r.id AS release_id,
+               row_number() OVER (ORDER BY r.name COLLATE musicbrainz, rg.name COLLATE musicbrainz)
+          FROM release r
+          JOIN release_group rg ON r.release_group = rg.id
+         WHERE rg.type != 12 -- not Broadcast
+    AND EXISTS (
+                SELECT TRUE
+                  FROM l_release_url lru
+                  JOIN link ON lru.link = link.id
+                 WHERE lru.entity0 = r.id 
+                   AND link.link_type = 729 -- show notes
+               )
+    SQL
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2023 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -101,6 +101,7 @@ my @all = qw(
     SeparateDiscs
     SetInDifferentRG
     ShouldNotHaveDiscIDs
+    ShowNotesButNotBroadcast
     SingleMediumReleasesWithMediumTitles
     SomeFormatsUnset
     SuperfluousDataTracks
@@ -201,6 +202,7 @@ use MusicBrainz::Server::Report::ReleasesConflictingDiscIDs;
 use MusicBrainz::Server::Report::SeparateDiscs;
 use MusicBrainz::Server::Report::SetInDifferentRG;
 use MusicBrainz::Server::Report::ShouldNotHaveDiscIDs;
+use MusicBrainz::Server::Report::ShowNotesButNotBroadcast;
 use MusicBrainz::Server::Report::SingleMediumReleasesWithMediumTitles;
 use MusicBrainz::Server::Report::SomeFormatsUnset;
 use MusicBrainz::Server::Report::SuperfluousDataTracks;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -458,6 +458,12 @@ const ReportsIndex = (): React$Element<typeof Layout> => {
             reportName="NonBootlegsOnBootlegLabels"
           />
           <ReportsIndexEntry
+            content={l(
+              'Non-broadcast releases with linked show notes',
+            )}
+            reportName="ShowNotesButNotBroadcast"
+          />
+          <ReportsIndexEntry
             content={l('Releases marked as low quality')}
             reportName="LowQualityReleases"
           />

--- a/root/report/ShowNotesButNotBroadcast.js
+++ b/root/report/ShowNotesButNotBroadcast.js
@@ -1,0 +1,44 @@
+/*
+ * @flow strict
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import ReleaseList from './components/ReleaseList.js';
+import ReportLayout from './components/ReportLayout.js';
+import type {ReportDataT, ReportReleaseT} from './types.js';
+
+const ShowNotesButNotBroadcast = ({
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
+  <ReportLayout
+    canBeFiltered={canBeFiltered}
+    description={exp.l(
+      `This report shows releases that have a {doc|show notes relationship},
+       but are not in a release group of type Broadcast.
+       Show notes are meant for podcasts and similar shows, and should
+       not be used to link to some random notes about any sort of release,
+       yet the relationship often gets used in that way. If that is the case,
+       the relationship should be either switched to a better type or removed
+       if nothing is a good fit. If the release is indeed a podcast, the
+       release group type should be set to Broadcast.`,
+      {doc: '/relationship/2d24d075-9943-4c4d-a659-8ce52e6e6b57'},
+    )}
+    entityType="release"
+    filtered={filtered}
+    generated={generated}
+    title={l('Non-broadcast releases with linked show notes')}
+    totalEntries={pager.total_entries}
+  >
+    <ReleaseList items={items} pager={pager} />
+  </ReportLayout>
+);
+
+export default ShowNotesButNotBroadcast;

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -297,6 +297,7 @@ export default {
   'report/SeparateDiscs': (): Promise<mixed> => import('../report/SeparateDiscs.js'),
   'report/SetInDifferentRg': (): Promise<mixed> => import('../report/SetInDifferentRg.js'),
   'report/ShouldNotHaveDiscIds': (): Promise<mixed> => import('../report/ShouldNotHaveDiscIds.js'),
+  'report/ShowNotesButNotBroadcast': (): Promise<mixed> => import('../report/ShowNotesButNotBroadcast.js'),
   'report/SingleMediumReleasesWithMediumTitles': (): Promise<mixed> => import('../report/SingleMediumReleasesWithMediumTitles.js'),
   'report/SomeFormatsUnset': (): Promise<mixed> => import('../report/SomeFormatsUnset.js'),
   'report/SuperfluousDataTracks': (): Promise<mixed> => import('../report/SuperfluousDataTracks.js'),


### PR DESCRIPTION
### Implement MBS-13252

# Description
Show notes is a relationship meant to link podcasts and similar broadcast releases to their, well, show notes. Users do seem to use it quite a bit to link to anything that has anything to do with any release, whether it is a podcast or not, probably because it sounds more generic than other choices. This should make it easier for editors to find these bad edits, fix them, and maybe let the user know so they stop doing it.

# Testing
Ran the report against the sample DB, found a few cases, all seemingly correct(ly incorrect).