### PR TITLE
MBS-13278: Show label type descriptions on edit form

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/Label.pm
@@ -219,6 +219,12 @@ with 'MusicBrainz::Server::Controller::Role::Edit' => {
     edit_type      => $EDIT_LABEL_EDIT,
 };
 
+before qw( create edit ) => sub {
+    my ($self, $c) = @_;
+    my %label_types = map {$_->id => $_} $c->model('LabelType')->get_all();
+    $c->stash->{label_types} = \%label_types;
+};
+
 around edit => sub {
     my $orig = shift;
     my ($self, $c) = @_;

--- a/lib/MusicBrainz/Server/Entity/LabelType.pm
+++ b/lib/MusicBrainz/Server/Entity/LabelType.pm
@@ -16,6 +16,11 @@ sub l_name {
     return lp($self->name, 'label_type')
 }
 
+sub l_description {
+    my $self = shift;
+    return lp($self->description, 'label_type');
+}
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/root/label/edit_form.tt
+++ b/root/label/edit_form.tt
@@ -51,11 +51,13 @@
     [%- area_bubble() -%]
     [%- ipi_bubble() -%]
     [%- isni_bubble() -%]
+    [%- type_bubble(form.field('type_id'), label_types) -%]
   </div>
 
 </form>
 
 [%- guesscase_options() -%]
+[% script_manifest('label/edit.js') %]
 
 <script type="text/javascript">
   (function () {

--- a/root/static/scripts/label/edit.js
+++ b/root/static/scripts/label/edit.js
@@ -1,0 +1,13 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import typeBubble from '../edit/typeBubble.js';
+
+const typeIdField = 'select[name=edit-label\\.type_id]';
+typeBubble(typeIdField);

--- a/webpack/client.config.mjs
+++ b/webpack/client.config.mjs
@@ -67,6 +67,7 @@ const entries = [
   'genre/index',
   'instrument/index',
   'jed-data.mjs',
+  'label/edit',
   'label/index',
   'place/edit',
   'place/index',


### PR DESCRIPTION
### Implement MBS-13278

# Problem
People are using the wrong label types relatively often (see MBS-13277 for an example); while it's probably not only because descriptions are missing, it certainly wouldn't hurt to have them and might avoid a fair amount of the misuse.

# Solution
This just uses the same `typeBubble` solution we already use for other entities; the main reason we didn't implement it here before is that we don't actually have descriptions for any of the types, which we need to add (little by little probably as to avoid overwhelming sir as much as possible).

# Action
1. Add descriptions to all label types

# Testing
Manually, on test data where I added a few descriptions. 