### PR TITLE
MBS-8952: Can rename recordings via autocomplete

### DIFF
--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -288,7 +288,11 @@ $.widget('mb.entitylookup', $.ui.autocomplete, {
      * entity (like release group types).
      */
 
-    if (currentSelection.id) {
+    if (
+      // entities from the search server will not have a numeric id
+      currentSelection.id ||
+      currentSelection.gid
+    ) {
       this.currentSelection(this._dataToEntity({name: name}));
     } else if (currentSelection.name !== name) {
       currentSelection.name = name;

--- a/root/static/scripts/release-editor/edits.js
+++ b/root/static/scripts/release-editor/edits.js
@@ -184,10 +184,14 @@ releaseEditor.edits = {
           if (oldRecording) {
             if (track.updateRecordingTitle() && !isBlank(trackData.name)) {
               newRecording.name = trackData.name;
+            } else {
+              newRecording.name = oldRecording.name;
             }
 
             if (track.updateRecordingArtist()) {
               newRecording.artist_credit = trackData.artist_credit;
+            } else {
+              newRecording.artist_credit = oldRecording.artist_credit;
             }
 
             if (!deepEqual(newRecording, oldRecording)) {

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -638,6 +638,7 @@ const seleniumTests = [
   {name: 'MBS-2604.json5', login: true},
   {name: 'MBS-5387.json5', login: true},
   {name: 'MBS-7456.json5', login: true},
+  {name: 'MBS-8952.json5', login: true},
   {name: 'MBS-9548.json5'},
   {name: 'MBS-9669.json5'},
   {name: 'MBS-9941.json5', login: true},

--- a/t/selenium/MBS-8952.json5
+++ b/t/selenium/MBS-8952.json5
@@ -1,0 +1,115 @@
+{
+  title: 'MBS-8952',
+  commands: [
+    {
+      command: 'open',
+      target: '/release/add',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=name',
+      value: 'Travelling Man',
+    },
+    {
+      command: 'type',
+      target: "css=td.release-artist span.autocomplete input.name",
+      value: 'Nine Inch Nails',
+    },
+    {
+      command: 'click',
+      target: "css=td.release-artist span.autocomplete img.search",
+      value: '',
+    },
+    {
+      command: 'pause',
+      target: '1000',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: "xpath=//li[contains(@class, 'ui-menu-item')][contains(., 'Nine Inch Nails')]",
+      value: '',
+    },
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#tracklist']",
+      value: '',
+    },
+    {
+      command: 'uncheck',
+      target: "xpath=//div[@id='add-medium-parser']//input[@name='lines-have-artists']",
+      value: '',
+    },
+    {
+      command: 'check',
+      target: "xpath=//div[@id='add-medium-parser']//input[@name='use-titles']",
+      value: '',
+    },
+    {
+      command: 'type',
+      target: "xpath=//div[@id='add-medium-parser']//textarea[contains(@class, 'tracklist')]",
+      value: '1. Travelling Man',
+    },
+    {
+      command: 'click',
+      target: "xpath=//div[@id='add-medium-dialog']//button[contains(text(), 'Add Medium')]",
+      value: '',
+    },
+    {
+      command: 'select',
+      target: "xpath=(//select[contains(@id, 'medium-format-')])[1]",
+      value: 'label=Vinyl',
+    },
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#recordings']",
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#recordings tr.track button.edit-track-recording',
+      value: '',
+    },
+    {
+      command: 'check',
+      target: 'css=#recording-assoc-bubble input[value="0f42ab32-22cd-4dcf-927b-a8d9a183d68b"]',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'css=#recording-assoc-bubble input.name.lookup-performed',
+      value: 'asdf',
+    },
+    {
+      command: 'assertEval',
+      target: 'document.querySelector("#recording-assoc-bubble input.name").classList.contains("lookup-performed")',
+      value: 'false',
+    },
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#edit-note']",
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: 'document.querySelector("#enter-edit").disabled',
+      value: 'true',
+    },
+    {
+      command: 'open',
+      target: '/',
+      value: '',
+    },
+    {
+      command: 'handleAlert',
+      target: 'accept',
+      value: '',
+    },
+    {
+      command: 'waitUntilUrlIs',
+      target: '/',
+      value: '',
+    },
+  ],
+}


### PR DESCRIPTION
# MBS-8952

## Problem

If you select any recording which was obtained from the search server in a "Suggested recordings:" list in the release editor, then updating the recording autocomplete text will allow you to change the recording's name and unintentionally submit edits doing the same.

## Solution

I was able to reproduce this using the steps in https://tickets.metabrainz.org/browse/MBS-13021.

The primary issue is that recordings from the search server don't include a database row ID, so the `if (currentSelection.id)` check modified here didn't clear the selection when modifying text. The `else` branch updated the recording name with the entered text and notified all subscribers of the autocomplete observable.

Checking for `currentSelection.gid` there fixes the bug. I also changed the edit generation code to revert any recording changes if the necessary settings to update them aren't enabled.

# Testing

Tested locally using a local search server.