### PR TITLE
MBS-13279: Don't consider the empty string an email address

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -6,7 +6,11 @@ use Authen::Passphrase;
 use DateTime;
 use Encode;
 use MusicBrainz::Server::Constants qw( $PASSPHRASE_BCRYPT_COST );
-use MusicBrainz::Server::Data::Utils qw( boolean_to_json datetime_to_iso8601 );
+use MusicBrainz::Server::Data::Utils qw(
+    boolean_to_json
+    datetime_to_iso8601
+    non_empty
+);
 use MusicBrainz::Server::Entity::Preferences;
 use MusicBrainz::Server::Entity::Types qw( Area ); ## no critic 'ProhibitUnusedImport'
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
@@ -128,8 +132,13 @@ sub public_privileges {
 has 'email' => (
     is        => 'rw',
     isa       => 'Str',
-    predicate => 'has_email_address',
 );
+
+sub has_email_address
+{
+    my $self = shift;
+    return non_empty($self->email);
+}
 
 sub has_confirmed_email_address
 {


### PR DESCRIPTION
### Fix MBS-13279

# Problem
We use `has_email_address` as a way to see whether the user has an email set that we can write to, but it's currently a Moose predicate for `email`. This means that if `email` is set to *anything*, it will return true, including the empty string (which we have for a couple thousand accounts) and, theoretically at least, `undef`. See https://metacpan.org/dist/Moose/view/lib/Moose/Manual/Attributes.pod#Predicate-and-clearer-methods

# Solution
I changed this to just use the predicate as the first check; if email is set it will make sure it's defined and not the empty string.

# Testing
Manually, checking the user mentioned on the ticket now shows `(none)` for their email.