### PR TITLE
MBS-13280: Block nominating unconfirmed editors

### DIFF
--- a/lib/MusicBrainz/Server/Controller/AutoEditorElections.pm
+++ b/lib/MusicBrainz/Server/Controller/AutoEditorElections.pm
@@ -34,7 +34,7 @@ sub nominate : Path('nominate') Args(1) RequireAuth(auto_editor) SecureForm
     my ($self, $c, $editor) = @_;
 
     my $candidate = $c->model('Editor')->get_by_name($editor);
-    $c->detach('/error_404')
+    $c->detach('/error_403')
         unless $c->user->can_nominate($candidate);
 
     my $form = $c->form( form => 'SecureConfirm' );

--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -233,7 +233,8 @@ sub age {
 sub can_nominate {
     my ($self, $candidate) = @_;
     return unless $candidate;
-    return $self->is_auto_editor && !$candidate->is_auto_editor && !$candidate->deleted;
+    return $self->is_auto_editor && !$candidate->is_auto_editor
+        && !$candidate->deleted && $candidate->has_confirmed_email_address;
 }
 
 has languages => (

--- a/root/utility/voting.js
+++ b/root/utility/voting.js
@@ -60,5 +60,6 @@ export function canNominate(
   nominee: ?UnsanitizedEditorT,
 ): boolean {
   return (!!nominator && !!nominee && isAutoEditor(nominator) &&
-    !isAutoEditor(nominee) && !nominee.deleted);
+    !isAutoEditor(nominee) && !nominee.deleted &&
+    nominee.has_confirmed_email_address);
 }


### PR DESCRIPTION
### Implement MBS-13280

# Problem
It is currently possible to nominate an editor for autoeditorship even if they have no verified email address, but an autoeditor who cannot enter edits is useless. It would limit clutter on the user profiles to not allow these nominations and not show the nomination link.

# Solution
This checks for `has_confirmed_email_address` both to show the nominate link and to actually allow the nomination page to load (with `can_nominate`).

# Testing
Manually with a newly-created (non-verified) user. Navigating to `/elections/nominate/username` gave a 404 which seems wrong, changing to 403 in a second commit.