### PR TITLE
MBS-13281: Don't check for mail confirmation for beginners

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -193,10 +193,7 @@ sub is_limited
     return
         !($self->id == $EDITOR_MODBOT) &&
         !$self->deleted &&
-        ( !$self->email_confirmation_date ||
-          $self->is_newbie ||
-          !$self->has_ten_accepted_edits
-        );
+        ($self->is_newbie || !$self->has_ten_accepted_edits);
 }
 
 has birth_date => (

--- a/lib/MusicBrainz/Server/Report/LimitedEditors.pm
+++ b/lib/MusicBrainz/Server/Report/LimitedEditors.pm
@@ -13,9 +13,10 @@ SELECT id,
   FROM editor eor
  WHERE id != $EDITOR_MODBOT
    AND NOT deleted
-   AND   ( email_confirm_date IS NULL
-        OR member_since < NOW() - INTERVAL '2 weeks'
-        OR (SELECT COUNT(*) FROM edit WHERE eor.id = edit.editor AND edit.status = 2 AND edit.autoedit = 0) < 10
+   AND   ( 
+            member_since < NOW() - INTERVAL '2 weeks'
+          OR
+            (SELECT COUNT(*) FROM edit WHERE eor.id = edit.editor AND edit.status = 2 AND edit.autoedit = 0) < 10
          )";
 }
 

--- a/root/layout.tt
+++ b/root/layout.tt
@@ -75,7 +75,8 @@
 
         [%- IF new_edit_notes &&
                new_edit_notes_mtime > (c.req.cookies.new_edit_notes_dismissed_mtime.value || 0) &&
-               (c.user.is_limited || (c.req.cookies.alert_new_edit_notes.value || 'true') != 'false') -%]
+               ((c.user && (c.user.is_limited || !c.user.has_confirmed_email_address)) ||
+                (c.req.cookies.alert_new_edit_notes.value || 'true') != 'false') -%]
             <div class="banner new-edit-notes">
                 <p>
                     [% l('{link|New notes} have been left on some of your edits. Please make sure to read them and respond if necessary.',

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -177,7 +177,8 @@ const Layout = ({
   const showNewEditNotesBanner = $c.stash.new_edit_notes /*:: === true */ &&
     ($c.stash.new_edit_notes_mtime ?? Infinity) > Number(
       getRequestCookie($c.req, 'new_edit_notes_dismissed_mtime', '0'),
-    ) && ($c.user?.is_limited ||
+    ) && (($c.user &&
+      ($c.user.is_limited || !$c.user.has_confirmed_email_address)) ||
       getRequestCookie($c.req, 'alert_new_edit_notes', 'true') !== 'false');
 
   return (


### PR DESCRIPTION
### Implement MBS-13281

# Problem
Checking for email confirmation in `is_limited` probably made sense when we called this "Limited user" (unconfirmed users are quite limited) but it doesn't make sense now that we explicitly use `is_limited` for beginners and claim everywhere the user is "new to MusicBrainz", since a user can remove their email even with thousands of edits.

# Solution
This just removes the no `email_confirmation_date` condition for `is_limited`. `editorMayVote` already checks for `email_confirmation_date` separately. Elsewhere, we seem to be using `is_limited` just for beginner checks. `Predicate::Role::User` already was not looking at mail confirmation.

# Testing
Tested with user `test`, which now shows as "Normal User"