### PR TITLE
MBS-13275: Don't send subscription emails to spammers

### DIFF
--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -513,6 +513,7 @@ sub editors_with_subscriptions {
                         ep.name = 'subscriptions_email_period'
                   WHERE editor.id > ?
                     AND editor.id IN ($ids)
+                    AND (editor.privs & $SPAMMER_FLAG) = 0
                ORDER BY editor.id ASC
                   LIMIT ?";
 

--- a/t/lib/t/MusicBrainz/Server/Data/Editor.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Editor.pm
@@ -206,6 +206,16 @@ subtest 'Find editors with subscriptions' => sub {
 
     @editors = $editor_data->editors_with_subscriptions(2, 1000);
     is(@editors => 0, 'found no editor');
+
+    note('We mark editor #2 as a spammer (plus block edits and notes privs)');
+    $test->c->sql->do(<<~'SQL');
+        UPDATE editor
+           SET privs = 7168
+         WHERE id = 2
+        SQL
+
+    @editors = $editor_data->editors_with_subscriptions(0, 1000);
+    is(@editors => 0, 'now-spammer editor #2 is no longer returned');
 };
 
 };


### PR DESCRIPTION
### Implement MBS-13275

# Problem
Spammers cannot log in and cannot edit, so processing their subscriptions is a waste of time. Additionally, it seems some use the subscription email to know if their spam is being deleted, and create a new account to readd it. It would seem sensible to just not send them any subscription emails.

# Solution
This explicitly excludes spammer editors when loading all editors we are going to process for mailing in `editors_with_subscriptions`.

# Testing
Added a small section to the appropriate `Data::Editor` test. The `SubscriptionEmails` test uses mocks so this probably cannot be tested from there, but making sure the editor is not available to the script for processing should be enough.