### PR TITLE
MBS-13284: Don't require edit note for alias removals

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Alias.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Alias.pm
@@ -135,7 +135,6 @@ sub delete_alias : Chained('alias') PathPart('delete') Edit
     cancel_or_action($c, $edit, $self->_aliases_url($c), sub {
         $self->edit_action($c,
             form => 'Confirm',
-            form_args => { requires_edit_note => 1 },
             type => $model_to_edit_type{delete}->{ $self->{model} },
             edit_args => {
                 alias  => $alias,

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/DeleteAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/DeleteAlias.pm
@@ -27,10 +27,7 @@ test 'Deleting an alias' => sub {
     );
     my @edits = capture_edits {
         $mech->submit_form_ok({
-                with_fields => {
-                    'confirm.edit_note' =>
-                        q(Some edit note since it's required)
-                }
+                with_fields => { 'confirm.edit_note' => '' },
             },
             'The form returned a 2xx response code',
         );
@@ -78,34 +75,6 @@ test 'Deleting an alias' => sub {
     $mech->content_contains(
         'Test Alias',
         'The edit page contains the alias name',
-    );
-};
-
-test 'Edit note is required' => sub {
-    my $test = shift;
-    my $mech = $test->mech;
-
-    prepare_test($test);
-
-    $mech->get_ok(
-        '/artist/745c079d-374e-4436-9448-da92dedef3ce/alias/1/delete',
-        'Fetched the delete alias page',
-    );
-    my @edits = capture_edits {
-        $mech->submit_form_ok({
-                with_fields => {
-                    'confirm.edit_note' => ''
-                }
-            },
-            'The form returned a 2xx response code',
-        );
-    } $test->c;
-
-    is(@edits, 0, 'No edit was entered');
-
-    $mech->content_contains(
-        'You must provide an edit note',
-        'Contains warning about edit note being required',
     );
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/DeleteAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/DeleteAlias.pm
@@ -27,10 +27,7 @@ test 'Deleting an alias' => sub {
     );
     my @edits = capture_edits {
         $mech->submit_form_ok({
-                with_fields => {
-                    'confirm.edit_note' =>
-                        q(Some edit note since it's required)
-                }
+                with_fields => { 'confirm.edit_note' => '' },
             },
             'The form returned a 2xx response code',
         );
@@ -78,34 +75,6 @@ test 'Deleting an alias' => sub {
     $mech->content_contains(
         'Test Label Alias',
         'The edit page contains the alias name',
-    );
-};
-
-test 'Edit note is required' => sub {
-    my $test = shift;
-    my $mech = $test->mech;
-
-    prepare_test($test);
-
-    $mech->get_ok(
-        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/alias/1/delete',
-        'Fetched the delete alias page',
-    );
-    my @edits = capture_edits {
-        $mech->submit_form_ok({
-                with_fields => {
-                    'confirm.edit_note' => ''
-                }
-            },
-            'The form returned a 2xx response code',
-        );
-    } $test->c;
-
-    is(@edits, 0, 'No edit was entered');
-
-    $mech->content_contains(
-        'You must provide an edit note',
-        'Contains warning about edit note being required',
     );
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/DeleteAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/DeleteAlias.pm
@@ -27,10 +27,7 @@ test 'Deleting an alias' => sub {
     );
     my @edits = capture_edits {
         $mech->submit_form_ok({
-                with_fields => {
-                    'confirm.edit_note' =>
-                        q(Some edit note since it's required)
-                }
+                with_fields => { 'confirm.edit_note' => '' },
             },
             'The form returned a 2xx response code',
         );
@@ -78,34 +75,6 @@ test 'Deleting an alias' => sub {
     $mech->content_contains(
         'Test Recording Alias',
         'The edit page contains the alias name',
-    );
-};
-
-test 'Edit note is required' => sub {
-    my $test = shift;
-    my $mech = $test->mech;
-
-    prepare_test($test);
-
-    $mech->get_ok(
-        '/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/alias/1/delete',
-        'Fetched the delete alias page',
-    );
-    my @edits = capture_edits {
-        $mech->submit_form_ok({
-                with_fields => {
-                    'confirm.edit_note' => ''
-                }
-            },
-            'The form returned a 2xx response code',
-        );
-    } $test->c;
-
-    is(@edits, 0, 'No edit was entered');
-
-    $mech->content_contains(
-        'You must provide an edit note',
-        'Contains warning about edit note being required',
     );
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/DeleteAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/DeleteAlias.pm
@@ -27,10 +27,7 @@ test 'Deleting an alias' => sub {
     );
     my @edits = capture_edits {
         $mech->submit_form_ok({
-                with_fields => {
-                    'confirm.edit_note' =>
-                        q(Some edit note since it's required)
-                }
+                with_fields => { 'confirm.edit_note' => '' },
             },
             'The form returned a 2xx response code',
         );
@@ -81,7 +78,7 @@ test 'Deleting an alias' => sub {
     );
 };
 
-test 'Edit note is required' => sub {
+test 'Edit note is not required (MBS-13284)' => sub {
     my $test = shift;
     my $mech = $test->mech;
 
@@ -101,12 +98,7 @@ test 'Edit note is required' => sub {
         );
     } $test->c;
 
-    is(@edits, 0, 'No edit was entered');
-
-    $mech->content_contains(
-        'You must provide an edit note',
-        'Contains warning about edit note being required',
-    );
+    is(@edits, 1, 'The edit was entered');
 };
 
 sub prepare_test {


### PR DESCRIPTION
### Implement MBS-13284

# Problem
This was originally added on my request over 10 years ago, but while it makes sense to require a note for all entity removals and other similarly destructive edits, alias removals just drop an MBID-less text field that is trivial to re-add, and is not significantly different from dropping a disambiguation or other similar text field.

# Solution
Just drop the `requires_edit_note` argument from `delete_alias`.

# Testing
Amusingly, we had more tests checking for this edit note requirement than most other more important ones...
I removed most, but left one testing it's no longer required.