### PR TITLE
Remove all uses of the smartmatch operator and switch feature

### DIFF
--- a/contrib/slowdown.psgi
+++ b/contrib/slowdown.psgi
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
-use feature "switch";
 
 # Sufficiently Sophisticated Simple Storage Service Slow Down Simulator.
 
@@ -87,12 +86,12 @@ sub {
     my $request = Plack::Request->new(shift);
 
     my $response;
+    my $method = $request->method;
 
-    given ($request->method) {
-        when ("PUT")     { $response = handle_other($request) }
-        when ("POST")    { $response = handle_other($request) }
-        when ("OPTIONS") { $response = handle_options($request) }
-    }
+
+    if ($method eq 'PUT') { $response = handle_other($request) }
+    elsif ($method eq 'POST') { $response = handle_other($request) }
+    elsif ($method eq 'OPTIONS') { $response = handle_options($request) }
 
     $response->header("Access-Control-Allow-Origin" => "*");
     return $response->finalize;

--- a/contrib/ssssss.psgi
+++ b/contrib/ssssss.psgi
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
-use feature "switch";
 
 # Sufficiently Sophisticated Simple Storage Service Simulator is a
 # drop-in replacement for the archive.org S3 service.  It mimics just
@@ -283,14 +282,13 @@ sub {
     my $request = Plack::Request->new(shift);
 
     my $response;
+    my $method = $request->method;
 
-    given ($request->method) {
-        when ("PUT")     { $response = handle_put($request) }
-        when ("POST")    { $response = handle_post($request) }
-        when ("OPTIONS") { $response = handle_options($request) }
-        when ("GET")     { $response = handle_get($request) }
-        when ("DELETE")  { $response = handle_delete($request) }
-    }
+    if ($method eq 'PUT') { $response = handle_put($request) }
+    elsif ($method eq 'POST') { $response = handle_post($request) }
+    elsif ($method eq 'OPTIONS') { $response = handle_options($request) }
+    elsif ($method eq 'GET') { $response = handle_get($request) }
+    elsif ($method eq 'DELETE') { $response = handle_delete($request) }
 
     $response->header("Access-Control-Allow-Origin" => "*");
     return $response->finalize;

--- a/lib/MusicBrainz/Server/Controller/Admin/Attributes.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin/Attributes.pm
@@ -3,11 +3,10 @@ use Moose;
 use namespace::autoclean;
 use utf8;
 
+use MusicBrainz::Server::Data::Utils qw( contains_string );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
 use MusicBrainz::Server::Translation qw( l );
-
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
 
 BEGIN { extends 'MusicBrainz::Server::Controller' };
 
@@ -47,7 +46,7 @@ sub index : Path('/admin/attributes') Args(0) RequireAuth(account_admin) {
 sub attribute_base : Chained('/') PathPart('admin/attributes') CaptureArgs(1) RequireAuth(account_admin) {
     my ($self, $c, $model) = @_;
 
-    $c->detach('/error_404') unless $model ~~ @models;
+    $c->detach('/error_404') unless contains_string(\@models, $model);
 
     $c->stash->{model} = $model;
 }

--- a/lib/MusicBrainz/Server/Controller/Role/Load.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Load.pm
@@ -3,13 +3,11 @@ package MusicBrainz::Server::Controller::Role::Load;
 use MooseX::MethodAttributes::Role;
 use MooseX::Role::Parameterized;
 use namespace::autoclean;
-use MusicBrainz::Server::Data::Utils qw( model_to_type );
+use MusicBrainz::Server::Data::Utils qw( contains_string model_to_type );
 use MusicBrainz::Server::Validation qw( is_guid is_positive_integer );
 use MusicBrainz::Server::Constants qw( :direction %ENTITIES );
 use Readonly;
 use aliased 'MusicBrainz::Server::Entity::RelationshipLinkTypeGroup';
-
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
 
 parameter 'model' => (
     isa => 'Str',
@@ -74,10 +72,10 @@ role
             my $relationships = $params->relationships;
             my $loaded = 0;
 
-            if ($action ~~ $relationships->{all}) {
+            if (contains_string($relationships->{all}, $action)) {
                 $c->model('Relationship')->load($entity);
                 $loaded = 1;
-            } elsif ($action ~~ $relationships->{cardinal}) {
+            } elsif (contains_string($relationships->{cardinal}, $action)) {
                 $c->model('Relationship')->load_cardinal($entity);
                 $loaded = 1;
             }

--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -10,7 +10,6 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 use MusicBrainz::Server::Form::Search::Query;
 use MusicBrainz::Server::Form::Search::Search;
 use Scalar::Util qw( looks_like_number );
-use feature 'switch';
 
 sub search : Path('')
 {
@@ -122,79 +121,77 @@ sub direct : Private
 
     my @entities = map { $_->entity } @$results;
 
-    given ($type) {
-        when ('artist') {
-            $c->model('ArtistType')->load(@entities);
-            $c->model('Area')->load(@entities);
-            $c->model('Gender')->load(@entities);
-        }
-        when ('editor') {
-            $c->model('Editor')->load_preferences(@entities);
-        }
-        when ('release_group') {
-            $c->model('ReleaseGroupType')->load(@entities);
-            $c->model('ReleaseGroup')->load_has_cover_art(@entities);
-        }
-        when ('release') {
-            $c->model('Language')->load(@entities);
-            $c->model('Release')->load_related_info(@entities);
-            $c->model('Release')->load_meta(@entities);
-            $c->model('Script')->load(@entities);
-            $c->model('ReleaseStatus')->load(@entities);
-            $c->model('ReleaseGroup')->load(@entities);
-            $c->model('ReleaseGroupType')->load(map { $_->release_group }
-                @entities);
-        }
-        when ('label') {
-            $c->model('LabelType')->load(@entities);
-            $c->model('Area')->load(@entities);
-        }
-        when ('recording') {
-            my %recording_releases_map = $c->model('Release')->find_by_recordings(map {
-                $_->entity->id
-            } @$results);
-            my %result_map = map { $_->entity->id => $_ } @$results;
+    if ($type eq 'artist') {
+        $c->model('ArtistType')->load(@entities);
+        $c->model('Area')->load(@entities);
+        $c->model('Gender')->load(@entities);
+    }
+    elsif ($type eq 'editor') {
+        $c->model('Editor')->load_preferences(@entities);
+    }
+    elsif ($type eq 'release_group') {
+        $c->model('ReleaseGroupType')->load(@entities);
+        $c->model('ReleaseGroup')->load_has_cover_art(@entities);
+    }
+    elsif ($type eq 'release') {
+        $c->model('Language')->load(@entities);
+        $c->model('Release')->load_related_info(@entities);
+        $c->model('Release')->load_meta(@entities);
+        $c->model('Script')->load(@entities);
+        $c->model('ReleaseStatus')->load(@entities);
+        $c->model('ReleaseGroup')->load(@entities);
+        $c->model('ReleaseGroupType')->load(map { $_->release_group }
+            @entities);
+    }
+    elsif ($type eq 'label') {
+        $c->model('LabelType')->load(@entities);
+        $c->model('Area')->load(@entities);
+    }
+    elsif ($type eq 'recording') {
+        my %recording_releases_map = $c->model('Release')->find_by_recordings(map {
+            $_->entity->id
+        } @$results);
+        my %result_map = map { $_->entity->id => $_ } @$results;
 
-            $result_map{$_}->extra($recording_releases_map{$_}) for keys %recording_releases_map;
+        $result_map{$_}->extra($recording_releases_map{$_}) for keys %recording_releases_map;
 
-            my @releases = map { $_->{release} } map { @{ $_->extra } } @$results;
-            $c->model('ReleaseGroup')->load(@releases);
-            $c->model('ReleaseGroupType')->load(map { $_->release_group } @releases);
-            $c->model('Medium')->load_for_releases(@releases);
-            $c->model('Track')->load_for_mediums(map { $_->all_mediums } @releases);
-            $c->model('Recording')->load(
-                map { $_->all_tracks } map { $_->all_mediums } @releases);
-            $c->model('ISRC')->load_for_recordings(map { $_->entity } @$results);
-        }
-        when ('work') {
-            $c->model('Work')->load_writers(@entities);
-            $c->model('Work')->load_recording_artists(@entities);
-            $c->model('ISWC')->load_for_works(@entities);
-            $c->model('Language')->load_for_works(@entities);
-            $c->model('WorkType')->load(@entities);
-        }
-        when ('area') {
-            $c->model('AreaType')->load(@entities);
-            $c->model('Area')->load_containment(@entities);
-        }
-        when ('place') {
-            $c->model('PlaceType')->load(@entities);
-            $c->model('Area')->load(@entities);
-        }
-        when ('instrument') {
-            $c->model('InstrumentType')->load(@entities);
-        }
-        when ('series') {
-            $c->model('SeriesType')->load(@entities);
-            $c->model('SeriesOrderingType')->load(@entities);
-        }
-        when ('event') {
-            $c->model('Event')->load_related_info(@entities);
-            $c->model('Event')->load_areas(@entities);
-        }
-        when ('tag') {
-            $c->model('Genre')->load(@entities);
-        }
+        my @releases = map { $_->{release} } map { @{ $_->extra } } @$results;
+        $c->model('ReleaseGroup')->load(@releases);
+        $c->model('ReleaseGroupType')->load(map { $_->release_group } @releases);
+        $c->model('Medium')->load_for_releases(@releases);
+        $c->model('Track')->load_for_mediums(map { $_->all_mediums } @releases);
+        $c->model('Recording')->load(
+            map { $_->all_tracks } map { $_->all_mediums } @releases);
+        $c->model('ISRC')->load_for_recordings(map { $_->entity } @$results);
+    }
+    elsif ($type eq 'work') {
+        $c->model('Work')->load_writers(@entities);
+        $c->model('Work')->load_recording_artists(@entities);
+        $c->model('ISWC')->load_for_works(@entities);
+        $c->model('Language')->load_for_works(@entities);
+        $c->model('WorkType')->load(@entities);
+    }
+    elsif ($type eq 'area') {
+        $c->model('AreaType')->load(@entities);
+        $c->model('Area')->load_containment(@entities);
+    }
+    elsif ($type eq 'place') {
+        $c->model('PlaceType')->load(@entities);
+        $c->model('Area')->load(@entities);
+    }
+    elsif ($type eq 'instrument') {
+        $c->model('InstrumentType')->load(@entities);
+    }
+    elsif ($type eq 'series') {
+        $c->model('SeriesType')->load(@entities);
+        $c->model('SeriesOrderingType')->load(@entities);
+    }
+    elsif ($type eq 'event') {
+        $c->model('Event')->load_related_info(@entities);
+        $c->model('Event')->load_areas(@entities);
+    }
+    elsif ($type eq 'tag') {
+        $c->model('Genre')->load(@entities);
     }
 
     if ($type =~ /(recording|release|release_group)/)
@@ -258,17 +255,14 @@ sub do_external_search {
         my $template = 'search/error/';
 
         # Switch on the response code to decide which template to provide
-        given ($ret->{code})
-        {
-            when (404) { $template .= 'NoResults'; }
-            when (403) { $template .= 'NoInfo'; };
-            when (414) { $template .= 'UriTooLarge'; };
-            when (500) { $template .= 'InternalError'; }
-            when (400) { $template .= 'Invalid'; }
-            when (503) { $template .= 'RateLimited'; }
-
-            default { $template .= 'General'; }
-        }
+        my $code = $ret->{code};
+        if ($code == 404) { $template .= 'NoResults'; }
+        elsif ($code == 403) { $template .= 'NoInfo'; }
+        elsif ($code == 414) { $template .= 'UriTooLarge'; }
+        elsif ($code == 500) { $template .= 'InternalError'; }
+        elsif ($code == 400) { $template .= 'Invalid'; }
+        elsif ($code == 503) { $template .= 'RateLimited'; }
+        else { $template .= 'General'; }
 
         my %props = (
             form => $c->stash->{form}->TO_JSON,

--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -12,8 +12,6 @@ use MusicBrainz::Server::Form::Search::Search;
 use Scalar::Util qw( looks_like_number );
 use feature 'switch';
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 sub search : Path('')
 {
     my ($self, $c) = @_;

--- a/lib/MusicBrainz/Server/Controller/WS/2/Tag.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Tag.pm
@@ -11,8 +11,6 @@ use MusicBrainz::Server::Data::Utils qw( non_empty trim type_to_model );
 use MusicBrainz::Server::Validation qw( is_guid );
 use MusicBrainz::Server::WebService::XML::XPath;
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 my $ws_defs = Data::OptList::mkopt([
      tag => {
                          method   => 'GET',
@@ -109,7 +107,7 @@ sub tag_submit : Private
                 $has_votes = 1;
 
                 $vote = $xp->find('@mb:vote', $_)->string_value;
-                unless ($vote ~~ [qw(upvote downvote withdraw)]) {
+                unless ($vote =~ /^(upvote|downvote|withdraw)$/) {
                     $self->_error($c, 'Unrecognized vote type: ' . $vote);
                 }
             }

--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -35,8 +35,6 @@ use List::AllUtils qw( any nsort_by part partition_by uniq );
 use aliased 'MusicBrainz::Server::Entity::RelationshipTargetTypeGroup';
 use aliased 'MusicBrainz::Server::Entity::RelationshipLinkTypeGroup';
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 extends 'MusicBrainz::Server::Data::Entity';
 
 my %TYPES = map { $_ => 1} @RELATABLE_ENTITIES;

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -63,7 +63,6 @@ use MusicBrainz::Server::Data::Utils qw( type_to_model );
 use MusicBrainz::Server::ExternalUtils qw( get_chunked_with_retry );
 use DateTime::Format::ISO8601;
 use Readonly;
-use feature 'switch';
 
 extends 'MusicBrainz::Server::Data::Entity';
 

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -14,7 +14,7 @@ use Data::UUID::MT;
 use Math::Random::Secure qw( irand );
 use MIME::Base64 qw( encode_base64url );
 use JSON::XS;
-use List::AllUtils qw( natatime sort_by );
+use List::AllUtils qw( any natatime sort_by );
 use MusicBrainz::Server::Constants qw(
     $DARTIST_ID
     $VARTIST_ID
@@ -39,6 +39,8 @@ our @EXPORT_OK = qw(
     boolean_to_json
     check_data
     conditional_merge_column_query
+    contains_number
+    contains_string
     copy_escape
     coordinates_to_hash
     datetime_to_iso8601
@@ -750,6 +752,20 @@ sub localized_note {
         version => 1,
         %opts,
     });
+}
+
+sub contains_number {
+    my ($array_ref, $number) = @_;
+
+    return 0 unless defined $array_ref;
+    return any { $_ == $number } @$array_ref;
+}
+
+sub contains_string {
+    my ($array_ref, $string) = @_;
+
+    return 0 unless defined $array_ref;
+    return any { $_ eq $string } @$array_ref;
 }
 
 1;

--- a/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
@@ -17,8 +17,6 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 extends 'MusicBrainz::Server::Edit::WithDifferences';
 with 'MusicBrainz::Server::Edit::Alias';
 with 'MusicBrainz::Server::Edit::CheckForConflicts';

--- a/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
@@ -131,18 +131,14 @@ sub _mapping
 around extract_property => sub {
     my ($orig, $self) = splice(@_, 0, 2);
     my ($property, $ancestor, $current, $new) = @_;
-    given ($property) {
-        when ('begin_date') {
-            return merge_partial_date('begin_date' => $ancestor, $current, $new);
-        }
-
-        when ('end_date') {
-            return merge_partial_date('end_date' => $ancestor, $current, $new);
-        }
-
-        default {
-            return ($self->$orig(@_));
-        }
+    if ($property eq 'begin_date') {
+        return merge_partial_date('begin_date' => $ancestor, $current, $new);
+    }
+    elsif ($property eq 'end_date') {
+        return merge_partial_date('end_date' => $ancestor, $current, $new);
+    }
+    else {
+        return ($self->$orig(@_));
     }
 };
 

--- a/lib/MusicBrainz/Server/Edit/Area/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Area/Edit.pm
@@ -155,17 +155,14 @@ sub _edit_hash {
 around extract_property => sub {
     my ($orig, $self) = splice(@_, 0, 2);
     my ($property, $ancestor, $current, $new) = @_;
-    given ($property) {
-        when ('begin_date') {
-            return merge_partial_date('begin_date' => $ancestor, $current, $new);
-        }
-
-        when ('end_date') {
-            return merge_partial_date('end_date' => $ancestor, $current, $new);
-        }
-        default {
-            return ($self->$orig(@_));
-        }
+    if ($property eq 'begin_date') {
+        return merge_partial_date('begin_date' => $ancestor, $current, $new);
+    }
+    elsif ($property eq 'end_date') {
+        return merge_partial_date('end_date' => $ancestor, $current, $new);
+    }
+    else {
+        return ($self->$orig(@_));
     }
 };
 

--- a/lib/MusicBrainz/Server/Edit/Area/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Area/Edit.pm
@@ -22,8 +22,6 @@ use MooseX::Types::Structured qw( Dict Optional );
 use aliased 'MusicBrainz::Server::Entity::Area';
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
 with 'MusicBrainz::Server::Edit::CheckForConflicts';
 with 'MusicBrainz::Server::Edit::Area';

--- a/lib/MusicBrainz/Server/Edit/Artist/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Edit.pm
@@ -27,8 +27,6 @@ use aliased 'MusicBrainz::Server::Entity::Artist';
 use aliased 'MusicBrainz::Server::Entity::Area';
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
 with 'MusicBrainz::Server::Edit::Artist';
 with 'MusicBrainz::Server::Edit::CheckForConflicts';

--- a/lib/MusicBrainz/Server/Edit/Artist/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Edit.pm
@@ -248,17 +248,14 @@ sub _edit_hash {
 around extract_property => sub {
     my ($orig, $self) = splice(@_, 0, 2);
     my ($property, $ancestor, $current, $new) = @_;
-    given ($property) {
-        when ('begin_date') {
-            return merge_partial_date('begin_date' => $ancestor, $current, $new);
-        }
-
-        when ('end_date') {
-            return merge_partial_date('end_date' => $ancestor, $current, $new);
-        }
-        default {
-            return ($self->$orig(@_));
-        }
+    if ($property eq 'begin_date') {
+        return merge_partial_date('begin_date' => $ancestor, $current, $new);
+    }
+    elsif ($property eq 'end_date') {
+        return merge_partial_date('end_date' => $ancestor, $current, $new);
+    }
+    else {
+        return ($self->$orig(@_));
     }
 };
 

--- a/lib/MusicBrainz/Server/Edit/Event/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Event/Edit.pm
@@ -165,22 +165,17 @@ sub _edit_hash {
 around extract_property => sub {
     my ($orig, $self) = splice(@_, 0, 2);
     my ($property, $ancestor, $current, $new) = @_;
-    given ($property) {
-        when ('begin_date') {
-            return merge_partial_date('begin_date' => $ancestor, $current, $new);
-        }
-
-        when ('end_date') {
-            return merge_partial_date('end_date' => $ancestor, $current, $new);
-        }
-
-        when ('time') {
-            return merge_time('time' => $ancestor, $current, $new);
-        }
-
-        default {
-            return ($self->$orig(@_));
-        }
+    if ($property eq 'begin_date') {
+        return merge_partial_date('begin_date' => $ancestor, $current, $new);
+    }
+    elsif ($property eq 'end_date') {
+        return merge_partial_date('end_date' => $ancestor, $current, $new);
+    }
+    elsif ($property eq 'time') {
+        return merge_time('time' => $ancestor, $current, $new);
+    }
+    else {
+        return ($self->$orig(@_));
     }
 };
 

--- a/lib/MusicBrainz/Server/Edit/Event/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Event/Edit.pm
@@ -28,8 +28,6 @@ use MooseX::Types::Structured qw( Dict Optional );
 use aliased 'MusicBrainz::Server::Entity::Event';
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
 with 'MusicBrainz::Server::Edit::CheckForConflicts';
 with 'MusicBrainz::Server::Edit::Event';

--- a/lib/MusicBrainz/Server/Edit/Genre/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Genre/Edit.pm
@@ -14,8 +14,6 @@ use MooseX::Types::Structured qw( Dict Optional );
 
 use aliased 'MusicBrainz::Server::Entity::Genre';
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
 with 'MusicBrainz::Server::Edit::CheckForConflicts';
 with 'MusicBrainz::Server::Edit::Genre';

--- a/lib/MusicBrainz/Server/Edit/Label/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Label/Edit.pm
@@ -26,8 +26,6 @@ use MooseX::Types::Structured qw( Dict Optional );
 use aliased 'MusicBrainz::Server::Entity::Label';
 use aliased 'MusicBrainz::Server::Entity::Area';
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
 with 'MusicBrainz::Server::Edit::Label';
 with 'MusicBrainz::Server::Edit::CheckForConflicts';

--- a/lib/MusicBrainz/Server/Edit/Label/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Label/Edit.pm
@@ -221,18 +221,14 @@ sub _edit_hash {
 around extract_property => sub {
     my ($orig, $self) = splice(@_, 0, 2);
     my ($property, $ancestor, $current, $new) = @_;
-    given ($property) {
-        when ('begin_date') {
-            return merge_partial_date('begin_date' => $ancestor, $current, $new);
-        }
-
-        when ('end_date') {
-            return merge_partial_date('end_date' => $ancestor, $current, $new);
-        }
-
-        default {
-            return ($self->$orig(@_));
-        }
+    if ($property eq 'begin_date') {
+        return merge_partial_date('begin_date' => $ancestor, $current, $new);
+    }
+    elsif ($property eq 'end_date') {
+        return merge_partial_date('end_date' => $ancestor, $current, $new);
+    }
+    else {
+        return ($self->$orig(@_));
     }
 };
 

--- a/lib/MusicBrainz/Server/Edit/Place/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Place/Edit.pm
@@ -30,8 +30,6 @@ use aliased 'MusicBrainz::Server::Entity::Area';
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 use aliased 'MusicBrainz::Server::Entity::Coordinates';
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
 with 'MusicBrainz::Server::Edit::CheckForConflicts';
 with 'MusicBrainz::Server::Edit::Place';

--- a/lib/MusicBrainz/Server/Edit/Place/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Place/Edit.pm
@@ -189,22 +189,17 @@ sub edit_template { 'EditPlace' }
 around extract_property => sub {
     my ($orig, $self) = splice(@_, 0, 2);
     my ($property, $ancestor, $current, $new) = @_;
-    given ($property) {
-        when ('begin_date') {
-            return merge_partial_date('begin_date' => $ancestor, $current, $new);
-        }
-
-        when ('end_date') {
-            return merge_partial_date('end_date' => $ancestor, $current, $new);
-        }
-
-        when ('coordinates') {
-            return merge_coordinates('coordinates' => $ancestor, $current, $new);
-        }
-
-        default {
-            return ($self->$orig(@_));
-        }
+    if ($property eq 'begin_date') {
+        return merge_partial_date('begin_date' => $ancestor, $current, $new);
+    }
+    elsif ($property eq 'end_date') {
+        return merge_partial_date('end_date' => $ancestor, $current, $new);
+    }
+    elsif ($property eq 'coordinates') {
+        return merge_coordinates('coordinates' => $ancestor, $current, $new);
+    }
+    else {
+        return ($self->$orig(@_));
     }
 };
 

--- a/lib/MusicBrainz/Server/Edit/Recording/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Recording/Edit.pm
@@ -204,14 +204,11 @@ before accept => sub {
 around extract_property => sub {
     my ($orig, $self) = splice(@_, 0, 2);
     my ($property, $ancestor, $current, $new) = @_;
-    given ($property) {
-        when ('artist_credit') {
-            return merge_artist_credit($self->c, $ancestor, $current, $new);
-        }
-
-        default {
-            return ($self->$orig(@_));
-        }
+    if ($property eq 'artist_credit') {
+        return merge_artist_credit($self->c, $ancestor, $current, $new);
+    }
+    else {
+        return ($self->$orig(@_));
     }
 };
 

--- a/lib/MusicBrainz/Server/Edit/Recording/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Recording/Edit.pm
@@ -26,8 +26,6 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Track;
 use MusicBrainz::Server::Translation qw( N_l );
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
 with 'MusicBrainz::Server::Edit::Recording::RelatedEntities';
 with 'MusicBrainz::Server::Edit::Recording';

--- a/lib/MusicBrainz/Server/Edit/Relationship.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship.pm
@@ -13,8 +13,6 @@ use namespace::autoclean;
 
 use MusicBrainz::Server::Translation qw ( l );
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 sub edit_category { l('Relationship') }
 
 sub check_attributes {
@@ -101,9 +99,9 @@ sub editor_may_edit_types {
     my ($self, $type0, $type1) = @_;
 
     my $types = join '_', sort($type0, $type1);
-    if ($types ~~ [qw(area_area area_url)]) {
+    if ($types =~ /^area_(area|url)$/) {
         return $self->editor->is_location_editor;
-    } elsif ($types ~~ [qw(area_instrument instrument_instrument instrument_url)]) {
+    } elsif ($types =~ /^(area_instrument|instrument_instrument|instrument_url)$/) {
         return $self->editor->is_relationship_editor;
     } else {
         return 1;

--- a/lib/MusicBrainz/Server/Edit/Release/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Edit.pm
@@ -252,18 +252,14 @@ around 'initialize' => sub
 around extract_property => sub {
     my ($orig, $self) = splice(@_, 0, 2);
     my ($property, $ancestor, $current, $new) = @_;
-    given ($property) {
-        when ('artist_credit') {
-            return merge_artist_credit($self->c, $ancestor, $current, $new);
-        }
-
-        when ('barcode') {
-            return merge_barcode($ancestor, $current, $new);
-        }
-
-        default {
-            return ($self->$orig(@_));
-        }
+    if ($property eq 'artist_credit') {
+        return merge_artist_credit($self->c, $ancestor, $current, $new);
+    }
+    elsif ($property eq 'barcode') {
+        return merge_barcode($ancestor, $current, $new);
+    }
+    else {
+        return ($self->$orig(@_));
     }
 };
 

--- a/lib/MusicBrainz/Server/Edit/Release/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Edit.pm
@@ -30,8 +30,6 @@ use MusicBrainz::Server::Entity::PartialDate;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
 with 'MusicBrainz::Server::Edit::Role::EditArtistCredit';
 with 'MusicBrainz::Server::Edit::Role::Preview';

--- a/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
@@ -332,18 +332,15 @@ sub current_instance {
 around extract_property => sub {
     my ($orig, $self) = splice(@_, 0, 2);
     my ($property, $ancestor, $current, $new) = @_;
-    given ($property) {
-        when ('label') {
-            return (
-                merge_value($ancestor->{label}),
-                merge_value(_serialize_label($current->label)),
-                merge_value($new->{label}),
-            );
-        }
-
-        default {
-            return ($self->$orig(@_));
-        }
+    if ($property eq 'label') {
+        return (
+            merge_value($ancestor->{label}),
+            merge_value(_serialize_label($current->label)),
+            merge_value($new->{label}),
+        );
+    }
+    else {
+        return ($self->$orig(@_));
     }
 };
 

--- a/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
@@ -17,8 +17,6 @@ use MusicBrainz::Server::Translation qw( N_l lp );
 use MusicBrainz::Server::Entity::Util::MediumFormat qw( combined_medium_format_name );
 use Scalar::Util qw( looks_like_number );
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 extends 'MusicBrainz::Server::Edit::WithDifferences';
 with 'MusicBrainz::Server::Edit::Role::Preview';
 with 'MusicBrainz::Server::Edit::Release::RelatedEntities';

--- a/lib/MusicBrainz/Server/Edit/ReleaseGroup/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/ReleaseGroup/Edit.pm
@@ -178,31 +178,29 @@ around initialize => sub
 around extract_property => sub {
     my ($orig, $self) = splice(@_, 0, 2);
     my ($property, $ancestor, $current, $new) = @_;
-    given ($property) {
-        when ('artist_credit') {
-            return merge_artist_credit($self->c, $ancestor, $current, $new);
-        }
-        when ('type_id') {
-            return (
-                merge_value($ancestor->{type_id}),
-                merge_value($current->primary_type_id),
-                merge_value($new->{type_id})
-            )
-        }
-        when ('secondary_type_ids') {
-            my $type_list_gen = sub {
-                my $type = shift;
-                return [ join(q(,), sort @$type), $type ];
-            };
-            return (
-                $type_list_gen->( $ancestor->{secondary_type_ids} ),
-                $type_list_gen->( [ map { $_->id } $current->all_secondary_types ] ),
-                $type_list_gen->( $new->{secondary_type_ids} ),
-            )
-        }
-        default {
-            return $self->$orig(@_);
-        }
+    if ($property eq 'artist_credit') {
+        return merge_artist_credit($self->c, $ancestor, $current, $new);
+    }
+    elsif ($property eq 'type_id') {
+        return (
+            merge_value($ancestor->{type_id}),
+            merge_value($current->primary_type_id),
+            merge_value($new->{type_id})
+        )
+    }
+    elsif ($property eq 'secondary_type_ids') {
+        my $type_list_gen = sub {
+            my $type = shift;
+            return [ join(q(,), sort @$type), $type ];
+        };
+        return (
+            $type_list_gen->( $ancestor->{secondary_type_ids} ),
+            $type_list_gen->( [ map { $_->id } $current->all_secondary_types ] ),
+            $type_list_gen->( $new->{secondary_type_ids} ),
+        )
+    }
+    else {
+        return $self->$orig(@_);
     }
 };
 

--- a/lib/MusicBrainz/Server/Edit/ReleaseGroup/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/ReleaseGroup/Edit.pm
@@ -27,8 +27,6 @@ use Scalar::Util qw( looks_like_number );
 
 use aliased 'MusicBrainz::Server::Entity::ReleaseGroup';
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
 with 'MusicBrainz::Server::Edit::ReleaseGroup::RelatedEntities';
 with 'MusicBrainz::Server::Edit::ReleaseGroup';

--- a/lib/MusicBrainz/Server/Edit/Series/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Series/Edit.pm
@@ -17,8 +17,6 @@ use MooseX::Types::Structured qw( Dict Optional );
 
 use aliased 'MusicBrainz::Server::Entity::Series';
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
 with 'MusicBrainz::Server::Edit::Series';
 with 'MusicBrainz::Server::Edit::CheckForConflicts';

--- a/lib/MusicBrainz/Server/Edit/URL/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/URL/Edit.pm
@@ -145,18 +145,15 @@ sub current_instance {
 around extract_property => sub {
     my ($orig, $self) = splice(@_, 0, 2);
     my ($property, $ancestor, $current, $new) = @_;
-    given ($property) {
-        when ('url') {
-            return (
-                [ $ancestor->{url}, $ancestor->{url} ],
-                [ $current->url->as_string, $current->url->as_string ],
-                [ $new->{url}, $new->{url} ]
-            );
-        }
-
-        default {
-            return ($self->$orig(@_));
-        }
+    if ($property eq 'url') {
+        return (
+            [ $ancestor->{url}, $ancestor->{url} ],
+            [ $current->url->as_string, $current->url->as_string ],
+            [ $new->{url}, $new->{url} ]
+        );
+    }
+    else {
+        return ($self->$orig(@_));
     }
 };
 

--- a/lib/MusicBrainz/Server/Edit/URL/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/URL/Edit.pm
@@ -16,8 +16,6 @@ use MusicBrainz::Server::Edit::Utils qw( changed_display_data );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
 with 'MusicBrainz::Server::Edit::URL';
 with 'MusicBrainz::Server::Edit::URL::RelatedEntities';

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/AppliedEdits.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/AppliedEdits.pm
@@ -1,7 +1,6 @@
 package MusicBrainz::Server::EditSearch::Predicate::AppliedEdits;
 use Moose;
 use namespace::autoclean;
-use feature 'switch';
 
 use MusicBrainz::Server::Constants qw( :edit_status );
 
@@ -13,13 +12,12 @@ sub combine_with_query {
     my $subquery = '(SELECT COUNT(*) FROM edit H WHERE H.editor = edit.editor AND H.status = ?)';
 
     my $sql;
-    given ($self->operator) {
-        when ('BETWEEN') {
-            $sql = $subquery . ' BETWEEN SYMMETRIC ? AND ?';
-        }
-        default {
-           $sql = join(' ', $subquery, $self->operator, '?');
-       }
+    my $operator = $self->operator;
+    if ($operator eq 'BETWEEN') {
+        $sql = $subquery . ' BETWEEN SYMMETRIC ? AND ?';
+    }
+    else {
+        $sql = join(' ', $subquery, $operator, '?');
     }
 
     $query->add_where([ $sql, [ $STATUS_APPLIED, @{ $self->sql_arguments } ] ]);

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/AppliedEdits.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/AppliedEdits.pm
@@ -5,8 +5,6 @@ use feature 'switch';
 
 use MusicBrainz::Server::Constants qw( :edit_status );
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 extends 'MusicBrainz::Server::EditSearch::Predicate::ID';
 
 sub combine_with_query {

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/ID.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/ID.pm
@@ -4,8 +4,6 @@ use MusicBrainz::Server::Validation qw( is_database_row_id is_integer );
 use namespace::autoclean;
 use feature 'switch';
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 with 'MusicBrainz::Server::EditSearch::Predicate';
 
 sub operator_cardinality_map {

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/ID.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/ID.pm
@@ -2,7 +2,6 @@ package MusicBrainz::Server::EditSearch::Predicate::ID;
 use Moose;
 use MusicBrainz::Server::Validation qw( is_database_row_id is_integer );
 use namespace::autoclean;
-use feature 'switch';
 
 with 'MusicBrainz::Server::EditSearch::Predicate';
 
@@ -17,13 +16,12 @@ sub combine_with_query {
     my ($self, $query) = @_;
 
     my $sql;
-    given ($self->operator) {
-        when ('BETWEEN') {
-            $sql = 'edit.' . $self->field_name . ' BETWEEN SYMMETRIC ? AND ?';
-        }
-        default {
-           $sql = join(' ', 'edit.'.$self->field_name, $self->operator, '?')
-       }
+    my $operator = $self->operator;
+    if ($operator eq 'BETWEEN') {
+        $sql = 'edit.' . $self->field_name . ' BETWEEN SYMMETRIC ? AND ?';
+    }
+    else {
+        $sql = join(' ', 'edit.'.$self->field_name, $operator, '?')
     }
 
     $query->add_where([ $sql, $self->sql_arguments ]);

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/Role/Subscribed.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/Role/Subscribed.pm
@@ -3,8 +3,6 @@ use 5.10.0;
 use MooseX::Role::Parameterized;
 use namespace::autoclean;
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 parameter type => (
     isa => 'Str',
     required => 1

--- a/lib/MusicBrainz/Server/Entity/Series.pm
+++ b/lib/MusicBrainz/Server/Entity/Series.pm
@@ -3,8 +3,6 @@ package MusicBrainz::Server::Entity::Series;
 use Moose;
 use MusicBrainz::Server::Entity::Types;
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 extends 'MusicBrainz::Server::Entity';
 with 'MusicBrainz::Server::Entity::Role::Relatable';
 with 'MusicBrainz::Server::Entity::Role::Taggable';

--- a/lib/MusicBrainz/Server/Plugin/Diff.pm
+++ b/lib/MusicBrainz/Server/Plugin/Diff.pm
@@ -14,8 +14,6 @@ use HTML::Entities qw( decode_entities );
 use Scalar::Util qw( blessed );
 use MusicBrainz::Server::Validation qw( encode_entities trim_in_place );
 
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
-
 sub new {
     my ($class, $context) = @_;
     return bless { c => $context }, $class;

--- a/script/dump-entities-sql.pl
+++ b/script/dump-entities-sql.pl
@@ -14,8 +14,6 @@ use Encode qw( encode );
 use MusicBrainz::Script::EntityDump qw( edits get_core_entities_by_gids );
 use MusicBrainz::Server::Context;
 
-no warnings 'experimental::smartmatch';
-
 my $database = 'READWRITE';
 my $aliases = 0;
 my $annotations = 0;

--- a/script/dump-entities-sql.pl
+++ b/script/dump-entities-sql.pl
@@ -2,8 +2,6 @@
 use strict;
 use warnings;
 
-use feature 'switch';
-
 use Moose;
 use namespace::autoclean;
 use FindBin;
@@ -46,14 +44,12 @@ sub quote_column {
 
     my $ret;
 
-    given ($type) {
-        when (/^integer\[\]/) { $ret = q('{) . join(',', @$data) . q(}'); }
-        when (/^integer/) { $ret = $data; }
-        when (/^smallint/) { $ret = $data; }
-        default {
-            $data =~ s/'/''/g;
-            $ret = "'$data'";
-        }
+    if ($type =~ /^integer\[\]/) { $ret = q('{) . join(',', @$data) . q(}'); }
+    elsif ($type =~ /^integer/) { $ret = $data; }
+    elsif ($type =~ /^smallint/) { $ret = $data; }
+    else {
+        $data =~ s/'/''/g;
+        $ret = "'$data'";
     }
 
     return $ret;


### PR DESCRIPTION
The smartmatch operator (`~~`) and switch feature (`given`/`when`) are both deprecated as of Perl 5.38.

https://perldoc.perl.org/perl5380delta#Switch-and-Smart-Match-operator