### PR TITLE
Use new contains_ functions in more places

### DIFF
--- a/admin/ExportAllTables
+++ b/admin/ExportAllTables
@@ -27,6 +27,7 @@ use MusicBrainz::Server::Constants qw(
     @WIKIDOCS_TABLE_LIST
     @DOCUMENTATION_TABLE_LIST
 );
+use MusicBrainz::Server::Data::Utils qw( contains_string );
 use MusicBrainz::Server::Log qw( log_info );
 
 use Getopt::Long;
@@ -154,7 +155,7 @@ my $mbdump = MusicBrainz::Script::DatabaseDump->new(
 @tables = () if not $fDoFullExport;
 
 # Sanitise various things for public consumption
-if (any { $_ eq 'editor_sanitised' } @tables)
+if (contains_string(\@tables, 'editor_sanitised'))
 {
     $sql->do("SELECT $EDITOR_SANITISED_COLUMNS
               INTO TEMPORARY editor_sanitised
@@ -295,7 +296,7 @@ if ($fDoReplication)
 
 # Dump this /after/ we've possibly updated the current_replication_sequence
 # Dump this table only if we're dumping everything (i.e., @tablelist is empty) or if it's explicitly requested.
-$mbdump->dump_table('replication_control') if (scalar @tablelist == 0 || any { $_ eq 'replication_control' } @tablelist);
+$mbdump->dump_table('replication_control') if (scalar @tablelist == 0 || contains_string(\@tablelist, 'replication_control'));
 
 $mbdump->end_dump;
 

--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -13,6 +13,7 @@ use MusicBrainz::Server::Data::Utils qw(
     is_special_artist
     add_partial_date_to_row
     conditional_merge_column_query
+    contains_string
     hash_to_row
     load_subobjects
     merge_table_attributes
@@ -397,12 +398,12 @@ sub merge
 
         my $merged_type_is_group =
             defined $merged_type &&
-            any { $merged_type eq $_ } @$group_types;
+            contains_string($group_types, $merged_type);
 
         if ($merged_type_is_group && $merged_gender) {
             my $target_type_is_group =
                 defined $target_type &&
-                any { $target_type eq $_ } @$group_types;
+                contains_string($group_types, $target_type);
 
             if ($target_type_is_group) {
                 $dropped_columns{gender} = $merged_gender;

--- a/lib/MusicBrainz/Server/Data/Edit.pm
+++ b/lib/MusicBrainz/Server/Data/Edit.pm
@@ -14,7 +14,11 @@ use Encode qw( decode );
 use Try::Tiny;
 use List::AllUtils qw( any uniq zip );
 use MusicBrainz::Server::Data::Editor;
-use MusicBrainz::Server::Data::Utils qw( non_empty type_to_model );
+use MusicBrainz::Server::Data::Utils qw(
+    contains_string
+    non_empty
+    type_to_model
+);
 use MusicBrainz::Server::EditRegistry;
 use MusicBrainz::Server::Edit::Exceptions;
 use MusicBrainz::Server::Constants qw(
@@ -649,7 +653,10 @@ sub load_all
                     } else {
                         for my $extra_model (@$extra_models) {
                             push @{ $post_load_models->{$model}->{$object_id} }, $extra_model
-                              unless (any { $_ eq $extra_model } @{ $post_load_models->{$model}->{$object_id} });
+                              unless (contains_string(
+                                $post_load_models->{$model}->{$object_id},
+                                $extra_model,
+                              ));
                         }
                     }
                 }

--- a/lib/MusicBrainz/Server/Sitemap/Builder.pm
+++ b/lib/MusicBrainz/Server/Sitemap/Builder.pm
@@ -13,6 +13,7 @@ use List::AllUtils qw( any natatime );
 use Moose;
 use MusicBrainz::Server::Constants qw( %ENTITIES );
 use MusicBrainz::Server::Context;
+use MusicBrainz::Server::Data::Utils qw( contains_string );
 use MusicBrainz::Server::Log qw( log_info );
 use MusicBrainz::Server::Sitemap::Constants qw( $MAX_SITEMAP_SIZE );
 use MusicBrainz::Server::Sitemap::Utils qw(
@@ -131,7 +132,6 @@ has sitemap_files => (
     traits => ['Array', 'NoGetopt'],
     handles => {
         add_sitemap_file => 'push',
-        all_sitemap_files => 'elements',
     },
 );
 
@@ -432,7 +432,7 @@ cleanup, after writing the index file.
 sub do_not_delete {
     my ($self, $file) = @_;
 
-    any { $_ eq $file } $self->all_sitemap_files;
+    contains_string($self->sitemap_files, $file);
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MusicBrainz/Server/Translation.pm
+++ b/lib/MusicBrainz/Server/Translation.pm
@@ -13,6 +13,7 @@ use POSIX qw( setlocale );
 use Text::Balanced qw( extract_bracketed );
 use Unicode::ICU::Collator qw( UCOL_NUMERIC_COLLATION UCOL_ON );
 
+use MusicBrainz::Server::Data::Utils qw( contains_string );
 use MusicBrainz::Server::Validation qw( encode_entities );
 
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'mb_server' };
@@ -141,7 +142,7 @@ sub set_language
         return $set_lang;
     }
     # Check if the language without country code is in MB_LANGUAGES
-    elsif (any { $set_lang_nocountry eq $_ } DBDefs->MB_LANGUAGES) {
+    elsif (contains_string([ DBDefs->MB_LANGUAGES ], $set_lang_nocountry)) {
         return $set_lang_nocountry;
     }
     # Give up, return the full language even though it looks wrong
@@ -176,7 +177,7 @@ sub language_from_cookie
         any { $cookie->value eq $_ || $cookie_munge eq $_ } DBDefs->MB_LANGUAGES) {
         return $cookie->value;
     } elsif (defined $cookie &&
-             any { $cookie_nocountry eq $_ } DBDefs->MB_LANGUAGES) {
+             contains_string([ DBDefs->MB_LANGUAGES ], $cookie_nocountry)) {
         return $cookie_nocountry;
     } else {
         return undef;

--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -4,6 +4,7 @@ use warnings;
 
 use Date::Calc;
 use List::AllUtils qw( any );
+use Readonly;
 
 require Exporter;
 {
@@ -52,6 +53,7 @@ use Encode qw( decode encode );
 use Scalar::Util qw( looks_like_number );
 use Text::Unaccent::PurePerl qw( unac_string_utf16 );
 use MusicBrainz::Server::Constants qw( $MAX_POSTGRES_INT $MAX_POSTGRES_BIGINT );
+use MusicBrainz::Server::Data::Utils qw( contains_number );
 use utf8;
 
 sub unaccent_utf16 ($)
@@ -260,6 +262,8 @@ sub is_valid_iso_3166_3
     return $iso_3166_3 =~ /^[A-Z]{4}$/;
 }
 
+Readonly my @MONTHS_WITH_30_DAYS => (4, 6, 9, 11);
+
 sub is_valid_partial_date
 {
     my ($year, $month, $day) = @_;
@@ -274,7 +278,8 @@ sub is_valid_partial_date
 
     if (defined $month && $day) {
         return 0 if $day > 29 && $month == 2;
-        return 0 if $day > 30 && any { $_ == $month } (4, 6, 9, 11);
+        return 0 if $day > 30 &&
+                    contains_number(\@MONTHS_WITH_30_DAYS, $month);
     }
 
     if (defined $year) {

--- a/t/hydration_i18n.t
+++ b/t/hydration_i18n.t
@@ -5,7 +5,7 @@ use Cwd;
 use File::Basename;
 use File::Spec;
 use FindBin qw( $Bin );
-use List::AllUtils qw( any );
+use MusicBrainz::Server::Data::Utils qw( contains_string );
 use String::ShellQuote qw( shell_quote );
 use Test::More;
 
@@ -95,7 +95,7 @@ sub check_imports {
             );
         }
 
-        unless (any { $_ eq $import } @source_path) {
+        unless (contains_string(\@source_path, $import)) {
             check_imports(@source_path, $import);
         }
     }


### PR DESCRIPTION
# Description
The new `contains_string` and `contains_number` functions added by https://github.com/metabrainz/musicbrainz-server/pull/3048 are way more readable than an `any { $_ eq whatever }` call so replacing the straight equivalents when possible.

# Testing
None other than CI for now.