### PR TITLE
MBS-13319: Show help bubble for language/script on release editor

### DIFF
--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -111,9 +111,11 @@
       [% table_row_select('status', l('Status:'), 2,
           'value: statusID, controlsBubble: $root.statusBubble', statuses) %]
 
-      [% table_row_select('language', l('Language:'), 2, 'value: languageID', languages) %]
+      [% table_row_select('language', l('Language:'), 2,
+          'value: languageID, controlsBubble: $root.languageBubble', languages) %]
 
-      [% table_row_select('script', l('Script:'), 2, 'value: scriptID', scripts) %]
+      [% table_row_select('script', l('Script:'), 2,
+          'value: scriptID, controlsBubble: $root.scriptBubble', scripts) %]
     </tbody>
     </table>
   </fieldset>
@@ -304,6 +306,18 @@
     <p>
       [% l('Review the {packaging|list of packaging types} for help.',
            { packaging => { href => doc_link('Release/Packaging'), target => '_blank' } }) %]
+    </p>
+  </div>
+
+  <div class="bubble" data-bind="bubble: $root.languageBubble">
+    <p>
+      [% l('The language attribute should be set to the language used for the release title and track titles. It should not be set to the language the lyrics are written in, nor to the language used for other extra information on the cover.') %]
+    </p>
+  </div>
+
+  <div class="bubble" data-bind="bubble: $root.scriptBubble">
+    <p>
+      [% l('The script attribute should be set to the script used for the release title and track titles.') %]
     </p>
   </div>
 

--- a/root/static/scripts/release-editor/bubbles.js
+++ b/root/static/scripts/release-editor/bubbles.js
@@ -37,6 +37,10 @@ releaseEditor.dateBubble = bubbleDoc({
   },
 });
 
+releaseEditor.languageBubble = bubbleDoc();
+
+releaseEditor.scriptBubble = bubbleDoc();
+
 releaseEditor.packagingBubble = bubbleDoc();
 
 releaseEditor.labelBubble = bubbleDoc({


### PR DESCRIPTION
### Implement MBS-13319

# Problem
It's not particularly obvious when adding or editing a release that the content of the language/script fields should be the language/script of the track titles rather than the lyrics or the liner notes. The info is in the release guidelines, but most new users are not going to get there for quite a while.

# Solution
This adds a bubble for the language and script fields, with a sentence for each based on the wording in the Style/Release guideline.

# Testing
Manually, from `/release/add`.