### PR TITLE
MBS-13320: Prompt before unloading modified forms

### DIFF
--- a/root/artist/edit_form.tt
+++ b/root/artist/edit_form.tt
@@ -111,5 +111,7 @@
 
     MB.Control.initializeBubble("#ipi-bubble", "input[name=edit-artist\\.ipi_codes\\.0]");
     MB.Control.initializeBubble("#isni-bubble", "input[name=edit-artist\\.isni_codes\\.0]");
+
+    MB.installFormUnloadWarning();
   }());
 </script>

--- a/root/event/edit_form.tt
+++ b/root/event/edit_form.tt
@@ -68,5 +68,7 @@
     MB.Control.initializeGuessCase("event", "id-edit-event");
 
     MB.initializeTooShortYearChecks('event');
+
+    MB.installFormUnloadWarning();
   }());
 </script>

--- a/root/label/edit_form.tt
+++ b/root/label/edit_form.tt
@@ -69,5 +69,7 @@
 
     MB.Control.initializeBubble("#ipi-bubble", "input[name=edit-label\\.ipi_codes\\.0]");
     MB.Control.initializeBubble("#isni-bubble", "input[name=edit-label\\.isni_codes\\.0]");
+
+    MB.installFormUnloadWarning();
   }());
 </script>

--- a/root/place/edit_form.tt
+++ b/root/place/edit_form.tt
@@ -59,3 +59,9 @@
 
 [%- guesscase_options() -%]
 [% script_manifest('place/edit.js') %]
+
+<script type="text/javascript">
+  (function () {
+    MB.installFormUnloadWarning();
+  }());
+</script>

--- a/root/recording/edit_form.tt
+++ b/root/recording/edit_form.tt
@@ -70,5 +70,6 @@
     );
     MB.Control.initGuessFeatButton('edit-recording');
     MB.Control.initializeBubble("#isrcs-bubble", "input[name=edit-recording\\.isrcs\\.0]");
+    MB.installFormUnloadWarning();
   });
 </script>

--- a/root/release_group/edit_form.tt
+++ b/root/release_group/edit_form.tt
@@ -40,5 +40,6 @@
     );
     MB.Control.initializeGuessCase("release_group", "id-edit-release-group");
     MB.Control.initGuessFeatButton('edit-release-group');
+    MB.installFormUnloadWarning();
   });
 </script>

--- a/root/series/edit_form.tt
+++ b/root/series/edit_form.tt
@@ -48,6 +48,7 @@
 $(function () {
   [%- USE JSON.Escape -%]
   MB.orderingTypesByID = [% series_ordering_types.json %];
+  MB.installFormUnloadWarning();
 });
 </script>
 

--- a/root/static/scripts/edit/components/forms.js
+++ b/root/static/scripts/edit/components/forms.js
@@ -59,3 +59,34 @@ MB.initializeArtistCredit = function (form, initialArtistCredit) {
     );
   });
 };
+
+/*
+ * Registers a beforeunload event listener on the window that prompts
+ * the user if any of the page's form inputs have been changed.
+ */
+MB.installFormUnloadWarning = function () {
+  let modified = false;
+
+  const form = document.querySelector('#page form');
+
+  // This is somewhat heavy-handed, in that it will still warn even if the
+  // user changes an input back to its original value.
+  form.addEventListener('change', () => {
+    modified = true;
+  });
+
+  // Disarm the warning when the form is being submitted.
+  form.addEventListener('submit', () => {
+    modified = false;
+  });
+
+  window.addEventListener('beforeunload', event => {
+    if (!modified) {
+      return false;
+    }
+    event.returnValue = l(
+      'All of your changes will be lost if you leave this page.',
+    );
+    return event.returnValue;
+  });
+};

--- a/root/static/scripts/edit/components/forms.js
+++ b/root/static/scripts/edit/components/forms.js
@@ -69,8 +69,10 @@ MB.installFormUnloadWarning = function () {
 
   const form = document.querySelector('#page form');
 
-  // This is somewhat heavy-handed, in that it will still warn even if the
-  // user changes an input back to its original value.
+  /*
+   * This is somewhat heavy-handed, in that it will still warn even if the
+   * user changes an input back to its original value.
+   */
   form.addEventListener('change', () => {
     modified = true;
   });

--- a/root/work/edit_form.tt
+++ b/root/work/edit_form.tt
@@ -109,3 +109,9 @@
 [%- USE JSON.Escape;
     script_manifest('work/edit.js', {'data-args' => work_form_json.json})
 -%]
+
+<script type="text/javascript">
+  (function () {
+    MB.installFormUnloadWarning();
+  }());
+</script>

--- a/t/selenium/Artist_Credit_Editor.json5
+++ b/t/selenium/Artist_Credit_Editor.json5
@@ -294,15 +294,20 @@
       target: "window.document.getElementById('ac-source-artist-0').classList.contains('lookup-performed')",
       value: 'false',
     },
+    // creating a new artist from the track AC bubble should not close it (MBS-7251)
+    {
+      command: 'open',
+      target: '/release/add',
+      value: '',
+    },
     // dismiss the beforeunload alert (shown since inputs were changed)
     {
       command: 'handleAlert',
       target: 'accept',
       value: '',
     },
-    // creating a new artist from the track AC bubble should not close it (MBS-7251)
     {
-      command: 'open',
+      command: 'waitUntilUrlIs',
       target: '/release/add',
       value: '',
     },

--- a/t/selenium/Artist_Credit_Editor.json5
+++ b/t/selenium/Artist_Credit_Editor.json5
@@ -294,6 +294,12 @@
       target: "window.document.getElementById('ac-source-artist-0').classList.contains('lookup-performed')",
       value: 'false',
     },
+    // dismiss the beforeunload alert (shown since inputs were changed)
+    {
+      command: 'handleAlert',
+      target: 'accept',
+      value: '',
+    },
     // creating a new artist from the track AC bubble should not close it (MBS-7251)
     {
       command: 'open',

--- a/t/selenium/Check_Duplicates.json5
+++ b/t/selenium/Check_Duplicates.json5
@@ -80,6 +80,11 @@
       target: 'document.getElementById("id-edit-artist.comment").getAttribute("required")',
       value: 'required',
     },
+    {
+      command: 'open',
+      target: '/',
+      value: '',
+    },
     // dismiss the beforeunload alert (shown since inputs were changed)
     {
       command: 'handleAlert',

--- a/t/selenium/Check_Duplicates.json5
+++ b/t/selenium/Check_Duplicates.json5
@@ -80,5 +80,11 @@
       target: 'document.getElementById("id-edit-artist.comment").getAttribute("required")',
       value: 'required',
     },
+    // dismiss the beforeunload alert (shown since inputs were changed)
+    {
+      command: 'handleAlert',
+      target: 'accept',
+      value: '',
+    },
   ],
 }

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -32,6 +32,17 @@
       target: '/artist/create',
       value: '',
     },
+    // dismiss the beforeunload alert (shown since inputs were changed)
+    {
+      command: 'handleAlert',
+      target: 'accept',
+      value: '',
+    },
+    {
+      command: 'waitUntilUrlIs',
+      target: '/artist/create',
+      value: '',
+    },
     // automatic link type detection for URL
     {
       command: 'click',

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -474,6 +474,12 @@
       target: '/release/24d4159a-99d9-425d-a7b8-1b9ec0261a33/edit',
       value: '',
     },
+    // dismiss the beforeunload alert (shown since inputs were changed)
+    {
+      command: 'handleAlert',
+      target: 'accept',
+      value: '',
+    },
     {
       command: 'pause',
       target: '1500',

--- a/t/selenium/MBS-9941.json5
+++ b/t/selenium/MBS-9941.json5
@@ -81,5 +81,11 @@
       target: '/set-language/en',
       value: '',
     },
+    {
+      // Dismiss the beforeunload alert (shown since inputs were changed).
+      command: 'handleAlert',
+      target: 'accept',
+      value: '',
+    },
   ],
 }

--- a/t/selenium/MBS-9941.json5
+++ b/t/selenium/MBS-9941.json5
@@ -81,8 +81,8 @@
       target: '/set-language/en',
       value: '',
     },
+    // Dismiss the beforeunload alert (shown since inputs were changed).
     {
-      // Dismiss the beforeunload alert (shown since inputs were changed).
       command: 'handleAlert',
       target: 'accept',
       value: '',


### PR DESCRIPTION
# MBS-13320

Install a beforeunload event listener on the artist, event, label, place, recording, release group, series, and work edit pages that prompts the user if any of the form's inputs have been changed.

One limitation of the approach used here is that it doesn't detect relationship changes.

Note that the release editor already displays a prompt if the page is unloaded with unsubmitted changes.

# Problem

If an editing page is accidentally closed or navigated away from by a user before it's been submitted, data entered in JavaScript-dependent fields like Area, Relationships, and External Links are lost.

# Solution

Listen for `change` events within `form` elements and install a `beforeunload` handler that prompts the user if the page is being unloaded after changes have been made. I added a small `MB.installFormUnloadWarning` function that seems to be sufficient for all of the forms that I'm updating here.

Note that since I'm watching for `change` events (rather than `input`), the prompt won't be primed until the user actually commits a change by e.g. de-focusing an input after typing into it. The approach used here doesn't seem to detect relationship changes; I think that the separate implementation of the relationship editor may make this challenging.

I think that the release editor is able to use a different approach where it maintains a list of unsubmitted changes, but I believe that that approach is unavailable in (all?) other pages.

# Testing

I verified that all of the pages that I've updated don't prompt if I close them without making any changes, but do prompt if I've made name, area, URL, etc. changes. They also don't prompt when the submit button is clicked.

As mentioned above, the prompt isn't shown if only relationships are changed.