### PR TITLE
Normalize plural form and capitalization of Various Artists

### DIFF
--- a/root/artist/ArtistIndex.js
+++ b/root/artist/ArtistIndex.js
@@ -103,14 +103,14 @@ const FooterSwitch = ({
     if (showVA) {
       links.push(
         <a href={`${artistLink}?va=1`} key="show-va">
-          {l('Show official various artist release groups')}
+          {l('Show official various artists release groups')}
         </a>,
       );
     }
     if (showAllVA) {
       links.push(
         <a href={`${artistLink}?all=1&va=1`} key="show-all-va">
-          {l('Show all various artist release groups')}
+          {l('Show all various artists release groups')}
         </a>,
       );
     }

--- a/root/artist/ArtistIndex.js
+++ b/root/artist/ArtistIndex.js
@@ -103,14 +103,14 @@ const FooterSwitch = ({
     if (showVA) {
       links.push(
         <a href={`${artistLink}?va=1`} key="show-va">
-          {l('Show official various artists release groups')}
+          {l('Show official Various Artists release groups')}
         </a>,
       );
     }
     if (showAllVA) {
       links.push(
         <a href={`${artistLink}?all=1&va=1`} key="show-all-va">
-          {l('Show all various artists release groups')}
+          {l('Show all Various Artists release groups')}
         </a>,
       );
     }
@@ -140,13 +140,13 @@ const FooterSwitch = ({
         {(!hasDefault && !hasExtra && !hasVariousArtists) ? (
           <p>
             {l(`This artist only has unofficial release groups by
-                various artists.`)}
+                Various Artists.`)}
           </p>
         ) : null}
         <p>
           {(hasVariousArtists || hasVariousArtistsExtra)
-            ? l('Showing all release groups for various artists')
-            : l(`This artist does not have any various artists
+            ? l('Showing all release groups for Various Artists')
+            : l(`This artist does not have any Various Artists
                  release groups`)}
           {buildLinks(hasDefault, hasExtra, hasVariousArtists, false)}
         </p>
@@ -155,11 +155,11 @@ const FooterSwitch = ({
       <>
         {(!hasDefault && !hasExtra) ? (
           <p>
-            {l('This artist only has release groups by various artists.')}
+            {l('This artist only has release groups by Various Artists.')}
           </p>
         ) : null}
         <p>
-          {l('Showing official release groups for various artists')}
+          {l('Showing official release groups for Various Artists')}
           {buildLinks(hasDefault, hasExtra, false, hasVariousArtistsExtra)}
         </p>
       </>

--- a/root/artist/ArtistReleases.js
+++ b/root/artist/ArtistReleases.js
@@ -77,7 +77,7 @@ const ArtistReleases = ({
 
       {wantVariousArtistsOnly ? (
         exp.l(
-          `Showing Various Artist releases.
+          `Showing Various Artists releases.
            {show_subset|Show releases by this artist instead}.`,
           {show_subset: `/artist/${artist.gid}/releases?va=0`},
         )
@@ -96,7 +96,7 @@ const ArtistReleases = ({
       ) : (
         exp.l(
           `Showing releases by this artist.
-           {show_all|Show Various Artist releases instead}.`,
+           {show_all|Show Various Artists releases instead}.`,
           {show_all: `/artist/${artist.gid}/releases?va=1`},
         )
       )}

--- a/root/artist/ArtistReleases.js
+++ b/root/artist/ArtistReleases.js
@@ -88,9 +88,9 @@ const ArtistReleases = ({
          */
         <p>
           {hasFilter ? (
-            l('This search only found releases by various artists.')
+            l('This search only found releases by Various Artists.')
           ) : (
-            l('This artist only has releases by various artists.')
+            l('This artist only has releases by Various Artists.')
           )}
         </p>
       ) : (

--- a/root/statistics/Index.js
+++ b/root/statistics/Index.js
@@ -382,7 +382,7 @@ const Index = ({
           </tr>
           <tr>
             <th />
-            <th colSpan="2">{l('by various artists:')}</th>
+            <th colSpan="2">{l('by Various Artists:')}</th>
             <td>{fc('release.various')}</td>
             <td>{fp('release.various', 'release')}</td>
           </tr>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

The special-purpose artist entity “[Various Artists](https://musicbrainz.org/artist/89ad4ac3-39f7-470e-963a-56509c546377)” is sometimes written in its singular form or in lowercase. Inconsistently using different forms isn’t always clear that it specifically refers to this SPA entity. It also makes translation slightly more complex. (Noticed while reviewing the translation glossary.)

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Use the most common form “Various Artists” all the time.

# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Normalize the two occurrences of “various artists” in the description of the release group secondary type “compilation”.