### PR TITLE
Normalize "pending edits" to "open edits" in UI

### DIFF
--- a/root/static/scripts/common/components/ArtistCreditLink.js
+++ b/root/static/scripts/common/components/ArtistCreditLink.js
@@ -46,12 +46,12 @@ export const MpIcon = (hydrate<MpIconProps>('span.ac-mp', (
   return (
     <Tooltip
       content={exp.l(
-        'This artist credit has {edit_search|pending edits}.',
+        'This artist credit has {edit_search|open edits}.',
         {edit_search: editSearch},
       )}
       target={
         <img
-          alt={l('This artist credit has pending edits.')}
+          alt={l('This artist credit has open edits.')}
           className="info"
           src={informationIconUrl}
         />

--- a/root/static/scripts/edit/components/EntityPendingEditsWarning.js
+++ b/root/static/scripts/edit/components/EntityPendingEditsWarning.js
@@ -30,12 +30,12 @@ const EntityPendingEditsWarning = ({
       {' '}
       <Tooltip
         content={exp.l(
-          'This entity has {edits_link|pending edits}.',
+          'This entity has {edits_link|open edits}.',
           {edits_link: openEditsLink},
         )}
         target={
           <img
-            alt={l('This entity has pending edits.')}
+            alt={l('This entity has open edits.')}
             className="info"
             height={16}
             src={openEditsForEntityIconUrl}

--- a/root/static/scripts/edit/components/RelationshipPendingEditsWarning.js
+++ b/root/static/scripts/edit/components/RelationshipPendingEditsWarning.js
@@ -37,12 +37,12 @@ const RelationshipPendingEditsWarning = ({
       {' '}
       <Tooltip
         content={exp.l(
-          'This relationship has {edit_search|pending edits}.',
+          'This relationship has {edit_search|open edits}.',
           {edit_search: openEditsLink},
         )}
         target={
           <img
-            alt={l('This relationship has pending edits.')}
+            alt={l('This relationship has open edits.')}
             className="info"
             height={16}
             src={openEditsForRelIconUrl}

--- a/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
@@ -899,7 +899,7 @@ const RelationshipDialogContent = (React.memo<PropsT>((
       {openEditsLink == null ? null : (
         <p className="msg warning">
           {exp.l(
-            `Warning: This relationship has pending edits. {show|Click here}
+            `Warning: This relationship has open edits. {show|Click here}
              to view these edits and make sure they do not conflict with
              your own.`,
             {


### PR DESCRIPTION
# Description
"pending edits" are, in the way we are using the term, exactly the same as "open edits". As such, this normalizes the user-facing strings so that we always use "open edits" when we mean that.

We could arguably use "pending edits" for edits that still have not been entered, like the ones that will be created by an open release editor or relationship editor session.
That would seem like a much better use of the term, but sadly might require a huge refactoring since we use "edits_pending" in our schema for open edits.

# Testing
None, but this changes strings only. I made sure this should be all of the translatable "pending" strings with a Weblate search.