### PR TITLE
Normalize "track duration" to "track length" in UI

### DIFF
--- a/admin/cleanup/FixTrackLength.pl
+++ b/admin/cleanup/FixTrackLength.pl
@@ -136,7 +136,7 @@ for my $medium (@mediums)
             if ($bad == 0) {
                 # All track lengths are wrong, so we change them with a
                 # SetTrackLengths edit
-                log_info { sprintf 'Set track durations from CDTOC #%d for medium #%d',
+                log_info { sprintf 'Set track lengths from CDTOC #%d for medium #%d',
                     $cdtoc->id, $medium->id
                 } if $verbose;
 

--- a/root/cdtoc/AttachCDTocConfirmation.js
+++ b/root/cdtoc/AttachCDTocConfirmation.js
@@ -77,7 +77,7 @@ const AttachCDTocConfirmation = ({
         </tbody>
       </table>
 
-      <h2>{l('Track duration comparison')}</h2>
+      <h2>{l('Track length comparison')}</h2>
 
       {areFormattedLengthsEqual ? (
         <p>

--- a/root/cdtoc/list.tt
+++ b/root/cdtoc/list.tt
@@ -51,7 +51,7 @@
             [%- IF !medium_cdtoc.is_perfect_match %]
               <a href="[% c.uri_for_action('/cdtoc/set_durations',
                               [ cdtoc.discid ], { medium => medium.id }) %]">
-                [% l('Set track durations') %]
+                [% l('Set track lengths') %]
               </a> |
             [%- END %]
               <a href="[% c.uri_for_action('cdtoc/remove',

--- a/root/release/discids.tt
+++ b/root/release/discids.tt
@@ -33,7 +33,7 @@
                       [%- IF !medium_cdtoc.is_perfect_match %]
                         <a href="[% c.uri_for_action('/cdtoc/set_durations',
                                         [ medium_cdtoc.cdtoc.discid ], { medium => medium.id }) %]">
-                          [% l('Set track durations') %]
+                          [% l('Set track lengths') %]
                         </a> |
                       [%- END %]
                       <a href="[% c.uri_for_action('cdtoc/remove',

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -9,7 +9,7 @@
       <li>2. P.S. I Love You - The Beatles (2:03)</li>
     </ul>
     <p>
-      [% l('You can use the checkboxes under the parser to deactivate some sections. For example, you can deactivate “{lines_have_artists}” if your data has no track artists, or “{use_track_lengths}” if you have track durations but want the parser to ignore them.', {lines_have_artists => l('Lines contain track artists'), use_track_lengths => l('Use track lengths')}) %]
+      [% l('You can use the checkboxes under the parser to deactivate some sections. For example, you can deactivate “{lines_have_artists}” if your data has no track artists, or “{use_track_lengths}” if you have track lengths but want the parser to ignore them.', {lines_have_artists => l('Lines contain track artists'), use_track_lengths => l('Use track lengths')}) %]
     </p>
     <p>
       [% l('If you select “{enable_vinyl_numbers}”, the parser will also accept strings such as “A1” as track numbers.', {enable_vinyl_numbers => l('Enable vinyl track numbers')}) %]

--- a/root/report/CDTocNotApplied.js
+++ b/root/report/CDTocNotApplied.js
@@ -22,10 +22,10 @@ const CDTocNotApplied = ({
     canBeFiltered={canBeFiltered}
     description={l(
       `This report shows disc IDs attached to a release but obviously not
-       applied because at least one track duration is unknown on the release.
+       applied because at least one track length is unknown on the release.
        The report is also restricted to mediums where only one disc ID is
        attached, so it is highly likely that the disc ID can be applied
-       without any worries. Do make sure though that no existing durations
+       without any worries. Do make sure though that no existing lengths
        clash with the disc ID, or that any clashes are clear mistakes.`,
     )}
     entityType="discId"

--- a/root/static/scripts/tests/release-editor/trackParser.js
+++ b/root/static/scripts/tests/release-editor/trackParser.js
@@ -64,7 +64,7 @@ parserTest('track numbers', function (t) {
 });
 
 parserTest((
-  'parsing track durations with trailing whitespace (MBS-1284)'
+  'parsing track lengths with trailing whitespace (MBS-1284)'
 ), function (t) {
   t.plan(1);
 

--- a/t/lib/t/MusicBrainz/Server/Edit/Medium/Delete.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Medium/Delete.pm
@@ -96,7 +96,7 @@ test 'Warning is shown if data has changed (MBS-11558)' => sub {
 
     $mech->get_ok(
         '/edit/' . $edit->id,
-        'Fetched the edit page after adding track duration',
+        'Fetched the edit page after adding track length',
     );
     $mech->text_contains('Warning:', 'Warning is present');
     $mech->text_contains('Original tracklist:', 'Old tracklist shown');


### PR DESCRIPTION
# Description

There seems to be no difference between "duration" and "length" for track times. As such, this normalizes the user-facing strings so that we always use "track lengths"; it should be more clear and easier to translate.

# Testing
None, but this changes strings only. I made sure this should be all of the translatable "track duration" strings with a Weblate search.