### PR TITLE
Capitalize URL in user-facing string

### DIFF
--- a/lib/MusicBrainz/Server/Form/Field/URL.pm
+++ b/lib/MusicBrainz/Server/Form/Field/URL.pm
@@ -23,7 +23,7 @@ sub validate
     my $url = $self->value;
     $url = URI->new($url)->canonical;
 
-    return $self->add_error(l('Enter a valid url e.g. "http://google.com/"'))
+    return $self->add_error(l('Enter a valid URL e.g. "http://google.com/"'))
         unless is_valid_url($url->as_string);
 
     return $self->add_error(l('URL protocol must be HTTP, HTTPS or FTP'))


### PR DESCRIPTION
# Description

We correctly use `URL` in all user-facing strings except this one, which uses `url`. Standardizing it.