### PR TITLE
Upgrade Flow to 0.219.2 and make a few small type improvements

### DIFF
--- a/entities.mjs
+++ b/entities.mjs
@@ -21,10 +21,6 @@ type AutomaticRemovalPropsT = {
   ...
 };
 
-type $MakeReadOnly =
-  & (<T: {...}>(T) => $ReadOnly<$ObjMap<T, $MakeReadOnly>>)
-  & (<T: mixed>(T) => T);
-
 const ENTITIES = {
   annotation: {
     model: 'Annotation',
@@ -895,4 +891,4 @@ const ENTITIES = {
 
 deepFreeze(ENTITIES);
 
-export default (ENTITIES: $Call<$MakeReadOnly, typeof ENTITIES>);
+export default (ENTITIES: DeepReadOnly<typeof ENTITIES>);

--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -109,11 +109,14 @@ sub show : PathPart('') Chained('load') {
     }
 
     my %props = (
-        entities          => to_json_array(\@entities),
+        listProps  => {
+            entities => to_json_array(\@entities),
+            seriesEntityType => $series->type->item_entity_type,
+            seriesItemNumbers => \@item_numbers,
+        },
         numberOfRevisions => $c->stash->{number_of_revisions},
         pager             => serialize_pager($c->stash->{pager}),
         series            => $series->TO_JSON,
-        seriesItemNumbers => \@item_numbers,
         wikipediaExtract  => to_json_object($c->stash->{wikipedia_extract}),
     );
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.33.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.219.2",
+    "flow-bin": "0.219.3",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.16.0",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.33.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.217.0",
+    "flow-bin": "0.217.1",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.16.0",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.33.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.219.0",
+    "flow-bin": "0.219.2",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.16.0",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.33.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.216.1",
+    "flow-bin": "0.217.0",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.16.0",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.33.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.217.1",
+    "flow-bin": "0.217.2",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.16.0",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.33.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.218.0",
+    "flow-bin": "0.218.1",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.16.0",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.33.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.217.2",
+    "flow-bin": "0.218.0",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.16.0",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.33.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.218.1",
+    "flow-bin": "0.219.0",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.16.0",
     "http-proxy": "1.18.1",

--- a/root/edit/components/EditNote.js
+++ b/root/edit/components/EditNote.js
@@ -87,7 +87,7 @@ const EditNote = ({
   const changeReason = editNote.latest_change?.reason;
   const changeTime = editNote.latest_change?.change_time
     ? formatUserDate($c, editNote.latest_change.change_time)
-    : null;
+    : '';
 
   /*
    * We only want to show the controls for modifying/removing a note
@@ -212,14 +212,12 @@ const EditNote = ({
                      Reason given: “{reason}”.`,
                     {
                       reason: changeReason,
-                      // $FlowIgnore[incompatible-call]
                       time: changeTime,
                     },
                   )
                 ) : (
                   texp.l(
                     'Last modified by the note author ({time}).',
-                    // $FlowIgnore[incompatible-call]
                     {time: changeTime},
                   )
                 )
@@ -230,14 +228,12 @@ const EditNote = ({
                      Reason given: “{reason}”.`,
                     {
                       reason: changeReason,
-                      // $FlowIgnore[incompatible-call]
                       time: changeTime,
                     },
                   )
                 ) : (
                   texp.l(
                     'Last modified by an admin ({time}).',
-                    // $FlowIgnore[incompatible-call]
                     {time: changeTime},
                   )
                 )

--- a/root/release/ChangeQuality.js
+++ b/root/release/ChangeQuality.js
@@ -13,6 +13,7 @@ import EnterEditNote
   from '../static/scripts/edit/components/EnterEditNote.js';
 import FormRowSelect
   from '../static/scripts/edit/components/FormRowSelect.js';
+import {expect} from '../utility/invariant.js';
 
 import ReleaseLayout from './ReleaseLayout.js';
 
@@ -37,9 +38,9 @@ const ChangeQuality = ({
   const qualityOptions = {
     grouped: false,
     options: [
-      {label: QUALITY_NAMES.get(0), value: 0},
-      {label: QUALITY_NAMES.get(1), value: 1},
-      {label: QUALITY_NAMES.get(2), value: 2},
+      {label: expect(QUALITY_NAMES.get(0)), value: 0},
+      {label: expect(QUALITY_NAMES.get(1)), value: 1},
+      {label: expect(QUALITY_NAMES.get(2)), value: 2},
     ],
   };
 
@@ -64,7 +65,6 @@ const ChangeQuality = ({
         <FormRowSelect
           field={form.field.quality}
           label={addColonText(l('Data Quality'))}
-          // $FlowIgnore[incompatible-type] we know these .get return a string
           options={qualityOptions}
           uncontrolled
         />

--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -167,7 +167,7 @@ type InitialStateT<T: EntityItemT> = {
 
 const EMPTY_ITEMS: $ReadOnlyArray<ItemT<empty>> = Object.freeze([]);
 
-export function createInitialState<+T: EntityItemT>(
+export function createInitialState<T: EntityItemT>(
   initialState: InitialStateT<T>,
 ): {...StateT<T>} {
   const {
@@ -238,7 +238,7 @@ type AutocompleteItemPropsT<T: EntityItemT> = {
   selectItem: (ItemT<T>) => boolean,
 };
 
-const AutocompleteItem = React.memo(<+T: EntityItemT>({
+const AutocompleteItem = React.memo(<T: EntityItemT>({
   autocompleteId,
   dispatch,
   formatOptions,
@@ -308,7 +308,7 @@ const AutocompleteItem = React.memo(<+T: EntityItemT>({
   );
 });
 
-const Autocomplete2 = (React.memo(<+T: EntityItemT>(
+const Autocomplete2 = (React.memo(<T: EntityItemT>(
   props: PropsT<T>,
 ): React$Element<'div'> => {
   const {dispatch, state} = props;

--- a/root/static/scripts/common/components/Autocomplete2/formatters.js
+++ b/root/static/scripts/common/components/Autocomplete2/formatters.js
@@ -65,7 +65,7 @@ function showExtraInfoLine(
   );
 }
 
-function formatName<+T: EntityItemT>(entity: T): string {
+function formatName<T: EntityItemT>(entity: T): string {
   return unwrapNl<string>(entity.name);
 }
 
@@ -560,7 +560,7 @@ export type FormatOptionsT = {
   +showDescriptions?: boolean,
 };
 
-export default function formatItem<+T: EntityItemT>(
+export default function formatItem<T: EntityItemT>(
   item: ItemT<T>,
   options?: ?FormatOptionsT,
 ): Expand2ReactOutput {

--- a/root/static/scripts/common/components/Autocomplete2/recentItems.js
+++ b/root/static/scripts/common/components/Autocomplete2/recentItems.js
@@ -33,7 +33,7 @@ import type {
  */
 type RecentEntitiesT = {[entityTypeKey: string]: mixed};
 
-type WsJsEntitiesDataT<+T: EntityItemT> = {
+type WsJsEntitiesDataT<T: EntityItemT> = {
   +results: {+[id: string]: ?T},
 };
 
@@ -156,7 +156,7 @@ export function clearRecentItems(
 const _recentItemsCache =
   new Map<string, $ReadOnlyArray<OptionItemT<EntityItemT>>>();
 
-export function getRecentItems<+T: EntityItemT>(
+export function getRecentItems<T: EntityItemT>(
   key: string,
 ): $ReadOnlyArray<OptionItemT<T>> {
   // $FlowIgnore[incompatible-return]
@@ -180,7 +180,7 @@ function getEntityName(
   }
 }
 
-export async function getOrFetchRecentItems<+T: EntityItemT>(
+export async function getOrFetchRecentItems<T: EntityItemT>(
   entityType: string,
   key?: string = entityType,
 ): Promise<$ReadOnlyArray<OptionItemT<T>>> {
@@ -253,7 +253,7 @@ export async function getOrFetchRecentItems<+T: EntityItemT>(
   return Promise.resolve(cachedList);
 }
 
-export function pushRecentItem<+T: EntityItemT>(
+export function pushRecentItem<T: EntityItemT>(
   item: OptionItemT<T>,
   key?: string = item.entity.entityType,
 ): $ReadOnlyArray<OptionItemT<T>> {

--- a/root/static/scripts/common/components/Autocomplete2/reducer.js
+++ b/root/static/scripts/common/components/Autocomplete2/reducer.js
@@ -45,7 +45,7 @@ import type {
   StateT,
 } from './types.js';
 
-function initSearch<+T: EntityItemT>(
+function initSearch<T: EntityItemT>(
   state: {...StateT<T>},
   action: SearchActionT,
 ) {
@@ -69,7 +69,7 @@ function initSearch<+T: EntityItemT>(
   }
 }
 
-export function generateItems<+T: EntityItemT>(
+export function generateItems<T: EntityItemT>(
   state: StateT<T>,
 ): $ReadOnlyArray<ItemT<T>> {
   const items: Array<ItemT<T>> = [];
@@ -188,7 +188,7 @@ export function generateItems<+T: EntityItemT>(
   return items;
 }
 
-export function determineIfUserCanAddEntities<+T: EntityItemT>(
+export function determineIfUserCanAddEntities<T: EntityItemT>(
   state: StateT<T>,
 ): boolean {
   const user = getCatalystContext().user;
@@ -212,7 +212,7 @@ export function determineIfUserCanAddEntities<+T: EntityItemT>(
   }
 }
 
-function getFirstHighlightableIndex<+T: EntityItemT>(
+function getFirstHighlightableIndex<T: EntityItemT>(
   state: StateT<T>,
 ): number {
   const items = state.items;
@@ -227,7 +227,7 @@ function getFirstHighlightableIndex<+T: EntityItemT>(
   return -1;
 }
 
-export function generateStatusMessage<+T: EntityItemT>(
+export function generateStatusMessage<T: EntityItemT>(
   state: StateT<T>,
 ): string {
   if (state.isOpen) {
@@ -270,7 +270,7 @@ export function generateStatusMessage<+T: EntityItemT>(
   return '';
 }
 
-export function filterStaticItems<+T: EntityItemT>(
+export function filterStaticItems<T: EntityItemT>(
   state: {...StateT<T>},
   newInputValue: string,
 ): void {
@@ -279,7 +279,7 @@ export function filterStaticItems<+T: EntityItemT>(
   state.results = searchItems(staticItems, newInputValue);
 }
 
-export function resetPage<+T: EntityItemT>(
+export function resetPage<T: EntityItemT>(
   state: {...StateT<T>},
 ): void {
   state.highlightedIndex = -1;
@@ -289,7 +289,7 @@ export function resetPage<+T: EntityItemT>(
   state.error = 0;
 }
 
-function selectItem<+T: EntityItemT>(
+function selectItem<T: EntityItemT>(
   state: {...StateT<T>},
   item: ItemT<T>,
 ) {
@@ -327,7 +327,7 @@ function selectItem<+T: EntityItemT>(
   state.pendingSearch = null;
 }
 
-function setError<+T: EntityItemT>(
+function setError<T: EntityItemT>(
   state: {...StateT<T>},
   error: number,
 ) {
@@ -335,7 +335,7 @@ function setError<+T: EntityItemT>(
   state.isOpen = true;
 }
 
-function highlightNextItem<+T: EntityItemT>(
+function highlightNextItem<T: EntityItemT>(
   state: {...StateT<T>},
   startingIndex: number,
   offset: number,
@@ -365,7 +365,7 @@ function highlightNextItem<+T: EntityItemT>(
 }
 
 // `runReducer` should only be run on a copy of the existing state.
-export function runReducer<+T: EntityItemT>(
+export function runReducer<T: EntityItemT>(
   state: {...StateT<T>},
   action: ActionT<T>,
 ): void {
@@ -625,7 +625,7 @@ export function runReducer<+T: EntityItemT>(
   }
 }
 
-export default function reducer<+T: EntityItemT>(
+export default function reducer<T: EntityItemT>(
   state: StateT<T>,
   action: ActionT<T>,
 ): StateT<T> {

--- a/root/static/scripts/common/components/Autocomplete2/searchItems.js
+++ b/root/static/scripts/common/components/Autocomplete2/searchItems.js
@@ -62,16 +62,16 @@ function* getNGrams(
   }
 }
 
-export function getItemName<+T: EntityItemT>(
+export function getItemName<T: EntityItemT>(
   item: OptionItemT<T>,
 ): Array<string> {
   return [unwrapNl<string>(item.name)];
 }
 
 const createItemSet =
-  <+T: EntityItemT>(): Set<OptionItemT<T>> => new Set();
+  <T: EntityItemT>(): Set<OptionItemT<T>> => new Set();
 
-export function indexItems<+T: EntityItemT>(
+export function indexItems<T: EntityItemT>(
   items: $ReadOnlyArray<ItemT<T>>,
   extractSearchTerms: (OptionItemT<T>) => Array<string>,
 ): void {
@@ -99,7 +99,7 @@ export function indexItems<+T: EntityItemT>(
   itemIndexes.set(items, index);
 }
 
-function getItem<+T: EntityItemT>(
+function getItem<T: EntityItemT>(
   itemAndRank: [OptionItemT<T>, number],
 ): OptionItemT<T> {
   const itemCopy = {...itemAndRank[0]};
@@ -112,14 +112,14 @@ function getItem<+T: EntityItemT>(
   return itemCopy;
 }
 
-function compareItemRanks<+T: EntityItemT>(
+function compareItemRanks<T: EntityItemT>(
   a: [OptionItemT<T>, number],
   b: [OptionItemT<T>, number],
 ): number {
   return b[1] - a[1];
 }
 
-function weightEntry<+T: EntityItemT>(
+function weightEntry<T: EntityItemT>(
   itemAndRank: [OptionItemT<T>, number],
   searchTerm: string,
 ): number {
@@ -146,7 +146,7 @@ function weightEntry<+T: EntityItemT>(
   return rank;
 }
 
-export default function searchItems<+T: EntityItemT>(
+export default function searchItems<T: EntityItemT>(
   items: $ReadOnlyArray<OptionItemT<T>>,
   searchTerm: string,
 ): $ReadOnlyArray<OptionItemT<T>> {

--- a/root/static/scripts/common/i18n/expand2.js
+++ b/root/static/scripts/common/i18n/expand2.js
@@ -34,14 +34,14 @@ export interface VarArgsClass<+T> {
   has(name: string): boolean,
 }
 
-export class VarArgs<+T, +U = T> implements VarArgsClass<T | U> {
+export class VarArgs<+T> implements VarArgsClass<T> {
   +data: VarArgsObject<T>;
 
   constructor(data: VarArgsObject<T>) {
     this.data = data;
   }
 
-  get(name: string): T | U {
+  get(name: string): T {
     return this.data[name];
   }
 
@@ -53,7 +53,6 @@ export class VarArgs<+T, +U = T> implements VarArgsClass<T | U> {
 export type Parser<+T, -V> = (VarArgsClass<V>) => T;
 
 const EMPTY_OBJECT = Object.freeze({});
-const EMPTY_VARARGS = new VarArgs<empty, empty>(EMPTY_OBJECT);
 
 type State = {
   /*
@@ -187,7 +186,7 @@ export function parseContinuousString<V>(
   );
 }
 
-export const createTextContentParser = <+T, V>(
+export const createTextContentParser = <T, V>(
   textPattern: RegExp,
   mapValue: (string) => T,
 ): Parser<T | string | NO_MATCH, V> => () => {
@@ -276,7 +275,7 @@ export const createCondSubstParser = <T, V>(
  * Thus these signatures provide type safety on both the return value
  * and input arg values.
  */
-export default function expand<+T, V>(
+export default function expand<T, V>(
   rootParser: (VarArgsClass<V>) => T,
   source: ?string,
   args: ?VarArgsClass<V>,
@@ -300,7 +299,7 @@ export default function expand<+T, V>(
 
   let result;
   try {
-    result = rootParser(args ?? EMPTY_VARARGS);
+    result = rootParser(args ?? (new VarArgs(EMPTY_OBJECT)));
 
     if (state.remainder) {
       throw error('unexpected token');

--- a/root/static/scripts/common/i18n/expand2.js
+++ b/root/static/scripts/common/i18n/expand2.js
@@ -167,11 +167,11 @@ export function parseContinuous<T, U, V>(
 
 function concatStringMatch(
   accum: string | NO_MATCH,
-  match: string | NO_MATCH,
+  match: string,
 ): string {
   return (
     (gotMatch(accum) ? accum : '') +
-    (gotMatch(match) ? match : '')
+    match
   );
 }
 

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -131,7 +131,7 @@ const parseLinkSubst: Parser<
     if (typeof props === 'string') {
       props = ({href: props}: AnchorProps);
     }
-    if (!props || typeof props === 'number' || empty(props.href)) {
+    if (props == null || typeof props !== 'object' || empty(props.href)) {
       throw error('bad link props');
     }
     return React.createElement('a', props, ...children);

--- a/root/static/scripts/common/utility/buildOptionList.js
+++ b/root/static/scripts/common/utility/buildOptionList.js
@@ -15,7 +15,7 @@ import {groupBy} from './arrays.js';
  * Unlike MB.forms.buildOptionsTree, this builds from a flat list.
  * TODO: These should probably be combined at some point?
  */
-export default function buildOptionList<+T>(
+export default function buildOptionList<T>(
   options: $ReadOnlyArray<OptionTreeT<T>>,
   localizeName: (string) => string,
 ): OptionListT {

--- a/root/static/scripts/common/utility/cloneDeep.mjs
+++ b/root/static/scripts/common/utility/cloneDeep.mjs
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-function _cloneDeep<+T>(
+function _cloneDeep<T>(
   value: T,
   seen: WeakMap<any, any>,
 ): any {
@@ -24,7 +24,7 @@ function _cloneDeep<+T>(
   return value;
 }
 
-function _cloneArrayDeep<+T>(
+function _cloneArrayDeep<T>(
   array: $ReadOnlyArray<T>,
   seen: WeakMap<any, any>,
 ): $ReadOnlyArray<T> {
@@ -37,7 +37,7 @@ function _cloneArrayDeep<+T>(
   return clone;
 }
 
-export function cloneArrayDeep<+T>(
+export function cloneArrayDeep<T>(
   array: $ReadOnlyArray<T>,
 ): $ReadOnlyArray<T> {
   return _cloneArrayDeep<T>(array, new WeakMap());
@@ -50,7 +50,7 @@ export function cloneArrayDeep<+T>(
 // $FlowIgnore[method-unbinding]
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
-function _cloneObjectDeep<+T: {...}>(
+function _cloneObjectDeep<T: {...}>(
   object: T,
   seen: WeakMap<any, any>,
 ): T {
@@ -64,7 +64,7 @@ function _cloneObjectDeep<+T: {...}>(
   return clone;
 }
 
-export function cloneObjectDeep<+T: {...}>(
+export function cloneObjectDeep<T: {...}>(
   object: T,
 ): T {
   return _cloneObjectDeep<T>(object, new WeakMap());

--- a/root/static/scripts/common/utility/formatDatePeriod.js
+++ b/root/static/scripts/common/utility/formatDatePeriod.js
@@ -12,7 +12,7 @@ import ko from 'knockout';
 import formatDate from './formatDate.js';
 
 function formatDatePeriod<
-  +T: $ReadOnly<{...DatePeriodRoleT, ...}>,
+  T: $ReadOnly<{...DatePeriodRoleT, ...}>,
 >(entity: T): string {
   const beginDate = formatDate(entity.begin_date);
   const endDate = formatDate(entity.end_date);

--- a/root/static/scripts/common/utility/formatEndDate.js
+++ b/root/static/scripts/common/utility/formatEndDate.js
@@ -9,7 +9,7 @@
 
 import formatDate from './formatDate.js';
 
-export default function formatEndDate<+T: $ReadOnly<{
+export default function formatEndDate<T: $ReadOnly<{
   ...DatePeriodRoleT,
   ...
 }>>(entity: T): null | string {

--- a/root/static/scripts/common/utility/memoize.js
+++ b/root/static/scripts/common/utility/memoize.js
@@ -21,7 +21,7 @@ type ObjectType = interface {} | $ReadOnlyArray<mixed>;
 const createWeakMap =
   <K: ObjectType, V>(): WeakMap<K, V> => new WeakMap<K, V>();
 
-function memoizeGeneric<-T, +U>(
+function memoizeGeneric<T, U>(
   func: (T) => U,
   createCache: () => MapInterface<T, U>,
 ): (T) => U {
@@ -37,13 +37,13 @@ function memoizeGeneric<-T, +U>(
   };
 }
 
-export default function memoize<-T: interface {}, +U>(
+export default function memoize<T: interface {}, U>(
   func: (T) => U,
 ): (T) => U {
   return memoizeGeneric(func, createWeakMap);
 }
 
-export function memoizeWithDefault<-T: interface {}, +U>(
+export function memoizeWithDefault<T: interface {}, U>(
   func: (T) => U,
   defaultValue: U,
 ): (?T) => U {

--- a/root/static/scripts/common/utility/pThrottle.js
+++ b/root/static/scripts/common/utility/pThrottle.js
@@ -50,8 +50,8 @@ export type ThrottleResultT<+R: mixed> = {
 };
 
 const pThrottle = <
-  -A: $ReadOnlyArray<mixed>,
-  +R: mixed,
+  A: $ReadOnlyArray<mixed>,
+  R: mixed,
 >({
   interval,
   limit,

--- a/root/static/scripts/common/utility/relationshipDateText.js
+++ b/root/static/scripts/common/utility/relationshipDateText.js
@@ -16,25 +16,26 @@ export default function relationshipDateText(
   r: $ReadOnly<{...DatePeriodRoleT, ...}>,
   bracketEnded?: boolean = true,
 ): string {
-  if (!isDateEmpty(r.begin_date)) {
-    if (!isDateEmpty(r.end_date)) {
-      if (areDatesEqual(r.begin_date, r.end_date)) {
-        // $FlowIssue[incompatible-use]
-        if (r.begin_date.day != null) {
-          return texp.l('on {date}', {date: formatDate(r.begin_date)});
+  const beginDate = r.begin_date;
+  const endDate = r.end_date;
+  if (!isDateEmpty(beginDate)) {
+    if (!isDateEmpty(endDate)) {
+      if (areDatesEqual(beginDate, endDate)) {
+        if (beginDate.day != null) {
+          return texp.l('on {date}', {date: formatDate(beginDate)});
         }
-        return texp.l('in {date}', {date: formatDate(r.begin_date)});
+        return texp.l('in {date}', {date: formatDate(beginDate)});
       }
       return texp.l('from {begin_date} until {end_date}', {
-        begin_date: formatDate(r.begin_date),
-        end_date: formatDate(r.end_date),
+        begin_date: formatDate(beginDate),
+        end_date: formatDate(endDate),
       });
     } else if (r.ended) {
-      return texp.l('from {date} to ????', {date: formatDate(r.begin_date)});
+      return texp.l('from {date} to ????', {date: formatDate(beginDate)});
     }
-    return texp.l('from {date} to present', {date: formatDate(r.begin_date)});
-  } else if (!isDateEmpty(r.end_date)) {
-    return texp.l('until {date}', {date: formatDate(r.end_date)});
+    return texp.l('from {date} to present', {date: formatDate(beginDate)});
+  } else if (!isDateEmpty(endDate)) {
+    return texp.l('until {date}', {date: formatDate(endDate)});
   } else if (r.ended) {
     let text = l('ended');
     if (bracketEnded) {

--- a/root/static/scripts/edit/components/FormRowCheckbox.js
+++ b/root/static/scripts/edit/components/FormRowCheckbox.js
@@ -27,6 +27,7 @@ type Props =
     }>
   | $ReadOnly<{
       ...CommonProps,
+      onChange?: void,
       uncontrolled: true,
     }>;
 
@@ -37,7 +38,6 @@ const FormRowCheckbox = ({
   hasNoMargin = false,
   help,
   label,
-  // $FlowIssue[prop-missing]
   onChange,
   uncontrolled,
 }: Props): React$Element<typeof FormRow> => {

--- a/root/static/scripts/edit/components/edit/RelationshipDiff.js
+++ b/root/static/scripts/edit/components/edit/RelationshipDiff.js
@@ -72,6 +72,7 @@ const RelationshipDiff = (React.memo(({
 
   const i18nConfig: LinkPhraseI18n<Expand2ReactOutput> = {
     commaList,
+    defaultValue: '',
     displayLinkAttribute: function (attr: LinkAttrT) {
       const typeId = String(attr.typeID);
       const display = displayLinkAttribute(attr);

--- a/root/static/scripts/edit/components/withLoadedTypeInfo.js
+++ b/root/static/scripts/edit/components/withLoadedTypeInfo.js
@@ -20,14 +20,14 @@ import {
 const typeInfoPromises = new Map<string, Promise<void>>();
 const loadedTypeInfo = new Set<string>();
 
-export default function withLoadedTypeInfo<-Config, +Instance = mixed>(
+export default function withLoadedTypeInfo<Config, Instance = mixed>(
   WrappedComponent: React$AbstractComponent<Config, Instance>,
   typeInfoToLoad: $ReadOnlySet<string>,
 ): React$AbstractComponent<Config, Instance> {
   const ComponentWrapper = React.forwardRef((
     props: Config,
     ref:
-      | {current: Instance | null, ...}
+      | {-current: Instance | null, ...}
       | ((Instance | null) => mixed),
   ) => {
     const [isLoading, setLoading] = React.useState<boolean>(true);
@@ -154,8 +154,8 @@ export default function withLoadedTypeInfo<-Config, +Instance = mixed>(
 }
 
 export function withLoadedTypeInfoForRelationshipEditor<
-  -Config,
-  +Instance = mixed,
+  Config,
+  Instance = mixed,
 >(
   WrappedComponent: React$AbstractComponent<Config, Instance>,
   extraTypeInfoToLoad?: $ReadOnlyArray<string> = [],

--- a/root/static/scripts/edit/utility/createField.js
+++ b/root/static/scripts/edit/utility/createField.js
@@ -40,7 +40,7 @@ export function createCompoundFieldFromObject<
   };
 }
 
-export function createCompoundField<+T>(
+export function createCompoundField<T>(
   name: string,
   fieldValues: T,
 ): ReadOnlyCompoundFieldT<T> {

--- a/root/static/scripts/edit/utility/editDiff.js
+++ b/root/static/scripts/edit/utility/editDiff.js
@@ -48,7 +48,7 @@ export type StringEditDiff = {
   +type: EditType,
 };
 
-function getChangeType<+T>(diff: GenericEditDiff<T>): EditType {
+function getChangeType<T>(diff: GenericEditDiff<T>): EditType {
   if (!diff.added && !diff.removed) {
     return EQUAL;
   }

--- a/root/static/scripts/edit/utility/linkPhrase.js
+++ b/root/static/scripts/edit/utility/linkPhrase.js
@@ -54,44 +54,44 @@ class PhraseVarArgs<T>
    * didn't appear in the link phrase, so that we can display them
    * separately).
    */
-   +usedPhraseAttributes: Array<string>;
+  +usedPhraseAttributes: Array<string>;
 
-   constructor(
-     args: ?VarArgsObject<LinkAttrs>,
-     i18n: LinkPhraseI18n<T>,
-     entity0: ?T,
-     entity1: ?T,
-   ) {
-     super(args || EMPTY_OBJECT);
-     this.i18n = i18n;
-     this.entity0 = nonEmpty(entity0) ? entity0 : '';
-     this.entity1 = nonEmpty(entity1) ? entity1 : '';
-     this.usedPhraseAttributes = [];
-   }
+  constructor(
+    args: ?VarArgsObject<LinkAttrs>,
+    i18n: LinkPhraseI18n<T>,
+    entity0: ?T,
+    entity1: ?T,
+  ) {
+    super(args || EMPTY_OBJECT);
+    this.i18n = i18n;
+    this.entity0 = nonEmpty(entity0) ? entity0 : '';
+    this.entity1 = nonEmpty(entity1) ? entity1 : '';
+    this.usedPhraseAttributes = [];
+  }
 
-   get(name: string): T | string {
-     if (name === 'entity0') {
-       return this.entity0;
-     }
-     if (name === 'entity1') {
-       return this.entity1;
-     }
-     const attributes = this.data[name];
-     if (attributes == null) {
-       return '';
-     }
-     if (Array.isArray(attributes)) {
-       return this.i18n.commaList(
-         attributes.map(this.i18n.displayLinkAttribute),
-       );
-     }
-     return this.i18n.displayLinkAttribute(attributes);
-   }
+  get(name: string): T | string {
+    if (name === 'entity0') {
+      return this.entity0;
+    }
+    if (name === 'entity1') {
+      return this.entity1;
+    }
+    const attributes = this.data[name];
+    if (attributes == null) {
+      return '';
+    }
+    if (Array.isArray(attributes)) {
+      return this.i18n.commaList(
+        attributes.map(this.i18n.displayLinkAttribute),
+      );
+    }
+    return this.i18n.displayLinkAttribute(attributes);
+  }
 
-   has(name: string): boolean {
-     this.usedPhraseAttributes.push(name);
-     return true;
-   }
+  has(name: string): boolean {
+    this.usedPhraseAttributes.push(name);
+    return true;
+  }
 }
 
 export type LinkPhraseI18n<T> = {

--- a/root/static/scripts/edit/utility/linkPhrase.js
+++ b/root/static/scripts/edit/utility/linkPhrase.js
@@ -11,7 +11,6 @@ import commaList, {commaListText} from '../../common/i18n/commaList.js';
 import {
   type VarArgsClass,
   type VarArgsObject,
-  VarArgs,
 } from '../../common/i18n/expand2.js';
 import {
   expand2reactWithVarArgsInstance,
@@ -39,14 +38,14 @@ export type LinkPhraseProp =
   | 'long_link_phrase'
   | 'reverse_link_phrase';
 
-class PhraseVarArgs<T>
-  extends VarArgs<LinkAttrs, T | string>
-  implements VarArgsClass<T | string> {
+class PhraseVarArgs<T> implements VarArgsClass<T> {
+  +data: VarArgsObject<LinkAttrs>;
+
   +i18n: LinkPhraseI18n<T>;
 
-  +entity0: T | string;
+  +entity0: T;
 
-  +entity1: T | string;
+  +entity1: T;
 
   /*
    * Contains attributes that appear in the text of the given link
@@ -62,14 +61,14 @@ class PhraseVarArgs<T>
     entity0: ?T,
     entity1: ?T,
   ) {
-    super(args || EMPTY_OBJECT);
+    this.data = args || EMPTY_OBJECT;
     this.i18n = i18n;
-    this.entity0 = nonEmpty(entity0) ? entity0 : '';
-    this.entity1 = nonEmpty(entity1) ? entity1 : '';
+    this.entity0 = nonEmpty(entity0) ? entity0 : i18n.defaultValue;
+    this.entity1 = nonEmpty(entity1) ? entity1 : i18n.defaultValue;
     this.usedPhraseAttributes = [];
   }
 
-  get(name: string): T | string {
+  get(name: string): T {
     if (name === 'entity0') {
       return this.entity0;
     }
@@ -78,7 +77,7 @@ class PhraseVarArgs<T>
     }
     const attributes = this.data[name];
     if (attributes == null) {
-      return '';
+      return this.i18n.defaultValue;
     }
     if (Array.isArray(attributes)) {
       return this.i18n.commaList(
@@ -96,24 +95,26 @@ class PhraseVarArgs<T>
 
 export type LinkPhraseI18n<T> = {
   commaList: ($ReadOnlyArray<T>) => T,
+  defaultValue: T,
   displayLinkAttribute: (LinkAttrT) => T,
   expand: (string, VarArgsClass<T>) => T,
 };
 
 const reactI18n: LinkPhraseI18n<Expand2ReactOutput> = {
   commaList,
+  defaultValue: '',
   displayLinkAttribute,
   expand: expand2reactWithVarArgsInstance,
 };
 
 const textI18n: LinkPhraseI18n<string> = {
   commaList: commaListText,
+  defaultValue: '',
   displayLinkAttribute: displayLinkAttributeText,
   expand: expand2textWithVarArgsClass,
 };
 
-function _getAttributesByRootName<T>(
-  i18n: LinkPhraseI18n<T | string>,
+function _getAttributesByRootName(
   linkType: LinkTypeT,
   attributes: $ReadOnlyArray<LinkAttrT>,
 ): LinkAttrsByRootName {
@@ -218,8 +219,7 @@ export function getPhraseAndExtraAttributes<T>(
     return ['', []];
   }
 
-  const attributesByRootName = _getAttributesByRootName<T | string>(
-    i18n,
+  const attributesByRootName = _getAttributesByRootName(
     linkType,
     attributes,
   );

--- a/root/static/scripts/edit/utility/reducerWithErrorHandling.js
+++ b/root/static/scripts/edit/utility/reducerWithErrorHandling.js
@@ -19,7 +19,7 @@ import coerceToError from '../../common/utility/coerceToError.js';
  */
 export default function reducerWithErrorHandling<
   S: {+reducerError: Error | null, ...},
-  -A,
+  A,
 >(
   reducer: (S, A) => S,
 ): (S, A) => S {

--- a/root/static/scripts/relationship-editor/utility/exportTypeInfo.js
+++ b/root/static/scripts/relationship-editor/utility/exportTypeInfo.js
@@ -24,7 +24,7 @@ export function exportLinkTypeInfo(
     [entityTypes: string]: Array<LinkTypeT>,
   } = {};
 
-  function mapItems<-T: LinkTypeT>(
+  function mapItems<T: LinkTypeT>(
     result: {-[idOrGid: StrOrNum]: T},
     item: T,
   ) {
@@ -78,7 +78,7 @@ export function exportLinkAttributeTypeInfo(
   const linkAttributeTypeChildren =
     groupBy(allLinkAttributeTypes, x => String(x.parent_id));
 
-  function mapItems<-T: LinkAttrTypeT>(
+  function mapItems<T: LinkAttrTypeT>(
     result: {-[idOrGid: StrOrNum]: T},
     item: T,
   ) {

--- a/root/static/scripts/relationship-editor/utility/prettyPrintRelationshipState.js
+++ b/root/static/scripts/relationship-editor/utility/prettyPrintRelationshipState.js
@@ -25,7 +25,7 @@ const _displayLinkType = (linkType: LinkTypeT | null): string => {
   return linkType ? linkType.name : 'none';
 };
 
-const _displayAttribute = (attribute: LinkAttrT): string => {
+const _displayAttribute = (attribute: LinkAttrT): StrOrNum => {
   return displayLinkAttributeCustom(
     attribute,
     (x) => x.name,

--- a/root/types/entity.js
+++ b/root/types/entity.js
@@ -37,21 +37,18 @@ declare type EntityWithAliasesTypeT =
   | 'series'
   | 'work';
 
-declare type EntityWithSeriesT =
-  | ArtistT
-  | EventT
-  | RecordingT
-  | ReleaseT
-  | ReleaseGroupT
-  | WorkT;
+declare type EntityWithSeriesMapT = {
+  'artist': ArtistT,
+  'event': EventT,
+  'recording': RecordingWithArtistCreditT,
+  'release': ReleaseT,
+  'release_group': ReleaseGroupT,
+  'work': WorkT,
+};
 
-declare type EntityWithSeriesTypeT =
-  | 'artist'
-  | 'event'
-  | 'recording'
-  | 'release'
-  | 'release_group'
-  | 'work';
+declare type EntityWithSeriesT = $Values<EntityWithSeriesMapT>;
+
+declare type EntityWithSeriesTypeT = $Keys<EntityWithSeriesMapT>;
 
 declare type AppearancesT<T> = {
   +hits: number,

--- a/root/types/misc.js
+++ b/root/types/misc.js
@@ -9,6 +9,10 @@
 
 /* eslint-disable no-unused-vars */
 
+declare type DeepReadOnly<T> =
+  T extends $ReadOnlyArray<infer V> ? $ReadOnlyArray<DeepReadOnly<V>> :
+  T extends {...} ? {+[K in keyof T]: DeepReadOnly<T[K]>} : T;
+
 /*
  * See http://search.cpan.org/~lbrocard/Data-Page-2.02/lib/Data/Page.pm
  * Serialized in MusicBrainz::Server::TO_JSON.

--- a/root/utility/age.js
+++ b/root/utility/age.js
@@ -18,7 +18,7 @@ function timestamp(date: PartialDateT) {
   );
 }
 
-export function hasAge<+T: $ReadOnly<{...DatePeriodRoleT, ...}>>(
+export function hasAge<T: $ReadOnly<{...DatePeriodRoleT, ...}>>(
   entity: T,
 ): boolean {
   const begin = entity.begin_date;
@@ -79,7 +79,7 @@ export function hasAge<+T: $ReadOnly<{...DatePeriodRoleT, ...}>>(
   return false;
 }
 
-export function age<+T: $ReadOnly<{...DatePeriodRoleT, ...}>>(
+export function age<T: $ReadOnly<{...DatePeriodRoleT, ...}>>(
   entity: T,
 ): [number, number, number] | null {
   const begin = entity.begin_date;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2662,10 +2662,10 @@ flatted@^3.2.7:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-flow-bin@0.218.0:
-  version "0.218.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.218.0.tgz#f91acd8a31d472cd8568442819d925c0881081f7"
-  integrity sha512-u4E0+AIoKKMSuv09Co2mNiQB2DqCcakWtMAPbMkVvvTTNoBSo+gYKrYKoRrmb0QqhdyHy1mRXQXjESW8Lml/MA==
+flow-bin@0.218.1:
+  version "0.218.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.218.1.tgz#2d6c14509db57b3b3ab609cc87bef44faf2970db"
+  integrity sha512-D0479Oxu6HWCBiALCTjf5RF99FkPODhbDQnLDK4f0FGS+L3+XVqFPZPdzOzWwe2k5jAWCfARLVjqKVa6brAgtg==
 
 follow-redirects@^1.0.0:
   version "1.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2662,10 +2662,10 @@ flatted@^3.2.7:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-flow-bin@0.217.0:
-  version "0.217.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.217.0.tgz#c255b4d8d815520d396416c2f712ab849d61f467"
-  integrity sha512-AbbDE6QUpR+jpY9ejNROAk0P5D/2PxJzjU4D5vfmMwtS+QjjPjzfZGuatEJIn2k4PTZ2agbncaCtyHGO0AvG7A==
+flow-bin@0.217.1:
+  version "0.217.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.217.1.tgz#45fd32309cf968bd6ff6656aaeaafbc1c30b006a"
+  integrity sha512-CJ4nIKzkCDcQ6BxbQz84xVGbtcOuousPsDvCJiuQQO305nukPGXEPNBirCgqg/HJK+aqTRWMbPm38UDC7eNpWA==
 
 follow-redirects@^1.0.0:
   version "1.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2662,10 +2662,10 @@ flatted@^3.2.7:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-flow-bin@0.219.2:
-  version "0.219.2"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.219.2.tgz#46d32f51df0e855974ef97ebda12acce8ff5652a"
-  integrity sha512-E0Dh5ZFIgjeW4VoCEr9KNPG3LS4PKqLMHOGQrzlJ/wOyFQvpNS4gXsxAPeqtxD+MHeV/tVeoD17WYJXkAXpgYw==
+flow-bin@0.219.3:
+  version "0.219.3"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.219.3.tgz#a3a26d27c726c7e20477f394570ec6b1fb41fbe0"
+  integrity sha512-5O+G8pXqu0UClXLhTj2g/ZdNCQo4odYKs/6VHCnhOcvATrJIJcOJuW7WgjXMsGuV4aVeBmeFO93isE4cop9K/Q==
 
 follow-redirects@^1.0.0:
   version "1.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2662,10 +2662,10 @@ flatted@^3.2.7:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-flow-bin@0.217.1:
-  version "0.217.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.217.1.tgz#45fd32309cf968bd6ff6656aaeaafbc1c30b006a"
-  integrity sha512-CJ4nIKzkCDcQ6BxbQz84xVGbtcOuousPsDvCJiuQQO305nukPGXEPNBirCgqg/HJK+aqTRWMbPm38UDC7eNpWA==
+flow-bin@0.217.2:
+  version "0.217.2"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.217.2.tgz#96affa17f3cb303019f740bffeb28cfab7ce1250"
+  integrity sha512-fk4NcfybYjzlww1sEsfk71nqXvonAYpMRFEjmZxibDWWBiaw8DGmqXWZ7XzSunVB15VkJfOstn/sYP1EYPPyWg==
 
 follow-redirects@^1.0.0:
   version "1.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2662,10 +2662,10 @@ flatted@^3.2.7:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-flow-bin@0.218.1:
-  version "0.218.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.218.1.tgz#2d6c14509db57b3b3ab609cc87bef44faf2970db"
-  integrity sha512-D0479Oxu6HWCBiALCTjf5RF99FkPODhbDQnLDK4f0FGS+L3+XVqFPZPdzOzWwe2k5jAWCfARLVjqKVa6brAgtg==
+flow-bin@0.219.0:
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.219.0.tgz#193ae6551e4eccad7435b2ec0cfa455a40f38889"
+  integrity sha512-nX1hLdYI+mRaO5hG4acjwMni9K3KqQzt3v0pDPHKGu1lEvxEPbL3GxruFbaq8dhKR3Ntk13ptsf2krYubZ1nCw==
 
 follow-redirects@^1.0.0:
   version "1.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2662,10 +2662,10 @@ flatted@^3.2.7:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-flow-bin@0.217.2:
-  version "0.217.2"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.217.2.tgz#96affa17f3cb303019f740bffeb28cfab7ce1250"
-  integrity sha512-fk4NcfybYjzlww1sEsfk71nqXvonAYpMRFEjmZxibDWWBiaw8DGmqXWZ7XzSunVB15VkJfOstn/sYP1EYPPyWg==
+flow-bin@0.218.0:
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.218.0.tgz#f91acd8a31d472cd8568442819d925c0881081f7"
+  integrity sha512-u4E0+AIoKKMSuv09Co2mNiQB2DqCcakWtMAPbMkVvvTTNoBSo+gYKrYKoRrmb0QqhdyHy1mRXQXjESW8Lml/MA==
 
 follow-redirects@^1.0.0:
   version "1.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2662,10 +2662,10 @@ flatted@^3.2.7:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-flow-bin@0.219.0:
-  version "0.219.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.219.0.tgz#193ae6551e4eccad7435b2ec0cfa455a40f38889"
-  integrity sha512-nX1hLdYI+mRaO5hG4acjwMni9K3KqQzt3v0pDPHKGu1lEvxEPbL3GxruFbaq8dhKR3Ntk13ptsf2krYubZ1nCw==
+flow-bin@0.219.2:
+  version "0.219.2"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.219.2.tgz#46d32f51df0e855974ef97ebda12acce8ff5652a"
+  integrity sha512-E0Dh5ZFIgjeW4VoCEr9KNPG3LS4PKqLMHOGQrzlJ/wOyFQvpNS4gXsxAPeqtxD+MHeV/tVeoD17WYJXkAXpgYw==
 
 follow-redirects@^1.0.0:
   version "1.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2662,10 +2662,10 @@ flatted@^3.2.7:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-flow-bin@0.216.1:
-  version "0.216.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.216.1.tgz#c370af830e46645087a2aea4056507cc44acc031"
-  integrity sha512-mdhkQiSSZ/nyPq/pmk2tdbV3btYTlTYqBT/96nSSTGQmvTWQ0no9XMLZ/SygNafL4PPerfkpwQwprA1M35+9Bg==
+flow-bin@0.217.0:
+  version "0.217.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.217.0.tgz#c255b4d8d815520d396416c2f712ab849d61f467"
+  integrity sha512-AbbDE6QUpR+jpY9ejNROAk0P5D/2PxJzjU4D5vfmMwtS+QjjPjzfZGuatEJIn2k4PTZ2agbncaCtyHGO0AvG7A==
 
 follow-redirects@^1.0.0:
   version "1.15.3"


### PR DESCRIPTION
This PR simply upgrades Flow to the latest version, continuing the progress made with https://github.com/metabrainz/musicbrainz-server/pull/2982.

The only real problematic version was 0.217.0, which removed support for variance annotations on functions. Removing those required fixing some new type errors.

There are a few additional, miscellaneous commits making small improvements to the types:

 * "Replace $MakeReadOnly type with one using infer" makes use of the new [conditional types](https://flow.org/en/docs/types/conditional/) feature, replacing the use of `$Call`, which was less obvious.
 * "Remove uses of any in SeriesIndex.js" is an example of using [mapped types](https://flow.org/en/docs/types/mapped-types/).