### PR TITLE
Remove unneeded abbreviations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,21 +41,22 @@ dependency updates, unnoticeable refactoring, and so on.
 
 #### Title
 
-Describe your change with a short imperative title, e.g.
+Describe your change with a short imperative title, such as
 
 > Change small unnoticeable bits
 
 If your change resolves a ticket (see [above](#ticket)), please make sure you
 prefix your pull request title with `MBS-XXX: ` in order for our issue tracker
-to link your pull request to that ticket, e.g.
+to link your pull request to that ticket, such as in
 
 > MBS-1234567: Change things relevant to users
 
-If it **partially resolves** a ticket, use parenthesis, e.g.
+If it **partially resolves** a ticket, use parenthesis, such as in
 
 > MBS-1234567 (I): Make first part of needed changes
 
-If your change relate to **several tickets**, separate these with commas, e.g.
+If your change relate to **several tickets**, separate these with commas,
+such as in
 
 > MBS-1234567, MBS-2345678: Change two related things at once
 
@@ -63,7 +64,8 @@ If your change relate to **several tickets**, separate these with commas, e.g.
 
 Just follow our [pull request template](.github/PULL_REQUEST_TEMPLATE.md).
 
-If your change relates to a ticket, make sure to mention it in the comment, e.g.
+If your change relates to a ticket, make sure to mention it in the comment,
+for example
 
 ```Markdown
 # Summary

--- a/HACKING-PROD.md
+++ b/HACKING-PROD.md
@@ -52,7 +52,8 @@ CircleCI supports debugging in their containers with SSH for this case. See
 [their documentation](https://circleci.com/docs/2.0/ssh-access-jobs/).
 
 Basically, you'll want to expand the "Rerun" menu and select "Rerun job with SSH".
-Then, under "Enable SSH", you'll be told how to SSH into the container, e.g.
+Then, under "Enable SSH", you'll be told how to SSH into the container,
+with a command like
 
     $ ssh -p port ip
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -51,13 +51,13 @@ Important folders are documented here, in alphabetical order.
          [HTML::FormHandler](http://search.cpan.org/dist/HTML-FormHandler/)
          classes, where most forms rendered by Template Toolkit get handled.
          The controller will create an instance of the corresponding class
-         here, and pass the request data to it. (See e.g.
+         here, and pass the request data to it. (See for example
          `MusicBrainz::Server::Controller::edit_action`). The form acts to
          validate the request data and return any errors.
 
          We have some forms that are mostly rendered client-side and submit
          JSON directly to some controller endpoint, which then performs its own
-         validation. (See e.g. `/ws/js/edit`.) Those have nothing to do with
+         validation. (See `/ws/js/edit`.) Those have nothing to do with
          the code here.
 
  * **root/**

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -436,7 +436,7 @@ If you intend to run a server with translations, there are a few steps to follow
     The `.po` files for all language(s) open to translation are
     in the `po/` folder with filenames ending with ISO language code,
     optionally followed by an underscore and an ISO country code
-    (e.g. `fr` for French, `fr_CA` for Canadian French).
+    (such as `fr` for French, `fr_CA` for Canadian French).
 
 4.  Install translations
 
@@ -446,7 +446,7 @@ If you intend to run a server with translations, there are a few steps to follow
     `lib/LocaleData/{language}/LC_MESSAGES/{domain}.mo`.
 
 5.  Add the languages to `MB_LANGUAGES` in DBDefs.pm. These should be formatted
-    {lang}-{country}, e.g. 'es', or 'fr-ca', in a space-separated list.
+    {lang}-{country}, such as 'es', or 'fr-ca', in a space-separated list.
 
 6.  Ensure you have a system locale for any languages you want to use. For many
     languages, this will suffice:

--- a/admin/InitDb.pl
+++ b/admin/InitDb.pl
@@ -426,7 +426,7 @@ sub SanityCheck
     {
         (defined($path_to_pending_so) || $dbmirror2) or die <<EOF;
 Error: this is a master replication server, but you did not specify
-the path to "pending.so" (i.e. --with-pending=PATH) while specifying
+the path to "pending.so" (using --with-pending=PATH) while specifying
 --nodbmirror2.
 EOF
 

--- a/lib/MusicBrainz/Server/Form/Field/URL.pm
+++ b/lib/MusicBrainz/Server/Form/Field/URL.pm
@@ -2,6 +2,7 @@ package MusicBrainz::Server::Form::Field::URL;
 use URI;
 use Moose;
 use namespace::autoclean;
+use utf8;
 
 use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Validation qw( is_valid_url );
@@ -23,7 +24,7 @@ sub validate
     my $url = $self->value;
     $url = URI->new($url)->canonical;
 
-    return $self->add_error(l('Enter a valid URL, such as "http://google.com/"'))
+    return $self->add_error(l('Enter a valid URL, such as “http://google.com/”'))
         unless is_valid_url($url->as_string);
 
     return $self->add_error(l('URL protocol must be HTTP, HTTPS or FTP'))

--- a/lib/MusicBrainz/Server/Form/Field/URL.pm
+++ b/lib/MusicBrainz/Server/Form/Field/URL.pm
@@ -23,7 +23,7 @@ sub validate
     my $url = $self->value;
     $url = URI->new($url)->canonical;
 
-    return $self->add_error(l('Enter a valid URL e.g. "http://google.com/"'))
+    return $self->add_error(l('Enter a valid URL, such as "http://google.com/"'))
         unless is_valid_url($url->as_string);
 
     return $self->add_error(l('URL protocol must be HTTP, HTTPS or FTP'))

--- a/po/README
+++ b/po/README
@@ -18,7 +18,7 @@ To accomplish that we'd need a two step solution:
 1. Prepare the code base for localization.
 
 This means writing localization routines and bringing our strings into
-shape for translation (i.e. marking them appropriately). No
+shape for translation (that is, marking them appropriately). No
 translations would be prepared at this step, the system would still
 work in English, but introducing translations would be a matter of
 including some .po files. This is currently implemented as
@@ -84,7 +84,7 @@ Plurals are done with an ln()-function:
 
 (proper syntax: ln(english_singular, english_plural, number, parameter_hash))
 
-**Warning**: Plural forms only apply to enumerable entities, i.e. "I
+**Warning**: Plural forms only apply to enumerable entities, that is, "I
   have X apples" should be localized with ln(), but "I have apples"
   should use l().
 

--- a/root/artist/ArtistMerge.js
+++ b/root/artist/ArtistMerge.js
@@ -48,7 +48,7 @@ const ArtistMerge = ({
               <p>
                 {l(
                   `You should only use the checkbox above
-                   to fix errors (e.g. typos).`,
+                   to fix errors (such as typos).`,
                 )}
               </p>
               <p>

--- a/root/report/DuplicateReleaseGroups.js
+++ b/root/report/DuplicateReleaseGroups.js
@@ -40,7 +40,7 @@ React$Element<typeof ReportLayout> => {
         artists. If the releases in the release groups should be grouped
         together (see the {url|guidelines}), they can be merged. If they
         shouldn\'t be grouped together but they can be distinguished by
-        the release group types, e.g. when an artist has an album and
+        the release group types, such as when an artist has an album and
         single with the same name, then there is usually no need to
         change anything. In other cases, a disambiguation comment may be
         helpful.`,

--- a/root/report/InstrumentsWithoutAnImage.js
+++ b/root/report/InstrumentsWithoutAnImage.js
@@ -22,7 +22,7 @@ const InstrumentsWithoutAnImage = ({
     canBeFiltered={canBeFiltered}
     description={l(
       `This report shows instruments without an image relationship
-       to StaticBrainz (i.e. without an IROMBOOK image).`,
+       to StaticBrainz (that is, without an IROMBOOK image).`,
     )}
     entityType="instrument"
     filtered={filtered}

--- a/root/report/MediumsWithSequenceIssues.js
+++ b/root/report/MediumsWithSequenceIssues.js
@@ -22,7 +22,7 @@ const MediumsWithSequenceIssues = ({
     canBeFiltered={canBeFiltered}
     description={l(
       `This report lists all releases with gaps in the medium numbers
-       (e.g. there is a medium 1 and 3 but no medium 2).`,
+       (for example, there is a medium 1 and 3 but no medium 2).`,
     )}
     entityType="release"
     filtered={filtered}

--- a/root/report/RecordingsWithFutureDates.js
+++ b/root/report/RecordingsWithFutureDates.js
@@ -54,7 +54,7 @@ React$Element<typeof ReportLayout> => {
       canBeFiltered={canBeFiltered}
       description={l(
         `This report shows recordings with relationships using dates in
-        the future. Those are probably typos (e.g. 2109 instead of 2019).`,
+        the future. Those are probably typos (such as 2109 instead of 2019).`,
       )}
       entityType="relationship"
       filtered={filtered}

--- a/root/report/TracksNamedWithSequence.js
+++ b/root/report/TracksNamedWithSequence.js
@@ -22,7 +22,7 @@ const TracksNamedWithSequence = ({
     canBeFiltered={canBeFiltered}
     description={l(
       `This report aims to identify releases where track names include
-       their own track number, e.g. "1) Some Name" (instead of just
+       their own track number, such as "1) Some Name" (instead of just
        "Some Name"). Notice that sometimes this is justified and correct,
        don't automatically assume it is a mistake! If you confirm it
        is a mistake, please correct it.`,

--- a/root/report/TracksWithSequenceIssues.js
+++ b/root/report/TracksWithSequenceIssues.js
@@ -22,8 +22,8 @@ const TracksWithSequenceIssues = ({
     canBeFiltered={canBeFiltered}
     description={l(
       `This report lists all releases where the track numbers are not
-       continuous (e.g. there is no "track 2"), or with duplicated
-       track numbers (e.g. there are two "track 4"s).`,
+       continuous (for example, there is no "track 2"), or with duplicated
+       track numbers (for example, there are two "track 4"s).`,
     )}
     entityType="release"
     filtered={filtered}

--- a/root/static/scripts/artist/components/ArtistCreditRenamer.js
+++ b/root/static/scripts/artist/components/ArtistCreditRenamer.js
@@ -225,7 +225,7 @@ const ArtistCreditRenamer = ({
       <p>
         {l(`This will enter additional edits to change each specific
             credit to use the new name. Only use this if you are sure
-            the existing credits are incorrect (e.g. for typos).`)}
+            the existing credits are incorrect (such as for typos).`)}
       </p>
       <p>
         {l(`Keep in mind artist credits should generally follow what is

--- a/root/user/PrivilegedUsers.js
+++ b/root/user/PrivilegedUsers.js
@@ -106,7 +106,7 @@ const PrivilegedUsers = ({
       <h2>{l('Banner message editors')}</h2>
       <p>
         {l(`Banner message editors are users who can set a message that
-            is shown in a banner on all pages, e.g. to warn users about
+            is shown in a banner on all pages, for example to warn users about
             upcoming site maintenance.`)}
       </p>
       <p>


### PR DESCRIPTION
# Description

As per the [design system guidelines](https://github.com/metabrainz/design-system/blob/master/guidelines/style-guidelines.md) we should not be using `i.e.` and `e.g.` since they are not as clear as "that is" and something like "such as" or "for example", respectively.

Changed all user-facing places I saw except for some API error strings using `e.g.` in case someone actually depends on the text of those for validation.
Separately changed all appearances I saw on other translatable places, such as relationship descriptions; appearances of `e.g.` on entity type descriptions left untouched for now to avoid causing issues with SIR.

# Testing
None, but these are string changes only.

# Notes
On top of https://github.com/metabrainz/musicbrainz-server/pull/3058 where `e.g.` was brought up.