### PR TITLE
MBS-13336: Add a script to rebuild all indexes using collations

### DIFF
--- a/admin/RebuildIndexesUsingCollations.pl
+++ b/admin/RebuildIndexesUsingCollations.pl
@@ -1,0 +1,31 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use MusicBrainz::Server::Context;
+
+my $c = MusicBrainz::Server::Context->create_script_context(database => 'MAINTENANCE');
+my $dbh = $c->dbh;
+
+my $indexes = $c->sql->select_list_of_hashes(<<~SQL);
+    SELECT n.nspname AS schema_name, i.relname AS index_name
+      FROM pg_index AS idx
+      JOIN pg_class AS c ON idx.indrelid = c.oid
+      JOIN pg_class AS i ON idx.indexrelid = i.oid
+      JOIN pg_namespace AS n ON n.oid = c.relnamespace
+      JOIN pg_attribute AS a ON (a.attnum = any(idx.indkey) AND a.attrelid = c.oid)
+      JOIN pg_collation AS col ON a.attcollation = col.oid
+     WHERE col.collname IN ('default', 'musicbrainz')
+    ORDER BY n.nspname, i.relname
+    SQL
+
+for my $index (@$indexes) {
+    my $schema_name = $dbh->quote_identifier($index->{schema_name});
+    my $index_name = $dbh->quote_identifier($index->{index_name});
+    my $reindex_cmd = "REINDEX INDEX CONCURRENTLY $schema_name.$index_name;";
+    print "$reindex_cmd\n";
+    $c->sql->auto_commit(1);
+    $c->sql->do($reindex_cmd);
+}


### PR DESCRIPTION
# Problem

MBS-13336

# Solution

Provide a script should be run after a system upgrade whenever the versions of libc/icu have changed, in order to avoid index corruption.

A future improvement may be to allow specifying which collation to rebuild indexes for, but it doesn't hurt to rebuild all of them (except for taking longer).