### PR TITLE
MBS-13334: Also find emails with capitalization differences in find_by_email

### DIFF
--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -182,7 +182,12 @@ around '_get_by_keys' => sub {
 sub find_by_email
 {
     my ($self, $email) = @_;
-    return $self->_get_by_keys('email', $email);
+
+    my $query = 'SELECT ' . $self->_columns .
+                ' FROM ' . $self->_table .
+                ' WHERE lower(email) = lower(?)';
+
+    $self->query_to_list($query, [$email]);
 }
 
 sub find_by_ip {

--- a/t/lib/t/MusicBrainz/Server/Data/Editor.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Editor.pm
@@ -167,6 +167,10 @@ test 'find_by_email and is_email_used_elsewhere' => sub {
     is(scalar(@editors), 1, 'An editor was found with the exact email');
     is($editors[0]->id, $new_editor_2->id, 'The right editor was found');
 
+    @editors = $editor_data->find_by_email('EDITOR@EXAMPLE.COM');
+    is(scalar(@editors), 1, 'An editor was found searching with all caps');
+    is($editors[0]->id, $new_editor_2->id, 'The right editor was found');
+
     note('We check is_email_used_elsewhere shows the email as being in use');
     ok(
         $editor_data->is_email_used_elsewhere(
@@ -177,10 +181,38 @@ test 'find_by_email and is_email_used_elsewhere' => sub {
     );
     ok(
         $editor_data->is_email_used_elsewhere(
-            'EDITOR@example.com',
+            'EDITOR@EXAMPLE.COM',
             $future_editor_id,
         ),
         'The email is shown to be in use even if searching with all caps',
+    );
+
+    note('We set an all caps email for the new editor with update_email');
+    $editor_data->update_email($new_editor_2, 'EDITOR@EXAMPLE.COM');
+
+    note('We search for the new editor email with find_by_email');
+    my @editors = $editor_data->find_by_email('EDITOR@EXAMPLE.COM');
+    is(scalar(@editors), 1, 'An editor was found with the exact email');
+    is($editors[0]->id, $new_editor_2->id, 'The right editor was found');
+
+    @editors = $editor_data->find_by_email('editor@example.com');
+    is(scalar(@editors), 1, 'An editor was found searching with normal caps');
+    is($editors[0]->id, $new_editor_2->id, 'The right editor was found');
+
+    note('We check is_email_used_elsewhere shows the email as being in use');
+    ok(
+        $editor_data->is_email_used_elsewhere(
+            'EDITOR@EXAMPLE.COM',
+            $future_editor_id,
+        ),
+        'The exact email is shown to be in use if another editor wants it',
+    );
+    ok(
+        $editor_data->is_email_used_elsewhere(
+            'editor@example.com',
+            $future_editor_id,
+        ),
+        'The email is shown to be in use even if searching with normal caps',
     );
 };
 


### PR DESCRIPTION
### Fix MBS-13334

# Problem
We just had a support case where the user already had an account, but `lost_username` claimed the email was not in use. When the user, confused, tried to create a new account, he got an email (using `is_email_used_elsewhere`) saying that the email is already in use. It seems the issue was due to capitalization differences (the email was stored in the DB with some capitalized letters)

# Solution
We had a better query in `is_email_used_elsewhere` so this just reuses effectively the same query for `find_by_email`.

Using `_get_by_keys` ran `load_preferences`, which this does not. Since we don't seem to use the preferences for our use of `find_by_email` I did not bother loading them with the new method.

# Testing
Added tests for these two email checks, and I improved and documented the `Data::Editor` test while at it so it wouldn't be a huge mess.