### PR TITLE
MBS-13320 (II): Warn on form unload with rel changes

### DIFF
--- a/root/static/scripts/edit/components/forms.js
+++ b/root/static/scripts/edit/components/forms.js
@@ -65,7 +65,8 @@ MB.initializeArtistCredit = function (form, initialArtistCredit) {
  * the user if any of the page's form inputs have been changed.
  */
 MB.installFormUnloadWarning = function () {
-  let modified = false;
+  let inputsChanged = false;
+  let submittingForm = false;
 
   const form = document.querySelector('#page form');
 
@@ -74,18 +75,31 @@ MB.installFormUnloadWarning = function () {
    * user changes an input back to its original value.
    */
   form.addEventListener('change', () => {
-    modified = true;
+    inputsChanged = true;
   });
 
   // Disarm the warning when the form is being submitted.
   form.addEventListener('submit', () => {
-    modified = false;
+    submittingForm = true;
   });
 
   window.addEventListener('beforeunload', event => {
-    if (!modified) {
+    if (submittingForm) {
       return false;
     }
+
+    // Check if there are pending relationship or URL changes.
+    if (!inputsChanged && !form.querySelector([
+      '#relationship-editor .rel-add',
+      '#relationship-editor .rel-edit',
+      '#relationship-editor .rel-remove',
+      '#external-links-editor .rel-add',
+      '#external-links-editor .rel-edit',
+      '#external-links-editor .rel-remove',
+    ].join(', '))) {
+      return false;
+    }
+
     event.returnValue = l(
       'All of your changes will be lost if you leave this page.',
     );

--- a/t/selenium/MBS-12641.json5
+++ b/t/selenium/MBS-12641.json5
@@ -66,5 +66,16 @@
       target: 'document.activeElement === document.querySelector("#add-relationship-dialog select.entity-type")',
       value: 'true',
     },
+    {
+      command: 'open',
+      target: '/',
+      value: '',
+    },
+    // Dismiss the beforeunload alert (shown since relationships were changed).
+    {
+      command: 'handleAlert',
+      target: 'accept',
+      value: '',
+    },
   ],
 }


### PR DESCRIPTION
# MBS-13320 (II)

Make the `beforeunload` listener installed by `MB.installFormUnloadWarning` additionally use CSS selectors to check for pending relationship or URL changes.

Previously, only changes to input elements were detected.

# Problem

#3054 only warns when navigating away from edit forms if a `change` event has been observed. This detects changes to text fields or checkboxes, but it doesn't catch relationship or URL changes. As a result, editors could still lose work if they accidentally closed or navigated away from forms when making relationship or URL edits.

# Solution

@jesus2099 pointed out that the relationship editor uses `rel-add`, `rel-edit`, and `rel-remove` CSS classes when relationships are being changed. This change queries for those classes in the `beforeunload` handler to additionally detect relationship and URL changes.

Just to mention it, I think that changes to the artist form's "area" input still aren't detected, but I don't see an obvious way to detect those without adding special code for that one specific case.

# Testing

I verified that I now get prompted when navigating away from the artist and release group forms after adding/editing/removing relationships and adding/editing/removing URLs.

I suspect that I'll need to update this PR to update fix Selenium tests that end with pending relationship/URL changes, but I don't think I have any easy way of figuring out which ones need to be updated until the checks run (since I'm using musicbrainz-docker, I can't run Selenium tests locally).

# Action

Nothing special needed here, I don't think.