### PR TITLE
Use "remove" consistently for non-editor cases

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -74,7 +74,7 @@ sub _do_add_or_remove {
         my $entity = $c->model(type_to_model($entity_type))->get_by_id($entity_id);
 
         unless ($entity) {
-            $c->stash->{message} = l('“{id}” is not a valid row ID; the entity might have been merged or deleted.', { id => $entity_id });
+            $c->stash->{message} = l('“{id}” is not a valid row ID; the entity might have been merged or removed.', { id => $entity_id });
             $c->detach('/error_400');
         }
 

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -117,7 +117,7 @@
 [% END %]
 
 [% BLOCK remove %]
-<button type="button" class="remove-item icon" title="[% l('Delete') %]"></button>
+<button type="button" class="remove-item icon" title="[% l('Remove') %]"></button>
 [% END %]
 
 [%- MACRO operators(operators, field_contents) BLOCK %]

--- a/root/mbid/NotFound.js
+++ b/root/mbid/NotFound.js
@@ -24,7 +24,7 @@ const MbidNotFound = ({
         exp.l(
           `No MusicBrainz {entity_doc|entities} match the {mbid_doc|MBID}
            {mbid}. Either it’s incorrect, it was for an entity that has since
-           been deleted, or it is an ID for something else than an entity
+           been removed, or it is an ID for something else than an entity
            (for example, a {rel_type_table|relationship type}).`,
           {
             entity_doc: '/doc/MusicBrainz_Entity',

--- a/root/relationship/linkattributetype/RelationshipAttributeTypeInUse.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypeInUse.js
@@ -21,7 +21,7 @@ const RelationshipAttributeTypeInUse = ({
       <h1>{l('Relationship attribute in use')}</h1>
       <p>
         {texp.l(
-          `The relationship attribute type “{type}” can’t be deleted
+          `The relationship attribute type “{type}” can’t be removed
            because it’s still in use.`,
           {type: type.name},
         )}

--- a/root/relationship/linktype/RelationshipTypeInUse.js
+++ b/root/relationship/linktype/RelationshipTypeInUse.js
@@ -21,7 +21,7 @@ const RelationshipTypeInUse = ({
       <h1>{l('Relationship Type In Use')}</h1>
       <p>
         {texp.l(
-          `The relationship type "{type}" can’t be removed
+          `The relationship type “{type}” can’t be removed
            because it’s still in use.`,
           {type: type.name},
         )}

--- a/root/relationship/linktype/RelationshipTypeInUse.js
+++ b/root/relationship/linktype/RelationshipTypeInUse.js
@@ -21,7 +21,7 @@ const RelationshipTypeInUse = ({
       <h1>{l('Relationship Type In Use')}</h1>
       <p>
         {texp.l(
-          `The relationship type "{type}" can’t be deleted
+          `The relationship type "{type}" can’t be removed
            because it’s still in use.`,
           {type: type.name},
         )}

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -499,7 +499,7 @@
                 [% l('Some discs contain a hidden track in the pregap section that precedes track 1. Use this to add (or remove) the special pregap track section.') %]
               </p>
               <p>
-                [% l('Keep in mind that unselecting this will delete the track if the medium has a disc ID! If you unselect it by mistake, please readd the pregap track before submitting.') %]
+                [% l('Keep in mind that unselecting this will remove the track if the medium has a disc ID! If you unselect it by mistake, please readd the pregap track before submitting.') %]
               </p>
             </div>
           </p>
@@ -514,7 +514,7 @@
                 [% l('Some discs contain one or more data tracks after all audio tracks. Use this to add (or remove) the special data tracks section. You should only add data tracks that contain audio or video ({info|more info})', { info => { href => doc_link('Data_Track'), target => '_blank' } }) %]
               </p>
               <p>
-                [% l('Keep in mind that unselecting this will delete the tracks if the medium has a disc ID! If you unselect it by mistake, please readd the data tracks before submitting.') %]
+                [% l('Keep in mind that unselecting this will remove the tracks if the medium has a disc ID! If you unselect it by mistake, please readd the data tracks before submitting.') %]
               </p>
             </div>
           </p>

--- a/root/static/scripts/common/MB/Control/EditSummary.js
+++ b/root/static/scripts/common/MB/Control/EditSummary.js
@@ -20,7 +20,7 @@ MB.Control.EditSummary = function (container) {
 
   self.addNote = function () {
     $toggleEditNote
-      .text(l('Delete Note'))
+      .text(lp('Remove Note', 'Edit note field toggle'))
       .unbind('click').click(self.deleteNote);
     $editNote.show();
     $editNoteField.focus();
@@ -28,7 +28,7 @@ MB.Control.EditSummary = function (container) {
 
   self.deleteNote = function () {
     $toggleEditNote
-      .text(l('Add Note'))
+      .text(lp('Add Note', 'Edit note field toggle'))
       .unbind('click').click(self.addNote);
     $editNote.hide();
     $editNoteField.val('');

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -807,7 +807,7 @@ const UserProfileStatistics = ({
                     <abbr
                       title={l('Tags are removed when an editor is deleted.')}
                     >
-                      {lp('Deleted', 'tags')}
+                      {lp('Removed', 'tags')}
                     </abbr>
                   ) : $c.user && upvotedTagCount > 0 ? exp.l(
                     '{count} ({view_url|view})',
@@ -823,7 +823,7 @@ const UserProfileStatistics = ({
                     <abbr
                       title={l('Tags are removed when an editor is deleted.')}
                     >
-                      {lp('Deleted', 'tags')}
+                      {lp('Removed', 'tags')}
                     </abbr>
                   ) : $c.user && downvotedTagCount > 0 ? exp.l(
                     '{count} ({view_url|view})',
@@ -843,7 +843,7 @@ const UserProfileStatistics = ({
                       l('Ratings are removed when an editor is deleted.')
                     }
                   >
-                    {lp('Deleted', 'ratings')}
+                    {lp('Removed', 'ratings')}
                   </abbr>
 
                 ) : $c.user && ratingCount > 0 ? exp.l(


### PR DESCRIPTION
# Description
We generally use "remove" for things like entities, and "delete" (which is almost the same but has a slightly stronger vibe) for editors only. This changes a few translatable "delete" strings that were actually meant for non-editors, so should probably use "remove".

# Testing
None, but this changes strings only.