### PR TITLE
MBS-4822: Drop duplicate colon strings 

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Utils.pm
+++ b/lib/MusicBrainz/Server/Edit/Utils.pm
@@ -10,7 +10,7 @@ use MusicBrainz::Server::Data::Utils qw( artist_credit_to_ref coordinates_to_has
 use MusicBrainz::Server::Edit::Exceptions;
 use MusicBrainz::Server::Entity::ArtistCredit;
 use MusicBrainz::Server::Entity::ArtistCreditName;
-use MusicBrainz::Server::Translation qw( N_l );
+use MusicBrainz::Server::Translation qw( N_l N_lp );
 use Scalar::Util qw( blessed );
 use Set::Scalar;
 
@@ -275,7 +275,7 @@ our @STATUS_MAP = (
     [ $STATUS_ERROR        => N_l('Error') ],
     [ $STATUS_FAILEDPREREQ => N_l('Failed prerequisite') ],
     [ $STATUS_NOVOTES      => N_l('No votes') ],
-    [ $STATUS_DELETED      => N_l('Cancelled') ],
+    [ $STATUS_DELETED      => N_lp('Cancelled', 'edit') ],
 );
 our %STATUS_NAMES = map { @$_ } @STATUS_MAP;
 

--- a/root/admin/EditUser.js
+++ b/root/admin/EditUser.js
@@ -174,7 +174,7 @@ const EditUser = ({
         <FormRowTextArea
           cols={80}
           field={form.field.biography}
-          label={l('Bio:')}
+          label={addColonText(l('Bio'))}
           rows={5}
         />
 

--- a/root/annotation/EditAnnotation.js
+++ b/root/annotation/EditAnnotation.js
@@ -59,7 +59,7 @@ const EditAnnotation = ({
 
       {showPreview ? (
         <>
-          <h3>{l('Preview:')}</h3>
+          <h3>{addColonText(lp('Preview', 'header'))}</h3>
           <div
             className="annotation-preview"
             dangerouslySetInnerHTML={{__html: preview}}
@@ -90,7 +90,7 @@ const EditAnnotation = ({
             type="submit"
             value="preview"
           >
-            {l('Preview')}
+            {lp('Preview', 'button')}
           </button>
         </EnterEdit>
       </form>

--- a/root/area/edit_form.tt
+++ b/root/area/edit_form.tt
@@ -9,9 +9,9 @@
       [%- form_row_name_with_guesscase(r) -%]
       [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
       [%- form_row_select(r, 'type_id', l('Type:')) -%]
-      [%- form_row_text_list(r, 'iso_3166_1', l('ISO 3166-1:'), l('ISO 3166-1')) -%]
-      [%- form_row_text_list(r, 'iso_3166_2', l('ISO 3166-2:'), l('ISO 3166-2')) -%]
-      [%- form_row_text_list(r, 'iso_3166_3', l('ISO 3166-3:'), l('ISO 3166-3')) -%]
+      [%- form_row_text_list(r, 'iso_3166_1', add_colon(l('ISO 3166-1')), l('ISO 3166-1')) -%]
+      [%- form_row_text_list(r, 'iso_3166_2', add_colon(l('ISO 3166-2')), l('ISO 3166-2')) -%]
+      [%- form_row_text_list(r, 'iso_3166_3', add_colon(l('ISO 3166-3')), l('ISO 3166-3')) -%]
     </fieldset>
 
     [% date_range_fieldset(r, 'area', l('This area has ended.')) %]

--- a/root/artist/edit_form.tt
+++ b/root/artist/edit_form.tt
@@ -14,10 +14,10 @@
         [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
         [%- disambiguation_error() -%]
         [%- form_row_select(r, 'type_id', l('Type:')) -%]
-        [%- form_row_select(r, 'gender_id', l('Gender:')) -%]
+        [%- form_row_select(r, 'gender_id', add_colon(l('Gender'))) -%]
         [% WRAPPER form_row %]
           [% area_field = form.field('area.name') %]
-          <label for="id-edit-artist.area.name">[% l('Area:') %]</label>
+          <label for="id-edit-artist.area.name">[% add_colon(l('Area')) %]</label>
           <span id="area" class="area autocomplete">
             [% React.embed(c, 'static/scripts/common/components/SearchIcon') %]
             [% r.hidden(form.field('area').field('gid'), { class => 'gid' }) %]
@@ -26,8 +26,8 @@
           </span>
           [% field_errors(r.form, 'area.name') %]
         [% END %]
-        [%- form_row_text_list(r, 'ipi_codes', l('IPI codes:'), l('IPI code')) -%]
-        [%- form_row_text_list(r, 'isni_codes', l('ISNI codes:'), l('ISNI code')) -%]
+        [%- form_row_text_list(r, 'ipi_codes', add_colon(l('IPI codes')), l('IPI code')) -%]
+        [%- form_row_text_list(r, 'isni_codes', add_colon(l('ISNI codes')), l('ISNI code')) -%]
       </fieldset>
 
       <fieldset>
@@ -35,11 +35,11 @@
         <p>
             [%- l('Dates are in the format YYYY-MM-DD. Partial dates such as YYYY-MM or just YYYY are OK, or you can omit the date entirely.') -%]
         </p>
-        [% form_row_date(r, 'period.begin_date', l('Begin date:')) %]
+        [% form_row_date(r, 'period.begin_date', add_colon(l('Begin date'))) %]
         [% too_short_year_error('too_short_begin_year') %]
         [% WRAPPER form_row %]
           [% begin_area_field = form.field('begin_area.name') %]
-          <label id="label-id-edit-artist.begin_area.name" for="id-edit-artist.begin_area.name">[% l('Begin Area:') %]</label>
+          <label id="label-id-edit-artist.begin_area.name" for="id-edit-artist.begin_area.name">[% add_colon(l('Begin Area')) %]</label>
           <span id="begin_area" class="area autocomplete">
             [% React.embed(c, 'static/scripts/common/components/SearchIcon') %]
             [% r.hidden(form.field('begin_area').field('gid'), { class => 'gid' }) %]
@@ -48,12 +48,12 @@
           </span>
           [% field_errors(r.form, 'begin_area.name') %]
         [% END %]
-        [% form_row_date(r, 'period.end_date', l('End date:')) %]
+        [% form_row_date(r, 'period.end_date', add_colon(l('End date'))) %]
         [% too_short_year_error('too_short_end_year') %]
         [% form_row_checkbox(r, 'period.ended', l('This artist has ended.')) %]
         [% WRAPPER form_row %]
           [% end_area_field = form.field('end_area.name') %]
-          <label id="label-id-edit-artist.end_area.name" for="id-edit-artist.end_area.name">[% l('End Area:') %]</label>
+          <label id="label-id-edit-artist.end_area.name" for="id-edit-artist.end_area.name">[% add_colon(l('End Area')) %]</label>
           <span id="end_area" class="area autocomplete">
             [% React.embed(c, 'static/scripts/common/components/SearchIcon') %]
             [% r.hidden(form.field('end_area').field('gid'), { class => 'gid' }) %]

--- a/root/artist/utils.js
+++ b/root/artist/utils.js
@@ -31,7 +31,7 @@ export function artistBeginLabel(typeId: ?number): string {
     case 4:
       return addColonText(lp('Created', 'character artist'));
     default:
-      return l('Begin date:');
+      return addColonText(l('Begin date'));
   }
 }
 
@@ -62,6 +62,6 @@ export function artistEndLabel(
         ? addColonText(lp('Dissolving', 'group artist'))
         : addColonText(lp('Dissolved', 'group artist'));
     default:
-      return l('End date:');
+      return addColonText(l('End date'));
   }
 }

--- a/root/cdtoc/CDTocInfo.js
+++ b/root/cdtoc/CDTocInfo.js
@@ -29,7 +29,7 @@ const CDTocInfo = ({cdToc}: Props): React$Element<typeof React.Fragment> => (
       </tr>
 
       <tr>
-        <th>{l('Disc ID:')}</th>
+        <th>{addColonText(l('Disc ID'))}</th>
         <td><code>{cdToc.discid}</code></td>
       </tr>
       <tr>

--- a/root/cdtoc/lookup.tt
+++ b/root/cdtoc/lookup.tt
@@ -72,7 +72,7 @@
   <form action="[% c.req.uri_for_action('/cdtoc/attach') %]" method="get">
     [% USE r = FormRenderer(query_artist) %]
     <input type="hidden" name="toc" value="[% toc %]" />
-    [% form_row_text(r, 'query', l('Artist:')) %]
+    [% form_row_text(r, 'query', add_colon(l('Artist'))) %]
     <div class="row no-label">
       [% form_submit(l('Search')) %]
     </div>

--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -209,9 +209,9 @@
       <p>
         [%- l('Dates are in the format YYYY-MM-DD. Partial dates such as YYYY-MM or just YYYY are OK, or you can omit the date entirely.') -%]
       </p>
-      [% form_row_date(r, 'period.begin_date', l('Begin date:')) %]
+      [% form_row_date(r, 'period.begin_date', add_colon(l('Begin date'))) %]
       [% too_short_year_error('too_short_begin_year') %]
-      [% form_row_date(r, 'period.end_date', l('End date:')) %]
+      [% form_row_date(r, 'period.end_date', add_colon(l('End date'))) %]
       [% too_short_year_error('too_short_end_year') %]
       [% form_row_checkbox(r, 'period.ended', ended_label) %]
     </fieldset>
@@ -223,7 +223,7 @@
 
 [%- MACRO form_row_name_with_guesscase(r, options) BLOCK # Converted to React at root/static/scripts/edit/components/FormRowNameWithGuessCase.js -%]
   [% WRAPPER form_row %]
-    [% r.label('name', options.label || l('Name:')) %]
+    [% r.label('name', options.label || add_colon(l('Name'))) %]
     [% r.text('name', { class => 'with-guesscase' _ (options.guessfeat ? '-guessfeat' : '') }) %]
     <button type="button" class="guesscase-title icon" title="[% l('Guess case') %]"></button>
     [%- IF options.guessfeat -%]
@@ -236,7 +236,7 @@
 
 [%- MACRO form_row_sortname_with_guesscase(r) BLOCK # Converted to React at root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js -%]
   [% WRAPPER form_row %]
-    [% r.label('sort_name', l('Sort name:')) %]
+    [% r.label('sort_name', add_colon(l('Sort name'))) %]
     [% r.text('sort_name', { class => 'with-guesscase' }) %]
     <button type="button" class="guesscase-sortname icon" title="[% l('Guess sort name') %]"></button>
     <button type="button" class="sortname-copy icon" title="[% l('Copy name') %]"></button>

--- a/root/components/list/ReleaseList.js
+++ b/root/components/list/ReleaseList.js
@@ -161,7 +161,7 @@ const ReleaseList = ({
           getText: entity => entity.status
             ? lp_attributes(entity.status.name, 'release_status')
             : '',
-          title: l('Status'),
+          title: lp('Status', 'release status'),
         })
         : null;
       const ratingsColumn = defineRatingsColumn<ReleaseT>({

--- a/root/edit/components/EditSidebar.js
+++ b/root/edit/components/EditSidebar.js
@@ -56,7 +56,7 @@ const EditSidebar = ({
             </div>
           </SidebarProperty>
         ) : (
-          <SidebarProperty className="" label={l('Closed:')}>
+          <SidebarProperty className="" label={addColonText(l('Closed'))}>
             <div className="edit-expiration">
               {formatUserDate($c, edit.close_time)}
             </div>

--- a/root/edit/components/EditSidebar.js
+++ b/root/edit/components/EditSidebar.js
@@ -34,7 +34,10 @@ const EditSidebar = ({
   return (
     <div id="sidebar">
       <SidebarProperties className="edit-status">
-        <SidebarProperty className="" label={lp('Status:', 'edit status')}>
+        <SidebarProperty
+          className=""
+          label={addColonText(lp('Status', 'edit status'))}
+        >
           {getEditStatusName(edit)}
         </SidebarProperty>
       </SidebarProperties>

--- a/root/edit/components/HistoricReleaseList.js
+++ b/root/edit/components/HistoricReleaseList.js
@@ -46,7 +46,7 @@ const HistoricReleaseList = ({
   releases,
 }: HistoricReleaseListProps): React$Element<'tr'> => (
   <tr>
-    <th>{nonEmpty(label) ? label : l('Releases:')}</th>
+    <th>{nonEmpty(label) ? label : addColonText(l('Releases'))}</th>
     <td colSpan={colSpan}>
       <HistoricReleaseListContent releases={releases} />
     </td>

--- a/root/edit/details/AddArea.js
+++ b/root/edit/details/AddArea.js
@@ -99,7 +99,7 @@ const AddArea = ({edit}: Props): React$MixedElement => {
         )}
 
         <tr>
-          <th>{addColonText(l('Ended'))}</th>
+          <th>{addColonText(lp('Ended', 'area ended boolean'))}</th>
           <td>{yesNo(display.ended)}</td>
         </tr>
       </table>

--- a/root/edit/details/AddArtist.js
+++ b/root/edit/details/AddArtist.js
@@ -126,7 +126,7 @@ const AddArtist = ({edit}: Props): React$MixedElement => {
         ) : null}
 
         <tr>
-          <th>{addColonText(l('Ended'))}</th>
+          <th>{addColonText(lp('Ended', 'artist ended boolean'))}</th>
           <td>{yesNo(display.ended)}</td>
         </tr>
 

--- a/root/edit/details/AddCoverArt.js
+++ b/root/edit/details/AddCoverArt.js
@@ -41,7 +41,7 @@ const AddCoverArt = ({edit}: Props): React$Element<'table'> => {
       </tr>
 
       <tr>
-        <th>{l('Filename:')}</th>
+        <th>{addColonText(l('Filename'))}</th>
         <td>
           <code>
             {display.artwork.filename}

--- a/root/edit/details/AddDiscId.js
+++ b/root/edit/details/AddDiscId.js
@@ -24,14 +24,14 @@ const AddDiscId = ({allowNew, edit}: Props): React$Element<'table'> => {
     <table className="details add-disc-id">
       {medium ? (
         <tr>
-          <th>{l('Medium:')}</th>
+          <th>{addColonText(l('Medium'))}</th>
           <td colSpan="2">
             <MediumLink allowNew={allowNew} medium={medium} />
           </td>
         </tr>
       ) : null}
       <tr>
-        <th>{l('Disc ID:')}</th>
+        <th>{addColonText(l('Disc ID'))}</th>
         <td>
           <CDTocLink cdToc={cdToc} />
         </td>

--- a/root/edit/details/AddEvent.js
+++ b/root/edit/details/AddEvent.js
@@ -47,7 +47,7 @@ const AddEvent = ({edit}: Props): React$MixedElement => {
         ) : null}
 
         <tr>
-          <th>{addColonText(l('Cancelled'))}</th>
+          <th>{addColonText(lp('Cancelled', 'event'))}</th>
           <td>{yesNo(display.cancelled)}</td>
         </tr>
 

--- a/root/edit/details/AddLabel.js
+++ b/root/edit/details/AddLabel.js
@@ -71,7 +71,7 @@ const AddLabel = ({allowNew, edit}: Props): React$MixedElement => {
           )}
 
           <tr>
-            <th>{addColonText(l('Ended'))}</th>
+            <th>{addColonText(lp('Ended', 'label ended boolean'))}</th>
             <td>{yesNo(display.ended)}</td>
           </tr>
 

--- a/root/edit/details/AddMedium.js
+++ b/root/edit/details/AddMedium.js
@@ -120,20 +120,20 @@ const AddMedium = ({allowNew, edit}: Props): React$MixedElement => {
       )}
 
       <tr>
-        <th>{l('Position:')}</th>
+        <th>{addColonText(l('Position'))}</th>
         <td>{display.position}</td>
       </tr>
 
       {nonEmpty(display.name) ? (
         <tr>
-          <th>{l('Name:')}</th>
+          <th>{addColonText(l('Name'))}</th>
           <td>{display.name}</td>
         </tr>
       ) : null}
 
       {format ? (
         <tr>
-          <th>{l('Format:')}</th>
+          <th>{addColonText(l('Format'))}</th>
           <td>
             {lp_attributes(format.name, 'medium_format')}
           </td>
@@ -159,7 +159,7 @@ const AddMedium = ({allowNew, edit}: Props): React$MixedElement => {
 
       {display.tracks?.length ? (
         <tr>
-          <th>{l('Artist Credits:')}</th>
+          <th>{addColonText(l('Artist Credits'))}</th>
           <td>
             <table className="tbl">
               <thead>

--- a/root/edit/details/AddPlace.js
+++ b/root/edit/details/AddPlace.js
@@ -81,7 +81,7 @@ const AddPlace = ({edit}: Props): React$MixedElement => {
             </tr>
           )}
           <tr>
-            <th>{addColonText(l('Ended'))}</th>
+            <th>{addColonText(lp('Ended', 'place ended boolean'))}</th>
             <td>{yesNo(display.ended)}</td>
           </tr>
         </tbody>

--- a/root/edit/details/AddRelationship.js
+++ b/root/edit/details/AddRelationship.js
@@ -19,7 +19,7 @@ const AddRelationship = ({edit}: Props): React$MixedElement => {
   return (
     <table className="details add-relationship">
       <tr>
-        <th>{l('Relationship:')}</th>
+        <th>{addColonText(l('Relationship'))}</th>
         <td>
           <Relationship
             allowNewEntity0={relationship.entity0_id === 0}

--- a/root/edit/details/AddRelease.js
+++ b/root/edit/details/AddRelease.js
@@ -79,7 +79,7 @@ const AddRelease = ({allowNew, edit}: Props): React$MixedElement => {
 
           {status ? (
             <tr>
-              <th>{lp('Status:', 'release status')}</th>
+              <th>{addColonText(lp('Status', 'release status'))}</th>
               <td>
                 {lp_attributes(status.name, 'release_status')}
               </td>

--- a/root/edit/details/AddReleaseLabel.js
+++ b/root/edit/details/AddReleaseLabel.js
@@ -23,7 +23,7 @@ const AddReleaseLabel = ({edit}: Props): React$Element<'table'> => {
     <table className="details add-release-label">
       {edit.preview /*:: === true */ ? null : (
         <tr>
-          <th>{l('Release:')}</th>
+          <th>{addColonText(l('Release'))}</th>
           <td>
             {display.release
               ? <DescriptiveLink entity={display.release} />
@@ -32,7 +32,7 @@ const AddReleaseLabel = ({edit}: Props): React$Element<'table'> => {
         </tr>
       )}
       <tr>
-        <th>{l('Label:')}</th>
+        <th>{addColonText(l('Label'))}</th>
         <td>
           {display.label
             ? <EntityLink entity={display.label} />
@@ -40,7 +40,7 @@ const AddReleaseLabel = ({edit}: Props): React$Element<'table'> => {
         </td>
       </tr>
       <tr>
-        <th>{l('Catalog number:')}</th>
+        <th>{addColonText(l('Catalog number'))}</th>
         <td>{display.catalog_number}</td>
       </tr>
     </table>

--- a/root/edit/details/AddRemoveAlias.js
+++ b/root/edit/details/AddRemoveAlias.js
@@ -101,7 +101,7 @@ const AddRemoveAlias = ({edit}: Props): React$Element<'table'> => {
 
         {ended == null ? null : (
           <tr>
-            <th>{addColonText(l('Ended'))}</th>
+            <th>{addColonText(lp('Ended', 'alias ended boolean'))}</th>
             <td>{yesNo(ended)}</td>
           </tr>
         )}

--- a/root/edit/details/EditAlias.js
+++ b/root/edit/details/EditAlias.js
@@ -122,7 +122,7 @@ const EditAlias = ({edit}: Props): React$Element<'table'> => {
         />
 
         <FullChangeDiff
-          label={addColonText(l('Ended'))}
+          label={addColonText(lp('Ended', 'alias ended boolean'))}
           newContent={yesNo(display.ended.new)}
           oldContent={yesNo(display.ended.old)}
         />

--- a/root/edit/details/EditArea.js
+++ b/root/edit/details/EditArea.js
@@ -116,7 +116,7 @@ const EditArea = ({edit}: Props): React$MixedElement => {
           ) : null}
           {ended ? (
             <FullChangeDiff
-              label={addColonText(l('Ended'))}
+              label={addColonText(lp('Ended', 'area ended boolean'))}
               newContent={yesNo(ended.new)}
               oldContent={yesNo(ended.old)}
             />

--- a/root/edit/details/EditArtist.js
+++ b/root/edit/details/EditArtist.js
@@ -152,7 +152,7 @@ const EditArtist = ({edit}: Props): React$MixedElement => {
           ) : null}
           {ended ? (
             <FullChangeDiff
-              label={addColonText(l('Ended'))}
+              label={addColonText(lp('Ended', 'artist ended boolean'))}
               newContent={yesNo(ended.new)}
               oldContent={yesNo(ended.old)}
             />

--- a/root/edit/details/EditArtist.js
+++ b/root/edit/details/EditArtist.js
@@ -159,7 +159,7 @@ const EditArtist = ({edit}: Props): React$MixedElement => {
           ) : null}
           {ipiCodes ? (
             <Diff
-              label={l('IPI codes:')}
+              label={addColonText(l('IPI codes'))}
               newText={ipiCodes.new ? commaOnlyListText(ipiCodes.new) : ''}
               oldText={ipiCodes.old ? commaOnlyListText(ipiCodes.old) : ''}
               split=", "
@@ -167,7 +167,7 @@ const EditArtist = ({edit}: Props): React$MixedElement => {
           ) : null}
           {isniCodes ? (
             <Diff
-              label={l('ISNI codes:')}
+              label={addColonText(l('ISNI codes'))}
               newText={isniCodes.new ? commaOnlyListText(isniCodes.new) : ''}
               oldText={isniCodes.old ? commaOnlyListText(isniCodes.old) : ''}
               split=", "

--- a/root/edit/details/EditCoverArt.js
+++ b/root/edit/details/EditCoverArt.js
@@ -44,7 +44,7 @@ const EditCoverArt = ({edit}: Props): React$Element<'table'> => {
 
       {nonEmpty(display.artwork.filename) ? (
         <tr>
-          <th>{l('Filename:')}</th>
+          <th>{addColonText(l('Filename'))}</th>
           <td colSpan="2">
             <code>
               {display.artwork.filename}

--- a/root/edit/details/EditEvent.js
+++ b/root/edit/details/EditEvent.js
@@ -51,7 +51,7 @@ const EditEvent = ({edit}: Props): React$Element<'table'> => {
       ) : null}
       {cancelled ? (
         <FullChangeDiff
-          label={addColonText(l('Cancelled'))}
+          label={addColonText(lp('Cancelled', 'event'))}
           newContent={yesNo(cancelled.new)}
           oldContent={yesNo(cancelled.old)}
         />

--- a/root/edit/details/EditLabel.js
+++ b/root/edit/details/EditLabel.js
@@ -108,7 +108,7 @@ const EditLabel = ({edit}: Props): React$Element<'table'> => {
 
         {ended ? (
           <FullChangeDiff
-            label={addColonText(l('Ended'))}
+            label={addColonText(lp('Ended', 'label ended boolean'))}
             newContent={yesNo(ended.new)}
             oldContent={yesNo(ended.old)}
           />

--- a/root/edit/details/EditPlace.js
+++ b/root/edit/details/EditPlace.js
@@ -106,7 +106,7 @@ const EditPlace = ({edit}: Props): React$Element<'table'> => {
         ) : null}
         {ended ? (
           <FullChangeDiff
-            label={addColonText(l('Ended'))}
+            label={addColonText(lp('Ended', 'place ended boolean'))}
             newContent={yesNo(ended.new)}
             oldContent={yesNo(ended.old)}
           />

--- a/root/edit/details/EditRelationshipType.js
+++ b/root/edit/details/EditRelationshipType.js
@@ -238,7 +238,7 @@ const EditRelationshipType = ({
 
         {childOrder ? (
           <FullChangeDiff
-            label={l('Child order:')}
+            label={addColonText(l('Child order'))}
             newContent={childOrder.new}
             oldContent={childOrder.old}
           />
@@ -314,7 +314,7 @@ const EditRelationshipType = ({
 
         {parent ? (
           <FullChangeDiff
-            label={l('Parent:')}
+            label={addColonText(l('Parent'))}
             newContent={parent.new ? <EntityLink entity={parent.new} /> : ''}
             oldContent={parent.old ? <EntityLink entity={parent.old} /> : ''}
           />

--- a/root/edit/details/EditRelease.js
+++ b/root/edit/details/EditRelease.js
@@ -98,7 +98,7 @@ const EditRelease = ({edit}: Props): React$MixedElement => {
 
       {status ? (
         <FullChangeDiff
-          label={lp('Status:', 'release status')}
+          label={addColonText(lp('Status', 'release status'))}
           newContent={status.new?.name
             ? lp_attributes(status.new.name, 'release_status')
             : ''}

--- a/root/edit/details/EditRelease.js
+++ b/root/edit/details/EditRelease.js
@@ -43,7 +43,7 @@ const EditRelease = ({edit}: Props): React$MixedElement => {
     <table className="details edit-release">
       {edit.preview /*:: === true */ ? null : (
         <tr>
-          <th>{l('Release:')}</th>
+          <th>{addColonText(l('Release'))}</th>
           <td colSpan="2">
             {display.release
               ? <DescriptiveLink entity={display.release} />

--- a/root/edit/details/MergeAreas.js
+++ b/root/edit/details/MergeAreas.js
@@ -16,7 +16,7 @@ type Props = {
 const MergeAreas = ({edit}: Props): React$Element<'table'> => (
   <table className="details merge-areas">
     <tr>
-      <th>{l('Merge:')}</th>
+      <th>{addColonText(lp('Merge', 'merge X into Y heading'))}</th>
       <td>
         <AreaList areas={edit.display_data.old} />
       </td>

--- a/root/edit/details/MergeArtists.js
+++ b/root/edit/details/MergeArtists.js
@@ -17,7 +17,7 @@ type Props = {
 const MergeArtists = ({edit}: Props): React$Element<'table'> => (
   <table className="details merge-artists">
     <tr>
-      <th>{l('Merge:')}</th>
+      <th>{addColonText(lp('Merge', 'merge X into Y heading'))}</th>
       <td>
         <ArtistList artists={edit.display_data.old} showBeginEnd />
       </td>

--- a/root/edit/details/MergeEvents.js
+++ b/root/edit/details/MergeEvents.js
@@ -16,7 +16,7 @@ type Props = {
 const MergeEvents = ({edit}: Props): React$Element<'table'> => (
   <table className="details merge-events">
     <tr>
-      <th>{l('Merge:')}</th>
+      <th>{addColonText(lp('Merge', 'merge X into Y heading'))}</th>
       <td>
         <EventList
           events={edit.display_data.old}

--- a/root/edit/details/MergeInstruments.js
+++ b/root/edit/details/MergeInstruments.js
@@ -16,7 +16,7 @@ type Props = {
 const MergeInstruments = ({edit}: Props): React$Element<'table'> => (
   <table className="details merge-instruments">
     <tr>
-      <th>{l('Merge:')}</th>
+      <th>{addColonText(lp('Merge', 'merge X into Y heading'))}</th>
       <td>
         <InstrumentList instruments={edit.display_data.old} />
       </td>

--- a/root/edit/details/MergeLabels.js
+++ b/root/edit/details/MergeLabels.js
@@ -16,7 +16,7 @@ type Props = {
 const MergeLabels = ({edit}: Props): React$Element<'table'> => (
   <table className="details merge-labels">
     <tr>
-      <th>{l('Merge:')}</th>
+      <th>{addColonText(lp('Merge', 'merge X into Y heading'))}</th>
       <td>
         <LabelList labels={edit.display_data.old} />
       </td>

--- a/root/edit/details/MergePlaces.js
+++ b/root/edit/details/MergePlaces.js
@@ -16,7 +16,7 @@ type Props = {
 const MergePlaces = ({edit}: Props): React$Element<'table'> => (
   <table className="details merge-place">
     <tr>
-      <th>{l('Merge:')}</th>
+      <th>{addColonText(lp('Merge', 'merge X into Y heading'))}</th>
       <td>
         <PlaceList places={edit.display_data.old} />
       </td>

--- a/root/edit/details/MergeRecordings.js
+++ b/root/edit/details/MergeRecordings.js
@@ -16,7 +16,7 @@ type Props = {
 const MergeRecordings = ({edit}: Props): React$Element<'table'> => (
   <table className="details merge-recordings">
     <tr>
-      <th>{l('Merge:')}</th>
+      <th>{addColonText(lp('Merge', 'merge X into Y heading'))}</th>
       <td>
         <RecordingList
           lengthClass={edit.display_data.large_spread ? 'warn-lengths' : ''}

--- a/root/edit/details/MergeReleaseGroups.js
+++ b/root/edit/details/MergeReleaseGroups.js
@@ -17,7 +17,7 @@ type Props = {
 const MergeReleaseGroups = ({edit}: Props): React$Element<'table'> => (
   <table className="details merge-release-groups">
     <tr>
-      <th>{l('Merge:')}</th>
+      <th>{addColonText(lp('Merge', 'merge X into Y heading'))}</th>
       <td>
         <ReleaseGroupListTable releaseGroups={edit.display_data.old} />
       </td>

--- a/root/edit/details/MergeSeries.js
+++ b/root/edit/details/MergeSeries.js
@@ -16,7 +16,7 @@ type Props = {
 const MergeSeries = ({edit}: Props): React$Element<'table'> => (
   <table className="details merge-series">
     <tr>
-      <th>{l('Merge:')}</th>
+      <th>{addColonText(lp('Merge', 'merge X into Y heading'))}</th>
       <td>
         <SeriesList series={edit.display_data.old} />
       </td>

--- a/root/edit/details/MergeWorks.js
+++ b/root/edit/details/MergeWorks.js
@@ -16,7 +16,7 @@ type Props = {
 const MergeWorks = ({edit}: Props): React$Element<'table'> => (
   <table className="details merge-works">
     <tr>
-      <th>{l('Merge:')}</th>
+      <th>{addColonText(lp('Merge', 'merge X into Y heading'))}</th>
       <td>
         <WorkList works={edit.display_data.old} />
       </td>

--- a/root/edit/details/MoveDiscId.js
+++ b/root/edit/details/MoveDiscId.js
@@ -23,7 +23,7 @@ const MoveDiscId = ({edit}: Props): React$Element<'table'> => {
   return (
     <table className="details move-disc-id">
       <tr>
-        <th>{l('Disc ID:')}</th>
+        <th>{addColonText(l('Disc ID'))}</th>
         <td>
           <CDTocLink cdToc={cdToc} />
         </td>

--- a/root/edit/details/RemoveCoverArt.js
+++ b/root/edit/details/RemoveCoverArt.js
@@ -42,7 +42,7 @@ const RemoveCoverArt = ({edit}: Props): React$Element<'table'> => {
 
       {nonEmpty(display.artwork.filename) ? (
         <tr>
-          <th>{l('Filename:')}</th>
+          <th>{addColonText(l('Filename'))}</th>
           <td>
             <code>
               {display.artwork.filename}

--- a/root/edit/details/RemoveDiscId.js
+++ b/root/edit/details/RemoveDiscId.js
@@ -22,13 +22,13 @@ const RemoveDiscId = ({edit}: Props): React$Element<'table'> => {
   return (
     <table className="details remove-disc-id">
       <tr>
-        <th>{l('Medium:')}</th>
+        <th>{addColonText(l('Medium'))}</th>
         <td colSpan="2">
           <MediumLink medium={medium} />
         </td>
       </tr>
       <tr>
-        <th>{l('Disc ID:')}</th>
+        <th>{addColonText(l('Disc ID'))}</th>
         <td>
           <CDTocLink cdToc={cdToc} />
         </td>

--- a/root/edit/details/RemoveRelationship.js
+++ b/root/edit/details/RemoveRelationship.js
@@ -17,7 +17,7 @@ type Props = {
 const RemoveRelationship = ({edit}: Props): React$MixedElement => (
   <table className="details remove-relationship">
     <tr>
-      <th>{l('Relationship:')}</th>
+      <th>{addColonText(l('Relationship'))}</th>
       <td><Relationship relationship={edit.display_data.relationship} /></td>
     </tr>
   </table>

--- a/root/edit/details/RemoveReleaseLabel.js
+++ b/root/edit/details/RemoveReleaseLabel.js
@@ -23,12 +23,12 @@ const RemoveReleaseLabel = ({edit}: Props): React$Element<'table'> => {
     <table className="details remove-release-label">
       {edit.preview /*:: === true */ ? null : (
         <tr>
-          <th>{l('Release:')}</th>
+          <th>{addColonText(l('Release'))}</th>
           <td><DescriptiveLink entity={display.release} /></td>
         </tr>
       )}
       <tr>
-        <th>{l('Label:')}</th>
+        <th>{addColonText(l('Label'))}</th>
         <td>
           {display.label
             ? <EntityLink entity={display.label} />
@@ -36,7 +36,7 @@ const RemoveReleaseLabel = ({edit}: Props): React$Element<'table'> => {
         </td>
       </tr>
       <tr>
-        <th>{l('Catalog number:')}</th>
+        <th>{addColonText(l('Catalog number'))}</th>
         <td>{display.catalog_number}</td>
       </tr>
     </table>

--- a/root/edit/details/ReorderMediums.js
+++ b/root/edit/details/ReorderMediums.js
@@ -39,7 +39,7 @@ const ReorderMediums = ({edit}: Props): React$Element<'table'> => {
         return (
           <tr key={'medium-change-' + index}>
             <th>
-              {showHeader ? l('Mediums:') : null}
+              {showHeader ? addColonText(l('Mediums')) : null}
             </th>
             <td>
               {nonEmpty(mediumEdit.title) && mediumEdit.old === 'new' ? (

--- a/root/edit/details/historic/AddDiscId.js
+++ b/root/edit/details/historic/AddDiscId.js
@@ -24,7 +24,7 @@ const AddDiscId = ({edit}: Props): React$Element<'table'> => (
       <td>{edit.display_data.full_toc}</td>
     </tr>
     <tr>
-      <th>{l('Disc ID:')}</th>
+      <th>{addColonText(l('Disc ID'))}</th>
       <td>
         <CDTocLink cdToc={edit.display_data.cdtoc} />
       </td>

--- a/root/edit/details/historic/AddRelationship.js
+++ b/root/edit/details/historic/AddRelationship.js
@@ -17,7 +17,7 @@ type Props = {
 const AddRelationship = ({edit}: Props): React$Element<'table'> => (
   <table className="details add-relationship-historic">
     <tr>
-      <th rowSpan="2">{l('Relationships:')}</th>
+      <th rowSpan="2">{addColonText(l('Relationships'))}</th>
       <td>
         <ul>
           {edit.display_data.relationships.map(relationship => (

--- a/root/edit/details/historic/AddRelease.js
+++ b/root/edit/details/historic/AddRelease.js
@@ -53,7 +53,7 @@ const AddRelease = ({edit}: Props): React$Element<'table'> => {
       </tr>
 
       <tr>
-        <th>{lp('Status:', 'release status')}</th>
+        <th>{addColonText(lp('Status', 'release status'))}</th>
         <td>
           {display.status
             ? lp_attributes(display.status.name, 'release_status')

--- a/root/edit/details/historic/AddRelease.js
+++ b/root/edit/details/historic/AddRelease.js
@@ -113,7 +113,7 @@ const AddRelease = ({edit}: Props): React$Element<'table'> => {
       </tr>
 
       <tr>
-        <th>{l('Release Events:')}</th>
+        <th>{addColonText(l('Release events'))}</th>
         <td>
           <table className="tbl">
             <thead>
@@ -121,7 +121,7 @@ const AddRelease = ({edit}: Props): React$Element<'table'> => {
                 <th>{l('Date')}</th>
                 <th>{l('Country')}</th>
                 <th>{l('Label')}</th>
-                <th>{l('Catalog Number')}</th>
+                <th>{l('Catalog number')}</th>
                 <th>{l('Barcode')}</th>
                 <th>{l('Format')}</th>
               </tr>

--- a/root/edit/details/historic/ChangeArtistQuality.js
+++ b/root/edit/details/historic/ChangeArtistQuality.js
@@ -21,7 +21,7 @@ const ChangeArtistQuality = ({edit}: Props): React$Element<'table'> => {
   return (
     <table className="details change-artist-quality">
       <tr>
-        <th>{l('Artist:')}</th>
+        <th>{addColonText(l('Artist'))}</th>
         <td colSpan="2">
           <DescriptiveLink entity={edit.display_data.artist} />
         </td>

--- a/root/edit/details/historic/ChangeReleaseArtist.js
+++ b/root/edit/details/historic/ChangeReleaseArtist.js
@@ -22,7 +22,7 @@ const ChangeReleaseArtist = ({edit}: Props): React$Element<'table'> => (
       releases={edit.display_data.releases}
     />
     <tr>
-      <th>{l('Artist:')}</th>
+      <th>{addColonText(l('Artist'))}</th>
       <td className="old">
         <DescriptiveLink entity={edit.display_data.artist.old} />
       </td>

--- a/root/edit/details/historic/ChangeReleaseGroup.js
+++ b/root/edit/details/historic/ChangeReleaseGroup.js
@@ -22,7 +22,7 @@ const ChangeReleaseGroup = ({edit}: Props): React$Element<'table'> => (
       releases={edit.display_data.releases}
     />
     <tr>
-      <th>{l('Release group:')}</th>
+      <th>{addColonText(l('Release group'))}</th>
       <td className="old">
         <DescriptiveLink entity={edit.display_data.release_group.old} />
       </td>

--- a/root/edit/details/historic/ChangeReleaseQuality.js
+++ b/root/edit/details/historic/ChangeReleaseQuality.js
@@ -25,7 +25,7 @@ const ChangeReleaseQuality = ({edit}: Props): React$Element<'table'> => (
       return (
         <React.Fragment key={index}>
           <tr>
-            <th>{l('Releases:')}</th>
+            <th>{addColonText(l('Releases'))}</th>
             <td colSpan="2">
               <ul>
                 {change.releases.map(release => (

--- a/root/edit/details/historic/EditReleaseAttributes.js
+++ b/root/edit/details/historic/EditReleaseAttributes.js
@@ -31,7 +31,7 @@ function getTypeName(
 const EditReleaseAttributes = ({edit}: Props): React$Element<'table'> => (
   <table className="details edit-release">
     <tr>
-      <th>{l('Old:')}</th>
+      <th>{addColonText(lp('Old', 'release type and status'))}</th>
       <td>
         <table>
           {edit.display_data.changes.map((change, index) => (

--- a/root/edit/details/historic/EditReleaseEvents.js
+++ b/root/edit/details/historic/EditReleaseEvents.js
@@ -118,7 +118,7 @@ const EditReleaseEvents = ({edit}: Props): React$Element<'table'> => (
       <>
         <thead>
           <tr>
-            <th colSpan="7">{l('Added')}</th>
+            <th colSpan="7">{lp('Added', 'list of added release events')}</th>
           </tr>
         </thead>
         <tbody>
@@ -132,7 +132,9 @@ const EditReleaseEvents = ({edit}: Props): React$Element<'table'> => (
       <>
         <thead>
           <tr>
-            <th colSpan="7">{l('Removed')}</th>
+            <th colSpan="7">
+              {lp('Removed', 'list of removed release events')}
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -146,7 +148,9 @@ const EditReleaseEvents = ({edit}: Props): React$Element<'table'> => (
       <>
         <thead>
           <tr>
-            <th colSpan="7">{l('Edited')}</th>
+            <th colSpan="7">
+              {lp('Edited', 'list of edited release events')}
+            </th>
           </tr>
         </thead>
         <tbody>

--- a/root/edit/details/historic/EditReleaseLanguage.js
+++ b/root/edit/details/historic/EditReleaseLanguage.js
@@ -17,7 +17,7 @@ type Props = {
 const EditReleaseLanguage = ({edit}: Props): React$Element<'table'> => (
   <table className="details edit-release">
     <tr>
-      <th>{l('Old:')}</th>
+      <th>{addColonText(lp('Old', 'release language'))}</th>
       <td>
         <table>
           {edit.display_data.old.map((change, index) => (

--- a/root/edit/details/historic/MoveDiscId.js
+++ b/root/edit/details/historic/MoveDiscId.js
@@ -18,7 +18,7 @@ type Props = {
 const MoveDiscId = ({edit}: Props): React$Element<'table'> => (
   <table className="details move-discid">
     <tr>
-      <th>{l('Disc ID:')}</th>
+      <th>{addColonText(l('Disc ID'))}</th>
       <td>
         <CDTocLink cdToc={edit.display_data.cdtoc} />
       </td>

--- a/root/edit/details/historic/MoveRelease.js
+++ b/root/edit/details/historic/MoveRelease.js
@@ -27,7 +27,7 @@ const MoveRelease = ({edit}: Props): React$Element<'table'> => (
       <td colSpan="2">{yesNo(edit.display_data.move_tracks)}</td>
     </tr>
     <tr>
-      <th>{l('Artist:')}</th>
+      <th>{addColonText(l('Artist'))}</th>
       <td className="old">
         <DescriptiveLink entity={edit.display_data.artist.old} />
       </td>

--- a/root/edit/details/historic/MoveReleaseToReleaseGroup.js
+++ b/root/edit/details/historic/MoveReleaseToReleaseGroup.js
@@ -19,13 +19,13 @@ const MoveReleaseToReleaseGroup = ({
 }: Props): React$Element<'table'> => (
   <table className="details edit-release">
     <tr>
-      <th>{l('Release:')}</th>
+      <th>{addColonText(l('Release'))}</th>
       <td colSpan="2">
         <DescriptiveLink entity={edit.display_data.release} />
       </td>
     </tr>
     <tr>
-      <th>{l('Release group:')}</th>
+      <th>{addColonText(l('Release group'))}</th>
       <td className="old">
         <DescriptiveLink entity={edit.display_data.release_group.old} />
       </td>

--- a/root/edit/details/historic/RemoveDiscId.js
+++ b/root/edit/details/historic/RemoveDiscId.js
@@ -20,7 +20,7 @@ const RemoveDiscId = ({edit}: Props): React$Element<'table'> => (
   <table className="details remove-discid">
     <HistoricReleaseList releases={edit.display_data.releases} />
     <tr>
-      <th>{l('Disc ID:')}</th>
+      <th>{addColonText(l('Disc ID'))}</th>
       <td>
         <CDTocLink cdToc={edit.display_data.cdtoc} />
       </td>

--- a/root/edit/details/historic/RemoveLabelAlias.js
+++ b/root/edit/details/historic/RemoveLabelAlias.js
@@ -14,7 +14,7 @@ type Props = {
 const RemoveLabelAlias = ({edit}: Props): React$Element<'table'> => (
   <table className="details remove-label-alias">
     <tr>
-      <th>{l('Alias:')}</th>
+      <th>{addColonText(l('Alias'))}</th>
       <td>{edit.display_data.alias}</td>
     </tr>
   </table>

--- a/root/edit/details/historic/RemoveRelationship.js
+++ b/root/edit/details/historic/RemoveRelationship.js
@@ -19,7 +19,7 @@ const RemoveRelationship = ({edit}: Props): React$Element<'table'> => (
     <tr>
       {edit.display_data.relationships.length ? (
         <>
-          <th>{l('Relationships:')}</th>
+          <th>{addColonText(l('Relationships'))}</th>
           <td>
             <ul>
               {edit.display_data.relationships.map(relationship => (

--- a/root/edit/details/historic/RemoveRelease.js
+++ b/root/edit/details/historic/RemoveRelease.js
@@ -23,7 +23,7 @@ const RemoveRelease = ({edit}: Props): React$Element<'table'> => {
       <HistoricReleaseList releases={edit.display_data.releases} />
       {artistCredit ? (
         <tr>
-          <th>{l('Artist:')}</th>
+          <th>{addColonText(l('Artist'))}</th>
           <td>
             <ArtistCreditLink artistCredit={artistCredit} />
           </td>

--- a/root/edit/details/historic/RemoveReleases.js
+++ b/root/edit/details/historic/RemoveReleases.js
@@ -17,7 +17,7 @@ type Props = {
 const RemoveReleases = ({edit}: Props): React$Element<'table'> => (
   <table className="details remove-releases">
     <tr>
-      <th>{l('Releases:')}</th>
+      <th>{addColonText(l('Releases'))}</th>
       <td colSpan="2">
         <ul>
           {edit.display_data.releases.map((release, index) => (

--- a/root/edit/details/historic/RemoveTrack.js
+++ b/root/edit/details/historic/RemoveTrack.js
@@ -20,7 +20,7 @@ const RemoveTrack = ({edit}: Props): React$Element<'table'> => (
   <table className="details remove-track">
     <HistoricReleaseList releases={edit.display_data.releases} />
     <tr>
-      <th>{l('Track:')}</th>
+      <th>{addColonText(l('Track'))}</th>
       <td>
         <DescriptiveLink
           content={edit.display_data.name}

--- a/root/elections/ElectionDetails.js
+++ b/root/elections/ElectionDetails.js
@@ -29,15 +29,15 @@ const ElectionDetails = ({election}: PropsT): React$MixedElement => {
       <h2>{l('Details')}</h2>
       <table className="properties">
         <tr>
-          <th>{l('Candidate:')}</th>
+          <th>{addColonText(l('Candidate'))}</th>
           <td><EditorLink editor={election.candidate} /></td>
         </tr>
         <tr>
-          <th>{l('Proposer:')}</th>
+          <th>{addColonText(l('Proposer'))}</th>
           <td><EditorLink editor={election.proposer} /></td>
         </tr>
         <tr>
-          <th>{l('1st seconder:')}</th>
+          <th>{addColonText(l('1st seconder'))}</th>
           <td>
             {election.seconder_1
               ? <EditorLink editor={election.seconder_1} />
@@ -45,7 +45,7 @@ const ElectionDetails = ({election}: PropsT): React$MixedElement => {
           </td>
         </tr>
         <tr>
-          <th>{l('2nd seconder:')}</th>
+          <th>{addColonText(l('2nd seconder'))}</th>
           <td>
             {election.seconder_2
               ? <EditorLink editor={election.seconder_2} />
@@ -60,11 +60,11 @@ const ElectionDetails = ({election}: PropsT): React$MixedElement => {
                 <td>{voteCount}</td>
               </tr>
               <tr>
-                <th>{l('Votes for:')}</th>
+                <th>{addColonText(l('Votes for'))}</th>
                 <td>{election.yes_votes}</td>
               </tr>
               <tr>
-                <th>{l('Votes against:')}</th>
+                <th>{addColonText(l('Votes against'))}</th>
                 <td>{election.no_votes}</td>
               </tr>
               <tr>

--- a/root/elections/ElectionDetails.js
+++ b/root/elections/ElectionDetails.js
@@ -86,7 +86,7 @@ const ElectionDetails = ({election}: PropsT): React$MixedElement => {
           )
         }
         <tr>
-          <th>{lp('Status:', 'election status')}</th>
+          <th>{addColonText(lp('Status', 'election status'))}</th>
           <td>
             {election.is_open && nonEmpty(election.open_time)
               ? (

--- a/root/elections/ElectionTable/index.js
+++ b/root/elections/ElectionTable/index.js
@@ -24,8 +24,8 @@ const ElectionTable = ({
         <th>{l('Start date')}</th>
         <th>{l('End date')}</th>
         <th>{l('Proposer')}</th>
-        <th>{l('Seconder 1')}</th>
-        <th>{l('Seconder 2')}</th>
+        <th>{l('1st seconder')}</th>
+        <th>{l('2nd seconder')}</th>
         <th>{l('Votes for')}</th>
         <th>{l('Votes against')}</th>
         <th>{'\u00A0'}</th>

--- a/root/event/edit_form.tt
+++ b/root/event/edit_form.tt
@@ -14,7 +14,7 @@
         [%- form_row_select(r, 'type_id', l('Type:')) -%]
         [% form_row_checkbox(r, 'cancelled', l('This event was cancelled.')) %]
         [% WRAPPER form_row %]
-          [% r.label('setlist', l('Setlist:')) %]
+          [% r.label('setlist', add_colon(l('Setlist'))) %]
           [% r.textarea('setlist', { cols => 80, rows => 10 }) %]
           [% field_errors(r.form, 'setlist') %]
         [% END %]
@@ -33,11 +33,11 @@
         <p>
             [%- l('Dates are in the format YYYY-MM-DD. Partial dates such as YYYY-MM or just YYYY are OK, or you can omit the date entirely.') -%]
         </p>
-        [% form_row_date(r, 'period.begin_date', l('Begin date:')) %]
+        [% form_row_date(r, 'period.begin_date', add_colon(l('Begin date'))) %]
         [% too_short_year_error('too_short_begin_year') %]
-        [% form_row_date(r, 'period.end_date', l('End date:')) %]
+        [% form_row_date(r, 'period.end_date', add_colon(l('End date'))) %]
         [% too_short_year_error('too_short_end_year') %]
-        [%- form_row_time(r, 'time', l('Time:')) -%]
+        [%- form_row_time(r, 'time', add_colon(l('Time'))) -%]
       </fieldset>
 
       [% PROCESS 'forms/relationship-editor.tt' %]

--- a/root/instrument/edit_form.tt
+++ b/root/instrument/edit_form.tt
@@ -10,7 +10,7 @@
       [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
       [%- form_row_select(r, 'type_id', l('Type:')) -%]
       [% WRAPPER form_row %]
-          [%- r.label('description', l('Description:')) -%]
+          [%- r.label('description', add_colon(l('Description'))) -%]
           [%- r.textarea('description', { rows => 5 }) -%]
           [%- field_errors(form, 'description') -%]
       [%- END -%]

--- a/root/label/edit_form.tt
+++ b/root/label/edit_form.tt
@@ -15,7 +15,7 @@
         [%- form_row_select(r, 'type_id', l('Type:')) -%]
         [% WRAPPER form_row %]
           [% area_field = form.field('area.name') %]
-          <label for="id-edit-label.area.name">[% l('Area:') %]</label>
+          <label for="id-edit-label.area.name">[% add_colon(l('Area')) %]</label>
           <span class="area autocomplete">
             [% React.embed(c, 'static/scripts/common/components/SearchIcon') %]
             [% r.hidden(form.field('area').field('gid'), { class => 'gid' }) %]
@@ -25,12 +25,12 @@
           [% field_errors(r.form, 'area.name') %]
         [% END %]
         [% WRAPPER form_row %]
-            [%- r.label('label_code', l('Label code:')) %]
+            [%- r.label('label_code', add_colon(l('Label code'))) %]
             LC- [% r.text('label_code', size => 5, class => "label-code", pattern => "[0-9]*") -%]
             [%- field_errors(form, 'label_code') -%]
         [% END %]
-        [%- form_row_text_list(r, 'ipi_codes', l('IPI codes:'), l('IPI code')) -%]
-        [%- form_row_text_list(r, 'isni_codes', l('ISNI codes:'), l('ISNI code')) -%]
+        [%- form_row_text_list(r, 'ipi_codes', add_colon(l('IPI codes')), l('IPI code')) -%]
+        [%- form_row_text_list(r, 'isni_codes', add_colon(l('ISNI codes')), l('ISNI code')) -%]
       </fieldset>
 
       [% date_range_fieldset(r, 'label', l('This label has ended.')) %]

--- a/root/layout/components/MergeHelper.js
+++ b/root/layout/components/MergeHelper.js
@@ -68,7 +68,7 @@ const MergeHelper = ({merger}: Props): React$Element<'div'> => {
               type="submit"
               value="merge"
             >
-              {l('Merge')}
+              {lp('Merge', 'button/link')}
             </button>
           ) : null}
           <button name="submit" type="submit" value="remove">

--- a/root/layout/components/sidebar/AreaSidebar.js
+++ b/root/layout/components/sidebar/AreaSidebar.js
@@ -55,20 +55,20 @@ const AreaSidebar = ({area}: Props): React$Element<'div'> => {
         <SidebarBeginDate
           age={areaAge}
           entity={area}
-          label={l('Begin date:')}
+          label={addColonText(l('Begin date'))}
         />
 
         <SidebarEndDate
           age={areaAge}
           entity={area}
-          label={l('End date:')}
+          label={addColonText(l('End date'))}
         />
 
         {area.iso_3166_1_codes.map(code => (
           <SidebarProperty
             className="iso-3166-1"
             key={'iso-3166-1-' + code}
-            label={l('ISO 3166-1:')}
+            label={addColonText(l('ISO 3166-1'))}
           >
             {code}
           </SidebarProperty>
@@ -78,7 +78,7 @@ const AreaSidebar = ({area}: Props): React$Element<'div'> => {
           <SidebarProperty
             className="iso-3166-2"
             key={'iso-3166-2-' + code}
-            label={l('ISO 3166-2:')}
+            label={addColonText(l('ISO 3166-2'))}
           >
             {code}
           </SidebarProperty>
@@ -88,7 +88,7 @@ const AreaSidebar = ({area}: Props): React$Element<'div'> => {
           <SidebarProperty
             className="iso-3166-3"
             key={'iso-3166-3-' + code}
-            label={l('ISO 3166-3:')}
+            label={addColonText(l('ISO 3166-3'))}
           >
             {code}
           </SidebarProperty>

--- a/root/layout/components/sidebar/ArtistSidebar.js
+++ b/root/layout/components/sidebar/ArtistSidebar.js
@@ -73,7 +73,10 @@ const ArtistSidebar = ({artist}: Props): React$Element<'div'> => {
 
       <SidebarProperties>
         {artist.name === artist.sort_name ? null : (
-          <SidebarProperty className="sort-name" label={l('Sort name:')}>
+          <SidebarProperty
+            className="sort-name"
+            label={addColonText(l('Sort name'))}
+          >
             {artist.sort_name}
           </SidebarProperty>
         )}
@@ -81,7 +84,10 @@ const ArtistSidebar = ({artist}: Props): React$Element<'div'> => {
         <SidebarType entity={artist} typeType="artist_type" />
 
         {gender ? (
-          <SidebarProperty className="gender" label={l('Gender:')}>
+          <SidebarProperty
+            className="gender"
+            label={addColonText(l('Gender'))}
+          >
             {lp_attributes(gender.name, 'gender')}
           </SidebarProperty>
         ) : null}
@@ -117,7 +123,7 @@ const ArtistSidebar = ({artist}: Props): React$Element<'div'> => {
         ) : null}
 
         {area ? (
-          <SidebarProperty className="area" label={l('Area:')}>
+          <SidebarProperty className="area" label={addColonText(l('Area'))}>
             <DescriptiveLink entity={area} />
           </SidebarProperty>
         ) : null}

--- a/root/layout/components/sidebar/CDStubSidebar.js
+++ b/root/layout/components/sidebar/CDStubSidebar.js
@@ -43,24 +43,32 @@ const CDStubSidebar = ({cdstub}: Props): React$Element<'div'> => {
   return (
     <div id="sidebar">
       <SidebarProperties>
-        <SidebarProperty className="" label={l('Added:')}>
+        <SidebarProperty
+          className=""
+          label={addColonText(lp('Added', 'CD stub addition time'))}
+        >
           {getCDStubAddedAgeAgo(cdstub)}
         </SidebarProperty>
 
-        <SidebarProperty className="" label={l('Last modified:')}>
+        <SidebarProperty
+          className=""
+          label={addColonText(
+            lp('Last modified', 'CD stub modification time'),
+          )}
+        >
           {getCDStubModifiedAgeAgo(cdstub)}
         </SidebarProperty>
 
-        <SidebarProperty className="" label={l('Lookup count:')}>
+        <SidebarProperty className="" label={addColonText(l('Lookup count'))}>
           {cdstub.lookup_count}
         </SidebarProperty>
 
-        <SidebarProperty className="" label={l('Modify count:')}>
+        <SidebarProperty className="" label={addColonText(l('Modify count'))}>
           {cdstub.modify_count}
         </SidebarProperty>
 
         {cdstub.barcode ? (
-          <SidebarProperty className="" label={l('Barcode:')}>
+          <SidebarProperty className="" label={addColonText(l('Barcode'))}>
             {cdstub.barcode}
           </SidebarProperty>
         ) : null}

--- a/root/layout/components/sidebar/EventSidebar.js
+++ b/root/layout/components/sidebar/EventSidebar.js
@@ -56,7 +56,10 @@ const EventSidebar = ({event}: Props): React$Element<'div'> => {
 
         {hasBegin || hasEnd ? (
           areDatesEqual(event.begin_date, event.end_date) ? (
-            <SidebarBeginDate entity={event} label={l('Date:')} />
+            <SidebarBeginDate
+              entity={event}
+              label={addColonText(l('Date'))}
+            />
           ) : (
             <>
               <SidebarBeginDate entity={event} label={l('Start Date:')} />
@@ -66,7 +69,7 @@ const EventSidebar = ({event}: Props): React$Element<'div'> => {
         ) : null}
 
         {event.time ? (
-          <SidebarProperty className="time" label={l('Time:')}>
+          <SidebarProperty className="time" label={addColonText(l('Time'))}>
             {event.time}
           </SidebarProperty>
         ) : null}

--- a/root/layout/components/sidebar/LabelSidebar.js
+++ b/root/layout/components/sidebar/LabelSidebar.js
@@ -78,13 +78,16 @@ const LabelSidebar = ({label}: Props): React$Element<'div'> => {
         <SidebarIsnis entity={label} />
 
         {label.label_code ? (
-          <SidebarProperty className="label-code" label={l('Label code:')}>
+          <SidebarProperty
+            className="label-code"
+            label={addColonText(l('Label code'))}
+          >
             {formatLabelCode(label.label_code)}
           </SidebarProperty>
         ) : null}
 
         {area ? (
-          <SidebarProperty className="area" label={l('Area:')}>
+          <SidebarProperty className="area" label={addColonText(l('Area'))}>
             <DescriptiveLink entity={area} />
           </SidebarProperty>
         ) : null}

--- a/root/layout/components/sidebar/MergeLink.js
+++ b/root/layout/components/sidebar/MergeLink.js
@@ -31,7 +31,7 @@ const MergeLink = ({entity}: Props): React$Element<'li'> => {
   return (
     <li>
       <a href={mergeUrl($c, entity)}>
-        {l('Merge')}
+        {lp('Merge', 'button/link')}
       </a>
     </li>
   );

--- a/root/layout/components/sidebar/PlaceSidebar.js
+++ b/root/layout/components/sidebar/PlaceSidebar.js
@@ -79,19 +79,25 @@ const PlaceSidebar = ({place}: Props): React$Element<'div'> => {
         />
 
         {place.address ? (
-          <SidebarProperty className="address" label={l('Address:')}>
+          <SidebarProperty
+            className="address"
+            label={addColonText(l('Address'))}
+          >
             {place.address}
           </SidebarProperty>
         ) : null}
 
         {area ? (
-          <SidebarProperty className="area" label={l('Area:')}>
+          <SidebarProperty className="area" label={addColonText(l('Area'))}>
             <DescriptiveLink entity={area} />
           </SidebarProperty>
         ) : null}
 
         {coordinates ? (
-          <SidebarProperty className="coordinates" label={l('Coordinates:')}>
+          <SidebarProperty
+            className="coordinates"
+            label={addColonText(l('Coordinates'))}
+          >
             <a href={osmUrl(coordinates, 16)}>
               {formatCoordinates(coordinates)}
             </a>

--- a/root/layout/components/sidebar/RecordingSidebar.js
+++ b/root/layout/components/sidebar/RecordingSidebar.js
@@ -46,12 +46,15 @@ const RecordingSidebar = ({recording}: Props): React$Element<'div'> => {
       </h2>
 
       <SidebarProperties>
-        <SidebarProperty className="artist" label={l('Artist:')}>
+        <SidebarProperty className="artist" label={addColonText(l('Artist'))}>
           <ArtistCreditLink artistCredit={recording.artistCredit} />
         </SidebarProperty>
 
         {recording.length ? (
-          <SidebarProperty className="length" label={l('Length:')}>
+          <SidebarProperty
+            className="length"
+            label={addColonText(l('Length'))}
+          >
             {formatTrackLength(recording.length)}
           </SidebarProperty>
         ) : null}

--- a/root/layout/components/sidebar/ReleaseGroupSidebar.js
+++ b/root/layout/components/sidebar/ReleaseGroupSidebar.js
@@ -57,7 +57,7 @@ const ReleaseGroupSidebar = ({
       </h2>
 
       <SidebarProperties>
-        <SidebarProperty className="artist" label={l('Artist:')}>
+        <SidebarProperty className="artist" label={addColonText(l('Artist'))}>
           <ArtistCreditLink artistCredit={releaseGroup.artistCredit} />
         </SidebarProperty>
 

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -164,7 +164,7 @@ const ReleaseSidebar = ({release}: Props): React$Element<'div'> | null => {
         {statusId == null ? null : (
           <SidebarProperty
             className="status"
-            label={lp('Status:', 'release status')}
+            label={addColonText(lp('Status', 'release status'))}
           >
             {lp_attributes(
               linkedEntities.release_status[statusId].name,

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -123,19 +123,28 @@ const ReleaseSidebar = ({release}: Props): React$Element<'div'> | null => {
 
       <SidebarProperties>
         {barcode ? (
-          <SidebarProperty className="barcode" label={l('Barcode:')}>
+          <SidebarProperty
+            className="barcode"
+            label={addColonText(l('Barcode'))}
+          >
             {barcode}
           </SidebarProperty>
         ) : null}
 
         {nonEmpty(combinedFormatName) ? (
-          <SidebarProperty className="format" label={l('Format:')}>
+          <SidebarProperty
+            className="format"
+            label={addColonText(l('Format'))}
+          >
             {combinedFormatName}
           </SidebarProperty>
         ) : null}
 
         {releaseLength == null ? null : (
-          <SidebarProperty className="length" label={l('Length:')}>
+          <SidebarProperty
+            className="length"
+            label={addColonText(l('Length'))}
+          >
             {formatTrackLength(releaseLength)}
           </SidebarProperty>
         )}
@@ -153,7 +162,10 @@ const ReleaseSidebar = ({release}: Props): React$Element<'div'> | null => {
         ) : null}
 
         {packagingId == null ? null : (
-          <SidebarProperty className="packaging" label={l('Packaging:')}>
+          <SidebarProperty
+            className="packaging"
+            label={addColonText(l('Packaging'))}
+          >
             {lp_attributes(
               linkedEntities.release_packaging[packagingId].name,
               'release_packaging',
@@ -174,7 +186,10 @@ const ReleaseSidebar = ({release}: Props): React$Element<'div'> | null => {
         )}
 
         {language ? (
-          <SidebarProperty className="language" label={l('Language:')}>
+          <SidebarProperty
+            className="language"
+            label={addColonText(l('Language'))}
+          >
             <LinkSearchableLanguage
               entityType="release"
               language={language}
@@ -183,7 +198,10 @@ const ReleaseSidebar = ({release}: Props): React$Element<'div'> | null => {
         ) : null}
 
         {script ? (
-          <SidebarProperty className="script" label={l('Script:')}>
+          <SidebarProperty
+            className="script"
+            label={addColonText(l('Script'))}
+          >
             <LinkSearchableProperty
               entityType="release"
               searchField="script"

--- a/root/layout/components/sidebar/SidebarIpis.js
+++ b/root/layout/components/sidebar/SidebarIpis.js
@@ -15,7 +15,7 @@ const buildSidebarIpi = (ipi: IpiCodeT) => (
   <SidebarProperty
     className="ipi-code"
     key={'ipi-code-' + ipi.ipi}
-    label={l('IPI code:')}
+    label={addColonText(l('IPI code'))}
   >
     {ipi.ipi}
   </SidebarProperty>

--- a/root/layout/components/sidebar/SidebarIsnis.js
+++ b/root/layout/components/sidebar/SidebarIsnis.js
@@ -19,7 +19,7 @@ const buildSidebarIsni = (isni: IsniCodeT) => (
   <SidebarProperty
     className="isni-code"
     key={'isni-code-' + isni.isni}
-    label={l('ISNI code:')}
+    label={addColonText(l('ISNI code'))}
   >
     <a href={isniUrl + isni.isni}>
       {formatIsni(isni.isni)}

--- a/root/layout/merge-helper.tt
+++ b/root/layout/merge-helper.tt
@@ -27,7 +27,7 @@
     [% END %]
     <div class="buttons" style="display: table-cell">
       [% IF merger.ready_to_merge %]
-        <button type="submit" name="submit" value="merge" class="positive">[% l('Merge') %]</button>
+        <button type="submit" name="submit" value="merge" class="positive">[% lp('Merge', 'button/link') %]</button>
       [% END %]
       <button type="submit" name="submit" value="remove">
         [% l('Remove selected entities') %]</button>

--- a/root/main/error/components/ErrorEnvironment.js
+++ b/root/main/error/components/ErrorEnvironment.js
@@ -24,7 +24,7 @@ const ErrorEnvironment = ({
   return (
     <>
       <p>
-        <strong>{l('Time:')}</strong>
+        <strong>{addColonText(l('Time'))}</strong>
         {' '}
         {new Date().toISOString()}
       </p>
@@ -46,7 +46,7 @@ const ErrorEnvironment = ({
       ) : null}
 
       <p>
-        <strong>{l('URL:')}</strong>
+        <strong>{addColonText(l('URL'))}</strong>
         {' '}
         <code>{$c.req.uri}</code>
       </p>

--- a/root/main/error/components/ErrorInfo.js
+++ b/root/main/error/components/ErrorInfo.js
@@ -18,7 +18,9 @@ const ErrorInfo = ({
 }: Props): (React$Element<'p'>) => (
   formattedErrors ? (
     <p id="errors">
-      <strong>{ln('Error:', 'Errors:', formattedErrors.length)}</strong>
+      <strong>
+        {addColonText(ln('Error', 'Errors', formattedErrors.length))}
+      </strong>
       {formattedErrors.map((error, index) => <pre key={index}>{error}</pre>)}
     </p>
   ) : (

--- a/root/place/edit_form.tt
+++ b/root/place/edit_form.tt
@@ -13,10 +13,10 @@
         [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
         [%- disambiguation_error() -%]
         [%- form_row_select(r, 'type_id', l('Type:')) -%]
-        [%- form_row_text_long(r, 'address', l('Address:')) -%]
+        [%- form_row_text_long(r, 'address', add_colon(l('Address'))) -%]
         [% WRAPPER form_row %]
           [% area_field = form.field('area.name') %]
-          <label for="id-edit-place.area.name">[% l('Area:') %]</label>
+          <label for="id-edit-place.area.name">[% add_colon(l('Area')) %]</label>
           <span class="area autocomplete">
             [% React.embed(c, 'static/scripts/common/components/SearchIcon') %]
             [% r.hidden(form.field('area').field('gid'), class => 'gid') %]

--- a/root/recording/edit_form.tt
+++ b/root/recording/edit_form.tt
@@ -32,17 +32,17 @@
       <div id="artist-credit-editor"></div>
       [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
       [%- IF !form.used_by_tracks || form.field('length').has_errors -%]
-        [%- form_row_text_long(r, 'length', l('Length:')) -%]
+        [%- form_row_text_long(r, 'length', add_colon(l('Length'))) -%]
       [%- ELSE -%]
         [% WRAPPER form_row %]
-          <label>[% l('Length:') %]</label>
+          <label>[% add_colon(l('Length')) %]</label>
           [% l('{recording_length} ({length_info|derived} from the associated track lengths)',
                 recording_length => format_length(form.field('length').value),
                 length_info => { href => doc_link('Recording'), target => '_blank' } ) %]
         [%- END -%]
       [%- END -%]
       [%- form_row_checkbox(r, 'video', l('Video')) -%]
-      [%- form_row_text_list(r, 'isrcs', l('ISRCs:'), l('ISRC')) -%]
+      [%- form_row_text_list(r, 'isrcs', add_colon(l('ISRCs')), l('ISRC')) -%]
     </fieldset>
 
     [% PROCESS 'forms/relationship-editor.tt' %]

--- a/root/relationship/linkattributetype/RelationshipAttributeTypeIndex.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypeIndex.js
@@ -115,11 +115,11 @@ const RelationshipAttributeTypeIndex = ({
         <p>
           {isRelationshipEditor($c.user) ? (
             <>
-              <strong>{l('ID:')}</strong>
+              <strong>{addColonText(l('ID'))}</strong>
               {' '}
               {attribute.id}
               <br />
-              <strong>{l('Child order:')}</strong>
+              <strong>{addColonText(l('Child order'))}</strong>
               {' '}
               {attribute.child_order}
               <br />

--- a/root/relationship/linkattributetype/RelationshipAttributeTypesList.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypesList.js
@@ -147,7 +147,7 @@ const AttributesList = ({root}: AttributesListProps) => {
                 <>
                   <br />
                   <br />
-                  {l('Possible values:')}
+                  {addColonText(l('Possible values'))}
                   <ul>
                     {childrenAttrs
                       .slice(0)

--- a/root/relationship/linkattributetype/form.tt
+++ b/root/relationship/linkattributetype/form.tt
@@ -1,18 +1,18 @@
 <form action="[% c.req.uri %]" method="post">
     [%- USE r = FormRenderer(form) -%]
 
-    [% form_row_select(r, 'parent_id', l('Parent:')) %]
+    [% form_row_select(r, 'parent_id', add_colon(l('Parent'))) %]
 
     [% WRAPPER form_row %]
-        [% r.label('child_order', l('Child order:')) %]
+        [% r.label('child_order', add_colon(l('Child order'))) %]
         [% r.number('child_order') %]
         [% field_errors(form, 'child_order') %]
     [% END %]
 
-    [% form_row_text(r, 'name', l('Name:')) %]
+    [% form_row_text(r, 'name', add_colon(l('Name'))) %]
 
     [% WRAPPER form_row %]
-        [% r.label('description', l('Description:')) %]
+        [% r.label('description', add_colon(l('Description'))) %]
         [% r.textarea('description', { cols => 80, rows => 6 }) %]
         [% field_errors(form, 'description') %]
     [% END %]

--- a/root/relationship/linktype/RelationshipTypeIndex.js
+++ b/root/relationship/linktype/RelationshipTypeIndex.js
@@ -153,13 +153,13 @@ const RelationshipTypeIndex = ({
                 * with the MBID (MBS-11175), this should be hidden
                 * if the user is not a relationship editor.
                 */}
-              <strong>{l('ID:')}</strong>
+              <strong>{addColonText(l('ID'))}</strong>
               {' '}
               {relType.id}
               <br />
               {isRelationshipEditor($c.user) ? (
                 <>
-                  <strong>{l('Child order:')}</strong>
+                  <strong>{addColonText(l('Child order'))}</strong>
                   {' '}
                   {relType.child_order}
                   <br />

--- a/root/relationship/linktype/RelationshipTypePairTree.js
+++ b/root/relationship/linktype/RelationshipTypePairTree.js
@@ -55,7 +55,7 @@ const RelationshipTypeDetails = ({
       >
         {isRelationshipEditor($c.user) ? (
           <>
-            <strong>{l('Child order:')}</strong>
+            <strong>{addColonText(l('Child order'))}</strong>
             {' '}
             {relType.child_order}
             <br />
@@ -83,7 +83,7 @@ const RelationshipTypeDetails = ({
           : lp('(none)', 'link phrase')}
         <br />
 
-        <strong>{l('Description:')}</strong>
+        <strong>{addColonText(l('Description'))}</strong>
         {' '}
         {relType.description
           ? expand2react(l_relationships(relType.description))

--- a/root/relationship/linktype/form.tt
+++ b/root/relationship/linktype/form.tt
@@ -1,15 +1,15 @@
 <form action="[% c.req.uri %]" method="post" class="edit-relationship">
     [%- USE r = FormRenderer(form) -%]
 
-    [% form_row_select(r, 'parent_id', l('Parent:')) %]
+    [% form_row_select(r, 'parent_id', add_colon(l('Parent'))) %]
 
     [% WRAPPER form_row %]
-        [% r.label('child_order', l('Child order:')) %]
+        [% r.label('child_order', add_colon(l('Child order'))) %]
         [% r.number('child_order') %]
         [% field_errors(form, 'child_order') %]
     [% END %]
 
-    [% form_row_text_long(r, 'name', l('Name:')) %]
+    [% form_row_text_long(r, 'name', add_colon(l('Name'))) %]
     [% form_row_text_long(r, 'link_phrase', l('Forward link phrase:')) %]
     [% form_row_text_long(r, 'reverse_link_phrase', l('Reverse link phrase:')) %]
     [% form_row_text_long(r, 'long_link_phrase', l('Long link phrase:')) %]
@@ -17,7 +17,7 @@
     [% form_row_checkbox(r, 'has_dates', l('This relationship allows setting dates')) %]
 
     [% WRAPPER form_row %]
-        [% r.label('description', l('Description:')) %]
+        [% r.label('description', add_colon(l('Description'))) %]
         [% r.textarea('description', { cols => 80, rows => 6 }) %]
         [% field_errors(form, 'description') %]
     [% END %]
@@ -49,7 +49,7 @@
     [% END %]
 
     [% WRAPPER form_row %]
-        <label>[% l('Attributes:') %]</label>
+        <label>[% add_colon(l('Attributes')) %]</label>
         [% FOR field IN form.field('attributes').fields %]
             <div class="no-label">
                     [% r.hidden(field.field('type')) %]
@@ -62,7 +62,7 @@
     [% END %]
 
     [% WRAPPER form_row %]
-      [% r.label('documentation', l('Documentation:')) %]
+      [% r.label('documentation', add_colon(l('Documentation'))) %]
       [% r.textarea('documentation', { cols => 80, rows => 10 }) %]
     [% END %]
 
@@ -74,7 +74,7 @@
                 [% WRAPPER form_row %]
                     <label class="required"
                            data-bind="attr: { for: examplePrefix($index(), 'name') }">
-                        [%- l('Name:') -%]
+                        [%- add_colon(l('Name')) -%]
                     </label>
                     <input type="text" data-bind="attr: { name: examplePrefix($index(), 'name') }, value: name" />
                     <button type="button" data-bind="click: removeExample">
@@ -104,7 +104,7 @@
 
         <h3>[% l('Add a New Example') %]</h3>
         [% WRAPPER form_row %]
-            <label>[% l('Name:') %]</label>
+            <label>[% add_colon(l('Name')) %]</label>
             <input type="text" data-bind="value: currentExample.name" />
         [% END %]
 

--- a/root/release/add_cover_art.tt
+++ b/root/release/add_cover_art.tt
@@ -66,7 +66,7 @@
               <p style="margin-left: 162px;">[%- l('Please see the {doc|Cover Art Types} documentation for a description of these types.', { doc => { href => doc_link('Cover_Art/Types'), target => '_blank' } }) -%]</p>
             </div>
             <div class="comment row" data-bind="visible: status() == 'waiting'">
-              <label>[%- l('Comment:') -%]</label>
+              <label>[%- add_colon(l('Comment')) -%]</label>
               <input class="comment" type="text" size="47" data-bind="value: comment" />
             </div>
           </td>
@@ -122,7 +122,7 @@
     </div>
 
     <div class="row" id="cover-art-position-row">
-      <label id="cover-art-position-label" class="required">[% l('Position:') %]</label>
+      <label id="cover-art-position-label" class="required">[% add_colon(l('Position')) %]</label>
 
       [%- IF images.size == 0 -%]
         <div class="image-position-only">
@@ -137,7 +137,7 @@
               [% React.embed(c, 'static/scripts/edit/components/InformationIcon', {
                 style => {'align-self' => 'flex-start'},
                 title => l('Types:') _ ' ' _ (comma_only_list(image.l_types) || '-') _ 
-                        (image.comment ? (' / ' _ l('Comment:') _ ' ' _ image.comment) : '')}) %]
+                        (image.comment ? (' / ' _ add_colon(l('Comment')) _ ' ' _ image.comment) : '')}) %]
             </div>
           </div>
         [%- END -%]

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -108,7 +108,7 @@
       </tr>
       [% END %]
 
-      [% table_row_select('status', l('Status:'), 2,
+      [% table_row_select('status', add_colon(lp('Status', 'release status')), 2,
           'value: statusID, controlsBubble: $root.statusBubble', statuses) %]
 
       [% table_row_select('language', l('Language:'), 2,

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -5,7 +5,7 @@
     <table class="row-form">
     <tbody>
       <tr>
-        <td><label for="title" class="required">[% l('Title:') %]</label></td>
+        <td><label for="title" class="required">[% add_colon(l('Title')) %]</label></td>
         <td colspan="2">
           <table>
             <tr>
@@ -23,7 +23,7 @@
       [% table_row_error(2, 'showErrorWhenTabIsSwitched: needsName', l('A release title is required.')) %]
 
       <tr>
-        <td><label for="release-artist" class="required">[% l('Artist:') %]</label></td>
+        <td><label for="release-artist" class="required">[% add_colon(l('Artist')) %]</label></td>
         <td class="release-artist" data-bind="artistCreditEditor: $data"></td>
       </tr>
 
@@ -34,7 +34,7 @@
       ) %]
 
       <tr>
-        <td><label for="release-group">[% l('Release Group:') %]</label></td>
+        <td><label for="release-group">[% add_colon(l('Release Group')) %]</label></td>
         <td colspan="2">
           <span class="autocomplete">
             <input id="release-group" type="text"
@@ -111,10 +111,10 @@
       [% table_row_select('status', add_colon(lp('Status', 'release status')), 2,
           'value: statusID, controlsBubble: $root.statusBubble', statuses) %]
 
-      [% table_row_select('language', l('Language:'), 2,
+      [% table_row_select('language', add_colon(l('Language')), 2,
           'value: languageID, controlsBubble: $root.languageBubble', languages) %]
 
-      [% table_row_select('script', l('Script:'), 2,
+      [% table_row_select('script', add_colon(l('Script')), 2,
           'value: scriptID, controlsBubble: $root.scriptBubble', scripts) %]
     </tbody>
     </table>
@@ -127,7 +127,7 @@
     <tbody>
     <!-- ko foreach: events -->
       <tr>
-        <td><label>[% l('Date:') %]</label></td>
+        <td><label>[% add_colon(l('Date')) %]</label></td>
         <td class="partial-date">
           <span class="partial-date">
             <input type="text" maxlength="4" placeholder="[% l('YYYY') %]" size="4"
@@ -153,7 +153,7 @@
                   controlsBubble: $root.dateBubble" />
           </span>
         </td>
-        [% table_cells_select('country', l('Country:'), 1,
+        [% table_cells_select('country', add_colon(l('Country')), 1,
             "value: countryID, withLabel: 'country'", countries) %]
         <td>
           <button type="button" class="icon remove-item remove-release-event" title="[% l('Remove Release Event') %]" data-click="removeReleaseEvent"></button>
@@ -176,7 +176,7 @@
 
     <!-- ko foreach: labels -->
       <tr>
-        <td><label>[% l('Label:') %]</label></td>
+        <td><label>[% add_colon(l('Label')) %]</label></td>
         <td>
           <span class="autocomplete">
             <input type="text" class="name"
@@ -219,7 +219,7 @@
       </tr>
 
       <tr>
-        <td><label for="barcode">[% l('Barcode:') %]</label></td>
+        <td><label for="barcode">[% add_colon(l('Barcode')) %]</label></td>
         <td colspan="4">
           <input id="barcode" type="text" pattern="[0-9]*" data-bind="value: barcode.value, valueUpdate: 'input', disable: barcode.none, controlsBubble: $root.barcodeBubble" />
         </td>
@@ -237,7 +237,7 @@
         </td>
       </tr>
 
-      [% table_row_select('packaging', l('Packaging:'), 4,
+      [% table_row_select('packaging', add_colon(l('Packaging')), 4,
           'value: packagingID, controlsBubble: $root.packagingBubble', packagings) %]
     </tbody>
     </table>
@@ -248,7 +248,7 @@
     <table class="row-form">
     <tbody>
       <tr>
-        <td><label for="annotation">[% l('Annotation:') %]</label></td>
+        <td><label for="annotation">[% add_colon(l('Annotation')) %]</label></td>
         <td>
           <textarea id="annotation" data-bind="value: annotation, controlsBubble: $root.annotationBubble"></textarea>
         </td>

--- a/root/release/edit/recordings.tt
+++ b/root/release/edit/recordings.tt
@@ -1,6 +1,6 @@
 <div class="changes" data-bind="with: rootField.release">
   <div class="warning field-error" data-bind="showErrorRightAway: needsRecordings">
-    <p><strong>[% l('Note:') %]</strong> [%- l('All tracks require an associated recording. Click “Edit” to select a recording for each track. Choose “Add a new recording” if an appropriate one doesn’t exist yet.') -%]</p>
+    <p><strong>[% add_colon(l('Note')) %]</strong> [%- l('All tracks require an associated recording. Click “Edit” to select a recording for each track. Choose “Add a new recording” if an appropriate one doesn’t exist yet.') -%]</p>
 
     <div data-bind="if: tracksWithUnsetPreviousRecordings().length">
       <p>
@@ -160,7 +160,7 @@
       <p>[% l('If we do not have a recording for this track in the database yet, please select "Add a new recording" below.') %]</p>
 
       <p data-bind="with: target">
-        [% l('Search:') %]
+        [% add_colon(l('Search')) %]
         <span class="autocomplete">
           [% React.embed(c, 'static/scripts/common/components/SearchIcon') %]
           <input type="text" class="name" data-bind="autocomplete: { entity: 'recording', currentSelection: recording, lookupHook: $root.recordingAssociation.autocompleteHook($data) }" />
@@ -196,7 +196,7 @@
           <tr>
             <td></td>
             <td colspan="3" class="appears-on">
-              [%- l('appears on:') %]
+              [%- add_colon(l('appears on')) %]
               <span class="appears" data-bind="html: appearsOn.results.map(function (x) { return x.html({ target: '_blank' }); }).join(', ')"></span>
             </td>
           </tr>

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -102,12 +102,12 @@
 <script type="text/html" id="template.medium-search">
   <table>
     <tr>
-      <td><label for="import-release">[% l('Release:') %]</label></td>
+      <td><label for="import-release">[% add_colon(l('Release')) %]</label></td>
       <td><input id="import-release" type="text" data-bind="value: releaseName, valueUpdate: 'afterkeydown'" data-keydown="keydownEvent" /></td>
       <td rowspan="2"></td>
     </tr>
     <tr>
-      <td><label for="import-artist">[% l('Artist:') %]</label></td>
+      <td><label for="import-artist">[% add_colon(l('Artist')) %]</label></td>
       <td><input id="import-artist" type="text" data-bind="value: artistName, valueUpdate: 'afterkeydown'" data-keydown="keydownEvent" /></td>
     </tr>
     <tr>
@@ -302,7 +302,7 @@
         </td>
 
         <td class="format">
-          <label data-bind="attr: { for: 'medium-format-' + uniqueID }">[% l('Format:') %]</label>
+          <label data-bind="attr: { for: 'medium-format-' + uniqueID }">[% add_colon(l('Format')) %]</label>
           <select data-bind="value: formatID, attr: { id: 'medium-format-' + uniqueID }">
             <option value="" selected="selected">—</option>
             [%- FOR format=formats %]
@@ -342,7 +342,7 @@
       <div class="medium-title warning">
         [%- warning_icon %]
         <p>
-          <strong>[% l('Warning:') | html_entity %]</strong>
+          <strong>[% add_colon(l('Warning')) | html_entity %]</strong>
           <span id="useless-medium-title-warning" data-bind='html: uselessMediumTitleWarning()' />
         </p>
         <label>
@@ -405,7 +405,7 @@
       <div class="various-artists warning">
         [%- warning_icon %]
         <p>
-          <strong>[% l('Warning:') | html_entity %]</strong>
+          <strong>[% add_colon(l('Warning')) | html_entity %]</strong>
           [% l('You’ve used the {valink|Various Artists} special purpose artist on some tracks below. {valink|Various Artists} should very rarely be used on tracks; please make sure the artists have been entered correctly.', { valink => va_doc_link }) %]
         </p>
         <label>

--- a/root/release/reorder_cover_art.tt
+++ b/root/release/reorder_cover_art.tt
@@ -19,7 +19,7 @@
             [% React.embed(c, 'static/scripts/edit/components/InformationIcon', {
               style => {'align-self' => 'flex-start'},
               title => l('Types:') _ ' ' _ (comma_only_list(image.l_types) || '-') _ 
-                       (image.comment ? (' / ' _ l('Comment:') _ ' ' _ image.comment) : '')}) %]
+                       (image.comment ? (' / ' _ add_colon(l('Comment')) _ ' ' _ image.comment) : '')}) %]
             <button type="button" class="right" style="float: right;">&rarr;</button>
           </div>
           <input type="hidden" value="[% image.id %]" class="id"

--- a/root/release_group/set_cover_art.tt
+++ b/root/release_group/set_cover_art.tt
@@ -29,37 +29,37 @@
           <div class="release-description">
             <p>
               [%- link_entity(release) -%]<br />
-              [%- l('Artist:') %] [% artist_credit(release.artist_credit) -%]
+              [%- add_colon(l('Artist')) %] [% artist_credit(release.artist_credit) -%]
             </p>
             [%- IF release.events -%]
               <p>
                 [%- IF release_dates_list(release.events) -%]
-                  [%- l('Date:') %] [% release_dates_list(release.events) %]
+                  [%- add_colon(l('Date')) %] [% release_dates_list(release.events) %]
                    <br />
                 [%- END -%]
                 [%- IF release_countries_list(release.events) -%]
-                  [%- l('Country:') %] [% release_countries_list(release.events) %]
+                  [%- add_colon(l('Country')) %] [% release_countries_list(release.events) %]
                 [%- END -%]
               </p>
             [%- END -%]
             <p>
-            [%- l('Format:') %] [% html_escape(release.combined_format_name) -%]<br/>
-            [%- l('Tracks:') %] [% release.combined_track_count -%]
+            [%- add_colon(l('Format')) %] [% html_escape(release.combined_format_name) -%]<br/>
+            [%- add_colon(l('Tracks')) %] [% release.combined_track_count -%]
             </p>
             [%- IF release.labels -%]
               <p>
                 [%- IF release_label_list(release.labels) -%]
-                  [%- l('Label:') %] [% release_label_list(release.labels) -%]
+                  [%- add_colon(l('Label')) %] [% release_label_list(release.labels) -%]
                   <br />
                 [%- END -%]
                 [%- IF release_catno_list(release.labels) -%]
-                  [%- l('Catalog#:') %] [% release_catno_list(release.labels) %]
+                  [%- add_colon(l('Catalog#')) %] [% release_catno_list(release.labels) %]
                 [%- END -%]
               </p>
             [%- END -%]
             [%- IF release.barcode -%]
               <p>
-                [%- l('Barcode:') %] [% release.barcode -%]
+                [%- add_colon(l('Barcode')) %] [% release.barcode -%]
               </p>
             [%- END -%]
             [%- IF image -%]
@@ -68,7 +68,7 @@
                 <ul>
                   <li>[%- l('Types:') %] [% comma_list(image.types) || '-' -%]</li>
                   [%- IF image.comment -%]
-                    <li>[%- l('Comment:') %] [% image.comment | html -%]</li>
+                    <li>[%- add_colon(l('Comment')) %] [% image.comment | html -%]</li>
                   [%- END -%]
                 </ul>
                 [%- IF originally_selected -%]

--- a/root/search/components/EventResults.js
+++ b/root/search/components/EventResults.js
@@ -75,7 +75,7 @@ const EventResults = ({
             <th>{l('Time')}</th>
             <th>{l('Type')}</th>
             <th>{l('Artists')}</th>
-            <th>{l('Location')}</th>
+            <th>{lp('Location', 'event location')}</th>
           </>
         }
         pager={pager}

--- a/root/search/components/ReleaseResults.js
+++ b/root/search/components/ReleaseResults.js
@@ -118,7 +118,7 @@ export const ReleaseResultsInline = ({
           <th>{l('Barcode')}</th>
           <th>{l('Language')}</th>
           <th>{l('Type')}</th>
-          <th>{l('Status')}</th>
+          <th>{lp('Status', 'release status')}</th>
           {$c?.session?.tport == null
             ? null
             : <th>{l('Tagger')}</th>}

--- a/root/series/edit_form.tt
+++ b/root/series/edit_form.tt
@@ -14,7 +14,7 @@
         [%- disambiguation_error() -%]
         [%# When porting this, remember no_default is equivalent to allowEmpty %]
         [%- form_row_select(r, 'type_id', l('Type:'), undef, {no_default => 1}) -%]
-        [%- form_row_select(r, 'ordering_type_id', l('Ordering Type:')) -%]
+        [%- form_row_select(r, 'ordering_type_id', add_colon(l('Ordering Type'))) -%]
       </fieldset>
 
       [% React.embed(c, 'static/scripts/series/components/SeriesRelationshipEditor', {

--- a/root/static/scripts/account/components/EditProfileForm.js
+++ b/root/static/scripts/account/components/EditProfileForm.js
@@ -242,7 +242,7 @@ class EditProfileForm extends React.Component<Props, State> {
         <FormRow>
           <FormLabel
             forField={areaField.name}
-            label={l('Location:')}
+            label={addColonText(lp('Location', 'user area'))}
           />
           <Autocomplete
             currentSelection={{

--- a/root/static/scripts/account/components/EditProfileForm.js
+++ b/root/static/scripts/account/components/EditProfileForm.js
@@ -234,7 +234,7 @@ class EditProfileForm extends React.Component<Props, State> {
         <FormRowSelect
           allowEmpty
           field={field.gender_id}
-          label={l('Gender:')}
+          label={addColonText(l('Gender'))}
           onChange={this.handleGenderChangeBound}
           options={genderOptions}
         />
@@ -286,7 +286,7 @@ class EditProfileForm extends React.Component<Props, State> {
 
         <FormRowTextArea
           field={field.biography}
-          label={l('Bio:')}
+          label={addColonText(l('Bio'))}
         />
 
         <FormRow>

--- a/root/static/scripts/annotation/AnnotationHistoryTable.js
+++ b/root/static/scripts/annotation/AnnotationHistoryTable.js
@@ -98,8 +98,8 @@ const AnnotationHistoryTable = ({
         <tr>
           {canCompare ? (
             <>
-              <th className="pos">{l('Old')}</th>
-              <th className="pos">{l('New')}</th>
+              <th className="pos">{lp('Old', 'annotation')}</th>
+              <th className="pos">{lp('New', 'annotation')}</th>
             </>
           ) : null}
           <th>{l('Editor')}</th>

--- a/root/static/scripts/artist/components/ArtistCreditRenamer.js
+++ b/root/static/scripts/artist/components/ArtistCreditRenamer.js
@@ -275,7 +275,7 @@ const ArtistCreditRenamer = ({
       ) : null}
       {state.selection.length ? (
         <>
-          <h2>{l('Preview')}</h2>
+          <h2>{lp('Preview', 'header')}</h2>
           <table
             className="details split-artist"
             style={MARGIN_1EM}

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -1045,7 +1045,10 @@ MB.Control.autocomplete_formatters = {
 
     if (item.related_entities) {
       entityRenderer(l('Performers'), item.related_entities.performers);
-      entityRenderer(l('Location'), item.related_entities.places);
+      entityRenderer(
+        lp('Location', 'event location'),
+        item.related_entities.places,
+      );
     }
 
     return $('<li>').append(a).appendTo(ul);

--- a/root/static/scripts/common/components/Autocomplete2/formatters.js
+++ b/root/static/scripts/common/components/Autocomplete2/formatters.js
@@ -217,7 +217,10 @@ function formatEvent(event: EventT) {
         l('Performers'),
         event.related_entities?.performers,
       )}
-      {showRelatedEntities(l('Location'), event.related_entities?.places)}
+      {showRelatedEntities(
+        lp('Location', 'event location'),
+        event.related_entities?.places,
+      )}
     </>
   );
 }

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -203,7 +203,7 @@ const FilterForm = ({form}: Props): React$Element<'div'> => {
             {statusIdField && statusIdOptions ? (
               <tr>
                 <td>
-                  {addColonText(l('Status'))}
+                  {addColonText(lp('Status', 'release status'))}
                 </td>
                 <td>
                   <SelectField

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -115,7 +115,7 @@ const FilterForm = ({form}: Props): React$Element<'div'> => {
             {artistCreditIdField && artistCreditIdOptions ? (
               <tr>
                 <td>
-                  {l('Artist credit:')}
+                  {addColonText(l('Artist credit'))}
                 </td>
                 <td>
                   <SelectField

--- a/root/static/scripts/edit/MB/Control/ArtistEdit.js
+++ b/root/static/scripts/edit/MB/Control/ArtistEdit.js
@@ -49,7 +49,7 @@ MB.Control.ArtistEdit = function () {
       case '0':
         self.changeDateText(
           l('Began:'),
-          l('Ended:'),
+          addColonText(lp('Ended', 'artist end date')),
           l('This artist has ended.'),
         );
         self.changeAreaText(l('Begin area:'), l('End area:'));

--- a/root/static/scripts/edit/components/ArtistCreditBubble.js
+++ b/root/static/scripts/edit/components/ArtistCreditBubble.js
@@ -67,7 +67,7 @@ const ArtistCreditBubble = ({
         {clean(reduceArtistCredit(artistCredit)) ? (
           <tr>
             <td colSpan="4" style={{paddingBottom: '1em'}}>
-              {l('Preview:') + ' '}
+              {addColonText(lp('Preview', 'header')) + ' '}
               {entity.entityType === 'track'
                 ? (
                   <DescriptiveLink

--- a/root/static/scripts/edit/components/edit/RelationshipDiff.js
+++ b/root/static/scripts/edit/components/edit/RelationshipDiff.js
@@ -196,7 +196,7 @@ const RelationshipDiff = (React.memo(({
   return (
     <>
       <tr>
-        <th rowSpan="2">{l('Relationship:')}</th>
+        <th rowSpan="2">{addColonText(l('Relationship'))}</th>
         <td className="old">
           {oldPhrase}
           {' '}

--- a/root/static/scripts/edit/components/edit/ReleaseEventsDiff.js
+++ b/root/static/scripts/edit/components/edit/ReleaseEventsDiff.js
@@ -119,7 +119,7 @@ const ReleaseEventsDiff = ({
 
   return (
     <tr className="release-events-diff">
-      <th>{l('Release events:')}</th>
+      <th>{addColonText(l('Release events'))}</th>
       <td className="old">
         <ul>
           {React.createElement(React.Fragment, null, ...oldSide)}

--- a/root/static/scripts/edit/components/forms.js
+++ b/root/static/scripts/edit/components/forms.js
@@ -26,7 +26,7 @@ export const FormRowArtistCredit = ({
 }) => (
   <FormRow>
     <label className="required" htmlFor="entity-artist">
-      {l('Artist:')}
+      {addColonText(l('Artist'))}
     </label>
     <ArtistCreditEditor
       entity={entity}

--- a/root/static/scripts/relationship-editor/components/DialogPreview.js
+++ b/root/static/scripts/relationship-editor/components/DialogPreview.js
@@ -169,7 +169,7 @@ const DialogPreview = (React.memo<PropsT>(({
       <h2>
         <div className="heading-line" />
         <span className="heading-text">
-          {l('Preview')}
+          {lp('Preview', 'header')}
         </span>
       </h2>
       {(oldRelationship && newRelationship) ? (

--- a/root/static/scripts/relationship-editor/components/DialogPreview.js
+++ b/root/static/scripts/relationship-editor/components/DialogPreview.js
@@ -130,7 +130,7 @@ const DialogPreview = (React.memo<PropsT>(({
       <table className={fullClassName}>
         <tbody>
           <tr>
-            <th>{l('Relationship:')}</th>
+            <th>{addColonText(l('Relationship'))}</th>
             <td>
               <Relationship
                 makeEntityLink={makeEntityLink}

--- a/root/static/scripts/release/components/EditWorkDialog.js
+++ b/root/static/scripts/release/components/EditWorkDialog.js
@@ -163,7 +163,7 @@ const EditWorkDialog: React$AbstractComponent<
       <table className="work-details">
         <tbody>
           <tr>
-            <td className="section">{l('Name:')}</td>
+            <td className="section">{addColonText(l('Name'))}</td>
             <td>
               <input
                 onChange={handleNameChange}

--- a/root/static/scripts/release/components/WorkTypeSelect.js
+++ b/root/static/scripts/release/components/WorkTypeSelect.js
@@ -55,7 +55,7 @@ const WorkTypeSelect: React$AbstractComponent<
 
   return (
     <tr>
-      <td className="section">{l('Work Type:')}</td>
+      <td className="section">{addColonText(l('Work type'))}</td>
       <td>
         <select
           id="work-type"

--- a/root/statistics/Index.js
+++ b/root/statistics/Index.js
@@ -91,59 +91,59 @@ const Index = ({
             <th colSpan="4">{l('Core Entities')}</th>
           </tr>
           <tr>
-            <th>{l('Artists:')}</th>
+            <th>{addColonText(l('Artists'))}</th>
             <td colSpan="3">{fc('artist')}</td>
           </tr>
           <tr>
-            <th>{l('Release Groups:')}</th>
+            <th>{addColonText(l('Release Groups'))}</th>
             <td colSpan="3">{fc('releasegroup')}</td>
           </tr>
           <tr>
-            <th>{l('Releases:')}</th>
+            <th>{addColonText(l('Releases'))}</th>
             <td colSpan="3">{fc('release')}</td>
           </tr>
           <tr>
-            <th>{l('Mediums:')}</th>
+            <th>{addColonText(l('Mediums'))}</th>
             <td colSpan="3">{fc('medium')}</td>
           </tr>
           <tr>
-            <th>{l('Recordings:')}</th>
+            <th>{addColonText(l('Recordings'))}</th>
             <td colSpan="3">{fc('recording')}</td>
           </tr>
           <tr>
-            <th>{l('Tracks:')}</th>
+            <th>{addColonText(l('Tracks)'))}</th>
             <td colSpan="3">{fc('track')}</td>
           </tr>
           <tr>
-            <th>{l('Labels:')}</th>
+            <th>{addColonText(l('Labels'))}</th>
             <td colSpan="3">{fc('label')}</td>
           </tr>
           <tr>
-            <th>{l('Works:')}</th>
+            <th>{addColonText(l('Works'))}</th>
             <td colSpan="3">{fc('work')}</td>
           </tr>
           <tr>
-            <th>{l('URLs:')}</th>
+            <th>{addColonText(l('URLs'))}</th>
             <td colSpan="3">{fc('url')}</td>
           </tr>
           <tr>
-            <th>{l('Areas:')}</th>
+            <th>{addColonText(l('Areas'))}</th>
             <td colSpan="3">{fc('area')}</td>
           </tr>
           <tr>
-            <th>{l('Places:')}</th>
+            <th>{addColonText(l('Places'))}</th>
             <td colSpan="3">{fc('place')}</td>
           </tr>
           <tr>
-            <th>{lp('Series:', 'plural')}</th>
+            <th>{addColonText(lp('Series', 'plural'))}</th>
             <td colSpan="3">{fc('series')}</td>
           </tr>
           <tr>
-            <th>{l('Instruments:')}</th>
+            <th>{addColonText(l('Instruments'))}</th>
             <td colSpan="3">{fc('instrument')}</td>
           </tr>
           <tr>
-            <th>{l('Events:')}</th>
+            <th>{addColonText(l('Events'))}</th>
             <td colSpan="3">{fc('event')}</td>
           </tr>
           <tr>
@@ -162,7 +162,7 @@ const Index = ({
             <td>{fc('editor.deleted')}</td>
           </tr>
           <tr>
-            <th>{l('Relationships:')}</th>
+            <th>{addColonText(l('Relationships'))}</th>
             <td colSpan="3">{fc('ar.links')}</td>
           </tr>
           <tr>
@@ -196,7 +196,7 @@ const Index = ({
             <th colSpan="4">{l('Identifiers')}</th>
           </tr>
           <tr>
-            <th>{l('MBIDs:')}</th>
+            <th>{addColonText(l('MBIDs'))}</th>
             <td colSpan="3">{fc('mbid')}</td>
           </tr>
           <tr>
@@ -212,19 +212,19 @@ const Index = ({
             <td>{fc('iswc')}</td>
           </tr>
           <tr>
-            <th>{l('Disc IDs:')}</th>
+            <th>{addColonText(l('Disc IDs'))}</th>
             <td colSpan="3">{fc('discid')}</td>
           </tr>
           <tr>
-            <th>{l('Barcodes:')}</th>
+            <th>{addColonText(l('Barcodes'))}</th>
             <td colSpan="3">{fc('barcode')}</td>
           </tr>
           <tr>
-            <th>{l('IPIs:')}</th>
+            <th>{addColonText(l('IPIs'))}</th>
             <td colSpan="3">{fc('ipi')}</td>
           </tr>
           <tr>
-            <th>{l('ISNIs:')}</th>
+            <th>{addColonText(l('ISNIs'))}</th>
             <td colSpan="3">{fc('isni')}</td>
           </tr>
         </tbody>
@@ -237,7 +237,7 @@ const Index = ({
             <th colSpan="4">{l('Artists')}</th>
           </tr>
           <tr>
-            <th colSpan="2">{l('Artists:')}</th>
+            <th colSpan="2">{addColonText(l('Artists'))}</th>
             <td>{fc('artist')}</td>
             <td />
           </tr>
@@ -376,7 +376,7 @@ const Index = ({
             <th colSpan="5">{l('Releases')}</th>
           </tr>
           <tr>
-            <th colSpan="3">{l('Releases:')}</th>
+            <th colSpan="3">{addColonText(l('Releases'))}</th>
             <td>{fc('release')}</td>
             <td />
           </tr>
@@ -398,7 +398,7 @@ const Index = ({
             <th colSpan="5">{l('Release Status')}</th>
           </tr>
           <tr>
-            <th colSpan="3">{l('Releases:')}</th>
+            <th colSpan="3">{addColonText(l('Releases'))}</th>
             <td>{fc('release')}</td>
             <td />
           </tr>
@@ -424,7 +424,7 @@ const Index = ({
             <th colSpan="5">{l('Release Packaging')}</th>
           </tr>
           <tr>
-            <th colSpan="3">{l('Releases:')}</th>
+            <th colSpan="3">{addColonText(l('Releases'))}</th>
             <td>{fc('release')}</td>
             <td />
           </tr>
@@ -450,7 +450,7 @@ const Index = ({
             <th colSpan="5">{l('Cover Art Sources')}</th>
           </tr>
           <tr>
-            <th colSpan="3">{l('Releases:')}</th>
+            <th colSpan="3">{addColonText(l('Releases'))}</th>
             <td>{fc('release')}</td>
             <td />
           </tr>
@@ -472,33 +472,33 @@ const Index = ({
             <th colSpan="5">{l('Data Quality')}</th>
           </tr>
           <tr>
-            <th colSpan="3">{l('Releases:')}</th>
+            <th colSpan="3">{addColonText(l('Releases'))}</th>
             <td>{fc('release')}</td>
             <td />
           </tr>
           <tr>
             <th />
-            <th colSpan="2">{l('High Data Quality:')}</th>
+            <th colSpan="2">{addColonText(l('High Data Quality'))}</th>
             <td>{fc('quality.release.high')}</td>
             <td>{fp('quality.release.high', 'release')}</td>
           </tr>
           <tr>
             <th />
-            <th colSpan="2">{l('Default Data Quality:')}</th>
+            <th colSpan="2">{addColonText(l('Default Data Quality'))}</th>
             <td>{fc('quality.release.default')}</td>
             <td>{fp('quality.release.default', 'release')}</td>
           </tr>
           <tr>
             <th />
             <th />
-            <th>{l('Normal Data Quality:')}</th>
+            <th>{addColonText(l('Normal Data Quality'))}</th>
             <td>{fc('quality.release.normal')}</td>
             <td>{fp('quality.release.normal', 'quality.release.default')}</td>
           </tr>
           <tr>
             <th />
             <th />
-            <th>{l('Unknown Data Quality:')}</th>
+            <th>{addColonText(l('Unknown Data Quality'))}</th>
             <td>{fc('quality.release.unknown')}</td>
             <td>
               {fp('quality.release.unknown', 'quality.release.default')}
@@ -506,7 +506,7 @@ const Index = ({
           </tr>
           <tr>
             <th />
-            <th colSpan="2">{l('Low Data Quality:')}</th>
+            <th colSpan="2">{addColonText(l('Low Data Quality'))}</th>
             <td>{fc('quality.release.low')}</td>
             <td>{fp('quality.release.low', 'release')}</td>
           </tr>
@@ -516,12 +516,12 @@ const Index = ({
             <th colSpan="5">{l('Disc IDs')}</th>
           </tr>
           <tr>
-            <th colSpan="3">{l('Disc IDs:')}</th>
+            <th colSpan="3">{addColonText(l('Disc IDs'))}</th>
             <td>{fc('discid')}</td>
             <td />
           </tr>
           <tr>
-            <th colSpan="3">{l('Releases:')}</th>
+            <th colSpan="3">{addColonText(l('Releases'))}</th>
             <td>{fc('release')}</td>
             <td />
           </tr>
@@ -565,7 +565,7 @@ const Index = ({
             <td>{fp('release.10discids', 'release.has_discid')}</td>
           </tr>
           <tr>
-            <th colSpan="3">{l('Mediums:')}</th>
+            <th colSpan="3">{addColonText(l('Mediums'))}</th>
             <td>{fc('medium')}</td>
             <td />
           </tr>
@@ -616,7 +616,7 @@ const Index = ({
             <th colSpan="4">{l('Primary Types')}</th>
           </tr>
           <tr>
-            <th colSpan="2">{l('Release Groups:')}</th>
+            <th colSpan="2">{addColonText(l('Release Groups'))}</th>
             <td>{fc('releasegroup')}</td>
             <td />
           </tr>
@@ -648,7 +648,7 @@ const Index = ({
             <th colSpan="4">{l('Secondary Types')}</th>
           </tr>
           <tr>
-            <th colSpan="2">{l('Release Groups:')}</th>
+            <th colSpan="2">{addColonText(l('Release Groups'))}</th>
             <td>{fc('releasegroup')}</td>
             <td />
           </tr>
@@ -686,12 +686,12 @@ const Index = ({
             <th colSpan="3">{l('Recordings')}</th>
           </tr>
           <tr>
-            <th>{l('Recordings:')}</th>
+            <th>{addColonText(l('Recordings'))}</th>
             <td>{fc('recording')}</td>
             <td />
           </tr>
           <tr>
-            <th>{l('Videos:')}</th>
+            <th>{addColonText(l('Videos'))}</th>
             <td>{fc('video')}</td>
             <td>{fp('video', 'recording')}</td>
           </tr>
@@ -743,7 +743,7 @@ const Index = ({
             <th colSpan="4">{l('Types')}</th>
           </tr>
           <tr>
-            <th colSpan="2">{l('Works:')}</th>
+            <th colSpan="2">{addColonText(l('Works'))}</th>
             <td>{fc('work')}</td>
             <td />
           </tr>
@@ -775,7 +775,7 @@ const Index = ({
             <th colSpan="4">{l('Attributes')}</th>
           </tr>
           <tr>
-            <th colSpan="2">{l('Works:')}</th>
+            <th colSpan="2">{addColonText(l('Works'))}</th>
             <td>{fc('work')}</td>
             <td />
           </tr>
@@ -805,7 +805,7 @@ const Index = ({
             <th colSpan="4">{l('Types')}</th>
           </tr>
           <tr>
-            <th colSpan="2">{l('Areas:')}</th>
+            <th colSpan="2">{addColonText(l('Areas'))}</th>
             <td>{fc('area')}</td>
             <td />
           </tr>
@@ -833,7 +833,7 @@ const Index = ({
             <th colSpan="4">{l('Types')}</th>
           </tr>
           <tr>
-            <th colSpan="2">{l('Places:')}</th>
+            <th colSpan="2">{addColonText(l('Places'))}</th>
             <td>{fc('place')}</td>
             <td />
           </tr>
@@ -861,7 +861,7 @@ const Index = ({
             <th colSpan="4">{l('Types')}</th>
           </tr>
           <tr>
-            <th colSpan="2">{lp('Series:', 'plural')}</th>
+            <th colSpan="2">{addColonText(lp('Series', 'plural'))}</th>
             <td>{fc('series')}</td>
             <td />
           </tr>
@@ -883,7 +883,7 @@ const Index = ({
             <th colSpan="4">{l('Types')}</th>
           </tr>
           <tr>
-            <th colSpan="2">{l('Instruments:')}</th>
+            <th colSpan="2">{addColonText(l('Instruments'))}</th>
             <td>{fc('instrument')}</td>
             <td />
           </tr>
@@ -913,7 +913,7 @@ const Index = ({
             <th colSpan="4">{l('Types')}</th>
           </tr>
           <tr>
-            <th colSpan="2">{l('Events:')}</th>
+            <th colSpan="2">{addColonText(('Events'))}</th>
             <td>{fc('event')}</td>
             <td />
           </tr>
@@ -1220,25 +1220,25 @@ const Index = ({
             <th colSpan="6">{l('Edits')}</th>
           </tr>
           <tr>
-            <th colSpan="4">{l('Edits:')}</th>
+            <th colSpan="4">{addColonText(l('Edits'))}</th>
             <td>{fc('edit')}</td>
             <td />
           </tr>
           <tr>
             <th />
-            <th colSpan="3">{l('Open:')}</th>
+            <th colSpan="3">{addColonText(l('Open'))}</th>
             <td>{fc('edit.open')}</td>
             <td>{fp('edit.open', 'edit')}</td>
           </tr>
           <tr>
             <th />
-            <th colSpan="3">{l('Applied:')}</th>
+            <th colSpan="3">{addColonText(l('Applied'))}</th>
             <td>{fc('edit.applied')}</td>
             <td>{fp('edit.applied', 'edit')}</td>
           </tr>
           <tr>
             <th />
-            <th colSpan="3">{l('Voted down:')}</th>
+            <th colSpan="3">{addColonText(l('Voted down'))}</th>
             <td>{fc('edit.failedvote')}</td>
             <td>{fp('edit.failedvote', 'edit')}</td>
           </tr>
@@ -1267,7 +1267,7 @@ const Index = ({
             <td>{fp('edit.deleted', 'edit')}</td>
           </tr>
           <tr>
-            <th colSpan="4">{l('Edits:')}</th>
+            <th colSpan="4">{addColonText(l('Edits'))}</th>
             <td>{fc('edit')}</td>
             <td />
           </tr>
@@ -1290,7 +1290,7 @@ const Index = ({
             <th colSpan="6">{l('Votes')}</th>
           </tr>
           <tr>
-            <th colSpan="4">{l('Votes:')}</th>
+            <th colSpan="4">{addColonText(l('Votes'))}</th>
             <td>{fc('vote')}</td>
             <td />
           </tr>
@@ -1319,7 +1319,7 @@ const Index = ({
             <td>{fp('vote.abstain', 'vote')}</td>
           </tr>
           <tr>
-            <th colSpan="4">{l('Votes:')}</th>
+            <th colSpan="4">{addColonText(l('Votes'))}</th>
             <td>{fc('vote')}</td>
             <td />
           </tr>

--- a/root/statistics/Index.js
+++ b/root/statistics/Index.js
@@ -1262,7 +1262,7 @@ const Index = ({
           </tr>
           <tr>
             <th />
-            <th colSpan="3">{l('Cancelled:')}</th>
+            <th colSpan="3">{addColonText(lp('Cancelled', 'edit'))}</th>
             <td>{fc('edit.deleted')}</td>
             <td>{fp('edit.deleted', 'edit')}</td>
           </tr>

--- a/root/statistics/Relationships.js
+++ b/root/statistics/Relationships.js
@@ -122,7 +122,7 @@ const Relationships = ({
               <th />
             </tr>
             <tr>
-              <th>{l('Relationships:')}</th>
+              <th>{addColonText(l('Relationships'))}</th>
               <td />
               <td>
                 {formatCount($c, stats['count.ar.links'])}

--- a/root/statistics/timeline.tt
+++ b/root/statistics/timeline.tt
@@ -16,7 +16,7 @@
             <tr><th>[% l('Zoom:') %]</th><td>[% l('Draw a rectangle on either graph') %]</td></tr>
             <tr><th>[% l('Reset:') %]</th><td>[% l('Click to deselect') %]</td></tr>
             <tr><th>[% l('Add/remove lines:') %]</th><td>[% l('Check boxes above') %]</td></tr>
-            <tr><th>[% l('MusicBrainz Events:') %]</th><td>[% l('Hover and click on vertical lines') %]</td></tr>
+            <tr><th>[% add_colon(l('MusicBrainz Events')) %]</th><td>[% l('Hover and click on vertical lines') %]</td></tr>
         </table>
         <div id="overview" data-bind="flot: 'overview'"></div>
     </div>

--- a/root/url/edit_form.tt
+++ b/root/url/edit_form.tt
@@ -3,7 +3,7 @@
 <h2>[% l('Edit URL') %]</h2>
 <form action="[% c.req.uri %]" method="post">
     [% USE r = FormRenderer(form) %]
-    [% form_row_url_long(r, 'url', l('URL:')) %]
+    [% form_row_url_long(r, 'url', add_colon(l('URL'))) %]
 
     [% React.embed(c, 'static/scripts/url/components/UrlRelationshipEditor', {
         formName => form.name,

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -271,7 +271,9 @@ const UserProfileInformation = ({
         ) : null}
 
         {area ? (
-          <UserProfileProperty name={l('Location:')}>
+          <UserProfileProperty
+            name={addColonText(lp('Location', 'user area'))}
+          >
             <DescriptiveLink entity={area} />
           </UserProfileProperty>
         ) : null}

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -641,7 +641,7 @@ const UserProfileStatistics = ({
             ) : formatCount($c, editStats.failed_count)}
           </UserProfileProperty>
 
-          <UserProfileProperty name={l('Cancelled')}>
+          <UserProfileProperty name={lp('Cancelled', 'edit')}>
             {$c.user ? exp.l(
               '{count} ({view_url|view})',
               {

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -186,7 +186,7 @@ const UserProfileInformation = ({
       <h2>{l('General Information')}</h2>
 
       <table className="profileinfo" role="presentation">
-        <UserProfileProperty name={l('Email:')}>
+        <UserProfileProperty name={addColonText(l('Email'))}>
           {user.has_email_address ? (
             <>
               {viewingOwnProfile ? email : l('(hidden)')}
@@ -265,7 +265,7 @@ const UserProfileInformation = ({
         ) : null}
 
         {gender ? (
-          <UserProfileProperty name={l('Gender:')}>
+          <UserProfileProperty name={addColonText(l('Gender'))}>
             {lp_attributes(gender.name, 'gender')}
           </UserProfileProperty>
         ) : null}
@@ -278,7 +278,7 @@ const UserProfileInformation = ({
           </UserProfileProperty>
         ) : null}
 
-        <UserProfileProperty name={l('Member since:')}>
+        <UserProfileProperty name={addColonText(l('Member since'))}>
           {memberSince}
         </UserProfileProperty>
 
@@ -291,7 +291,7 @@ const UserProfileInformation = ({
 
         {(viewingOwnProfile || isAccountAdmin(viewingUser)) ? (
           <>
-            <UserProfileProperty name={l('Last login:')}>
+            <UserProfileProperty name={addColonText(l('Last login'))}>
               {nonEmpty(user.last_login_date)
                 ? formatUserDate($c, user.last_login_date)
                 : l("Hasn't logged in yet")}
@@ -350,7 +350,7 @@ const UserProfileInformation = ({
         ) : null}
 
         {user.deleted ? null : (
-          <UserProfileProperty name={l('Subscribers:')}>
+          <UserProfileProperty name={addColonText(l('Subscribers'))}>
             {subscriberCount ? (
               exp.l(
                 '{count} ({url|view list})',
@@ -392,7 +392,10 @@ const UserProfileInformation = ({
         )}
 
         {nonEmpty(biography) ? (
-          <UserProfileProperty className="biography" name={l('Bio:')}>
+          <UserProfileProperty
+            className="biography"
+            name={addColonText(l('Bio'))}
+          >
             {showBioAndURL ? (
               expand2react(biography)
             ) : (
@@ -408,7 +411,7 @@ const UserProfileInformation = ({
         ) : null}
 
         {languages?.length ? (
-          <UserProfileProperty name={l('Languages:')}>
+          <UserProfileProperty name={addColonText(l('Languages'))}>
             <ul className="inline">
               {languages.map(language => (
                 <li key={language.language.id}>

--- a/root/utility/edit.js
+++ b/root/utility/edit.js
@@ -38,7 +38,7 @@ const EXPIRE_ACTIONS = {
 
 const STATUS_NAMES = {
   [EDIT_STATUS_APPLIED]:        N_l('Applied'),
-  [EDIT_STATUS_DELETED]:        N_l('Cancelled'),
+  [EDIT_STATUS_DELETED]:        N_lp('Cancelled', 'edit'),
   [EDIT_STATUS_ERROR]:          N_l('Error'),
   [EDIT_STATUS_FAILEDDEP]:      N_l('Failed dependency'),
   [EDIT_STATUS_FAILEDPREREQ]:   N_l('Failed prerequisite'),

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -380,7 +380,7 @@ export function defineLocationColumn<D>(
       const entity = props.getEntity(original);
       return entity ? <EventLocations event={entity} /> : null;
     },
-    Header: N_l('Location'),
+    Header: N_lp('Location', 'event location'),
     id: 'location',
   };
 }

--- a/root/work/edit_form.tt
+++ b/root/work/edit_form.tt
@@ -13,7 +13,7 @@
       [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
       [%- form_row_select(r, 'type_id', l('Type:')) -%]
       <div id="work-languages-editor"></div>
-      [%- form_row_text_list(r, 'iswcs', l('ISWCs:'), l('ISWC')) -%]
+      [%- form_row_text_list(r, 'iswcs', add_colon(l('ISWCs')), l('ISWC')) -%]
     </fieldset>
 
     <fieldset>


### PR DESCRIPTION
### Implement MBS-4822

# Description
This looks at what seem to be all or at least most cases where we have two separate strings, `X` and `X:`, when we could use `addColon`, and uses it (generally `add_colon` or `addColonText` for Perl and JS respectively). When I saw cases where the strings had different meanings I added context using `lp` - I also did that to the existing strings without colons when relevant. There's of course a lot more places where context would be very useful, this is not meant to be an exhaustive solution for MBS-5380.

# Testing
None, but effectively string changes only.