### PR TITLE
MBS-13207 (II): Move "Add a new recording" above suggestions

### DIFF
--- a/root/release/edit/recordings.tt
+++ b/root/release/edit/recordings.tt
@@ -169,9 +169,20 @@
 
       <table data-bind="with: target">
         <tbody>
+          <tr>
+            <td>
+              <input name="recording-selection" value="" type="radio" id="add-new-recording" data-bind="checked: hasNewRecording, checkedValue: true" />
+            </td>
+            <td colspan="3">
+              <label for="add-new-recording">
+                [% l('Add a new recording') %]
+              </label>
+            </td>
+          </tr>
+
           <!-- ko if: loadingSuggestedRecordings -->
           <tr>
-            <td colspan="4" style="padding-bottom: 1em; vertical-align: top;" class="loading-message">
+            <td colspan="4" style="background-position: left 1em; padding-bottom: 1em; padding-top: 1em; vertical-align: top;" class="loading-message">
               [% l('Looking for suggested recordings...') %]
             </td>
           </tr>
@@ -202,17 +213,6 @@
           </tr>
           <!-- /ko -->
           <!-- /ko -->
-
-          <tr>
-            <td>
-              <input name="recording-selection" value="" type="radio" id="add-new-recording" data-bind="checked: hasNewRecording, checkedValue: true" />
-            </td>
-            <td colspan="3">
-              <label for="add-new-recording">
-                [% l('Add a new recording') %]
-              </label>
-            </td>
-          </tr>
         </tbody>
       </table>
 

--- a/root/static/scripts/tests/release-editor/seeds/mbs-13207.html
+++ b/root/static/scripts/tests/release-editor/seeds/mbs-13207.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <form action="/release/add" method="POST">
+      <input type="hidden" name="name" value="MBS-13207" />
+      <input type="hidden" name="artist_credit.names.0.artist.name" value="Nine Inch Nails" />
+      <input type="hidden" name="artist_credit.names.0.mbid" value="b7ffd2af-418f-4be2-bdd1-22f8b48613da" />
+      <input type="hidden" name="mediums.0.format" value="Digital Media" />
+      <input type="hidden" name="mediums.0.track.0.name" value="Piggy" />
+      <input type="hidden" name="mediums.0.track.0.length" value="264000" />
+      <input type="hidden" name="edit_note" value="Testing MBS-13207" />
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -694,6 +694,7 @@ const seleniumTests = [
     name: 'release-editor/MBS-12077.json5',
     sql: 'vision_creation_newsun.sql',
   },
+  {name: 'release-editor/MBS-13207.json5', login: true},
   {
     name: 'Check_Duplicates.json5',
     login: true,

--- a/t/selenium/release-editor/MBS-13207.json5
+++ b/t/selenium/release-editor/MBS-13207.json5
@@ -1,0 +1,87 @@
+{
+  title: 'MBS-13207',
+  commands: [
+    {
+      command: 'open',
+      target: '/static/scripts/tests/release-editor/seeds/mbs-13207.html',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'pause',
+      target: '500',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=a[href="#recordings"]',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=button.edit-track-recording',
+      value: '',
+    },
+    {
+      command: 'pause',
+      target: '1000',
+      value: '',
+    },
+    // Check that there's a radio button for at least one existing recording
+    // in addition to the "Add a new recording" button -- if there's only one
+    // button, then we can't verify the fix.
+    {
+      command: 'assertEval',
+      target: 'document.querySelectorAll("#recording-assoc-bubble input[name=recording-selection]").length > 1',
+      value: 'true',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=:focus',
+      value: '${KEY_TAB}',
+    },
+    // The "Add a new recording" radio button should receive the focus.
+    {
+      command: 'assertEval',
+      target: 'document.activeElement === document.getElementById("add-new-recording")',
+      value: 'true',
+    },
+    // The down key should move the focus to the next radio button.
+    {
+      command: 'sendKeys',
+      target: 'css=:focus',
+      value: '${KEY_DOWN}',
+    },
+    // The suggested recording's radio button should receive the focus.
+    {
+      command: 'assertEval',
+      target: 'document.activeElement === document.querySelectorAll("#recording-assoc-bubble input[name=recording-selection]")[1]',
+      value: 'true',
+    },
+    // It should also be selected.
+    {
+      command: 'assertEval',
+      target: 'document.querySelectorAll("#recording-assoc-bubble input[name=recording-selection]")[1].checked',
+      value: 'true',
+    },
+    {
+      command: 'open',
+      target: '/',
+      value: '',
+    },
+    {
+      command: 'handleAlert',
+      target: 'accept',
+      value: '',
+    },
+    {
+      command: 'waitUntilUrlIs',
+      target: '/',
+      value: '',
+    },
+  ],
+}


### PR DESCRIPTION
# MBS-13207 (II)

Make "Add a new recording" appear above suggested recordings rather than below them in the release editor. This is intended to make it possible to select recordings using the keyboard (which is currently challenging due to W3C-mandated radio button focus behavior).

# Problem

When adding a release, it's currently very difficult to assign existing recordings to tracks using only the keyboard.

After opening the recording-selection bubble, the focus is initially assigned to the search input. The Tab key cannot be used to advance the focus to an existing recording's radio button. Instead, the user must advance the focus through all of the recording, artist, and release group links before focusing the "Add a new recording" radio button (currently at the bottom of the table), at which point they can use the Up arrow key to select the desired recording.

This is due to W3C-mandated behavior: per https://www.w3.org/wiki/RadioButton, the Tab key can only be used to focus the currently-selected radio button.

# Solution

This change moves "Add a new recording" to the top of the table. This radio button is selected by default if a recording has not already been assigned, so the user can just press Tab once to focus it and then use the arrow keys to select the desired recording.

Please see #3006 (a different approach) for earlier discussion.

# Actions

I'm not running a search server and just have test data loaded, so I've only been able to test this by using direct search to manually add recordings to the bubble. If possible, please manually test this using a more-realistic setup.