### PR TITLE
Use exactCount for newline-after-import eslint rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -232,7 +232,9 @@ rules:
   import/export: error
   import/extensions: [error, ignorePackages]
   import/first: warn
-  import/newline-after-import: [warn, {count: 1}]
+  import/newline-after-import: [warn, {count: 1,
+                                       exactCount: true,
+                                       considerComments: true}]
   import/no-commonjs: error
   import/no-duplicates: warn
   import/no-dynamic-require: error

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "eslint": "8.46.0",
     "eslint-plugin-fb-flow": "0.0.4",
     "eslint-plugin-ft-flow": "3.0.1",
-    "eslint-plugin-import": "2.28.0",
+    "eslint-plugin-import": "2.29.0",
     "eslint-plugin-react": "7.33.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",

--- a/root/report/CatNoLooksLikeLabelCode.js
+++ b/root/report/CatNoLooksLikeLabelCode.js
@@ -12,7 +12,6 @@ import ReportLayout from './components/ReportLayout.js';
 import useCatNoColumn from './hooks/useCatNoColumn.js';
 import type {ReportDataT, ReportReleaseCatNoT} from './types.js';
 
-
 const CatNoLooksLikeLabelCode = ({
   canBeFiltered,
   filtered,

--- a/root/report/RecordingsWithFutureDates.js
+++ b/root/report/RecordingsWithFutureDates.js
@@ -18,7 +18,6 @@ import RecordingList from './components/RecordingList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportRecordingRelationshipT} from './types.js';
 
-
 const RecordingsWithFutureDates = ({
   canBeFiltered,
   filtered,

--- a/root/static/scripts/edit/components/ArtistCreditBubble.js
+++ b/root/static/scripts/edit/components/ArtistCreditBubble.js
@@ -15,7 +15,6 @@ import clean from '../../common/utility/clean.js';
 
 import ArtistCreditNameEditor from './ArtistCreditNameEditor.js';
 
-
 function onBubbleKeyDown(done, hide, event) {
   if (event.isDefaultPrevented()) {
     return;

--- a/root/static/scripts/guess-case/utils.js
+++ b/root/static/scripts/guess-case/utils.js
@@ -17,7 +17,6 @@ import * as flags from './flags.js';
 import * as modes from './modes.js';
 import type {GuessCaseModeT} from './types.js';
 
-
 /*
  * Words which are turned to lowercase if in brackets, but
  * are *not* put in brackets if they're found at the end of the sentence.

--- a/root/static/scripts/release-editor/duplicates.js
+++ b/root/static/scripts/release-editor/duplicates.js
@@ -19,7 +19,6 @@ import request from '../common/utility/request.js';
 import utils from './utils.js';
 import releaseEditor from './viewModel.js';
 
-
 var releaseGroupReleases = ko.observableArray([]);
 
 

--- a/root/static/scripts/release/components/ReleaseRelationshipEditor.js
+++ b/root/static/scripts/release/components/ReleaseRelationshipEditor.js
@@ -7,6 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+/* eslint-disable import/newline-after-import -- the FlowIgnore triggers it */
 import {captureException} from '@sentry/browser';
 import deepFreeze from 'deep-freeze-strict';
 import * as React from 'react';

--- a/root/static/scripts/work/edit.js
+++ b/root/static/scripts/work/edit.js
@@ -7,6 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+/* eslint-disable import/newline-after-import -- the FlowIgnore triggers it */
 import $ from 'jquery';
 import ko, {
   type Observable as KnockoutObservable,

--- a/root/user/ContactUser.js
+++ b/root/user/ContactUser.js
@@ -23,7 +23,6 @@ import FormRowTextLong
   from '../static/scripts/edit/components/FormRowTextLong.js';
 import FormSubmit from '../static/scripts/edit/components/FormSubmit.js';
 
-
 type Props = {
   +form: FormT<{
     +body: FieldT<string>,

--- a/root/utility/hydrate.js
+++ b/root/utility/hydrate.js
@@ -7,6 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+/* eslint-disable import/newline-after-import -- the FlowIgnore triggers it */
 import * as Sentry from '@sentry/browser';
 import * as React from 'react';
 // $FlowIgnore[missing-export]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2305,7 +2305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-includes@npm:^3.1.6":
+"array-includes@npm:^3.1.6, array-includes@npm:^3.1.7":
   version: 3.1.7
   resolution: "array-includes@npm:3.1.7"
   dependencies:
@@ -2318,7 +2318,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.findlastindex@npm:^1.2.2":
+"array.prototype.findlastindex@npm:^1.2.3":
   version: 1.2.3
   resolution: "array.prototype.findlastindex@npm:1.2.3"
   dependencies:
@@ -2331,7 +2331,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.flat@npm:^1.3.1":
+"array.prototype.flat@npm:^1.3.1, array.prototype.flat@npm:^1.3.2":
   version: 1.3.2
   resolution: "array.prototype.flat@npm:1.3.2"
   dependencies:
@@ -2343,7 +2343,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.flatmap@npm:^1.3.1":
+"array.prototype.flatmap@npm:^1.3.1, array.prototype.flatmap@npm:^1.3.2":
   version: 1.3.2
   resolution: "array.prototype.flatmap@npm:1.3.2"
   dependencies:
@@ -3335,7 +3335,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-node@npm:^0.3.7":
+"eslint-import-resolver-node@npm:^0.3.9":
   version: 0.3.9
   resolution: "eslint-import-resolver-node@npm:0.3.9"
   dependencies:
@@ -3380,31 +3380,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:2.28.0":
-  version: 2.28.0
-  resolution: "eslint-plugin-import@npm:2.28.0"
+"eslint-plugin-import@npm:2.29.0":
+  version: 2.29.0
+  resolution: "eslint-plugin-import@npm:2.29.0"
   dependencies:
-    array-includes: "npm:^3.1.6"
-    array.prototype.findlastindex: "npm:^1.2.2"
-    array.prototype.flat: "npm:^1.3.1"
-    array.prototype.flatmap: "npm:^1.3.1"
+    array-includes: "npm:^3.1.7"
+    array.prototype.findlastindex: "npm:^1.2.3"
+    array.prototype.flat: "npm:^1.3.2"
+    array.prototype.flatmap: "npm:^1.3.2"
     debug: "npm:^3.2.7"
     doctrine: "npm:^2.1.0"
-    eslint-import-resolver-node: "npm:^0.3.7"
+    eslint-import-resolver-node: "npm:^0.3.9"
     eslint-module-utils: "npm:^2.8.0"
-    has: "npm:^1.0.3"
-    is-core-module: "npm:^2.12.1"
+    hasown: "npm:^2.0.0"
+    is-core-module: "npm:^2.13.1"
     is-glob: "npm:^4.0.3"
     minimatch: "npm:^3.1.2"
-    object.fromentries: "npm:^2.0.6"
-    object.groupby: "npm:^1.0.0"
-    object.values: "npm:^1.1.6"
-    resolve: "npm:^1.22.3"
+    object.fromentries: "npm:^2.0.7"
+    object.groupby: "npm:^1.0.1"
+    object.values: "npm:^1.1.7"
     semver: "npm:^6.3.1"
     tsconfig-paths: "npm:^3.14.2"
   peerDependencies:
     eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-  checksum: 0d7b978a3c4778b68bede2c8a14512e33581091bd8a508c4a424d2e8bff1f174549ffc3f2b7cfb28345cfb63061d3e43fdaa810ebfe9c96b5a4a1dc4047f6e9d
+  checksum: 761a4e1fbc2cd318e62350bed4c448f8b11ed83091d6bb7776f096556363a09debd9922b39fd2714c895edc9aaea82e08e684eb632283f880c58a91e4bae6733
   languageName: node
   linkType: hard
 
@@ -4155,7 +4154,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has@npm:^1.0.3, has@npm:~1.0.1":
+"has@npm:~1.0.1":
   version: 1.0.4
   resolution: "has@npm:1.0.4"
   checksum: 82c1220573dc1f0a014a5d6189ae52a1f820f99dfdc00323c3a725b5002dcb7f04e44f460fea7af068474b2dd7c88cbe1846925c84017be9e31e1708936d305b
@@ -4519,7 +4518,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.12.1, is-core-module@npm:^2.13.0":
+"is-core-module@npm:^2.13.0, is-core-module@npm:^2.13.1":
   version: 2.13.1
   resolution: "is-core-module@npm:2.13.1"
   dependencies:
@@ -5607,7 +5606,7 @@ __metadata:
     eslint: "npm:8.46.0"
     eslint-plugin-fb-flow: "npm:0.0.4"
     eslint-plugin-ft-flow: "npm:3.0.1"
-    eslint-plugin-import: "npm:2.28.0"
+    eslint-plugin-import: "npm:2.29.0"
     eslint-plugin-react: "npm:7.33.1"
     eslint-plugin-react-hooks: "npm:4.6.0"
     eslint-plugin-simple-import-sort: "npm:^7.0.0"
@@ -5917,7 +5916,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.fromentries@npm:^2.0.6":
+"object.fromentries@npm:^2.0.6, object.fromentries@npm:^2.0.7":
   version: 2.0.7
   resolution: "object.fromentries@npm:2.0.7"
   dependencies:
@@ -5928,7 +5927,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.groupby@npm:^1.0.0":
+"object.groupby@npm:^1.0.1":
   version: 1.0.1
   resolution: "object.groupby@npm:1.0.1"
   dependencies:
@@ -5950,7 +5949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.values@npm:^1.1.6":
+"object.values@npm:^1.1.6, object.values@npm:^1.1.7":
   version: 1.1.7
   resolution: "object.values@npm:1.1.7"
   dependencies:
@@ -6853,7 +6852,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.6, resolve@npm:^1.10.0, resolve@npm:^1.14.2, resolve@npm:^1.22.3, resolve@npm:^1.22.4":
+"resolve@npm:^1.1.6, resolve@npm:^1.10.0, resolve@npm:^1.14.2, resolve@npm:^1.22.4":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -6888,7 +6887,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.1.6#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.3#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.1.6#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:


### PR DESCRIPTION
# Description
The last version of `newline-after-import` in `eslint-plugin-import 2.29.0` allows to actually specify the amount of lines as an exact count, not just a minimum, by setting `exactCount` to `true`. I also had to use `considerComments` so it would look at comments after import blocks as also needing to be separated with one blank line.

# Testing
I ran the rule until it was happy. Does not change actual code bits.