### PR TITLE
MBS-5987: Add "Submit votes & edit notes" to top

### DIFF
--- a/root/edit/components/EditList.js
+++ b/root/edit/components/EditList.js
@@ -98,8 +98,13 @@ const EditList = ({
 
       {edits.length ? (
         <div id="edits">
-          <PaginatedResults guessSearch={mightBeMoreEdits} pager={pager}>
-            <form action="/edit/enter_votes" method="post">
+          <form action="/edit/enter_votes" method="post">
+            <PaginatedResults guessSearch={mightBeMoreEdits} pager={pager}>
+              {$c.user ? (
+                <div className="align-right clear-both row no-label">
+                  <FormSubmit label={l('Submit votes & edit notes')} />
+                </div>
+              ) : null}
               {edits.map((edit, index) => (
                 <ListEdit
                   edit={edit}
@@ -116,8 +121,8 @@ const EditList = ({
                   <FormSubmit label={l('Submit votes & edit notes')} />
                 </div>
               ) : null}
-            </form>
-          </PaginatedResults>
+            </PaginatedResults>
+          </form>
         </div>
       ) : null}
 

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -147,6 +147,8 @@ pre code {
 .align-left { text-align: left !important; }
 .align-top { vertical-align: top; }
 
+.clear-both { clear: both !important; }
+
 /*
 ** Header
 */


### PR DESCRIPTION
# MBS-5987

Add a second "Submit votes & edit notes" button near the top of the /edits page so that users don't need to scroll to the end of a long page when voting and commenting on recent edits.

# Problem

When viewing an entity's list of edits, the open edits are at the top of the page. It's unintuitive and a bit tedious to need to scroll all the way to the bottom of the page to submit votes and comments on open edits.

# Solution

Add a second button near the top of the page. I had to move the `form` element outside of `PaginatedResults` in order for the button to be a child of the form.

# Testing

I verified that both the top and bottom buttons work when viewing edits while logged in, and that the page renders as before when not logged in.

# Action

N/A
