### PR TITLE
MBS-13348: Fix edit_data_idx_link_type

### DIFF
--- a/admin/sql/CreateIndexes.sql
+++ b/admin/sql/CreateIndexes.sql
@@ -147,7 +147,7 @@ CREATE INDEX edit_data_idx_link_type ON edit_data USING GIN (
                      (data#>>'{link,link_type,id}')::int,
                      (data#>>'{old,link_type,id}')::int,
                      (data#>>'{new,link_type,id}')::int,
-                     (data#>>'{relationship,link_type,id}')::int
+                     (data#>>'{relationship,link,type,id}')::int
                  ], NULL)
 );
 

--- a/admin/sql/updates/20231005-edit-data-idx-link-type.sql
+++ b/admin/sql/updates/20231005-edit-data-idx-link-type.sql
@@ -1,0 +1,17 @@
+\set ON_ERROR_STOP 1
+
+BEGIN;
+
+DROP INDEX CONCURRENTLY IF EXISTS edit_data_idx_link_type;
+
+CREATE INDEX CONCURRENTLY edit_data_idx_link_type ON edit_data USING GIN (
+    array_remove(ARRAY[
+                     (data#>>'{link_type,id}')::int,
+                     (data#>>'{link,link_type,id}')::int,
+                     (data#>>'{old,link_type,id}')::int,
+                     (data#>>'{new,link_type,id}')::int,
+                     (data#>>'{relationship,link,type,id}')::int
+                 ], NULL)
+);
+
+COMMIT;

--- a/upgrade.json
+++ b/upgrade.json
@@ -218,5 +218,10 @@
     "master_and_standalone": [
       "20211203-mbs-11312-standalone.sql"
     ]
+  },
+  "29": {
+    "all": [
+      "20231005-edit-data-idx-link-type.sql"
+    ]
   }
 }


### PR DESCRIPTION
# Problem

MBS-13348

The query in the edit search that is supposed to make use of this index was changed in b21e5c579d0201325f5fbe385a51b663ae6caa69, but the actual index was never updated to match (so it could not be used).

# Solution

This patch provides an upgrade script to run during the next schema change.

Note: This was already fixed in production.
