### PR TITLE
MBS-13347: Relationship Type edit search times out

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate.pm
@@ -98,4 +98,6 @@ sub valid {
     return 1;
 }
 
+sub disable_limit_for_edit_listing { 0 }
+
 1;

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/RelationshipType.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/RelationshipType.pm
@@ -35,4 +35,7 @@ sub combine_with_query {
     ]);
 }
 
+# MBS-13347
+sub disable_limit_for_edit_listing { 1 }
+
 1;


### PR DESCRIPTION
# Problem

MBS-13347

The use of `LIMIT 500` inside an edit search sub-query using the Relationship Type predicate causes PostgreSQL to ignore `edit_data_idx_link_type` and make use of a much less efficient query plan.

# Solution

This commit adds a flag to `EditSearch::Predicate` which can be used to disable the addition of `$LIMIT_FOR_EDIT_LISTING` if the given predicate is present.
