### PR TITLE
MBS-13309: Restrict cross-origin requests to /ws/js/edit

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -713,6 +713,9 @@ sub edit : Chained('/') PathPart('ws/js/edit') CaptureArgs(0) Edit {
     if ($c->user->is_editing_disabled) {
         $c->forward('/ws/js/detach_with_error', ['you are not allowed to enter edits']);
     }
+    if ($c->is_cross_origin && !$c->user->is_bot) {
+        $c->forward('/ws/js/detach_with_error', ['cross-origin requests are allowed only for bot accounts', 403]);
+    }
 }
 
 sub create : Chained('edit') PathPart('create') Edit {


### PR DESCRIPTION
# Problem

MBS-13309

/ws/js/edit is prone to CSRF attacks that could be used to trick editors into submitting edits without their review.

# Solution

Restrict submissions from external origins to bot accounts.
