### PR TITLE
MBS-13350: Return all barcode matches in release editor

### DIFF
--- a/root/static/scripts/release-editor/validation.js
+++ b/root/static/scripts/release-editor/validation.js
@@ -127,7 +127,7 @@ $(function () {
 
 // Search releases with the same barcode
 function searchExistingBarcode(field, barcode, releaseId) {
-  utils.search('release', `barcode:${barcode}`, 1).done(data => {
+  utils.search('release', `barcode:${barcode}`).done(data => {
     const releases = data.releases;
     const hasBarcodeInUse = releases.length > 1 ||
       (releases.length === 1 && releases[0].id !== releaseId);


### PR DESCRIPTION
### Fix MBS-13350

# Problem
The release editor bubble showing other releases with the same barcode as entered does not show all matching releases, causing people to enter duplicates. 

# Solution
While the code here speaks of multiple releases and is clearly meant to support more than one result, we were making the search with limit 1. I checked the original PR and did not find a reason why, other than it seems to have been part of my code suggestion (good job me). This just removes the limit.

# Testing
Manually with full data tunnel, with the same barcode as in the ticket which does correctly show two releases now.