### PR TITLE
MBS-13349: Support LibraryThing disambiguation URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3493,11 +3493,11 @@ const CLEANUPS: CleanupEntries = {
     match: [new RegExp('^(https?://)?(www\\.)?librarything\\.com', 'i')],
     restrict: [LINK_TYPES.otherdatabases],
     clean: function (url) {
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?librarything\.com\/(author|nseries|work)\/([0-9a-z]+)(?:[/?#].*)?$/, 'https://www.librarything.com/$1/$2');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?librarything\.com\/(author|nseries|work)\/([0-9a-z-]+)(?:[/?#].*)?$/, 'https://www.librarything.com/$1/$2');
       return url;
     },
     validate: function (url, id) {
-      const m = /^https:\/\/www\.librarything\.com\/([a-z]+)\/[0-9a-z]+$/.exec(url);
+      const m = /^https:\/\/www\.librarything\.com\/([a-z]+)\/[0-9a-z-]+$/.exec(url);
       if (m) {
         const prefix = m[1];
         switch (id) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3334,6 +3334,13 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist'],
   },
   {
+                     input_url: 'https://www.librarything.com/author/alexandermichelle-1',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.librarything.com/author/alexandermichelle-1',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'https://www.librarything.com/work/7940036/reviews',
              input_entity_type: 'work',
     expected_relationship_type: 'otherdatabases',


### PR DESCRIPTION
### Fix MBS-13349

# Problem
LibraryThing uses -1, -2, etc. after the author name for authors of the same name (such as https://www.librarything.com/author/alexandermichelle-1). We currently (accidentally) block these.

# Solution
It seems sensible and safe to allow hyphens alongside the already allowed numbers and letters, so this just does that.

# Testing
Added a test with the URL given above.