### PR TITLE
MBS-13346: Support GTIN-14 barcodes

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Barcode.pm
+++ b/lib/MusicBrainz/Server/Entity/Barcode.pm
@@ -14,6 +14,7 @@ sub type {
     return 'EAN' if length($self->code) == 8;
     return 'UPC' if length($self->code) == 12;
     return 'EAN' if length($self->code) == 13;
+    return 'GTIN' if length($self->code) == 14;
 }
 
 sub format

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -932,12 +932,12 @@ class Barcode {
   }
 
   checkDigit(barcode) {
-    if (barcode.length !== 12) {
+    if (barcode.length !== 13) {
       return false;
     }
 
     let calc = 0;
-    for (let i = 0; i < 12; i++) {
+    for (let i = 0; i < 13; i++) {
       calc += parseInt(barcode[i], 10) * this.weights[i];
     }
 
@@ -946,8 +946,8 @@ class Barcode {
   }
 
   validateCheckDigit(barcode) {
-    return this.checkDigit(barcode.slice(0, 12)) ===
-            parseInt(barcode[12], 10);
+    return this.checkDigit(barcode.slice(0, 13)) ===
+            parseInt(barcode[13], 10);
   }
 
   writeBarcode(barcode) {
@@ -956,7 +956,7 @@ class Barcode {
   }
 }
 
-Barcode.prototype.weights = [1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3];
+Barcode.prototype.weights = [3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3];
 
 fields.Barcode = Barcode;
 

--- a/root/static/scripts/release-editor/validation.js
+++ b/root/static/scripts/release-editor/validation.js
@@ -190,7 +190,7 @@ utils.withRelease(function (release) {
       ),
     );
   } else if (barcode.length === 12) {
-    if (field.validateCheckDigit('0' + barcode)) {
+    if (field.validateCheckDigit('00' + barcode)) {
       field.message(l('The barcode you entered is a valid UPC code.'));
       searchExistingBarcode(field, barcode, release.gid());
     } else {
@@ -209,7 +209,7 @@ utils.withRelease(function (release) {
       );
     }
   } else if (barcode.length === 13) {
-    if (field.validateCheckDigit(barcode)) {
+    if (field.validateCheckDigit('0' + barcode)) {
       field.message(l('The barcode you entered is a valid EAN code.'));
       searchExistingBarcode(field, barcode, release.gid());
     } else {
@@ -219,9 +219,20 @@ utils.withRelease(function (release) {
         doubleCheckText,
       );
     }
+  } else if (barcode.length === 14) {
+    if (field.validateCheckDigit(barcode)) {
+      field.message(l('The barcode you entered is a valid GTIN code.'));
+      searchExistingBarcode(field, barcode, release.gid());
+    } else {
+      field.error(
+        l('The barcode you entered is not a valid GTIN code.') +
+        ' ' +
+        doubleCheckText,
+      );
+    }
   } else {
     field.error(
-      l('The barcode you entered is not a valid UPC or EAN code.') +
+      l('The barcode you entered is not a valid UPC, EAN or GTIN code.') +
       ' ' +
       doubleCheckText,
     );

--- a/root/static/scripts/tests/release-editor/validation.js
+++ b/root/static/scripts/tests/release-editor/validation.js
@@ -143,3 +143,19 @@ validationTest((
 
   t.ok(validation.errorsExist());
 });
+
+validationTest((
+  'Barcode validation'
+), function (t) {
+  t.plan(5);
+
+  const release = releaseEditor.rootField.release();
+  const field = release.barcode;
+
+  t.ok(field.validateCheckDigit('00810121774182'), '0-padded GTIN-14');
+  t.ok(field.validateCheckDigit('12345678901231'), 'GTIN-14');
+  // Adding '0' + as it matches what the actual release editor code does
+  t.ok(field.validateCheckDigit('0' + '0810121774182'), '0-padded EAN-13');
+  t.ok(field.validateCheckDigit('0' + '9399431762528'), 'EAN-13');
+  t.ok(field.validateCheckDigit('00' + '810121774182'), 'UPC');
+});


### PR DESCRIPTION
### Implement MBS-13346

# Problem
GTIN-14 identifiers ("barcodes") seem to be becoming more common in digital storefronts and the like. Since these are the identifiers sent by the distributors, we should keep them, even they are generally just zero-padded EANs. Right now the release editor considers these invalid and asks the user to check the box though.

# Solution

`is_valid_ean` on the Perl side already accepts GTIN-14 so nothing to change there - this mostly just changes the release editor validation and adds a basic test for it.

I added a `GTIN` type to `Entity::Barcode` since I guess it cannot hurt. Not sure if we use these at all but :)

# Testing
Manually in the release editor, plus added a test.