### PR TITLE
Allow connecting to any database with SYSTEM credentials

### DIFF
--- a/admin/DisableAllTriggers
+++ b/admin/DisableAllTriggers
@@ -10,14 +10,7 @@ use DBDefs;
 use aliased 'MusicBrainz::Server::DatabaseConnectionFactory' => 'Databases';
 use MusicBrainz::Server::Constants qw( @FULL_TABLE_LIST );
 
-my $readwrite_db = Databases->get('READWRITE');
-my $system_db = Databases->get('SYSTEM');
-my $sysmb_db = $system_db->meta->clone_object(
-    $system_db,
-    database => $readwrite_db->database,
-);
-Databases->register_database('SYSMB', $sysmb_db);
-my $conn = Databases->get_connection('SYSMB');
+my $conn = Databases->get_connection('SYSTEM_READWRITE');
 my $sql = Sql->new($conn->conn);
 
 for my $table (@FULL_TABLE_LIST) {

--- a/admin/InitDb.pl
+++ b/admin/InitDb.pl
@@ -520,12 +520,7 @@ GetOptions(
 my $DB = Databases->get($databaseName);
 # Register a new database connection as the system user, but to the MB
 # database
-my $SYSTEM = Databases->get('SYSTEM');
-my $SYSMB  = $SYSTEM->meta->clone_object(
-    $SYSTEM,
-    database => $DB->database
-);
-Databases->register_database('SYSMB', $SYSMB);
+my $SYSMB = Databases->get('SYSTEM_' . $databaseName);
 
 if ($fInstallExtension)
 {

--- a/admin/psql
+++ b/admin/psql
@@ -26,9 +26,26 @@ GetOptions(
 
 my $key = shift // 'READWRITE';
 
-if ($help) {
-    die "Usage: psql [database]\n\n  database -- the DBDefs name of the database to connect to. (default is READWRITE)\n";
-}
+die <<EOF if $help;
+Usage: $0 [options] [database]
+
+Arguments:
+
+    database    The name of the database connection definition to use,
+                as registered in DBDefs.
+                (default: READWRITE)
+
+Options:
+
+    --system    Partly overwrite the database connection definition
+                with the properties (usually username/password)
+                of the database connection definition SYSTEM.
+                It allows connecting to any database as superuser.
+             
+Environment:
+
+    PGPASSWORD  If set, it is used as password to connect to the database.
+EOF
 
 my $db = Databases->get($key) or die "No such database '$key'\n";
 

--- a/admin/psql
+++ b/admin/psql
@@ -33,8 +33,7 @@ if ($help) {
 my $db = Databases->get($key) or die "No such database '$key'\n";
 
 if ($system) {
-    my $sys_db = Databases->get('SYSTEM');
-    $db = $db->meta->clone_object($sys_db, database => $db->database);
+    $db = Databases->get('SYSTEM_' . $key);
 }
 
 $ENV{'PGPASSWORD'} = $db->password;

--- a/lib/MusicBrainz/Server/DatabaseConnectionFactory.pm
+++ b/lib/MusicBrainz/Server/DatabaseConnectionFactory.pm
@@ -67,8 +67,18 @@ sub get {
 
     my $database = $databases{$name};
 
-    if ($name eq 'MAINTENANCE' && !defined($database)) {
-        $database = $databases{READWRITE};
+    unless (defined $database) {
+        if ($name eq 'MAINTENANCE') {
+            $database = $databases{READWRITE};
+        } elsif ($name =~ /^SYSTEM_(.+)$/) {
+            my $base_dbdef_key = $1;
+            my $system = $class->get('SYSTEM');
+            $database = $system->meta->clone_object(
+                $system,
+                database => $class->get($base_dbdef_key)->database,
+            );
+            $class->register_database($name, $database);
+        }
     }
 
     return $database;


### PR DESCRIPTION
# Problem

Sometimes it's necessary to connect to the database specified by `MAINTENANCE` or `READWRITE` using `SYSTEM` credentials (because certain objects owned by a superuser need to be updated).

# Solution

This is now possible by connecting to `SYSTEM_MAINTENANCE`, `SYSTEM_READWRITE`, or any variant of `SYSTEM_FOO`, where `FOO` is the name of a database defined in lib/DBDefs.pm.

This magic is only performed if `SYSTEM_FOO` isn't otherwise defined.

# Testing

 * Tested the InitDb.pl changes by running `dropdb -U postgres musicbrainz_test && ./script/create_test_db.sh`.
 * Tested the psql changes by running `./admin/psql --system MAINTENANCE`.
 * ~Did not test the DisableAllTriggers changes.~ [See below](#issuecomment-1798292409).