### PR TITLE
RebuildIndexesUsingCollations.pl improvements

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -467,6 +467,13 @@ If you intend to run a server with translations, there are a few steps to follow
         sudo apt-get install language-pack-{language code}
 
 
+Server maintenance
+------------------
+
+For maintenance operations that may be necessary over time while running
+MusicBrainz Server, see [MAINTENANCE.md].
+
+
 Troubleshooting
 ---------------
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -5,7 +5,7 @@ Indexes and collations
 ----------------------
 
 After upgrading your system running PostgreSQL, you may encounter the
-following kinds of warnings in your database logs:
+following kinds of warnings in the logs of your PostgreSQL database server:
 
     WARNING:  collation "XYZ" has version mismatch
     DETAIL:  The collation in the database was created using version 1.2.3,

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,32 @@
+MusicBrainz Server Maintenance
+==============================
+
+Indexes and collations
+----------------------
+
+After upgrading your system running PostgreSQL, you may encounter the
+following kinds of warnings in your database logs:
+
+    WARNING:  collation "XYZ" has version mismatch
+    DETAIL:  The collation in the database was created using version 1.2.3,
+             but the operating system provides version 4.5.6.
+    HINT:  Rebuild all objects affected by this collation and run
+           ALTER COLLATION "XYZ" REFRESH VERSION, or build PostgreSQL with
+           the right library version.
+
+This can occur if the versions of glibc or libicu change on your system.
+As the warning indicates, the correct course of action is to rebuild all
+indexes using the affected collations. Since PostgreSQL doesn't currently
+have a convenient way of doing this, MusicBrainz provides its own script
+for that purpose:
+
+    ./admin/RebuildIndexesUsingCollations.pl
+
+This will connect to the MAINTENANCE database defined in lib/DBDefs.pm
+and run `REINDEX` statements for every index using the "default" or
+"musicbrainz" collations. By default, this is done `CONCURRENTLY` so as
+not to disrupt existing database traffic; if you don't mind temporarily
+locking the tables against writes, you can disable concurrent reindexing
+and speed things up:
+
+    ./admin/RebuildIndexesUsingCollations.pl --noconcurrently

--- a/admin/RebuildIndexesUsingCollations.pl
+++ b/admin/RebuildIndexesUsingCollations.pl
@@ -16,8 +16,13 @@ sub usage {
     print <<~EOF;
         Usage: RebuildIndexesUsingCollations.pl [options]
 
+        Rebuild all indexes using collations,
+        as needed in case of a version mismatch after an update of glibc or libicu.
+
+        Options:
             --database          database to connect to (default: MAINTENANCE)
             --[no]concurrently  enable or disable concurrent reindexing
+                                (concurrent is slower but doesn't lock any table)
                                 (default: enabled)
             --help              show this help
         EOF


### PR DESCRIPTION
 * Adds some flags to the script: `--database`, `--[no]concurrently`, and `--help`.
 * Refreshes the "musicbrainz" collation version at the end of the script.
 * Adds documentation in MAINTENANCE.md, referenced from INSTALL.md.