### PR TITLE
MBS-13326: Add documentation bubble for the artist sort name field

### DIFF
--- a/root/artist/edit_form.tt
+++ b/root/artist/edit_form.tt
@@ -89,6 +89,8 @@
   <div class="documentation">
     [%- area_bubble() -%]
 
+    [%- sort_name_bubble() -%]
+
     [%- type_bubble(form.field('type_id'), artist_types) -%]
 
     [%- ipi_bubble() -%]
@@ -109,6 +111,7 @@
     MB.initializeToggleEnded('id-edit-artist');
     MB.initializeTooShortYearChecks('artist');
 
+    MB.Control.initializeBubble("#sort-name-bubble", "input[name=edit-artist\\.sort_name");
     MB.Control.initializeBubble("#ipi-bubble", "input[name=edit-artist\\.ipi_codes\\.0]");
     MB.Control.initializeBubble("#isni-bubble", "input[name=edit-artist\\.isni_codes\\.0]");
 

--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -359,7 +359,7 @@
       <p>[% l('The sort name is an artist name variant used when sorting alphabetically.
                For usage information check the {sort_name_doc|sort name guidelines}.',
             { sort_name_doc => doc_link('Style/Artist/Sort_Name') }) %]</p>
-      <p>[% l('Last Name, First Name” and “Group, The” are common examples of sort names.') %]</p>
+      <p>[% l('“Last Name, First Name” and “Group, The” are common examples of sort names.') %]</p>
     </div>
 [%- END -%]
 

--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -354,6 +354,15 @@
     </div>
 [%- END -%]
 
+[%- MACRO sort_name_bubble BLOCK -%]
+    <div class="bubble" id="sort-name-bubble">
+      <p>[% l('The sort name is an artist name variant used when sorting alphabetically.
+               For usage information check the {sort_name_doc|sort name guidelines}.',
+            { sort_name_doc => doc_link('Style/Artist/Sort_Name') }) %]</p>
+      <p>[% l('Last Name, First Name” and “Group, The” are common examples of sort names.') %]</p>
+    </div>
+[%- END -%]
+
 [%- MACRO type_bubble(form, types) BLOCK -%]
     <div class="bubble" id="type-bubble">
       <span id="type-bubble-default" [% IF form.value %] style="display:none" [% END %]>


### PR DESCRIPTION
### Implement MBS-13326

# Problem
"Sort name" is a non-obvious field. Recently we've seen people reading it as "short name", but even without that, it's often filled wrong.

# Solution
There seems to be entirely no downsides to adding a bubble with a short explanation and a link to the guidelines, so I'm doing that and hoping it's enough to clarify the usage.

![Screenshot from 2023-11-07 22-18-41](https://github.com/metabrainz/musicbrainz-server/assets/1069224/0221dd89-cee9-45fb-9436-0a3c742e66b6)


# Testing
Manually, just to make sure the bubble appears and goes away as expected.