### PR TITLE
MBS-13273: Update track credits with matching prefixes

### DIFF
--- a/root/static/scripts/common/immutable-entities.js
+++ b/root/static/scripts/common/immutable-entities.js
@@ -33,7 +33,26 @@ export const isCompleteArtistCredit =
     ac.names.every(hasArtist);
 
 export const reduceArtistCredit =
-  (ac: ArtistCreditT): string => ac.names.reduce(reduceName, '');
+  (ac: ArtistCreditT): string => reduceArtistCreditNames(ac.names);
+
+/*
+ * Joins the supplied credits into a single string, using credited-as names if
+ * set or artist names otherwise. If dropFinalJoinPhrase is true, the final
+ * join phrase is omitted from the returned string.
+ */
+export function reduceArtistCreditNames(
+  names: $ReadOnlyArray<ArtistCreditNameT>,
+  dropFinalJoinPhrase?: false,
+): string {
+  let s = names.reduce(reduceName, '');
+  if (dropFinalJoinPhrase && names.length > 0) {
+    const finalJoinPhrase = names[names.length - 1].joinPhrase;
+    if (finalJoinPhrase) {
+      s = s.slice(0, s.length - finalJoinPhrase.length);
+    }
+  }
+  return s;
+}
 
 export const isComplexArtistCredit = function (ac: ArtistCreditT): boolean {
   const firstName = ac.names[0];

--- a/root/static/scripts/tests/common/immutable-entities.js
+++ b/root/static/scripts/tests/common/immutable-entities.js
@@ -11,6 +11,8 @@ import test from 'tape';
 import {
   artistCreditsAreEqual,
   isComplexArtistCredit,
+  reduceArtistCredit,
+  reduceArtistCreditNames,
 } from '../../common/immutable-entities.js';
 
 const bowie = {
@@ -23,6 +25,59 @@ const crosby = {
   id: 99,
   name: 'bing crosby',
 };
+
+test('reduceArtistCredit', function (t) {
+  t.plan(4);
+
+  let ac = {names: []};
+  t.equal(reduceArtistCredit(ac), '', 'zero names');
+
+  ac.names = [{artist: bowie}];
+  t.equal(reduceArtistCredit(ac), 'david bowie', 'one name');
+
+  ac.names = [
+    {artist: bowie, joinPhrase: ' feat. '},
+    {artist: crosby},
+  ];
+  t.equal(
+    reduceArtistCredit(ac),
+    'david bowie feat. bing crosby',
+    'two names',
+  );
+
+  ac.names = [
+    {artist: bowie, name: 'dave bowie', joinPhrase: ' & ('},
+    {artist: crosby, joinPhrase: ')'},
+  ];
+  t.equal(
+    reduceArtistCredit(ac),
+    'dave bowie & (bing crosby)',
+    'credited-as and trailing join phrase',
+  );
+});
+
+test('reduceArtistCreditNames', function (t) {
+  t.plan(2);
+
+  /*
+   * This function is already exercised by the reduceArtistCredit test, so
+   * just verify that the dropFinalJoinPhrase parameter is honored.
+   */
+  const names = [
+    {artist: bowie, name: 'dave bowie', joinPhrase: ' feat. '},
+    {artist: crosby, joinPhrase: ' & '},
+  ];
+  t.equal(
+    reduceArtistCreditNames(names, false),
+    'dave bowie feat. bing crosby & ',
+    'keep final join phrase',
+  );
+  t.equal(
+    reduceArtistCreditNames(names, true),
+    'dave bowie feat. bing crosby',
+    'drop final join phrase',
+  );
+});
 
 test('isComplexArtistCredit', function (t) {
   t.plan(4);

--- a/root/static/scripts/tests/release-editor/seeds/mbs-13273.html
+++ b/root/static/scripts/tests/release-editor/seeds/mbs-13273.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <form action="/release/add" method="POST">
+      <input type="hidden" name="name" value="MBS-13273" />
+      <input type="hidden" name="artist_credit.names.0.artist.name" value="Nine Inch Nails" />
+      <input type="hidden" name="artist_credit.names.0.mbid" value="b7ffd2af-418f-4be2-bdd1-22f8b48613da" />
+      <input type="hidden" name="artist_credit.names.0.join_phrase" value=" & " />
+      <input type="hidden" name="artist_credit.names.1.artist.name" value="David Bowie" />
+      <input type="hidden" name="artist_credit.names.1.mbid" value="5441c29d-3602-4898-b1a1-b77fa23b8e50" />
+      <input type="hidden" name="mediums.0.format" value="Digital Media" />
+      <input type="hidden" name="mediums.0.track.0.name" value="Release Artists" />
+      <input type="hidden" name="mediums.0.track.1.name" value="Featured Artist" />
+      <input type="hidden" name="mediums.0.track.1.artist_credit.names.0.name" value="Nine Inch Nails" />
+      <input type="hidden" name="mediums.0.track.1.artist_credit.names.0.mbid" value="b7ffd2af-418f-4be2-bdd1-22f8b48613da" />
+      <input type="hidden" name="mediums.0.track.1.artist_credit.names.0.join_phrase" value=" & " />
+      <input type="hidden" name="mediums.0.track.1.artist_credit.names.1.name" value="David Bowie" />
+      <input type="hidden" name="mediums.0.track.1.artist_credit.names.1.mbid" value="5441c29d-3602-4898-b1a1-b77fa23b8e50" />
+      <input type="hidden" name="mediums.0.track.1.artist_credit.names.1.join_phrase" value=" feat. " />
+      <input type="hidden" name="mediums.0.track.1.artist_credit.names.2.name" value="Bing Crosby" />
+      <input type="hidden" name="mediums.0.track.1.artist_credit.names.2.mbid" value="2437980f-513a-44fc-80f1-b90d9d7fcf8f" />
+      <input type="hidden" name="mediums.0.track.2.name" value="First Artist" />
+      <input type="hidden" name="mediums.0.track.2.artist_credit.names.0.name" value="Nine Inch Nails" />
+      <input type="hidden" name="mediums.0.track.2.artist_credit.names.0.mbid" value="b7ffd2af-418f-4be2-bdd1-22f8b48613da" />
+      <input type="hidden" name="mediums.0.track.3.name" value="Second Artist" />
+      <input type="hidden" name="mediums.0.track.3.artist_credit.names.0.name" value="David Bowie" />
+      <input type="hidden" name="mediums.0.track.3.artist_credit.names.0.mbid" value="5441c29d-3602-4898-b1a1-b77fa23b8e50" />
+      <input type="hidden" name="mediums.0.track.4.name" value="Different Artist" />
+      <input type="hidden" name="mediums.0.track.4.artist_credit.names.0.name" value="Bing Crosby" />
+      <input type="hidden" name="mediums.0.track.4.artist_credit.names.0.mbid" value="2437980f-513a-44fc-80f1-b90d9d7fcf8f" />
+      <input type="hidden" name="edit_note" value="Testing MBS-13273" />
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -707,6 +707,7 @@ const seleniumTests = [
     sql: 'vision_creation_newsun.sql',
   },
   {name: 'release-editor/MBS-13207.json5', login: true},
+  {name: 'release-editor/MBS-13273.json5', login: true},
   {
     name: 'Check_Duplicates.json5',
     login: true,

--- a/t/selenium/release-editor/MBS-13273.json5
+++ b/t/selenium/release-editor/MBS-13273.json5
@@ -1,0 +1,105 @@
+{
+  title: 'MBS-13273',
+  commands: [
+    // Add a release that's initially credited to Nine Inch Nails and David Bowie.
+    {
+      command: 'open',
+      target: '/static/scripts/tests/release-editor/seeds/mbs-13273.html',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=a[href="#edit-note"]',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'id=enter-edit',
+      value: '',
+    },
+    // Change the first release artist to Lethal Bizzle and the second to Super Furry Animals.
+    {
+      command: 'clickAndWait',
+      target: 'css=.tabs a[href$="/edit"]',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#information button.open-ac',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'css=#artist-credit-bubble tbody tr:nth-child(1) input.name',
+      value: '1155431a-d35e-4863-9ae0-e3c24eb61aa9',
+    },
+    {
+      command: 'type',
+      target: 'css=#artist-credit-bubble tbody tr:nth-child(2) input.name',
+      value: 'c5f5dc27-3059-49c0-ae45-5009a01bb9ec',
+    },
+    {
+      command: 'pause',
+      target: '500',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#artist-credit-bubble .buttons button.positive',
+      value: '',
+    },
+    // After switching to the tracklist tab, the first two tracks' artist credits should be updated
+    // since they began with the original release credits, but the remaining tracks' credits should
+    // be unchanged.
+    {
+      command: 'click',
+      target: 'css=a[href="#tracklist"]',
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelectorAll('#tracklist span.artist.autocomplete input.name')[0].value",
+      value: 'Lethal Bizzle & Super Furry Animals',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelectorAll('#tracklist span.artist.autocomplete input.name')[1].value",
+      value: 'Lethal Bizzle & Super Furry Animals feat. Bing Crosby',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelectorAll('#tracklist span.artist.autocomplete input.name')[2].value",
+      value: 'Nine Inch Nails',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelectorAll('#tracklist span.artist.autocomplete input.name')[3].value",
+      value: 'David Bowie',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelectorAll('#tracklist span.artist.autocomplete input.name')[4].value",
+      value: 'Bing Crosby',
+    },
+    {
+      command: 'open',
+      target: '/',
+      value: '',
+    },
+    {
+      command: 'handleAlert',
+      target: 'accept',
+      value: '',
+    },
+    {
+      command: 'waitUntilUrlIs',
+      target: '/',
+      value: '',
+    },
+  ],
+}


### PR DESCRIPTION
# MBS-13273

When release artist credits are updated, also update track credits that start with the old release credits (instead of only ones that exactly match the release credits).

For example, if the release credits are changed from "A" to "B", a track that was credited to "A feat. C" will be updated to "B feat. C".

# Problem

When updating the artist credits on a release, track credits that exactly match the old release credits are automatically updated to use the new credits, but tracks that also include featured artists are not updated.

It's easy for an editor not to notice that some of the tracks weren't updated if the old and new artists have the same name. For example, see [edit #103710653](https://musicbrainz.org/edit/103710653) (later fixed by [edit #103710691](https://musicbrainz.org/edit/103710691)).

# Solution

Suppose a track's credits include T artists and the old release credits include R artists. If the track's reduced credits don't exactly match the release credits and T > R, check if the first R artists from the track credits match the old release credits. If so, update the first R artists in the track credits to instead use the new release credits.

Some examples:
* If a release is updated from `A` to `B` and a track credits `A feat. F`, update the track to credit `B feat. F`.
* If a release is updated from `A & B` to `A & C` and a track credits `A & B feat. F & G`, update the track to credit `A & C feat. F & G`.

# Action

N/A