### PR TITLE
MBS-11934: Add report for releases without CAA

### DIFF
--- a/lib/MusicBrainz/Server/Report/ReleasesWithoutCAA.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesWithoutCAA.pm
@@ -1,0 +1,37 @@
+package MusicBrainz::Server::Report::ReleasesWithoutCAA;
+use Moose;
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub component_name { 'ReleasesWithoutCaa' }
+sub query {<<~'SQL'}
+    SELECT r.id AS release_id,
+           row_number() OVER (ORDER BY ac.name COLLATE musicbrainz, r.name COLLATE musicbrainz)
+      FROM (
+        SELECT DISTINCT r.*
+          FROM release r
+         WHERE NOT EXISTS (
+            SELECT 1
+              FROM cover_art_archive.cover_art
+             WHERE cover_art.release = r.id
+         )
+      ) r
+      JOIN artist_credit ac ON r.artist_credit = ac.id
+    SQL
+
+sub table { 'releases_without_caa' }
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2023 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -93,6 +93,7 @@ my @all = qw(
     ReleasesWithEmptyMediums
     ReleasesWithMailOrderRelationships
     ReleasesWithNoMediums
+    ReleasesWithoutCAA
     ReleasesWithoutVACredit
     ReleasesWithoutVALink
     ReleasesWithUnlikelyLanguageScript
@@ -194,6 +195,7 @@ use MusicBrainz::Server::Report::ReleasesWithDownloadRelationships;
 use MusicBrainz::Server::Report::ReleasesWithEmptyMediums;
 use MusicBrainz::Server::Report::ReleasesWithMailOrderRelationships;
 use MusicBrainz::Server::Report::ReleasesWithNoMediums;
+use MusicBrainz::Server::Report::ReleasesWithoutCAA;
 use MusicBrainz::Server::Report::ReleasesWithoutVACredit;
 use MusicBrainz::Server::Report::ReleasesWithoutVALink;
 use MusicBrainz::Server::Report::ReleasesWithUnlikelyLanguageScript;

--- a/root/report/ReleasesWithoutCaa.js
+++ b/root/report/ReleasesWithoutCaa.js
@@ -1,0 +1,47 @@
+/*
+ * @flow strict
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import ReleaseList from './components/ReleaseList.js';
+import ReportLayout from './components/ReportLayout.js';
+import type {ReportDataT, ReportReleaseT} from './types.js';
+
+const ReleasesWithoutCaa = ({
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
+  <ReportLayout
+    canBeFiltered={canBeFiltered}
+    description={exp.l(
+      `This report shows releases that have no cover art in the Cover Art
+       Archive. Given that most releases have some form of cover art, the
+       vast majority of releases in this report should have artwork 
+       {caa_how_to|uploaded to the Cover Art Archive}.
+       Note that the cover art uploaded for a release must always exactly
+       match the actual art for that specific release (for example,
+       they should have the same barcode, format, etc.).`,
+      {caa_how_to: '/doc/How_to_Add_Cover_Art'},
+    )}
+    entityType="release"
+    extraInfo={l(
+      `We strongly suggest restricting this report to entities
+       in your subscriptions only for a more manageable list of results.`,
+    )}
+    filtered={filtered}
+    generated={generated}
+    title={l('Releases without any art in the Cover Art Archive')}
+    totalEntries={pager.total_entries}
+  >
+    <ReleaseList items={items} pager={pager} />
+  </ReportLayout>
+);
+
+export default ReleasesWithoutCaa;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -362,6 +362,10 @@ const ReportsIndex = (): React$Element<typeof Layout> => {
             reportName="ReleasesWithCAANoTypes"
           />
           <ReportsIndexEntry
+            content={l('Releases without any art in the Cover Art Archive')}
+            reportName="ReleasesWithoutCAA"
+          />
+          <ReportsIndexEntry
             content={l('Releases with mediums named after their position')}
             reportName="MediumsWithOrderInTitle"
           />

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -288,6 +288,7 @@ export default {
   'report/ReleasesWithEmptyMediums': (): Promise<mixed> => import('../report/ReleasesWithEmptyMediums.js'),
   'report/ReleasesWithMailOrderRelationships': (): Promise<mixed> => import('../report/ReleasesWithMailOrderRelationships.js'),
   'report/ReleasesWithNoMediums': (): Promise<mixed> => import('../report/ReleasesWithNoMediums.js'),
+  'report/ReleasesWithoutCaa': (): Promise<mixed> => import('../report/ReleasesWithoutCaa.js'),
   'report/ReleasesWithoutVaCredit': (): Promise<mixed> => import('../report/ReleasesWithoutVaCredit.js'),
   'report/ReleasesWithoutVaLink': (): Promise<mixed> => import('../report/ReleasesWithoutVaLink.js'),
   'report/ReleasesWithUnlikelyLanguageScript': (): Promise<mixed> => import('../report/ReleasesWithUnlikelyLanguageScript.js'),


### PR DESCRIPTION
### Implement MBS-11934

# Description
This report lists all releases that have no images in the Cover Art Archive at all. In its default state that's a ton (around 1.5 million), but this is mostly useful when filtered for subscriptions, allowing users to quickly find all the music by their favourite artists or labels that is missing cover art.

# Testing
I tested locally (on sample) that the report runs and displays fine. That does not have CAA set up, but I quickly tested the query on jimmy to make sure it seemed sensible there and it gave a number of results similar to substracting total releases vs releases with cover art in our statistics from yesterday :)
