### PR TITLE
Use the same error message for all URL fields

### DIFF
--- a/lib/MusicBrainz/Server/Form/Field/URL.pm
+++ b/lib/MusicBrainz/Server/Form/Field/URL.pm
@@ -24,7 +24,10 @@ sub validate
     my $url = $self->value;
     $url = URI->new($url)->canonical;
 
-    return $self->add_error(l('Enter a valid URL, such as “http://google.com/”'))
+    return $self->add_error(l(
+            'Please enter a valid URL, such as “{example_url}”.',
+            { example_url => 'http://example.com/' }
+        ))
         unless is_valid_url($url->as_string);
 
     return $self->add_error(l('URL protocol must be HTTP, HTTPS or FTP'))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Two different messages were used for the same error in two different forms, needlessly requiring an extra translation.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This patch makes the URL entity editor use the same error message as the external link field in the other entity editors.

The only display difference is that no HTML formatting is supported at the moment.

# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Tested by editing an artist and adding the external link `javascript:boo`
* [x] Tested by editing an URL and changing it to `javascript:boo`