### PR TITLE
Fix formatting OAuth URI error messages

### DIFF
--- a/lib/MusicBrainz/Server/Form/Application.pm
+++ b/lib/MusicBrainz/Server/Form/Application.pm
@@ -48,15 +48,16 @@ sub validate
             );
         } elsif ($self->field('oauth_redirect_uri')->value !~ $OAUTH_WEB_APP_REDIRECT_URI_RE) {
             $self->field('oauth_redirect_uri')->add_error(
-                l('Redirect URL scheme must be either <code>http</code> or ' .
-                  '<code>https</code> for web applications.')
+                l('Redirect URL scheme must be either “http” or ' .
+                  '“https” for web applications.')
             );
         }
     } elsif ($self->field('oauth_redirect_uri')->value) {
         if ($self->field('oauth_redirect_uri')->value !~ $OAUTH_INSTALLED_APP_REDIRECT_URI_RE) {
             $self->field('oauth_redirect_uri')->add_error(
                 l('Redirect URL scheme must be a reverse-DNS string, as in ' .
-                  '<code>org.example.app://auth</code>, for installed applications.')
+                  '“{example_url}”, for installed applications.',
+                  { example_url => 'org.example.app://auth' })
             );
         }
     }

--- a/lib/MusicBrainz/Server/Form/Application.pm
+++ b/lib/MusicBrainz/Server/Form/Application.pm
@@ -1,4 +1,5 @@
 package MusicBrainz::Server::Form::Application;
+use utf8;
 use strict;
 use warnings;
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* `<code>` was wrongly displayed in the error messages for the callback URL when registering an application as a developer.
* The example URL was needlessly part of the message to be translated.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

* Replace `<code>` with double quotes.
* Use a variable placeholder for the example URL.

# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Testing the form `http://localhost:5000/account/applications/register` with the callback URL `javascript:boo` and either type of application.