### PR TITLE
MBS-13362: Handle Spotify prerelease URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5216,7 +5216,7 @@ const CLEANUPS: CleanupEntries = {
             };
           case LINK_TYPES.streamingfree.release:
             return {
-              result: prefix === 'album',
+              result: prefix === 'album' || prefix === 'prerelease',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.streamingfree.recording:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5138,6 +5138,13 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['release'],
   },
   {
+                     input_url: 'https://open.spotify.com/prerelease/1Kqdup6HEqeP3hHXDELQHl',
+             input_entity_type: 'release',
+    expected_relationship_type: 'streamingfree',
+            expected_clean_url: 'https://open.spotify.com/prerelease/1Kqdup6HEqeP3hHXDELQHl',
+       only_valid_entity_types: ['release'],
+  },
+  {
                      input_url: 'http://open.spotify.com/local/Electrolyze/Single/Belief/265',
              input_entity_type: 'release',
     expected_relationship_type: 'streamingfree',


### PR DESCRIPTION
# Problem MBS-13362
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Spotify prerelease URLs were unknowingly blocked from being added to the external links of upcoming releases.

Note: Prerelease Spotify URLs point to countdown pages until the time the album is released, then it redirects to the album, so they allow streaming the music of the album once the countdown is reached.

For reference: https://artists.spotify.com/blog/countdown-pages-get-fans-hyped-for-your-new-album-spotify-stream-on

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Auto-selecting the streaming relationship type for Spotify streaming URLs, as it eventually allows to stream it.

Ideally the relationship begin date should be set to the countdown date.

# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Added CI test