### PR TITLE
Add a tool that can execute any file via Webpack

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -571,6 +571,38 @@ modern browsers when compiling static resources by specifying the
 env MODERN_BROWSERS=1 ./script/compile_resources.sh
 ```
 
+Sometimes you may want to test how a certain module or function behaves
+locally, in Node.js, without setting up a whole test suite or Webpack
+configuration for it. This can be difficult, because most modules you would
+want to test are using Flow syntax, which can't be executed directly;
+furthermore, they may rely on some auto-imported functions, like `l`, which
+are injected by Webpack.
+
+There are two utilities which can help here:
+
+ 1. ./bin/sucrase-node
+
+    If you'd like to execute an ES module which uses *at most* Flow syntax,
+    and not any magic Webpack imports, then you may do so with
+    ./bin/sucrase-node (the same as you would with just `node`).
+
+ 2. ./webpack/exec.mjs
+
+    If you'd like to execute any kind of script (ESM or CommonJS) which may
+    import modules that make use of magic Webpack imports, then use
+    ./webpack/exec.mjs instead. This tools works by compiling the input
+    script to a temporary file, which is then executed directly and cleaned
+    up once it's finished with.
+
+    ```sh
+    $ cat <<EOF > test.js
+    const commaOnlyList =
+      require('./root/static/scripts/common/i18n/commaOnlyList.js').default;
+    console.log(commaOnlyList([1, 2, 3]));
+    EOF
+    $ ./webpack/exec.mjs test.js
+    ```
+
 Potential issues and fixes
 --------------------------
 

--- a/webpack/exec.mjs
+++ b/webpack/exec.mjs
@@ -1,0 +1,92 @@
+#!./bin/sucrase-node
+/*
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+/*
+ * See HACKING.md > Debugging > JavaScript for usage.
+ */
+
+import {execFile} from 'child_process';
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+import webpack from 'webpack';
+
+import MB_SERVER_ROOT from '../root/utility/serverRootDir.mjs';
+
+import moduleConfig from './moduleConfig.mjs';
+import serverConfig from './server.config.mjs';
+
+const entryFilePath = path.resolve(process.argv[2]);
+const outputFileName = crypto.randomBytes(8).toString('base64') + '.js';
+const outputFileDir = path.dirname(entryFilePath);
+const outputFilePath = path.resolve(outputFileDir, outputFileName);
+
+const compiler = webpack({
+  context: MB_SERVER_ROOT,
+
+  entry: entryFilePath,
+
+  externals: serverConfig.externals,
+
+  mode: 'production',
+
+  module: moduleConfig,
+
+  optimization: {
+    minimize: false,
+  },
+
+  output: {
+    environment: {
+      module: false,
+    },
+    filename: outputFileName,
+    libraryTarget: 'commonjs2',
+    path: outputFileDir,
+  },
+
+  plugins: serverConfig.plugins.filter((plugin) => !(
+    plugin instanceof webpack.ProgressPlugin
+  )),
+
+  target: 'node',
+});
+
+process.on('exit', () => {
+  fs.unlink(outputFilePath, console.error);
+});
+
+compiler.run((err, stats) => {
+  if (err) {
+    console.error(err.stack || err);
+    if (err.details) {
+      console.error(err.details);
+    }
+    return;
+  }
+
+  let compilationErrors = stats.compilation.errors;
+  if (compilationErrors.length) {
+    for (const error of compilationErrors) {
+      console.log(error);
+    }
+    return;
+  }
+
+  execFile('node', [outputFilePath], (error, stdout, stderr) => {
+    if (error) {
+      throw error;
+    }
+    if (stderr) {
+      console.error(stderr);
+    }
+    console.log(stdout);
+  });
+});


### PR DESCRIPTION
# Problem

Sometimes I want to write a quick, one-off script that imports some of our JavaScript modules and executes some functions in them. This is very difficult because the modules probably rely on Flow syntax and Webpack auto-imports.

# Solution

Adds webpack/exec.mjs which can be used for this. Documents it and ./bin/sucrase-node (which is actually used to execute webpack/exec.mjs) in HACKING.md.