### PR TITLE
MBS-13117: Prevent localizing admin-only messages

### DIFF
--- a/.eslintrc.unfixed.yaml
+++ b/.eslintrc.unfixed.yaml
@@ -4,6 +4,9 @@ rules:
   wrap-iife: warn
   camelcase: [warn, {properties: never,
                      allow: [
+                       "l_admin",
+                       "ln_admin",
+                       "lp_admin",
                        "l_attributes",
                        "ln_attributes",
                        "lp_attributes",

--- a/.eslintrc.unfixed.yaml
+++ b/.eslintrc.unfixed.yaml
@@ -6,7 +6,6 @@ rules:
                      allow: [
                        "l_admin",
                        "ln_admin",
-                       "lp_admin",
                        "l_attributes",
                        "ln_attributes",
                        "lp_attributes",

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -42,6 +42,9 @@ globals:
   N_lp: readonly
   exp: readonly
   texp: readonly
+  l_admin: readonly
+  ln_admin: readonly
+  lp_admin: readonly
   l_attributes: readonly
   ln_attributes: readonly
   lp_attributes: readonly

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -44,7 +44,6 @@ globals:
   texp: readonly
   l_admin: readonly
   ln_admin: readonly
-  lp_admin: readonly
   l_attributes: readonly
   ln_attributes: readonly
   lp_attributes: readonly

--- a/docker/musicbrainz-tests/run_circleci_tests.sh
+++ b/docker/musicbrainz-tests/run_circleci_tests.sh
@@ -8,7 +8,7 @@ rm /etc/service/{postgresql,redis}/down && sv start postgresql redis
 
 sudo -E -H -u musicbrainz carton exec -- ./script/create_test_db.sh
 
-sudo -E -H -u musicbrainz make -C po all_quiet deploy
+sudo -E -H -u musicbrainz make -C po test_source all_quiet deploy
 
 MUSICBRAINZ_RUNNING_TESTS=1 \
     NODE_ENV=test \

--- a/lib/MusicBrainz/Server/Controller/Admin.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin.pm
@@ -6,7 +6,6 @@ use Try::Tiny;
 
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 
-use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Constants qw( :privileges );
 use MusicBrainz::Server::ControllerUtils::JSON qw( serialize_pager );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
@@ -89,7 +88,7 @@ sub edit_user : Path('/admin/user/edit') Args(1) RequireAuth HiddenOnMirrors Sec
             }
         }
 
-        $c->flash->{message} = l('User successfully edited.');
+        $c->flash->{message} = 'User successfully edited.';
         $c->response->redirect($c->uri_for_action('/user/profile', [$form->field('username')->value]));
         $c->detach;
     } else {
@@ -151,7 +150,7 @@ sub edit_banner : Path('/admin/banner/edit') Args(0) RequireAuth(banner_editor) 
         $store->set($alert_cache_key, $form->values->{message});
         $store->set($alert_mtime_cache_key, time());
 
-        $c->flash->{message} = l('Banner updated. Remember that each server has its own, independent banner.');
+        $c->flash->{message} = 'Banner updated. Remember that each server has its own, independent banner.';
         $c->response->redirect($c->uri_for('/'));
         $c->detach;
     } else {
@@ -187,7 +186,7 @@ sub email_search : Path('/admin/email-search') Args(0) RequireAuth(account_admin
         } catch {
             my $error = $_;
             if ("$error" =~ m/invalid regular expression/) {
-                $form->field('email')->add_error(l('Invalid regular expression.'));
+                $form->field('email')->add_error('Invalid regular expression.');
                 $c->response->status(HTTP_BAD_REQUEST);
             } else {
                 die $error;
@@ -253,7 +252,7 @@ sub locked_username_search : Path('/admin/locked-usernames/search') Args(0) Requ
         } catch {
             my $error = $_;
             if ("$error" =~ m/invalid regular expression/) {
-                $form->field('username')->add_error(l('Invalid regular expression.'));
+                $form->field('username')->add_error('Invalid regular expression.');
                 $c->response->status(HTTP_BAD_REQUEST);
             } else {
                 die $error;

--- a/lib/MusicBrainz/Server/Controller/Admin/Attributes.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin/Attributes.pm
@@ -6,8 +6,6 @@ use utf8;
 use MusicBrainz::Server::Data::Utils qw( contains_string );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
-use MusicBrainz::Server::Translation qw( l );
-
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 
 my @models = qw(
@@ -127,7 +125,8 @@ sub delete : Chained('attribute_base') Args(1) RequireAuth(account_admin) Secure
     $c->stash->{attribute} = $attr;
 
     if ($c->model($model)->in_use($id)) {
-        my $error_message = l('You cannot remove the attribute "{name}" because it is still in use.', { name => $attr->name });
+        my $attr_name = $attr->name;
+        my $error_message = "You cannot remove the attribute “$attr_name” because it is still in use.";
 
         $c->stash(
             current_view => 'Node',
@@ -139,7 +138,8 @@ sub delete : Chained('attribute_base') Args(1) RequireAuth(account_admin) Secure
     }
 
     if ($c->model($model)->has_children($id)) {
-        my $error_message = l('You cannot remove the attribute “{name}” because it is the parent of other attributes.', { name => $attr->name });
+        my $attr_name = $attr->name;
+        my $error_message = "You cannot remove the attribute “$attr_name” because it is the parent of other attributes.";
 
         $c->stash(
             current_view => 'Node',

--- a/lib/MusicBrainz/Server/Form/Admin/Attributes/Language.pm
+++ b/lib/MusicBrainz/Server/Form/Admin/Attributes/Language.pm
@@ -5,7 +5,6 @@ use warnings;
 use HTML::FormHandler::Moose;
 
 use MusicBrainz::Server::Constants qw( :language_frequency );
-use MusicBrainz::Server::Translation qw( lp );
 
 extends 'MusicBrainz::Server::Form';
 with 'MusicBrainz::Server::Form::Role::Edit';
@@ -48,9 +47,9 @@ has_field 'frequency' => (
 
 sub options_frequency {
     return [
-        $LANGUAGE_FREQUENCY_HIDDEN, lp('Hidden', 'language optgroup'),
-        $LANGUAGE_FREQUENCY_OTHER, lp('Other', 'language optgroup'),
-        $LANGUAGE_FREQUENCY_FREQUENT, lp('Frequently used', 'language optgroup'),
+        $LANGUAGE_FREQUENCY_HIDDEN, 'Hidden',
+        $LANGUAGE_FREQUENCY_OTHER, 'Other',
+        $LANGUAGE_FREQUENCY_FREQUENT, 'Frequently used',
     ];
 }
 

--- a/lib/MusicBrainz/Server/Form/Admin/Attributes/Script.pm
+++ b/lib/MusicBrainz/Server/Form/Admin/Attributes/Script.pm
@@ -5,7 +5,6 @@ use warnings;
 use HTML::FormHandler::Moose;
 
 use MusicBrainz::Server::Constants qw( :script_frequency );
-use MusicBrainz::Server::Translation qw( lp );
 
 extends 'MusicBrainz::Server::Form';
 with 'MusicBrainz::Server::Form::Role::Edit';
@@ -39,10 +38,10 @@ has_field 'frequency' => (
 
 sub options_frequency {
     return [
-        $SCRIPT_FREQUENCY_HIDDEN, lp('Hidden', 'script frequency'),
-        $SCRIPT_FREQUENCY_UNCOMMON, lp('Other (Uncommon)', 'script frequency'),
-        $SCRIPT_FREQUENCY_OTHER, lp('Other', 'script frequency'),
-        $SCRIPT_FREQUENCY_FREQUENT, lp('Frequently used', 'script frequency'),
+        $SCRIPT_FREQUENCY_HIDDEN, 'Hidden',
+        $SCRIPT_FREQUENCY_UNCOMMON, 'Other (Uncommon)',
+        $SCRIPT_FREQUENCY_OTHER, 'Other',
+        $SCRIPT_FREQUENCY_FREQUENT, 'Frequently used',
     ];
 }
 

--- a/lib/MusicBrainz/Server/Form/Admin/LinkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Form/Admin/LinkAttributeType.pm
@@ -5,7 +5,6 @@ use warnings;
 use HTML::FormHandler::Moose;
 use MusicBrainz::Server::Form::Utils qw( select_options_tree );
 use MusicBrainz::Server::Constants qw( $INSTRUMENT_ROOT_ID );
-use MusicBrainz::Server::Translation qw( l );
 
 extends 'MusicBrainz::Server::Form';
 with 'MusicBrainz::Server::Form::Role::Edit';
@@ -56,7 +55,7 @@ after validate => sub {
 
     my $root = defined $parent ? ($parent->root_id // $parent->id) : 0;
     if ($root == $INSTRUMENT_ROOT_ID) {
-        $self->field('parent_id')->add_error(l('Cannot add or edit instruments here; use the instrument editing forms instead.'));
+        $self->field('parent_id')->add_error('Cannot add or edit instruments here; use the instrument editing forms instead.');
     }
 };
 

--- a/po/Makefile
+++ b/po/Makefile
@@ -10,13 +10,13 @@ GIT_LS_PERL:=git ls-files -- \
 	| $(SED_ESCAPE_SPACES)
 
 GIT_LS_JS:=git ls-files -- \
-    ':(top,glob)root/**/*.js' \
-    ':(top,glob,exclude)root/admin/**/*.js' \
-    ':(top,glob,exclude)root/static/scripts/tests/**/*.js' \
-    ':(top,glob,exclude)root/static/build/**/*.js' \
-    ':(top,glob,exclude)root/static/lib/**/*.js' \
-    ':(top,glob,exclude)root/statistics/**/*.js' \
-    | $(SED_ESCAPE_SPACES)
+	':(top,glob)root/**/*.js' \
+	':(top,glob,exclude)root/admin/**/*.js' \
+	':(top,glob,exclude)root/static/scripts/tests/**/*.js' \
+	':(top,glob,exclude)root/static/build/**/*.js' \
+	':(top,glob,exclude)root/static/lib/**/*.js' \
+	':(top,glob,exclude)root/statistics/**/*.js' \
+	| $(SED_ESCAPE_SPACES)
 
 GIT_LS_ADMINPERL:=git ls-files -- \
 	':(top,glob)lib/**/*Admin*.pm' \
@@ -32,10 +32,10 @@ GIT_LS_ADMINJS:=git ls-files -- \
 	| $(SED_ESCAPE_SPACES)
 
 GIT_LS_TT:=git ls-files -- \
-    ':(top,glob)root/**/*.tt' \
-    ':(top,glob,exclude)root/admin/**/*.tt' \
-    ':(top,glob,exclude)root/statistics/**/*.tt' \
-    | $(SED_ESCAPE_SPACES)
+	':(top,glob)root/**/*.tt' \
+	':(top,glob,exclude)root/admin/**/*.tt' \
+	':(top,glob,exclude)root/statistics/**/*.tt' \
+	| $(SED_ESCAPE_SPACES)
 
 GIT_LS_STATTT:=git ls-files -- \
 	':(top,glob)root/statistics/**/*.tt' \

--- a/po/Makefile
+++ b/po/Makefile
@@ -18,6 +18,19 @@ GIT_LS_JS:=git ls-files -- \
     ':(top,glob,exclude)root/statistics/**/*.js' \
     | $(SED_ESCAPE_SPACES)
 
+GIT_LS_ADMINPERL:=git ls-files -- \
+	':(top,glob)lib/**/*Admin*.pm' \
+	':(top,glob)lib/**/*Admin*/**/*.pm' \
+	| $(SED_ESCAPE_SPACES)
+
+GIT_LS_ADMINTT:=git ls-files -- \
+	':(top,glob)root/admin/**/*.tt' \
+	| $(SED_ESCAPE_SPACES)
+
+GIT_LS_ADMINJS:=git ls-files -- \
+	':(top,glob)root/admin/**/*.js' \
+	| $(SED_ESCAPE_SPACES)
+
 GIT_LS_TT:=git ls-files -- \
     ':(top,glob)root/**/*.tt' \
     ':(top,glob,exclude)root/admin/**/*.tt' \
@@ -35,6 +48,9 @@ GIT_LS_STATJS:=git ls-files -- \
 POTFILES=$(shell $(GIT_LS_PERL))
 JSFILES=$(shell $(GIT_LS_JS))
 TT=$(shell $(GIT_LS_TT))
+ADMINPERL=$(shell $(GIT_LS_ADMINPERL))
+ADMINTT=$(shell $(GIT_LS_ADMINTT))
+ADMINJS=$(shell $(GIT_LS_ADMINJS))
 STATTT=$(shell $(GIT_LS_STATTT))
 STATJS=$(shell $(GIT_LS_STATJS))
 
@@ -142,3 +158,36 @@ check_quiet:
 	@for file in $(POFILES); do \
 		msgfmt -o /dev/null -c $$file;\
 	done
+
+test_source: test_no_admin
+
+test_no_admin: $(ADMINPERL) $(ADMINTT) $(ADMINJS) $(wildcard extract_pot_templates)
+	@echo "Testing that no admin files contain any translatable messages (MBS-13117)";
+	@count=0; \
+	for file in $(ADMINPERL); do \
+		pot=`xgettext --from-code utf-8 --keyword=__ --keyword=l --keyword=lp:1,2c --keyword=N_lp:1,2c --keyword=N_l --keyword=ln:1,2 --keyword=N_ln:1,2 --keyword=__x --keyword=__nx:1,2 --keyword=__n:1,2 -Lperl -o - $$file`; \
+		if [ -n "$$pot" ]; then \
+			printf "$$pot" | grep '^#:'; \
+			count=`expr $$count + 1`; \
+		fi; \
+	done; \
+	for file in $(ADMINTT); do \
+		pot=`./extract_pot_templates $$file`; \
+		if [ -n "$$pot" ]; then \
+			printf "$$pot" | grep '^#:'; \
+			count=`expr $$count + 1`; \
+		fi; \
+	done; \
+	for file in $(ADMINJS); do \
+		pot=`../script/xgettext.js $$file`; \
+		if [ -n "$$pot" ]; then \
+			printf "$$pot" | grep '^#:'; \
+			count=`expr $$count + 1`; \
+		fi; \
+	done; \
+	if [ $$count -gt 0 ]; then \
+		echo "Error: Found $$count admin files wrongly containing translatable messages"; \
+		exit 1; \
+	else \
+		echo "OK"; \
+	fi

--- a/po/Makefile
+++ b/po/Makefile
@@ -5,7 +5,6 @@ MSGWRAP:=79
 
 GIT_LS_PERL:=git ls-files -- \
 	':(top,glob)lib/**/*.pm' \
-	':(top,glob)lib/**/*.pl' \
 	':(top,glob,exclude)lib/**/*Admin*.pm' \
 	':(top,glob,exclude)lib/**/*Admin*/**/*.pm' \
 	| $(SED_ESCAPE_SPACES)

--- a/po/Makefile
+++ b/po/Makefile
@@ -6,10 +6,13 @@ MSGWRAP:=79
 GIT_LS_PERL:=git ls-files -- \
 	':(top,glob)lib/**/*.pm' \
 	':(top,glob)lib/**/*.pl' \
+	':(top,glob,exclude)lib/**/*Admin*.pm' \
+	':(top,glob,exclude)lib/**/*Admin*/**/*.pm' \
 	| $(SED_ESCAPE_SPACES)
 
 GIT_LS_JS:=git ls-files -- \
     ':(top,glob)root/**/*.js' \
+    ':(top,glob,exclude)root/admin/**/*.js' \
     ':(top,glob,exclude)root/static/scripts/tests/**/*.js' \
     ':(top,glob,exclude)root/static/build/**/*.js' \
     ':(top,glob,exclude)root/static/lib/**/*.js' \
@@ -18,6 +21,7 @@ GIT_LS_JS:=git ls-files -- \
 
 GIT_LS_TT:=git ls-files -- \
     ':(top,glob)root/**/*.tt' \
+    ':(top,glob,exclude)root/admin/**/*.tt' \
     ':(top,glob,exclude)root/statistics/**/*.tt' \
     | $(SED_ESCAPE_SPACES)
 

--- a/po/Makefile
+++ b/po/Makefile
@@ -191,3 +191,5 @@ test_no_admin: $(ADMINPERL) $(ADMINTT) $(ADMINJS) $(wildcard extract_pot_templat
 	else \
 		echo "OK"; \
 	fi
+
+.PHONY: all all_quiet check check_quiet clean pot test_source test_no_admin

--- a/po/Makefile
+++ b/po/Makefile
@@ -18,19 +18,6 @@ GIT_LS_JS:=git ls-files -- \
 	':(top,glob,exclude)root/statistics/**/*.js' \
 	| $(SED_ESCAPE_SPACES)
 
-GIT_LS_ADMINPERL:=git ls-files -- \
-	':(top,glob)lib/**/*Admin*.pm' \
-	':(top,glob)lib/**/*Admin*/**/*.pm' \
-	| $(SED_ESCAPE_SPACES)
-
-GIT_LS_ADMINTT:=git ls-files -- \
-	':(top,glob)root/admin/**/*.tt' \
-	| $(SED_ESCAPE_SPACES)
-
-GIT_LS_ADMINJS:=git ls-files -- \
-	':(top,glob)root/admin/**/*.js' \
-	| $(SED_ESCAPE_SPACES)
-
 GIT_LS_TT:=git ls-files -- \
 	':(top,glob)root/**/*.tt' \
 	':(top,glob,exclude)root/admin/**/*.tt' \
@@ -48,9 +35,6 @@ GIT_LS_STATJS:=git ls-files -- \
 POTFILES=$(shell $(GIT_LS_PERL))
 JSFILES=$(shell $(GIT_LS_JS))
 TT=$(shell $(GIT_LS_TT))
-ADMINPERL=$(shell $(GIT_LS_ADMINPERL))
-ADMINTT=$(shell $(GIT_LS_ADMINTT))
-ADMINJS=$(shell $(GIT_LS_ADMINJS))
 STATTT=$(shell $(GIT_LS_STATTT))
 STATJS=$(shell $(GIT_LS_STATJS))
 
@@ -159,37 +143,7 @@ check_quiet:
 		msgfmt -o /dev/null -c $$file;\
 	done
 
-test_source: test_no_admin
+test_source:
+	@../t/no_gettext_for_admin.sh
 
-test_no_admin: $(ADMINPERL) $(ADMINTT) $(ADMINJS) $(wildcard extract_pot_templates)
-	@echo "Testing that no admin files contain any translatable messages (MBS-13117)";
-	@count=0; \
-	for file in $(ADMINPERL); do \
-		pot=`xgettext --from-code utf-8 --keyword=__ --keyword=l --keyword=lp:1,2c --keyword=N_lp:1,2c --keyword=N_l --keyword=ln:1,2 --keyword=N_ln:1,2 --keyword=__x --keyword=__nx:1,2 --keyword=__n:1,2 -Lperl -o - $$file`; \
-		if [ -n "$$pot" ]; then \
-			printf "$$pot" | grep '^#:'; \
-			count=`expr $$count + 1`; \
-		fi; \
-	done; \
-	for file in $(ADMINTT); do \
-		pot=`./extract_pot_templates $$file`; \
-		if [ -n "$$pot" ]; then \
-			printf "$$pot" | grep '^#:'; \
-			count=`expr $$count + 1`; \
-		fi; \
-	done; \
-	for file in $(ADMINJS); do \
-		pot=`../script/xgettext.js $$file`; \
-		if [ -n "$$pot" ]; then \
-			printf "$$pot" | grep '^#:'; \
-			count=`expr $$count + 1`; \
-		fi; \
-	done; \
-	if [ $$count -gt 0 ]; then \
-		echo "Error: Found $$count admin files wrongly containing translatable messages"; \
-		exit 1; \
-	else \
-		echo "OK"; \
-	fi
-
-.PHONY: all all_quiet check check_quiet clean pot test_source test_no_admin
+.PHONY: all all_quiet check check_quiet clean pot test_source

--- a/root/admin/DeleteUser.js
+++ b/root/admin/DeleteUser.js
@@ -37,9 +37,9 @@ const DeleteUser = ({
     <UserAccountLayout
       entity={user}
       page="delete"
-      title={l('Delete Account')}
+      title="Delete Account"
     >
-      <h2>{l('Delete Account')}</h2>
+      <h2>{'Delete Account'}</h2>
       <p>
         {exp.l_admin(
           `Are you sure you want to delete all information about {e}?

--- a/root/admin/DeleteUser.js
+++ b/root/admin/DeleteUser.js
@@ -41,7 +41,7 @@ const DeleteUser = ({
     >
       <h2>{l('Delete Account')}</h2>
       <p>
-        {exp.l(
+        {exp.l_admin(
           `Are you sure you want to delete all information about {e}?
            This cannot be undone!`,
           {e: <EditorLink editor={user} />},
@@ -53,7 +53,7 @@ const DeleteUser = ({
         <FormRowCheckbox
           field={form.field.allow_reuse}
           hasNoMargin
-          label={texp.l(
+          label={texp.l_admin(
             'Allow the name “{editor_name}” to be reused.',
             {editor_name: user.name},
           )}
@@ -63,7 +63,7 @@ const DeleteUser = ({
         <div className="row no-margin">
           <FormSubmit
             inputClassName="negative"
-            label={texp.l('Delete {e}', {e: user.name})}
+            label={texp.l_admin('Delete {e}', {e: user.name})}
           />
         </div>
       </form>

--- a/root/admin/EditBanner.js
+++ b/root/admin/EditBanner.js
@@ -8,6 +8,7 @@
  */
 
 import Layout from '../layout/index.js';
+import {l_admin} from '../static/scripts/common/i18n/admin.js';
 import FormCsrfToken
   from '../static/scripts/edit/components/FormCsrfToken.js';
 import FormRowTextArea
@@ -22,21 +23,21 @@ type Props = {
 };
 
 const EditBanner = ({form}: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Edit Banner Message')}>
+  <Layout fullWidth title="Edit Banner Message">
     <div id="content">
-      <h1>{l('Edit banner message')}</h1>
+      <h1>{'Edit banner message'}</h1>
       <p>
-        {l(`This will set the banner message that is shown at the top
-            of each page. An empty string removes the banner.`)}
+        {l_admin(`This will set the banner message that is shown at the top
+                  of each page. An empty string removes the banner.`)}
       </p>
       <form action="/admin/banner/edit" method="post">
         <FormCsrfToken form={form} />
         <FormRowTextArea
           field={form.field.message}
-          label={addColonText(l('Banner message'))}
+          label="Banner message:"
         />
         <div className="row no-label">
-          <FormSubmit label={l('Update')} />
+          <FormSubmit label="Update" />
         </div>
       </form>
     </div>

--- a/root/admin/EditUser.js
+++ b/root/admin/EditUser.js
@@ -137,7 +137,7 @@ const EditUser = ({
         <h2>{l('Administration flags')}</h2>
         <FormRowCheckbox
           field={form.field.mbid_submitter}
-          label={exp.l(
+          label={exp.l_admin(
             '<abbr title="MusicBrainz Identifier">MBID</abbr> submitter',
           )}
           uncontrolled

--- a/root/admin/EditUser.js
+++ b/root/admin/EditUser.js
@@ -66,75 +66,75 @@ const EditUser = ({
     <UserAccountLayout
       entity={user}
       page="edit_user"
-      title={l('Adjust User Account Flags')}
+      title="Adjust User Account Flags"
     >
       <form method="post">
         <FormCsrfToken form={form} />
 
         <input name="submitted" type="hidden" value="1" />
 
-        <h2>{l('User permissions')}</h2>
+        <h2>{'User permissions'}</h2>
         <FormRowCheckbox
           field={form.field.auto_editor}
-          label={l('Auto-editor')}
+          label="Auto-editor"
           uncontrolled
         />
         <FormRowCheckbox
           field={form.field.wiki_transcluder}
-          label={l('Transclusion editor')}
+          label="Transclusion editor"
           uncontrolled
         />
         <FormRowCheckbox
           field={form.field.link_editor}
-          label={l('Relationship editor')}
+          label="Relationship editor"
           uncontrolled
         />
         <FormRowCheckbox
           field={form.field.location_editor}
-          label={l('Location editor')}
+          label="Location editor"
           uncontrolled
         />
         <FormRowCheckbox
           field={form.field.banner_editor}
-          label={l('Banner message editor')}
+          label="Banner message editor"
           uncontrolled
         />
 
-        <h2>{l('User sanctions')}</h2>
+        <h2>{'User sanctions'}</h2>
         <FormRowCheckbox
           field={form.field.spammer}
-          label={l('Spammer')}
+          label="Spammer"
           uncontrolled
         />
         <FormRowCheckbox
           field={form.field.editing_disabled}
-          label={l('Editing/voting disabled')}
+          label="Editing/voting disabled"
           uncontrolled
         />
         <FormRowCheckbox
           field={form.field.adding_notes_disabled}
-          label={l('Edit notes disabled')}
+          label="Edit notes disabled"
           uncontrolled
         />
         <FormRowCheckbox
           field={form.field.untrusted}
-          label={l('Untrusted')}
+          label="Untrusted"
           uncontrolled
         />
 
-        <h2>{l('Technical flags')}</h2>
+        <h2>{'Technical flags'}</h2>
         <FormRowCheckbox
           field={form.field.bot}
-          label={l('Bot')}
+          label="Bot"
           uncontrolled
         />
         <FormRowCheckbox
           field={form.field.no_nag}
-          label={l('No nag')}
+          label="No nag"
           uncontrolled
         />
 
-        <h2>{l('Administration flags')}</h2>
+        <h2>{'Administration flags'}</h2>
         <FormRowCheckbox
           field={form.field.mbid_submitter}
           label={exp.l_admin(
@@ -145,41 +145,41 @@ const EditUser = ({
         <FormRowCheckbox
           disabled={viewingOwnProfile}
           field={form.field.account_admin}
-          label={l('Account admin')}
+          label="Account admin"
           uncontrolled
         />
 
-        <h2>{l('Edit profile')}</h2>
+        <h2>{'Edit profile'}</h2>
         <FormRowText
           field={form.field.username}
-          label={addColonText(l('Username'))}
+          label="Username:"
           required
           uncontrolled
         />
         <FormRowEmailLong
           field={form.field.email}
-          label={addColonText(l('Email'))}
+          label="Email:"
           uncontrolled
         />
         <FormRowCheckbox
           field={form.field.skip_verification}
-          label={l('Skip verification')}
+          label="Skip verification"
           uncontrolled
         />
         <FormRowURLLong
           field={form.field.website}
-          label={addColonText(l('Website'))}
+          label="Website:"
           uncontrolled
         />
         <FormRowTextArea
           cols={80}
           field={form.field.biography}
-          label={addColonText(l('Bio'))}
+          label="Bio:"
           rows={5}
         />
 
         <FormRow hasNoLabel>
-          <FormSubmit label={l('Edit user')} />
+          <FormSubmit label="Edit user" />
         </FormRow>
       </form>
     </UserAccountLayout>

--- a/root/admin/EmailSearch.js
+++ b/root/admin/EmailSearch.js
@@ -28,9 +28,9 @@ const EmailSearch = ({
   pager,
   results,
 }: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Search users by email')}>
+  <Layout fullWidth title="Search users by email">
     <div id="content">
-      <h1>{l('Search users by email')}</h1>
+      <h1>{'Search users by email'}</h1>
 
       <form action="/admin/email-search" method="post">
         <p>
@@ -65,14 +65,14 @@ const EmailSearch = ({
 
         <FormRowText
           field={form.field.email}
-          label={addColonText(l('Email'))}
+          label="Email:"
           size={50}
           uncontrolled
         />
 
         <div className="row no-label">
           <FormSubmit
-            label={l('Search')}
+            label="Search"
             name="emailsearch.submit"
             value="1"
           />
@@ -84,7 +84,7 @@ const EmailSearch = ({
               <UserList users={results} />
             </PaginatedResults>
           ) : (
-            <p>{l('No results found.')}</p>
+            <p>{'No results found.'}</p>
           )
         ) : null}
       </form>

--- a/root/admin/EmailSearch.js
+++ b/root/admin/EmailSearch.js
@@ -34,7 +34,7 @@ const EmailSearch = ({
 
       <form action="/admin/email-search" method="post">
         <p>
-          {exp.l(
+          {exp.l_admin(
             'Enter a {link|POSIX regular expression}.',
             {
               link: 'https://www.postgresql.org/docs/12/' +

--- a/root/admin/EmailSearch.js
+++ b/root/admin/EmailSearch.js
@@ -9,7 +9,6 @@
 
 import PaginatedResults from '../components/PaginatedResults.js';
 import Layout from '../layout/index.js';
-import expand2react from '../static/scripts/common/i18n/expand2react.js';
 import FormRowText from '../static/scripts/edit/components/FormRowText.js';
 import FormSubmit from '../static/scripts/edit/components/FormSubmit.js';
 
@@ -43,7 +42,7 @@ const EmailSearch = ({
           )}
         </p>
         <p>
-          {expand2react(
+          {exp.l_admin(
             `Since periods (<code>.</code>) and tags preceded with a
              <code>+</code> sign on the user side of the address (that is,
              before the <code>@</code> sign) are often used as “free aliases”

--- a/root/admin/IpLookup.js
+++ b/root/admin/IpLookup.js
@@ -23,11 +23,11 @@ const IpLookup = ({
   pager,
   users,
 }: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('IP lookup')}>
+  <Layout fullWidth title="IP lookup">
     <div id="content">
-      <h1>{l('IP lookup')}</h1>
+      <h1>{'IP lookup'}</h1>
       <p>
-        {l('IP hash:') + ' ' + ipHash}
+        {'IP hash: ' + ipHash}
       </p>
       {users.length ? (
         <PaginatedResults pager={pager}>
@@ -35,7 +35,7 @@ const IpLookup = ({
         </PaginatedResults>
       ) : (
         <p>
-          {l('No results')}
+          {'No results'}
         </p>
       )}
     </div>

--- a/root/admin/LockedUsernameSearch.js
+++ b/root/admin/LockedUsernameSearch.js
@@ -8,7 +8,6 @@
  */
 
 import Layout from '../layout/index.js';
-import expand2react from '../static/scripts/common/i18n/expand2react.js';
 import bracketed from '../static/scripts/common/utility/bracketed.js';
 import FormRowCheckbox
   from '../static/scripts/edit/components/FormRowCheckbox.js';
@@ -35,7 +34,7 @@ const LockedUsernameSearch = ({
 
       <form action="/admin/locked-usernames/search" method="post">
         <p>
-          {expand2react(
+          {exp.l_admin(
             'Enter a username or a {link|POSIX regular expression}.',
             {
               link: 'https://www.postgresql.org/docs/12/' +

--- a/root/admin/LockedUsernameUnlock.js
+++ b/root/admin/LockedUsernameUnlock.js
@@ -8,7 +8,6 @@
  */
 
 import Layout from '../layout/index.js';
-import expand2text from '../static/scripts/common/i18n/expand2text.js';
 import FormCsrfToken
   from '../static/scripts/edit/components/FormCsrfToken.js';
 import FormSubmit from '../static/scripts/edit/components/FormSubmit.js';
@@ -26,7 +25,7 @@ const LockedUsernameUnlock = ({
     <div id="content">
       <h1>{'Unlock username'}</h1>
       <p>
-        {expand2text(
+        {texp.l_admin(
           `Are you sure you wish to unlock
            the username “{username}” for reuse?`,
           {username: username},

--- a/root/admin/PrivilegeSearch.js
+++ b/root/admin/PrivilegeSearch.js
@@ -9,6 +9,7 @@
 
 import PaginatedResults from '../components/PaginatedResults.js';
 import Layout from '../layout/index.js';
+import {l_admin} from '../static/scripts/common/i18n/admin.js';
 import FormRowCheckbox
   from '../static/scripts/edit/components/FormRowCheckbox.js';
 import FormSubmit from '../static/scripts/edit/components/FormSubmit.js';
@@ -41,109 +42,109 @@ const PrivilegeSearch = ({
   pager,
   results,
 }: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Search users by privileges')}>
+  <Layout fullWidth title="Search users by privileges">
     <div id="content">
-      <h1>{l('Search users by privileges')}</h1>
+      <h1>{'Search users by privileges'}</h1>
 
       <form action="/admin/privilege-search" method="get">
         <p>
-          {l(`Select the flags you want to match. Editors which have
-              other flags in addition to the selected ones will also be shown,
-              unless you select “Exact match only” below.`)}
+          {l_admin(`Select the flags you want to match. Editors which have
+                    other flags in addition to the selected ones will also be
+                    shown, unless you select “Exact match only” below.`)}
         </p>
 
         <div className="checkbox-block">
           <FormRowCheckbox
             field={form.field.show_exact}
-            label={l('Exact match only')}
+            label="Exact match only"
             uncontrolled
           />
         </div>
 
-        <h2>{l('User permissions')}</h2>
+        <h2>{'User permissions'}</h2>
         <div className="checkbox-block">
           <FormRowCheckbox
             field={form.field.auto_editor}
-            label={l('Auto-editor')}
+            label="Auto-editor"
             uncontrolled
           />
           <FormRowCheckbox
             field={form.field.wiki_transcluder}
-            label={l('Transclusion editor')}
+            label="Transclusion editor"
             uncontrolled
           />
           <FormRowCheckbox
             field={form.field.link_editor}
-            label={l('Relationship editor')}
+            label="Relationship editor"
             uncontrolled
           />
           <FormRowCheckbox
             field={form.field.location_editor}
-            label={l('Location editor')}
+            label="Location editor"
             uncontrolled
           />
           <FormRowCheckbox
             field={form.field.banner_editor}
-            label={l('Banner message editor')}
+            label="Banner message editor"
             uncontrolled
           />
         </div>
 
-        <h2>{l('User sanctions')}</h2>
+        <h2>{'User sanctions'}</h2>
         <div className="checkbox-block">
           <FormRowCheckbox
             field={form.field.spammer}
-            label={l('Spammer')}
+            label="Spammer"
             uncontrolled
           />
 
           <FormRowCheckbox
             field={form.field.editing_disabled}
-            label={l('Editing/voting disabled')}
+            label="Editing/voting disabled"
             uncontrolled
           />
           <FormRowCheckbox
             field={form.field.adding_notes_disabled}
-            label={l('Edit notes disabled')}
+            label="Edit notes disabled"
             uncontrolled
           />
           <FormRowCheckbox
             field={form.field.untrusted}
-            label={l('Untrusted')}
+            label="Untrusted"
             uncontrolled
           />
         </div>
 
-        <h2>{l('Technical flags')}</h2>
+        <h2>{'Technical flags'}</h2>
         <div className="checkbox-block">
           <FormRowCheckbox
             field={form.field.bot}
-            label={l('Bot')}
+            label="Bot"
             uncontrolled
           />
           <FormRowCheckbox
             field={form.field.no_nag}
-            label={l('No nag')}
+            label="No nag"
             uncontrolled
           />
         </div>
 
-        <h2>{l('Administration flags')}</h2>
+        <h2>{'Administration flags'}</h2>
         <div className="checkbox-block">
           <FormRowCheckbox
             field={form.field.mbid_submitter}
-            label={l('MBID submitter')}
+            label="MBID submitter"
             uncontrolled
           />
           <FormRowCheckbox
             field={form.field.account_admin}
-            label={l('Account admin')}
+            label="Account admin"
             uncontrolled
           />
         </div>
 
         <div className="row no-margin">
-          <FormSubmit label={l('Search')} />
+          <FormSubmit label="Search" />
         </div>
 
         {pager ? (

--- a/root/admin/attributes/Attribute.js
+++ b/root/admin/attributes/Attribute.js
@@ -10,7 +10,6 @@
 
 import Layout from '../../layout/index.js';
 import {compare} from '../../static/scripts/common/i18n.js';
-import expand2react from '../../static/scripts/common/i18n/expand2react.js';
 import yesNo from '../../static/scripts/common/utility/yesNo.js';
 import loopParity from '../../utility/loopParity.js';
 
@@ -92,7 +91,7 @@ const Attribute = ({
             <tr className={loopParity(index)} key={attribute.id}>
               <td>{attribute.id}</td>
               <td>{attribute.name}</td>
-              <td>{expand2react(attribute.description)}</td>
+              <td>{exp.l_admin(attribute.description)}</td>
               <td>{attribute.gid}</td>
               <td>{attribute.child_order}</td>
               <td>{attribute.parent_id}</td>

--- a/root/admin/attributes/Attribute.js
+++ b/root/admin/attributes/Attribute.js
@@ -26,17 +26,17 @@ const renderAttributesHeaderAccordingToModel = (model: string) => {
     case 'MediumFormat': {
       return (
         <>
-          <th>{l('Year')}</th>
-          <th>{l('Disc IDs allowed')}</th>
+          <th>{'Year'}</th>
+          <th>{'Disc IDs allowed'}</th>
         </>
       );
     }
     case 'SeriesType':
     case 'CollectionType': {
-      return <th>{l('Entity type')}</th>;
+      return <th>{'Entity type'}</th>;
     }
     case 'WorkAttributeType': {
-      return <th>{l('Free text')}</th>;
+      return <th>{'Free text'}</th>;
     }
     default: return null;
   }
@@ -69,20 +69,20 @@ const Attribute = ({
 }: Props): React$Element<typeof Layout> => (
   <Layout fullWidth title={model}>
     <h1>
-      <a href="/admin/attributes">{l('Attributes')}</a>
+      <a href="/admin/attributes">{'Attributes'}</a>
       {' / ' + model}
     </h1>
     <table className="tbl">
       <thead>
         <tr>
-          <th>{l('ID')}</th>
-          <th>{l('Name')}</th>
-          <th>{l('Description')}</th>
-          <th>{l('MBID')}</th>
-          <th>{l('Child order')}</th>
-          <th>{l('Parent ID')}</th>
+          <th>{'ID'}</th>
+          <th>{'Name'}</th>
+          <th>{'Description'}</th>
+          <th>{'MBID'}</th>
+          <th>{'Child order'}</th>
+          <th>{'Parent ID'}</th>
           {renderAttributesHeaderAccordingToModel(model)}
-          <th>{l('Actions')}</th>
+          <th>{'Actions'}</th>
         </tr>
       </thead>
       <tbody>
@@ -99,11 +99,11 @@ const Attribute = ({
               {renderAttributes(attribute)}
               <td>
                 <a href={`/admin/attributes/${model}/edit/${attribute.id}`}>
-                  {l('Edit')}
+                  {'Edit'}
                 </a>
                 {' | '}
                 <a href={`/admin/attributes/${model}/delete/${attribute.id}`}>
-                  {l('Remove')}
+                  {'Remove'}
                 </a>
               </td>
             </tr>
@@ -113,7 +113,7 @@ const Attribute = ({
     <p>
       <span className="buttons">
         <a href={`/admin/attributes/${model}/create`}>
-          {l('Add new attribute')}
+          {'Add new attribute'}
         </a>
       </span>
     </p>

--- a/root/admin/attributes/CannotRemoveAttribute.js
+++ b/root/admin/attributes/CannotRemoveAttribute.js
@@ -16,8 +16,8 @@ type Props = {
 const CannotRemoveAttribute = ({
   message,
 }: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Cannot Remove Attribute')}>
-    <h1>{l('Cannot Remove Attribute')}</h1>
+  <Layout fullWidth title="Cannot Remove Attribute">
+    <h1>{'Cannot Remove Attribute'}</h1>
     <p>
       {message}
     </p>

--- a/root/admin/attributes/DeleteAttribute.js
+++ b/root/admin/attributes/DeleteAttribute.js
@@ -27,7 +27,7 @@ const DeleteAttribute = ({
        <strong>{name}</strong> attribute?`,
       {name: attribute.name},
     )}
-    title={l('Remove Attribute')}
+    title="Remove Attribute"
   />
 );
 

--- a/root/admin/attributes/DeleteAttribute.js
+++ b/root/admin/attributes/DeleteAttribute.js
@@ -22,7 +22,7 @@ const DeleteAttribute = ({
 }: Props): React$Element<typeof ConfirmLayout> => (
   <ConfirmLayout
     form={form}
-    question={exp.l(
+    question={exp.l_admin(
       `Are you sure you wish to remove the
        <strong>{name}</strong> attribute?`,
       {name: attribute.name},

--- a/root/admin/attributes/Index.js
+++ b/root/admin/attributes/Index.js
@@ -15,8 +15,8 @@ type Props = {
 };
 
 const Attributes = ({models}: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Attributes')}>
-    <h1>{l('Attributes')}</h1>
+  <Layout fullWidth title="Attributes">
+    <h1>{'Attributes'}</h1>
     <ul>
       {models.sort().map((item) => (
         <li key={item}>

--- a/root/admin/attributes/Language.js
+++ b/root/admin/attributes/Language.js
@@ -13,9 +13,9 @@ import {compare} from '../../static/scripts/common/i18n.js';
 import loopParity from '../../utility/loopParity.js';
 
 const frequencyLabels = {
-  [0]: N_lp('Hidden', 'language optgroup'),
-  [1]: N_lp('Other', 'language optgroup'),
-  [2]: N_lp('Frequently used', 'language optgroup'),
+  [0]: 'Hidden',
+  [1]: 'Other',
+  [2]: 'Frequently used',
 };
 
 type Props = {
@@ -28,22 +28,22 @@ const Language = ({
   attributes,
 }: Props): React$Element<typeof Layout> => {
   return (
-    <Layout fullWidth title={model || l('Language')}>
+    <Layout fullWidth title={model || 'Language'}>
       <h1>
-        <a href="/admin/attributes">{l('Attributes')}</a>
-        {' / ' + l('Language')}
+        <a href="/admin/attributes">{'Attributes'}</a>
+        {' / Language'}
       </h1>
       <table className="tbl">
         <thead>
           <tr>
-            <th>{l('ID')}</th>
-            <th>{l('Name')}</th>
-            <th>{l('ISO 639-1')}</th>
-            <th>{l('ISO 639-2/B')}</th>
-            <th>{l('ISO 639-2/T')}</th>
-            <th>{l('ISO 639-3')}</th>
-            <th>{l('Frequency')}</th>
-            <th>{l('Actions')}</th>
+            <th>{'ID'}</th>
+            <th>{'Name'}</th>
+            <th>{'ISO 639-1'}</th>
+            <th>{'ISO 639-2/B'}</th>
+            <th>{'ISO 639-2/T'}</th>
+            <th>{'ISO 639-3'}</th>
+            <th>{'Frequency'}</th>
+            <th>{'Actions'}</th>
           </tr>
         </thead>
         {attributes
@@ -58,14 +58,14 @@ const Language = ({
               <td>{attr.iso_code_2b}</td>
               <td>{attr.iso_code_2t}</td>
               <td>{attr.iso_code_3}</td>
-              <td>{frequencyLabels[attr.frequency]()}</td>
+              <td>{frequencyLabels[attr.frequency]}</td>
               <td>
                 <a href={`/admin/attributes/${model}/edit/${attr.id}`}>
-                  {l('Edit')}
+                  {'Edit'}
                 </a>
                 {' | '}
                 <a href={`/admin/attributes/${model}/delete/${attr.id}`}>
-                  {l('Remove')}
+                  {'Remove'}
                 </a>
               </td>
             </tr>
@@ -74,7 +74,7 @@ const Language = ({
       <p>
         <span className="buttons">
           <a href={`/admin/attributes/${model}/create`}>
-            {l('Add new attribute')}
+            {'Add new attribute'}
           </a>
         </span>
       </p>

--- a/root/admin/attributes/Script.js
+++ b/root/admin/attributes/Script.js
@@ -13,10 +13,10 @@ import {compare} from '../../static/scripts/common/i18n.js';
 import loopParity from '../../utility/loopParity.js';
 
 const frequencyLabels = {
-  [1]: N_lp('Hidden', 'script frequency'),
-  [2]: N_lp('Other (Uncommon)', 'script frequency'),
-  [3]: N_lp('Other', 'script frequency'),
-  [4]: N_lp('Frequently used', 'script frequency'),
+  [1]: 'Hidden',
+  [2]: 'Other (Uncommon)',
+  [3]: 'Other',
+  [4]: 'Frequently used',
 };
 
 type Props = {
@@ -28,21 +28,21 @@ const Script = ({
   model,
   attributes,
 }: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={model || l('Script')}>
+  <Layout fullWidth title={model || 'Script'}>
     <h1>
-      <a href="/admin/attributes">{l('Attributes')}</a>
-      {' / ' + l('Script')}
+      <a href="/admin/attributes">{'Attributes'}</a>
+      {' / Script'}
     </h1>
 
     <table className="tbl">
       <thead>
         <tr>
-          <th>{l('ID')}</th>
-          <th>{l('Name')}</th>
-          <th>{l('ISO code')}</th>
-          <th>{l('ISO number')}</th>
-          <th>{l('Frequency')}</th>
-          <th>{l('Actions')}</th>
+          <th>{'ID'}</th>
+          <th>{'Name'}</th>
+          <th>{'ISO code'}</th>
+          <th>{'ISO number'}</th>
+          <th>{'Frequency'}</th>
+          <th>{'Actions'}</th>
         </tr>
       </thead>
       {attributes
@@ -55,14 +55,14 @@ const Script = ({
             <td>{attr.name}</td>
             <td>{attr.iso_code}</td>
             <td>{attr.iso_number}</td>
-            <td>{frequencyLabels[attr.frequency]()}</td>
+            <td>{frequencyLabels[attr.frequency]}</td>
             <td>
               <a href={`/admin/attributes/${model}/edit/${attr.id}`}>
-                {l('Edit')}
+                {'Edit'}
               </a>
               {' | '}
               <a href={`/admin/attributes/${model}/delete/${attr.id}`}>
-                {l('Remove')}
+                {'Remove'}
               </a>
             </td>
           </tr>
@@ -72,7 +72,7 @@ const Script = ({
     <p>
       <span className="buttons">
         <a href={`/admin/attributes/${model}/create`}>
-          {l('Add new attribute')}
+          {'Add new attribute'}
         </a>
       </span>
     </p>

--- a/root/admin/attributes/create.tt
+++ b/root/admin/attributes/create.tt
@@ -1,6 +1,6 @@
-[% WRAPPER "layout.tt" title=l("New Attribute") full_width=1 %]
+[% WRAPPER "layout.tt" title="New Attribute" full_width=1 %]
     <div id="content">
-        <h1>[% l("New Attribute") %]</h1>
+        <h1>[% "New Attribute" %]</h1>
         [% INCLUDE "admin/attributes/form.tt" %]
     </div>
 [% END %]

--- a/root/admin/attributes/edit.tt
+++ b/root/admin/attributes/edit.tt
@@ -1,6 +1,6 @@
-[% WRAPPER "layout.tt" title=l("Edit Attribute") full_width=1 %]
+[% WRAPPER "layout.tt" title="Edit Attribute" full_width=1 %]
     <div id="content">
-        <h1>[% l("Edit Attribute") %]</h1>
+        <h1>[% "Edit Attribute" %]</h1>
         [% INCLUDE "admin/attributes/form.tt" %]
     </div>
 [% END %]

--- a/root/admin/attributes/form.tt
+++ b/root/admin/attributes/form.tt
@@ -4,37 +4,37 @@
     [% form_csrf_token(r) %]
 
     [% IF model == "Language" %]
-        [% form_row_text(r, 'name', add_colon(l('Name'))) %]
-        [% form_row_text(r, 'iso_code_1', add_colon(l('ISO 639-1'))) %]
-        [% form_row_text(r, 'iso_code_2b', add_colon(l('ISO 639-2/B'))) %]
-        [% form_row_text(r, 'iso_code_2t', add_colon(l('ISO 639-2/T'))) %]
-        [% form_row_text(r, 'iso_code_3', add_colon(l('ISO 639-3'))) %]
-        [% form_row_select(r, 'frequency', add_colon(l('Frequency'))) %]
+        [% form_row_text(r, 'name', add_colon('Name')) %]
+        [% form_row_text(r, 'iso_code_1', add_colon('ISO 639-1')) %]
+        [% form_row_text(r, 'iso_code_2b', add_colon('ISO 639-2/B')) %]
+        [% form_row_text(r, 'iso_code_2t', add_colon('ISO 639-2/T')) %]
+        [% form_row_text(r, 'iso_code_3', add_colon('ISO 639-3')) %]
+        [% form_row_select(r, 'frequency', add_colon('Frequency')) %]
         <p>
-            [% l('Frequency notes:') %]
+            [% 'Frequency notes:' %]
             <ul>
-                <li>[% l('Hidden should be used for sign languages and languages with no ISO 639-3 code.') %]
-                <li>[% l('Hidden is used by default for ancient languages and languages only in ISO 639-3 (until requested by a user).') %]</li>
+                <li>[% 'Hidden should be used for sign languages and languages with no ISO 639-3 code.' %]
+                <li>[% 'Hidden is used by default for ancient languages and languages only in ISO 639-3 (until requested by a user).' %]</li>
             </ul>
         </p>
 
 
     [% ELSIF model == "Script" %]
-        [% form_row_text(r, 'name', add_colon(l('Name'))) %]
-        [% form_row_text(r, 'iso_code', add_colon(l('ISO code'))) %]
-        [% form_row_text(r, 'iso_number', add_colon(l('ISO number'))) %]
-        [% form_row_select(r, 'frequency', add_colon(l('Frequency'))) %]
+        [% form_row_text(r, 'name', add_colon('Name')) %]
+        [% form_row_text(r, 'iso_code', add_colon('ISO code')) %]
+        [% form_row_text(r, 'iso_number', add_colon('ISO number')) %]
+        [% form_row_select(r, 'frequency', add_colon('Frequency')) %]
         <p>
-            [% l('Frequency notes:') %]
+            [% 'Frequency notes:' %]
             <ul>
-                <li>[% l('Both Other and Uncommon are shown in the "other" section, but Uncommon should be used for scripts in Unicode which are unlikely to be used.') %]</li>
-                <li>[% l('Hidden should be used for scripts not in Unicode.') %]</li>
+                <li>[% 'Both Other and Uncommon are shown in the "other" section, but Uncommon should be used for scripts in Unicode which are unlikely to be used.' %]</li>
+                <li>[% 'Hidden should be used for scripts not in Unicode.' %]</li>
             </ul>
         </p>
 
     [% ELSE %]
         [%~ IF model == "CollectionType" || model == "SeriesType" ~%]
-            [% form_row_select(r, 'item_entity_type', add_colon(l('Entity type'))) %]
+            [% form_row_select(r, 'item_entity_type', add_colon('Entity type')) %]
             [%~ IF c.action.name == "edit" ~%]
                 <script>
                     $(function () {
@@ -47,38 +47,38 @@
             [%~ END ~%]
         [%~ END ~%]
 
-        [% form_row_select(r, 'parent_id', add_colon(l('Parent'))) %]
+        [% form_row_select(r, 'parent_id', add_colon('Parent')) %]
 
         [% WRAPPER form_row %]
-            [% r.label('child_order', add_colon(l('Child order'))) %]
+            [% r.label('child_order', add_colon('Child order')) %]
             [% r.text('child_order', { size => 5 }) %]
             [% field_errors(form, 'child_order') %]
         [% END %]
 
-        [% form_row_text(r, 'name', add_colon(l('Name'))) %]
+        [% form_row_text(r, 'name', add_colon('Name')) %]
 
         [% WRAPPER form_row %]
-            [% r.label('description', add_colon(l('Description'))) %]
+            [% r.label('description', add_colon('Description')) %]
             [% r.textarea('description', { cols => 80, rows => 6 }) %]
             [% field_errors(form, 'description') %]
         [% END %]
 
         [%~ IF model == "MediumFormat" ~%]
             [% WRAPPER form_row %]
-                [% r.label('year', add_colon(l('Year'))) %]
+                [% r.label('year', add_colon('Year')) %]
                 [% r.text('year', { size => 5 }) %]
                 [% field_errors(form, 'year') %]
             [% END %]
 
-            [% form_row_checkbox(r, 'has_discids', l('This format can have disc IDs')) %]
+            [% form_row_checkbox(r, 'has_discids', 'This format can have disc IDs') %]
         [%~ END ~%]
 
         [%~ IF model == "WorkAttributeType" ~%]
-            [% form_row_checkbox(r, 'free_text', l('This is a free text work attribute')) %]
+            [% form_row_checkbox(r, 'free_text', 'This is a free text work attribute') %]
         [%~ END ~%]
     [% END %]
 
     <div class="row no-label">
-        [% form_submit(l('Save')) %]
+        [% form_submit('Save') %]
     </div>
 </form>

--- a/root/admin/components/UserList.js
+++ b/root/admin/components/UserList.js
@@ -26,13 +26,13 @@ const UserList = ({users}: Props): React$Element<'table'> => {
     <table className="tbl">
       <thead>
         <tr>
-          <th>{l('Editor')}</th>
-          <th>{l('Member since')}</th>
-          <th>{l('Website')}</th>
-          <th>{l('Email')}</th>
-          <th>{l('Verified on')}</th>
-          <th>{l('Last login')}</th>
-          <th>{l('Bio')}</th>
+          <th>{'Editor'}</th>
+          <th>{'Member since'}</th>
+          <th>{'Website'}</th>
+          <th>{'Email'}</th>
+          <th>{'Verified on'}</th>
+          <th>{'Last login'}</th>
+          <th>{'Bio'}</th>
         </tr>
       </thead>
       <tbody>
@@ -49,7 +49,7 @@ const UserList = ({users}: Props): React$Element<'table'> => {
                         '/admin/user/delete/' + encodeURIComponent(user.name)
                       }
                     >
-                      {l('delete')}
+                      {'delete'}
                     </a>,
                   )}
                 </>

--- a/root/admin/statistics-events/CreateStatisticsEvent.js
+++ b/root/admin/statistics-events/CreateStatisticsEvent.js
@@ -18,9 +18,9 @@ type PropsT = {
 const CreateStatisticsEvent = ({
   form,
 }: PropsT): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Add a new statistics event')}>
+  <Layout fullWidth title="Add a new statistics event">
     <div id="content">
-      <h1>{l('Add a new statistics event')}</h1>
+      <h1>{'Add a new statistics event'}</h1>
       <StatisticsEventEditForm form={form} />
     </div>
   </Layout>

--- a/root/admin/statistics-events/DeleteStatisticsEvent.js
+++ b/root/admin/statistics-events/DeleteStatisticsEvent.js
@@ -8,7 +8,6 @@
  */
 
 import Layout from '../../layout/index.js';
-import expand2react from '../../static/scripts/common/i18n/expand2react.js';
 import FormSubmit from '../../static/scripts/edit/components/FormSubmit.js';
 
 type PropsT = {
@@ -31,7 +30,7 @@ const DeleteStatisticsEvent = ({
       </tr>
       <tr>
         <th>{'Description:'}</th>
-        <td>{expand2react(event.description)}</td>
+        <td>{exp.l_admin(event.description)}</td>
       </tr>
       <tr>
         <th>{'Link:'}</th>

--- a/root/admin/statistics-events/DeleteStatisticsEvent.js
+++ b/root/admin/statistics-events/DeleteStatisticsEvent.js
@@ -18,31 +18,31 @@ type PropsT = {
 const DeleteStatisticsEvent = ({
   event,
 }: PropsT): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Remove statistics event')}>
-    <h2>{l('Remove statistics event')}</h2>
+  <Layout fullWidth title="Remove statistics event">
+    <h2>{'Remove statistics event'}</h2>
     <table className="details">
       <tr>
-        <th>{addColonText(l('Date'))}</th>
+        <th>{'Date:'}</th>
         <td>{event.date}</td>
       </tr>
       <tr>
-        <th>{addColonText(l('Title'))}</th>
+        <th>{'Title:'}</th>
         <td>{event.title}</td>
       </tr>
       <tr>
-        <th>{addColonText(l('Description'))}</th>
+        <th>{'Description:'}</th>
         <td>{expand2react(event.description)}</td>
       </tr>
       <tr>
-        <th>{addColonText(l('Link'))}</th>
+        <th>{'Link:'}</th>
         <td><a href={event.link}>{event.link}</a></td>
       </tr>
     </table>
     <p>
-      {l('Are you sure you want to remove this statistics event?')}
+      {'Are you sure you want to remove this statistics event?'}
     </p>
     <form method="post">
-      <FormSubmit label={l('Remove statistics event')} />
+      <FormSubmit label="Remove statistics event" />
     </form>
   </Layout>
 );

--- a/root/admin/statistics-events/EditStatisticsEvent.js
+++ b/root/admin/statistics-events/EditStatisticsEvent.js
@@ -18,7 +18,7 @@ type PropsT = {
 const EditStatisticsEvent = ({
   form,
 }: PropsT): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Edit statistics event')}>
+  <Layout fullWidth title="Edit statistics event">
     <StatisticsEventEditForm form={form} />
   </Layout>
 );

--- a/root/admin/statistics-events/StatisticsEventEditForm.js
+++ b/root/admin/statistics-events/StatisticsEventEditForm.js
@@ -24,33 +24,33 @@ const StatisticsEventForm = ({
     <FormCsrfToken form={form} />
     <div className="half-width">
       <fieldset>
-        <legend>{l('Statistics event details')}</legend>
+        <legend>{'Statistics event details'}</legend>
         <FormRowTextLong
           field={form.field.date}
-          label={addColonText(l('Date'))}
+          label="Date:"
           required
           uncontrolled
         />
         <FormRowTextLong
           field={form.field.title}
-          label={addColonText(l('Title'))}
+          label="Title:"
           required
           uncontrolled
         />
         <FormRowTextLong
           field={form.field.description}
-          label={addColonText(l('Description'))}
+          label="Description:"
           uncontrolled
         />
         <FormRowTextLong
           field={form.field.link}
-          label={addColonText(l('Link'))}
+          label="Link:"
           uncontrolled
         />
       </fieldset>
     </div>
     <div className="row no-label">
-      <FormSubmit label={l('Submit')} />
+      <FormSubmit label="Submit" />
     </div>
   </form>
 );

--- a/root/admin/statistics-events/StatisticsEventIndex.js
+++ b/root/admin/statistics-events/StatisticsEventIndex.js
@@ -18,16 +18,16 @@ type PropsT = {
 const StatisticsEventIndex = ({
   events,
 }: PropsT): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Statistics Events')}>
-    <h1>{l('Statistics Events')}</h1>
+  <Layout fullWidth title="Statistics Events">
+    <h1>{'Statistics Events'}</h1>
     <table className="tbl">
       <thead>
         <tr>
-          <th>{l('Date')}</th>
-          <th>{l('Title')}</th>
-          <th>{l('Description')}</th>
-          <th>{l('Link')}</th>
-          <th>{l('Actions')}</th>
+          <th>{'Date'}</th>
+          <th>{'Title'}</th>
+          <th>{'Description'}</th>
+          <th>{'Link'}</th>
+          <th>{'Actions'}</th>
         </tr>
       </thead>
       <tbody>
@@ -42,11 +42,11 @@ const StatisticsEventIndex = ({
               </td>
               <td>
                 <a href={`/admin/statistics-events/edit/${event.date}`}>
-                  {l('Edit')}
+                  {'Edit'}
                 </a>
                 {' | '}
                 <a href={`/admin/statistics-events/delete/${event.date}`}>
-                  {l('Remove')}
+                  {'Remove'}
                 </a>
               </td>
             </tr>
@@ -56,7 +56,7 @@ const StatisticsEventIndex = ({
     <p>
       <span className="buttons">
         <a href="/admin/statistics-events/create">
-          {lp('Add new event', 'statistics event')}
+          {'Add new event'}
         </a>
       </span>
     </p>

--- a/root/admin/statistics-events/StatisticsEventIndex.js
+++ b/root/admin/statistics-events/StatisticsEventIndex.js
@@ -8,7 +8,6 @@
  */
 
 import Layout from '../../layout/index.js';
-import expand2react from '../../static/scripts/common/i18n/expand2react.js';
 import loopParity from '../../utility/loopParity.js';
 
 type PropsT = {
@@ -36,7 +35,7 @@ const StatisticsEventIndex = ({
             <tr className={loopParity(index)} key={event.date}>
               <td>{event.date}</td>
               <td>{event.title}</td>
-              <td>{expand2react(event.description)}</td>
+              <td>{exp.l_admin(event.description)}</td>
               <td>
                 <a href={event.link}>{event.link}</a>
               </td>

--- a/root/admin/wikidoc/CreateWikiDoc.js
+++ b/root/admin/wikidoc/CreateWikiDoc.js
@@ -26,26 +26,26 @@ type Props = {
 const CreateWikiDoc = ({
   form,
 }: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Add Page')}>
+  <Layout fullWidth title="Add Page">
     <div id="content">
-      <h1>{l('Add Page')}</h1>
+      <h1>{'Add Page'}</h1>
       <form method="post">
         <FormCsrfToken form={form} />
         <FormRowTextLong
           field={form.field.page}
-          label={l('Page:')}
+          label="Page:"
           required
           uncontrolled
         />
         <FormRowText
           field={form.field.version}
-          label={l('Version:')}
+          label="Version:"
           required
           type="number"
           uncontrolled
         />
         <div className="row no-label">
-          <FormSubmit label={l('Add Page')} />
+          <FormSubmit label="Add Page" />
         </div>
       </form>
     </div>

--- a/root/admin/wikidoc/DeleteWikiDoc.js
+++ b/root/admin/wikidoc/DeleteWikiDoc.js
@@ -21,9 +21,9 @@ const DeleteWikiDoc = ({
   form,
   page,
 }: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Remove Page')}>
+  <Layout fullWidth title="Remove Page">
     <div id="content">
-      <h1>{l('Remove Page')}</h1>
+      <h1>{'Remove Page'}</h1>
       <p>
         {exp.l_admin(`Are you sure you wish to remove the page
                       “{page_uri|{page_name}}” from the transclusion table?`,
@@ -35,7 +35,7 @@ const DeleteWikiDoc = ({
       <form method="post" name="confirm">
         <FormCsrfToken form={form} />
         <FormSubmit
-          label={l('Yes, I am sure')}
+          label="Yes, I am sure"
           name="confirm.submit"
           value="1"
         />

--- a/root/admin/wikidoc/DeleteWikiDoc.js
+++ b/root/admin/wikidoc/DeleteWikiDoc.js
@@ -25,12 +25,12 @@ const DeleteWikiDoc = ({
     <div id="content">
       <h1>{l('Remove Page')}</h1>
       <p>
-        {exp.l(`Are you sure you wish to remove the page
-                “{page_uri|{page_name}}” from the transclusion table?`,
-               {
-                 page_name: page,
-                 page_uri: '/doc/' + encodeURIComponent(page),
-               })}
+        {exp.l_admin(`Are you sure you wish to remove the page
+                      “{page_uri|{page_name}}” from the transclusion table?`,
+                     {
+                       page_name: page,
+                       page_uri: '/doc/' + encodeURIComponent(page),
+                     })}
       </p>
       <form method="post" name="confirm">
         <FormCsrfToken form={form} />

--- a/root/admin/wikidoc/EditWikiDoc.js
+++ b/root/admin/wikidoc/EditWikiDoc.js
@@ -27,28 +27,28 @@ const EditWikiDoc = ({
   form,
   page,
 }: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Update Page')}>
+  <Layout fullWidth title="Update Page">
     <div id="content">
-      <h1>{l('Update Page')}</h1>
+      <h1>{'Update Page'}</h1>
       <form method="post">
         <FormCsrfToken form={form} />
         <div className="row">
-          <label>{l('Page:')}</label>
+          <label>{'Page:'}</label>
           <span>{page}</span>
         </div>
         <div className="row">
-          <label>{l('Current version:')}</label>
+          <label>{'Current version:'}</label>
           <span>{currentVersion}</span>
         </div>
         <FormRowText
           field={form.field.version}
-          label={l('New version:')}
+          label="New version:"
           required
           type="number"
           uncontrolled
         />
         <div className="row no-label">
-          <FormSubmit label={l('Update')} />
+          <FormSubmit label="Update" />
         </div>
       </form>
     </div>

--- a/root/admin/wikidoc/WikiDocIndex.js
+++ b/root/admin/wikidoc/WikiDocIndex.js
@@ -38,13 +38,13 @@ const WikiDocTable = ({
         Cell: ({cell: {value}}: CellRenderProps<WikiDocT, string>) => (
           <a href={'/doc/' + encodeURIComponent(value)}>{value}</a>
         ),
-        Header: N_l('Page name'),
+        Header: 'Page name',
         accessor: (x: WikiDocT) => x.id,
         cellProps: {className: 'title'},
         id: 'name',
       };
       const transcludedVersionColumn = {
-        Header: N_l('Transcluded version'),
+        Header: 'Transcluded version',
         accessor: (x: WikiDocT) => x.version,
         cellProps: {
           className: 'c transcluded-version',
@@ -65,7 +65,7 @@ const WikiDocTable = ({
                   style={{color: 'red'}}
                 >
                   {original.wiki_version === 0
-                    ? l('Error!')
+                    ? 'Error!'
                     : original.wiki_version}
                 </span>
                 {original.wiki_version ? (
@@ -78,7 +78,7 @@ const WikiDocTable = ({
                               '?diff=' + original.wiki_version +
                               '&oldid=' + original.version}
                       >
-                        {l('diff')}
+                        {'diff'}
                       </a>,
                     )}
                   </>
@@ -87,7 +87,7 @@ const WikiDocTable = ({
             )}
           </>
         ),
-        Header: N_l('Wiki version'),
+        Header: 'Wiki version',
         accessor: (x: WikiDocT) => x.wiki_version,
         headerProps: {className: 'c'},
         id: 'wiki-version',
@@ -99,23 +99,23 @@ const WikiDocTable = ({
                      '?page=' + encodeURIComponent(original.id) +
                      '&new_version=' + original.wiki_version}
             >
-              {l('Update')}
+              {'Update'}
             </a>
             {' | '}
             <a href={'/admin/wikidoc/delete' +
                      '?page=' + encodeURIComponent(original.id)}
             >
-              {l('Remove')}
+              {'Remove'}
             </a>
             {' | '}
             <a href={'//' + wikiServer +
                      '/' + encodeURIComponent(original.id)}
             >
-              {l('View on wiki')}
+              {'View on wiki'}
             </a>
           </>
         ),
-        Header: l('Actions'),
+        Header: 'Actions',
         accessor: (x: WikiDocT) => x.id,
         cellProps: {className: 'actions c'},
         headerProps: {className: 'c'},
@@ -146,9 +146,9 @@ const WikiDocTable = ({
 const WikiDocIndex = (props: PropsT): React$Element<typeof Layout> => {
   const $c = React.useContext(SanitizedCatalystContext);
   return (
-    <Layout fullWidth title={l('Transclusion Table')}>
+    <Layout fullWidth title="Transclusion Table">
       <div className="content">
-        <h1>{l('Transclusion Table')}</h1>
+        <h1>{'Transclusion Table'}</h1>
         <p>
           {exp.l_admin(
             `Read the {doc|WikiDocs} documentation for an overview of how
@@ -161,12 +161,12 @@ const WikiDocIndex = (props: PropsT): React$Element<typeof Layout> => {
             <ul>
               <li key="create">
                 <a href="/admin/wikidoc/create">
-                  {l('Add a new entry')}
+                  {'Add a new entry'}
                 </a>
               </li>
               <li key="history">
                 <a href="/admin/wikidoc/history">
-                  {l('View transclusion history')}
+                  {'View transclusion history'}
                 </a>
               </li>
             </ul>
@@ -182,7 +182,7 @@ const WikiDocIndex = (props: PropsT): React$Element<typeof Layout> => {
 
         {props.wikiIsUnreachable ? (
           <p style={{color: 'red', fontWeight: 'bold'}}>
-            {l('There was a problem accessing the wiki API.')}
+            {'There was a problem accessing the wiki API.'}
           </p>
         ) : null}
       </div>

--- a/root/admin/wikidoc/WikiDocIndex.js
+++ b/root/admin/wikidoc/WikiDocIndex.js
@@ -150,7 +150,7 @@ const WikiDocIndex = (props: PropsT): React$Element<typeof Layout> => {
       <div className="content">
         <h1>{l('Transclusion Table')}</h1>
         <p>
-          {exp.l(
+          {exp.l_admin(
             `Read the {doc|WikiDocs} documentation for an overview of how
              transclusion works.`,
             {doc: '/doc/WikiDocs'},
@@ -171,11 +171,11 @@ const WikiDocIndex = (props: PropsT): React$Element<typeof Layout> => {
               </li>
             </ul>
             <p>
-              {exp.l(`<strong>Note:</strong> MediaWiki does not check to
-                      see if the version number matches the page name,
-                      it will take the version number and provide
-                      whatever page is associated with it. Make sure to
-                      double check your work when updating a page!`)}
+              {exp.l_admin(`<strong>Note:</strong> MediaWiki does not check to
+                            see if the version number matches the page name,
+                            it will take the version number and provide
+                            whatever page is associated with it. Make sure to
+                            double check your work when updating a page!`)}
             </p>
           </>
         ) : null}

--- a/root/components/UserAccountTabs.js
+++ b/root/components/UserAccountTabs.js
@@ -9,6 +9,7 @@
 
 import {CatalystContext} from '../context.mjs';
 import DBDefs from '../static/scripts/common/DBDefs.mjs';
+import {l_admin} from '../static/scripts/common/i18n/admin.js';
 import {isAccountAdmin} from '../static/scripts/common/utility/privileges.js';
 import buildTab from '../utility/buildTab.js';
 
@@ -99,7 +100,7 @@ function buildTabs(
     DBDefs.DB_STAGING_TESTING_FEATURES && $c.user) {
     tabs.push(buildTab(
       page,
-      l('Edit User'),
+      l_admin('Edit User'),
       '/admin/user/edit/' + userName,
       'edit_user',
     ));

--- a/root/edit/components/EditNote.js
+++ b/root/edit/components/EditNote.js
@@ -17,6 +17,7 @@ import {
 } from '../../constants.js';
 import {CatalystContext} from '../../context.mjs';
 import EditorLink from '../../static/scripts/common/components/EditorLink.js';
+import {l_admin} from '../../static/scripts/common/i18n/admin.js';
 import bracketed from '../../static/scripts/common/utility/bracketed.js';
 import {isAccountAdmin, isAddingNotesDisabled}
   from '../../static/scripts/common/utility/privileges.js';
@@ -191,7 +192,7 @@ const EditNote = ({
               {' '}
               {bracketed(
                 <a href={`/edit-note/${editNote.id}/changes`}>
-                  {lp('see all changes', 'edit note')}
+                  {l_admin('see all changes')}
                 </a>,
               )}
             </span>
@@ -243,7 +244,7 @@ const EditNote = ({
                   {' '}
                   {bracketed(
                     <a href={`/edit-note/${editNote.id}/changes`}>
-                      {lp('see all changes', 'edit note')}
+                      {l_admin('see all changes')}
                     </a>,
                   )}
                 </>

--- a/root/futureColumnLabels.js
+++ b/root/futureColumnLabels.js
@@ -1,0 +1,42 @@
+/*
+ * @flow strict
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+/*
+ * This file just keeps some messages and their translations until
+ * https://tickets.metabrainz.org/browse/MBS-11178 gets resolved.
+ */
+
+const collectionTypeColumnLabels = [
+  N_l('Entity type'),
+];
+
+const languageColumnLabels = [
+  N_l('ID'),
+  N_l('Name'),
+  N_l('ISO 639-1'),
+  N_l('ISO 639-2/B'),
+  N_l('ISO 639-2/T'),
+  N_l('ISO 639-3'),
+  N_l('Frequency'),
+  N_l('Actions'),
+];
+
+const mediumFormatColumnLabels = [
+  N_l('Year'),
+  N_l('Disc IDs allowed'),
+];
+
+const scriptColumnLabels = [
+  N_l('ID'),
+  N_l('Name'),
+  N_l('ISO code'),
+  N_l('ISO number'),
+  N_l('Frequency'),
+  N_l('Actions'),
+];

--- a/root/layout/components/TopMenu.js
+++ b/root/layout/components/TopMenu.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import RequestLogin from '../../components/RequestLogin.js';
 import {CatalystContext} from '../../context.mjs';
+import {l_admin} from '../../static/scripts/common/i18n/admin.js';
 import {
   isAccountAdmin,
   isAdmin,
@@ -147,35 +148,37 @@ const AdminMenu = ({user}: UserProp) => (
 
       {isWikiTranscluder(user) ? (
         <li>
-          <a href="/admin/wikidoc">{l('Transclude WikiDocs')}</a>
+          <a href="/admin/wikidoc">{l_admin('Transclude WikiDocs')}</a>
         </li>
       ) : null}
 
       {isBannerEditor(user) ? (
         <li>
-          <a href="/admin/banner/edit">{l('Edit Banner Message')}</a>
+          <a href="/admin/banner/edit">{l_admin('Edit Banner Message')}</a>
         </li>
       ) : null}
 
       {isAccountAdmin(user) ? (
         <>
           <li>
-            <a href="/admin/attributes">{l('Edit Attributes')}</a>
+            <a href="/admin/attributes">{l_admin('Edit Attributes')}</a>
           </li>
           <li>
             <a href="/admin/statistics-events">
-              {l('Edit Statistics Events')}
+              {l_admin('Edit Statistics Events')}
             </a>
           </li>
           <li>
-            <a href="/admin/email-search">{l('Email Search')}</a>
+            <a href="/admin/email-search">{l_admin('Email Search')}</a>
           </li>
           <li>
-            <a href="/admin/privilege-search">{l('Privilege Search')}</a>
+            <a href="/admin/privilege-search">
+              {l_admin('Privilege Search')}
+            </a>
           </li>
           <li>
             <a href="/admin/locked-usernames/search">
-              {l('Locked Username Search')}
+              {l_admin('Locked Username Search')}
             </a>
           </li>
         </>

--- a/root/report/LimitedEditors.js
+++ b/root/report/LimitedEditors.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../context.mjs';
+import {l_admin} from '../static/scripts/common/i18n/admin.js';
 import {isAccountAdmin} from '../static/scripts/common/utility/privileges.js';
 
 import EditorList from './components/EditorList.js';
@@ -27,14 +28,14 @@ const LimitedEditors = ({
   return (
     <ReportLayout
       canBeFiltered={canBeFiltered}
-      description={exp.l(
+      description={exp.l_admin(
         'This report lists {url|beginner/limited editors}.',
         {url: '/doc/How_to_Create_an_Account'},
       )}
       entityType="editor"
       filtered={filtered}
       generated={generated}
-      title={l('Beginner/limited editors')}
+      title={l_admin('Beginner/limited editors')}
       totalEntries={pager.total_entries}
     >
       {isAccountAdmin($c.user) ? (

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import {SanitizedCatalystContext} from '../context.mjs';
 import Layout from '../layout/index.js';
+import {l_admin} from '../static/scripts/common/i18n/admin.js';
 import {
   isAccountAdmin,
   isRelationshipEditor,
@@ -124,11 +125,11 @@ const ReportsIndex = (): React$Element<typeof Layout> => {
 
         {isAccountAdmin($c.user) ? (
           <>
-            <h2>{l('Editors')}</h2>
+            <h2>{l_admin('Editors')}</h2>
 
             <ul>
               <ReportsIndexEntry
-                content={l('Beginner/limited editors')}
+                content={l_admin('Beginner/limited editors')}
                 reportName="LimitedEditors"
               />
             </ul>

--- a/root/report/components/EditorList.js
+++ b/root/report/components/EditorList.js
@@ -13,6 +13,7 @@ import type {CellRenderProps} from 'react-table';
 import PaginatedResults from '../../components/PaginatedResults.js';
 import useTable from '../../hooks/useTable.js';
 import EditorLink from '../../static/scripts/common/components/EditorLink.js';
+import {l_admin} from '../../static/scripts/common/i18n/admin.js';
 import bracketed from '../../static/scripts/common/utility/bracketed.js';
 import {
   defineTextColumn,
@@ -54,34 +55,34 @@ const EditorList = ({
                   href={'/admin/user/delete/' +
                   encodeURIComponent(editor.name)}
                 >
-                  {l('delete')}
+                  {l_admin('delete')}
                 </a>,
               )}
             </>
           );
         },
-        Header: l('Editor'),
+        Header: l_admin('Editor'),
         id: 'editor',
       };
       const memberSinceColumn = defineTextColumn<ReportEditorT>({
         columnName: 'registration_date',
         getText: result => result.editor?.registration_date ?? '',
-        title: l('Member since'),
+        title: l_admin('Member since'),
       });
       const websiteColumn = defineTextColumn<ReportEditorT>({
         columnName: 'website',
         getText: result => result.editor?.website ?? '',
-        title: l('Website'),
+        title: l_admin('Website'),
       });
       const emailColumn = defineTextColumn<ReportEditorT>({
         columnName: 'email',
         getText: result => result.editor?.email ?? '',
-        title: l('Email'),
+        title: l_admin('Email'),
       });
       const bioColumn = defineTextColumn<ReportEditorT>({
         columnName: 'biography',
         getText: result => result.editor?.biography ?? '',
-        title: l('Bio'),
+        title: l_admin('Bio'),
       });
 
       return [

--- a/root/static/scripts/common/i18n/admin.js
+++ b/root/static/scripts/common/i18n/admin.js
@@ -1,0 +1,22 @@
+/*
+ * @flow strict
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import cleanMsgid from './cleanMsgid.js';
+
+export const l_admin: (string) => string =
+  cleanMsgid;
+
+export function ln_admin(skey: string, pkey: string, val: number): string {
+  return val > 1 ? cleanMsgid(pkey) : cleanMsgid(skey);
+}
+
+// eslint-disable-next-line no-unused-vars -- map context
+export const lp_admin = (key: string, context: string): string => (
+  cleanMsgid(key)
+);

--- a/root/static/scripts/common/i18n/admin.js
+++ b/root/static/scripts/common/i18n/admin.js
@@ -15,8 +15,3 @@ export const l_admin: (string) => string =
 export function ln_admin(skey: string, pkey: string, val: number): string {
   return val > 1 ? cleanMsgid(pkey) : cleanMsgid(skey);
 }
-
-// eslint-disable-next-line no-unused-vars -- map context
-export const lp_admin = (key: string, context: string): string => (
-  cleanMsgid(key)
-);

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -15,6 +15,11 @@ import {
   ln as lnActual,
   lp as lpActual,
 } from '../i18n.js';
+import {
+  l_admin as lAdminActual,
+  ln_admin as lnAdminActual,
+  lp_admin as lpAdminActual,
+} from '../i18n/admin.js';
 
 import expand, {
   type NO_MATCH,
@@ -395,6 +400,11 @@ export const l = (
   args?: ?VarArgsObject<Input>,
 ): Output => expand2react(lActual(key), args);
 
+export const l_admin = (
+  key: string,
+  args?: ?VarArgsObject<Input>,
+): Output => expand2react(lAdminActual(key), args);
+
 export const ln = (
   skey: string,
   pkey: string,
@@ -402,8 +412,21 @@ export const ln = (
   args?: ?VarArgsObject<Input>,
 ): Output => expand2react(lnActual(skey, pkey, val), args);
 
+export const ln_admin = (
+  skey: string,
+  pkey: string,
+  val: number,
+  args?: ?VarArgsObject<Input>,
+): Output => expand2react(lnAdminActual(skey, pkey, val), args);
+
 export const lp = (
   key: string,
   context: string,
   args?: ?VarArgsObject<Input>,
 ): Output => expand2react(lpActual(key, context), args);
+
+export const lp_admin = (
+  key: string,
+  context: string,
+  args?: ?VarArgsObject<Input>,
+): Output => expand2react(lpAdminActual(key, context), args);

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -18,7 +18,6 @@ import {
 import {
   l_admin as lAdminActual,
   ln_admin as lnAdminActual,
-  lp_admin as lpAdminActual,
 } from '../i18n/admin.js';
 
 import expand, {
@@ -424,9 +423,3 @@ export const lp = (
   context: string,
   args?: ?VarArgsObject<Input>,
 ): Output => expand2react(lpActual(key, context), args);
-
-export const lp_admin = (
-  key: string,
-  context: string,
-  args?: ?VarArgsObject<Input>,
-): Output => expand2react(lpAdminActual(key, context), args);

--- a/root/static/scripts/common/i18n/expand2text.js
+++ b/root/static/scripts/common/i18n/expand2text.js
@@ -12,6 +12,11 @@ import {
   ln as lnActual,
   lp as lpActual,
 } from '../i18n.js';
+import {
+  l_admin as lAdminActual,
+  ln_admin as lnAdminActual,
+  lp_admin as lpAdminActual,
+} from '../i18n/admin.js';
 
 import expand, {
   type NO_MATCH,
@@ -107,6 +112,11 @@ export const l = (
   args: VarArgsObject<StrOrNum>,
 ): string => expand2text(lActual(key), args);
 
+export const l_admin = (
+  key: string,
+  args: VarArgsObject<StrOrNum>,
+): string => expand2text(lAdminActual(key), args);
+
 export const ln = (
   skey: string,
   pkey: string,
@@ -114,8 +124,21 @@ export const ln = (
   args: VarArgsObject<StrOrNum>,
 ): string => expand2text(lnActual(skey, pkey, val), args);
 
+export const ln_admin = (
+  skey: string,
+  pkey: string,
+  val: number,
+  args: VarArgsObject<StrOrNum>,
+): string => expand2text(lnAdminActual(skey, pkey, val), args);
+
 export const lp = (
   key: string,
   context: string,
   args: VarArgsObject<StrOrNum>,
 ): string => expand2text(lpActual(key, context), args);
+
+export const lp_admin = (
+  key: string,
+  context: string,
+  args: VarArgsObject<StrOrNum>,
+): string => expand2text(lpAdminActual(key, context), args);

--- a/root/static/scripts/common/i18n/expand2text.js
+++ b/root/static/scripts/common/i18n/expand2text.js
@@ -15,7 +15,6 @@ import {
 import {
   l_admin as lAdminActual,
   ln_admin as lnAdminActual,
-  lp_admin as lpAdminActual,
 } from '../i18n/admin.js';
 
 import expand, {
@@ -136,9 +135,3 @@ export const lp = (
   context: string,
   args: VarArgsObject<StrOrNum>,
 ): string => expand2text(lpActual(key, context), args);
-
-export const lp_admin = (
-  key: string,
-  context: string,
-  args: VarArgsObject<StrOrNum>,
-): string => expand2text(lpAdminActual(key, context), args);

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -19,6 +19,7 @@ import Warning from '../static/scripts/common/components/Warning.js';
 import {FLUENCY_NAMES} from '../static/scripts/common/constants.js';
 import * as TYPES from '../static/scripts/common/constants/editTypes.js';
 import {compare} from '../static/scripts/common/i18n.js';
+import {l_admin} from '../static/scripts/common/i18n/admin.js';
 import commaList, {commaListText}
   from '../static/scripts/common/i18n/commaList.js';
 import commaOnlyList, {commaOnlyListText}
@@ -229,7 +230,7 @@ const UserProfileInformation = ({
                           type="submit"
                           value="1"
                         >
-                          {l('find all users of this email')}
+                          {l_admin('find all users of this email')}
                         </button>
                       </form>
                     ) : null}
@@ -425,7 +426,7 @@ const UserProfileInformation = ({
         ) : null}
 
         {isAccountAdmin($c.user) && ipHashes.length ? (
-          <UserProfileProperty name={addColonText(l('IP lookup'))}>
+          <UserProfileProperty name={addColonText(l_admin('IP lookup'))}>
             <ul className="inline">
               {commaOnlyList(ipHashes.map(ipHash => (
                 <a
@@ -905,7 +906,7 @@ const UserProfile = ({
   }
   // We specifically never show "untrusted" to non-admin users
   if (adminViewing && isUntrusted(user)) {
-    restrictions.push(l('Untrusted'));
+    restrictions.push(l_admin('Untrusted'));
   }
 
   return (
@@ -928,8 +929,8 @@ const UserProfile = ({
           {isSpammer(user) && adminViewing ? (
             <Warning
               message={
-                l(`This user is marked as a spammer and is blocked
-                   for all non-admin users.`)
+                l_admin(`This user is marked as a spammer and is blocked
+                         for all non-admin users.`)
               }
             />
           ) : null}
@@ -938,7 +939,7 @@ const UserProfile = ({
           {restrictions.length && adminViewing ? (
             <Warning
               message={
-                texp.l(
+                texp.l_admin(
                   `This user’s editing rights have been restricted.
                    Active restrictions: {restrictions}.`,
                   {

--- a/root/vars.js
+++ b/root/vars.js
@@ -48,6 +48,10 @@ declare var N_l: (key: string) => () => string;
 declare var N_ln: (skey: string, pkey: string) => (val: number) => string;
 declare var N_lp: (key: string, context: string) => () => string;
 
+declare var l_admin: typeof l;
+declare var ln_admin: typeof ln;
+declare var lp_admin: typeof lp;
+
 declare var l_attributes: typeof l;
 declare var ln_attributes: typeof ln;
 declare var lp_attributes: typeof lp;
@@ -85,13 +89,28 @@ declare var exp: {
     key: string,
     args?: ?{+[arg: string]: Expand2ReactInput, ...},
   ) => Expand2ReactOutput,
+  +l_admin: (
+    key: string,
+    args?: ?{+[arg: string]: Expand2ReactInput, ...},
+  ) => Expand2ReactOutput,
   +ln: (
     skey: string,
     pkey: string,
     val: number,
     args?: ?{+[arg: string]: Expand2ReactInput, ...},
   ) => Expand2ReactOutput,
+  +ln_admin: (
+    skey: string,
+    pkey: string,
+    val: number,
+    args?: ?{+[arg: string]: Expand2ReactInput, ...},
+  ) => Expand2ReactOutput,
   +lp: (
+    key: string,
+    context: string,
+    args?: ?{+[arg: string]: Expand2ReactInput},
+  ) => Expand2ReactOutput,
+  +lp_admin: (
     key: string,
     context: string,
     args?: ?{+[arg: string]: Expand2ReactInput},
@@ -103,13 +122,28 @@ declare var texp: {
     key: string,
     args: {+[arg: string]: StrOrNum, ...},
   ) => string,
+  +l_admin: (
+    key: string,
+    args: {+[arg: string]: StrOrNum, ...},
+  ) => string,
   +ln: (
     skey: string,
     pkey: string,
     val: number,
     args: {+[arg: string]: StrOrNum, ...},
   ) => string,
+  +ln_admin: (
+    skey: string,
+    pkey: string,
+    val: number,
+    args: {+[arg: string]: StrOrNum, ...},
+  ) => string,
   +lp: (
+    key: string,
+    context: string,
+    args: {+[arg: string]: StrOrNum, ...},
+  ) => string,
+  +lp_admin: (
     key: string,
     context: string,
     args: {+[arg: string]: StrOrNum, ...},

--- a/root/vars.js
+++ b/root/vars.js
@@ -50,7 +50,6 @@ declare var N_lp: (key: string, context: string) => () => string;
 
 declare var l_admin: typeof l;
 declare var ln_admin: typeof ln;
-declare var lp_admin: typeof lp;
 
 declare var l_attributes: typeof l;
 declare var ln_attributes: typeof ln;
@@ -110,11 +109,6 @@ declare var exp: {
     context: string,
     args?: ?{+[arg: string]: Expand2ReactInput},
   ) => Expand2ReactOutput,
-  +lp_admin: (
-    key: string,
-    context: string,
-    args?: ?{+[arg: string]: Expand2ReactInput},
-  ) => Expand2ReactOutput,
 };
 
 declare var texp: {
@@ -139,11 +133,6 @@ declare var texp: {
     args: {+[arg: string]: StrOrNum, ...},
   ) => string,
   +lp: (
-    key: string,
-    context: string,
-    args: {+[arg: string]: StrOrNum, ...},
-  ) => string,
-  +lp_admin: (
     key: string,
     context: string,
     args: {+[arg: string]: StrOrNum, ...},

--- a/script/.check_eslint_rule_config.yaml
+++ b/script/.check_eslint_rule_config.yaml
@@ -40,7 +40,6 @@ globals:
   texp: readonly
   l_admin: readonly
   ln_admin: readonly
-  lp_admin: readonly
   l_attributes: readonly
   ln_attributes: readonly
   lp_attributes: readonly

--- a/script/.check_eslint_rule_config.yaml
+++ b/script/.check_eslint_rule_config.yaml
@@ -38,6 +38,9 @@ globals:
   N_lp: readonly
   exp: readonly
   texp: readonly
+  l_admin: readonly
+  ln_admin: readonly
+  lp_admin: readonly
   l_attributes: readonly
   ln_attributes: readonly
   lp_attributes: readonly

--- a/t/lib/t/MusicBrainz/Server/Controller/Admin/Attributes/Delete.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Admin/Attributes/Delete.pm
@@ -1,4 +1,5 @@
 package t::MusicBrainz::Server::Controller::Admin::Attributes::Delete;
+use utf8;
 use strict;
 use warnings;
 
@@ -43,7 +44,7 @@ test 'Delete standard attribute (series type)' => sub {
     $mech->get('/admin/attributes/SeriesType/delete/2');
     html_ok($mech->content);
     $mech->text_contains(
-      'You cannot remove the attribute "Release series" because it is still in use.',
+      'You cannot remove the attribute “Release series” because it is still in use.',
       'Series type in use on a series cannot be deleted',
     );
 
@@ -99,21 +100,21 @@ test 'Delete language' => sub {
     $mech->get_ok('/admin/attributes/Language/delete/120');
     html_ok($mech->content);
     $mech->text_contains(
-      'You cannot remove the attribute "English" because it is still in use.',
+      'You cannot remove the attribute “English” because it is still in use.',
       'Language in use on a release cannot be deleted',
     );
 
     $mech->get_ok('/admin/attributes/Language/delete/27');
     html_ok($mech->content);
     $mech->text_contains(
-      'You cannot remove the attribute "Asturian" because it is still in use.',
+      'You cannot remove the attribute “Asturian” because it is still in use.',
       'Language in use on a work cannot be deleted',
     );
 
     $mech->get_ok('/admin/attributes/Language/delete/123');
     html_ok($mech->content);
     $mech->text_contains(
-      'You cannot remove the attribute "Estonian" because it is still in use.',
+      'You cannot remove the attribute “Estonian” because it is still in use.',
       'Language in use on an editor cannot be deleted',
     );
 
@@ -162,7 +163,7 @@ test 'Delete script' => sub {
     $mech->get_ok('/admin/attributes/Script/delete/28');
     html_ok($mech->content);
     $mech->text_contains(
-      'You cannot remove the attribute "Latin" because it is still in use.',
+      'You cannot remove the attribute “Latin” because it is still in use.',
       'Script in use on a release cannot be deleted',
     );
 

--- a/t/no_gettext_for_admin.sh
+++ b/t/no_gettext_for_admin.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -e -u
+
+SCRIPT_NAME=$(basename "$0")
+
+HELP=$(cat <<EOH
+Usage: $SCRIPT_NAME
+
+Test that no admin files contain any translatable messages (MBS-13117).
+EOH
+)
+
+if [ $# -gt 1 ]
+then
+  echo >&2 "$SCRIPT_NAME: too many arguments"
+  echo >&2 "$HELP"
+  exit 64
+elif [ $# -eq 1 ]
+then
+  if echo "$1" | grep -Eqx -- '-*h(elp)?'
+  then
+    echo "$HELP"
+    exit
+  elif [ "$1" != '--commit' ]
+  then
+    echo >&2 "$SCRIPT_NAME: unrecognized option: $1"
+    echo >&2 "$HELP"
+    exit 64
+  fi
+fi
+
+MB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
+
+cd "$MB_SERVER_ROOT"
+
+echo "Testing that no admin files contain any translatable messages (MBS-13117)";
+
+cd po
+
+function sed_escape_spaces() {
+  sed -e 's/ /\\ /g'
+}
+
+declare -a admin_perl_files=( $(git ls-files -- \
+  ':(top,glob)lib/**/*Admin*.pm' \
+  ':(top,glob)lib/**/*Admin*/**/*.pm' \
+  | sed_escape_spaces) )
+
+declare -a admin_tt_files=( $(git ls-files -- \
+  ':(top,glob)root/admin/**/*.tt' \
+  | sed_escape_spaces) )
+
+declare -a admin_js_files=( $(git ls-files -- \
+  ':(top,glob)root/admin/**/*.js' \
+  | sed_escape_spaces) )
+
+declare count=0
+
+for file in ${admin_perl_files[@]}
+do
+  pot=`xgettext --from-code utf-8 --keyword=__ --keyword=l --keyword=lp:1,2c --keyword=N_lp:1,2c --keyword=N_l --keyword=ln:1,2 --keyword=N_ln:1,2 --keyword=__x --keyword=__nx:1,2 --keyword=__n:1,2 -Lperl -o - $file`
+  if [ -n "$pot" ]
+  then
+    printf "$pot" | grep '^#:'
+    count=`expr $count + 1`
+  fi
+done
+
+for file in ${admin_tt_files[@]}
+do
+  pot=`./extract_pot_templates $file | sed '1,10d'`
+  if [ -n "$pot" ]
+  then
+    printf "$pot" | grep '^#:'
+    count=`expr $count + 1`
+  fi
+done
+
+for file in ${admin_js_files[@]}
+do
+  pot=`../script/xgettext.js $file | sed '1,12d'`
+  if [ -n "$pot" ]
+  then
+    printf "$pot" | grep '^#:'
+    count=`expr $count + 1`
+  fi
+done
+
+if [ $count -gt 0 ]
+then
+  echo "Error: Found $count admin files wrongly containing translatable messages"
+  exit 1
+else
+  echo "OK"
+fi
+
+# vi: set et sts=2 sw=2 ts=2 :

--- a/webpack/providePluginConfig.mjs
+++ b/webpack/providePluginConfig.mjs
@@ -50,6 +50,14 @@ const providePluginConfig = {
   'texp.l': [expandTextPath, 'l'],
   'texp.ln': [expandTextPath, 'ln'],
   'texp.lp': [expandTextPath, 'lp'],
+
+  'exp.l_admin': [expandPath, 'l_admin'],
+  'exp.ln_admin': [expandPath, 'ln_admin'],
+  'exp.lp_admin': [expandPath, 'lp_admin'],
+
+  'texp.l_admin': [expandTextPath, 'l_admin'],
+  'texp.ln_admin': [expandTextPath, 'ln_admin'],
+  'texp.lp_admin': [expandTextPath, 'lp_admin'],
   /* eslint-enable sort-keys */
 };
 

--- a/webpack/providePluginConfig.mjs
+++ b/webpack/providePluginConfig.mjs
@@ -53,11 +53,9 @@ const providePluginConfig = {
 
   'exp.l_admin': [expandPath, 'l_admin'],
   'exp.ln_admin': [expandPath, 'ln_admin'],
-  'exp.lp_admin': [expandPath, 'lp_admin'],
 
   'texp.l_admin': [expandTextPath, 'l_admin'],
   'texp.ln_admin': [expandTextPath, 'ln_admin'],
-  'texp.lp_admin': [expandTextPath, 'lp_admin'],
   /* eslint-enable sort-keys */
 };
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem MBS-13117
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Messages intended for admins only are needlessly extracted for translation.
Indeed admins are required to be English-speaking anyway.
So it is a waste of time for translators so far.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

* Prevent extracting any message from admin-only pages.
* Add and use `((t)exp).(N_)l[np]_admin` functions for admin-only messages in other pages.
  It makes explicit that some messages are intentionally not translated because these are intended for admin.
  This approach works well in JavaScript, should we follow the same in Perl (under `lib` only)?

# Draft progress checklist
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Test navigating admin and non-admin pages with different UI languages
* [x] Decide on an approach for admin messages in Perl. See current occurrences:
  ```sh
  git grep -w '\(N_\)\?l[np]\?' $(git ls-files 'lib/**Admin**')
  ```
* [x] Implement the same approach in both JavaScript and Perl.
* [x] Uniformize the existing admin code to use this approach.
* [x] Re-test regenerating the file `po/mb_server_pot` <del>after the singular/plural issue has been resolved</del>.
* [x] Re-test navigating admin and non-admin pages with different UI languages

# Action

* Revert the last committed hack when resolving MBS-11178.