### PR TITLE
MBS-13368: Properly compare series relationships if series is target

### DIFF
--- a/root/static/scripts/relationship-editor/utility/compareRelationships.js
+++ b/root/static/scripts/relationship-editor/utility/compareRelationships.js
@@ -318,6 +318,28 @@ export default function compareRelationships(
     if (seriesItemCmp) {
       return seriesItemCmp;
     }
+  } else if (
+    targetIdCmp === 0 &&
+    targetA.entityType === 'series' &&
+    targetA.orderingTypeID === SERIES_ORDERING_TYPE_AUTOMATIC &&
+    linkTypeId != null &&
+    PART_OF_SERIES_LINK_TYPE_IDS.includes(linkTypeId)
+  ){
+    const seriesItemCmp = (
+      /*
+       * If the number attributes are different, the relationships would
+       * reference different rows in the link table, which is enough to
+       * establish uniqueness.
+       */
+      compareStrings(
+        getPaddedSeriesNumber(a),
+        getPaddedSeriesNumber(b),
+      ) ||
+      compareDatePeriods(a, b)
+    );
+    if (seriesItemCmp) {
+      return seriesItemCmp;
+    }
   }
 
   const linkOrderCmp = a.linkOrder - b.linkOrder;

--- a/root/static/scripts/tests/index-web.js
+++ b/root/static/scripts/tests/index-web.js
@@ -13,6 +13,7 @@ require('./i18n.js');
 require('./i18n/expand2.js');
 require('./relationship-editor.js');
 require('./relationship-editor/dialog.js');
+require('./relationship-editor/utility/compareRelationships.js');
 require('./release-editor/actions.js');
 require('./release-editor/common.js');
 require('./release-editor/dialogs.js');

--- a/root/static/scripts/tests/relationship-editor/utility/compareRelationships.js
+++ b/root/static/scripts/tests/relationship-editor/utility/compareRelationships.js
@@ -1,0 +1,260 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import test from 'tape';
+import * as tree from 'weight-balanced-tree';
+
+import {
+  SERIES_ORDERING_ATTRIBUTE,
+  SERIES_ORDERING_TYPE_AUTOMATIC,
+} from '../../../common/constants.js';
+import {
+  createArtistObject,
+  createRecordingObject,
+  createSeriesObject,
+} from '../../../common/entity2.js';
+import {emptyRelationship} from '../constants.js';
+import compareRelationships
+  from '../../../relationship-editor/utility/compareRelationships.js';
+import {
+  exportLinkAttributeTypeInfo,
+  exportLinkTypeInfo,
+} from '../../../relationship-editor/utility/exportTypeInfo.js';
+import {linkAttributeTypes, linkTypes} from '../../typeInfo.js';
+
+exportLinkTypeInfo(linkTypes);
+exportLinkAttributeTypeInfo(linkAttributeTypes);
+
+test('compareRelationships: Basic comparisons', function (t) {
+  t.plan(8);
+
+  const artist = createArtistObject({
+    id: 1,
+    name: 'Artist',
+  });
+
+  const recording = createArtistObject({
+    id: 1,
+    name: 'Recording',
+  });
+
+  const artistRecordingRel = {
+    ...emptyRelationship,
+    entity0: artist,
+    entity1: recording,
+    id: -1,
+    linkTypeID: 154,
+  }
+
+  t.ok(
+    compareRelationships(
+      artistRecordingRel,
+      artistRecordingRel,
+      false,
+    ) === 0,
+    'The exact same relationship is seen as equal',
+  );
+
+  t.ok(
+    compareRelationships(
+      artistRecordingRel,
+      artistRecordingRel,
+      true,
+    ) === 0,
+    'The exact same relationship is seen as equal when backward',
+  );
+
+  const differentArtist = createArtistObject({
+    id: 2,
+    name: 'Some Other Artist',
+  });
+
+  const changedArtistRecordingRel = {
+    ...artistRecordingRel,
+    entity0: differentArtist,
+  };
+
+  t.ok(
+    compareRelationships(
+      artistRecordingRel,
+      changedArtistRecordingRel,
+      true,
+    ) === -1,
+    'The same relationship with a different entity0 target is not seen as equal, and sort alphabetically by target name',
+  );
+
+  const differentRecording = createRecordingObject({
+    id: 2,
+    name: 'Some Other Recording',
+  });
+
+  const artistChangedRecordingRel = {
+    ...artistRecordingRel,
+    entity1: differentRecording,
+  };
+
+  t.ok(
+    compareRelationships(
+      artistRecordingRel,
+      artistChangedRecordingRel,
+      false,
+    ) === -1,
+    'The same relationship with a different entity1 target is not seen as equal, and sort alphabetically by target name',
+  );
+
+  const artistRecordingRelDated = {
+    ...artistRecordingRel,
+    begin_date: {day: 1, month: 1, year: 2000},
+  };
+
+  t.ok(
+    compareRelationships(
+      artistRecordingRelDated,
+      artistRecordingRelDated,
+      false,
+    ) === 0,
+    'The same relationship with the same dates is seen as equal',
+  );
+
+  t.ok(
+    compareRelationships(
+      artistRecordingRel,
+      artistRecordingRelDated,
+      false,
+    ) === -1,
+    'The same relationship with and without dates is not seen as equal, and undated sorts first',
+  );
+
+  const artistRecordingRelDatedAndEnded = {
+    ...artistRecordingRelDated,
+    ended: true,
+  };
+
+  t.ok(
+    compareRelationships(
+      artistRecordingRelDated,
+      artistRecordingRelDatedAndEnded,
+      false,
+    ) === 1,
+    'The same dated relationship with and without "ended" is not seen as equal, and ended sorts first',
+  );
+
+  // Insert test for entity credits here
+  const artistRecordingRelCredited = {
+    ...artistRecordingRel,
+    entity0_credit: 'Some Fancy a.k.a.',
+  };
+
+  t.ok(
+    compareRelationships(
+      artistRecordingRel,
+      artistRecordingRelCredited,
+      true,
+    ) === 0,
+    'The exact same relationship is seen as equal with an entity credit',
+  );
+});
+
+test('compareRelationships: Series comparisons', function (t) {
+  t.plan(4);
+
+  const recording = createArtistObject({
+    id: 1,
+    name: 'Recording',
+  });
+
+  const series = createSeriesObject({
+    id: 1,
+    name: 'Series',
+    orderingTypeID: SERIES_ORDERING_TYPE_AUTOMATIC,
+  });
+
+  const attributesWithOrdering1 = tree.fromDistinctAscArray([{
+    text_value: '1',
+    type: {
+      gid: SERIES_ORDERING_ATTRIBUTE,
+    },
+    typeID: 788,
+    typeName: 'number',
+  }]);
+
+  const attributesWithOrdering2 = tree.fromDistinctAscArray([{
+    text_value: '2',
+    type: {
+      gid: SERIES_ORDERING_ATTRIBUTE,
+    },
+    typeID: 788,
+    typeName: 'number',
+  }]);
+
+  const recordingSeriesRelOrder1 = {
+    ...emptyRelationship,
+    attributes: attributesWithOrdering1,
+    entity0: recording,
+    entity1: series,
+    id: -1,
+    linkTypeID: 154, // Not part of series
+  };
+
+  const recordingSeriesRelOrder2 = {
+    ...recordingSeriesRelOrder1,
+    attributes: attributesWithOrdering2,
+  };
+
+  t.ok(
+    compareRelationships(
+      recordingSeriesRelOrder1,
+      recordingSeriesRelOrder1,
+      false,
+    ) === 0,
+    'The same non-"part of series" relationship is seen as equal',
+  );
+
+
+  t.ok(
+    compareRelationships(
+      recordingSeriesRelOrder1,
+      recordingSeriesRelOrder2,
+      false,
+    ) === 0,
+    'The same non-"part of series" relationship with different order attributes is seen as equal',
+  );
+
+  const recordingSeriesPartOfRelOrder1 = {
+    ...emptyRelationship,
+    attributes: attributesWithOrdering1,
+    entity0: recording,
+    entity1: series,
+    id: -1,
+    linkTypeID: 740, // Part of series
+  };
+
+  const recordingSeriesPartOfRelOrder2 = {
+    ...recordingSeriesPartOfRelOrder1,
+    attributes: attributesWithOrdering2,
+  };
+
+  t.ok(
+    compareRelationships(
+      recordingSeriesPartOfRelOrder1,
+      recordingSeriesPartOfRelOrder1,
+      false,
+    ) === 0,
+    'The exact same "part of series" relationship is seen as equal',
+  );
+
+  t.ok(
+    compareRelationships(
+      recordingSeriesPartOfRelOrder1,
+      recordingSeriesPartOfRelOrder2,
+      false,
+    ) === -1,
+    'The same "part of series" relationship with different order attributes is not seen as equal, and smaller order sorts first',
+  );
+});


### PR DESCRIPTION
### Fix MBS-13368

# Problem
We were only performing special series checks in compareRelationships in cases where the series entity is the source. This means entering relationships to series from other entities was entirely skipping this mechanism, so that different numbers for the same series got blocked as a duplicate relationship.

# Solution
This commit makes it so that the same mechanism is used if both targets are the same series, and the other conditions apply.

# Testing
Manually. We don't seem to have any tests for rejecting duplicate relationships (just for merging them); we probably should. @mwiencek, you might be a lot faster writing these than I would, could I convince you to?