### PR TITLE
MBS-13366: Also show medium data on Edit medium preview

### DIFF
--- a/root/edit/details/EditMedium.js
+++ b/root/edit/details/EditMedium.js
@@ -455,14 +455,12 @@ const EditMedium = ({edit}: Props): React$MixedElement => {
 
   return (
     <table className="details edit-medium">
-      {edit.preview /*:: === true */ ? null : (
-        <tr>
-          <th>{addColonText(l('Medium'))}</th>
-          <td colSpan="2">
-            <MediumLink medium={display.medium} />
-          </td>
-        </tr>
-      )}
+      <tr>
+        <th>{addColonText(l('Medium'))}</th>
+        <td colSpan="2">
+          <MediumLink medium={display.medium} />
+        </td>
+      </tr>
 
       {position ? (
         <FullChangeDiff


### PR DESCRIPTION
### Implement MBS-13366

# Problem
While this data is obviously less important here than on a general edit listing, since we know at least what the release is, it seems like a good idea to still show what edit preview applies to what medium, especially for multi-medium releases.

# Solution
I couldn't think of any single good reason to drop this in previews (it doesn't even take much space) so I just dropped the difference entirely.

# Testing
Manually.