### PR TITLE
Drop hard-coded IP address for incrental JSON dump

### DIFF
--- a/admin/config.incremental-json-dump.sh
+++ b/admin/config.incremental-json-dump.sh
@@ -1,4 +1,4 @@
-RSYNC_FULLEXPORT_HOST='10.2.2.39'
+RSYNC_FULLEXPORT_HOST='mbincrementaljson.local'
 RSYNC_FULLEXPORT_DIR="$JSON_DUMP_DIR/incremental"
 RSYNC_FULLEXPORT_KEY='~/.ssh/rsync-json-dumps-incremental'
 RSYNC_LATEST_KEY=''


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

The IP address of the SSH server used to sync incremental JSON dumps could not be changed without changing it in the current container, and ultimately in the source code/image.


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This patch instead uses the hostname `mbincrementaljson.local` that must be defined in the container, for example by using the option `--add-host` of `docker run`.

It follows the same approach as for full export dump.

It intentionally targets the branch `production` for a deployment today as the SSH server will be moved.


# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Make sure to set `mbincrementaljson.local` through `--add-host` before deploying a new `json-dump` container.
