### PR TITLE
MBS-13369 (1/3): Also allow Bugs! MV links on releases

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1761,7 +1761,12 @@ const CLEANUPS: CleanupEntries = {
             }
             break;
           default: // mv
-            if (sourceType === 'recording') {
+            if (sourceType === 'release') {
+              return [
+                LINK_TYPES.downloadpurchase.release,
+                LINK_TYPES.streamingpaid.release,
+              ];
+            } else if (sourceType === 'recording') {
               return [
                 LINK_TYPES.downloadpurchase.recording,
                 LINK_TYPES.streamingpaid.recording,
@@ -1792,7 +1797,7 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.downloadpurchase.release:
           case LINK_TYPES.streamingpaid.release:
             return {
-              result: prefix === 'album',
+              result: prefix === 'album' || prefix === 'mv',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.downloadpurchase.artist:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1460,6 +1460,17 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://music.bugs.co.kr/album/20488834',
   },
   {
+                     input_url: 'https://music.bugs.co.kr/mv/618959',
+             input_entity_type: 'release',
+       input_relationship_type: 'streamingpaid',
+    expected_relationship_type: ['downloadpurchase', 'streamingpaid'],
+limited_link_type_combinations: [
+                                  ['downloadpurchase', 'streamingpaid'],
+                                  'streamingpaid',
+                                ],
+            expected_clean_url: 'https://music.bugs.co.kr/mv/618959',
+  },
+  {
                      input_url: 'https://music.bugs.co.kr/artist/80276288?wl_ref=M_Search_01_01',
              input_entity_type: 'artist',
     expected_relationship_type: ['downloadpurchase', 'streamingpaid'],


### PR DESCRIPTION
# Problem MBS-13369 (1/3)

Currently, music videos from Bugs! are only allowed on recordings.

# Solution

Like YouTube videos, it would make sense to be able to add them to releases as well.