### PR TITLE
MBS-13369 (2/3): Add support for Melon MV links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3807,7 +3807,7 @@ const CLEANUPS: CleanupEntries = {
       LINK_TYPES.streamingpaid,
     ],
     select: function (url, sourceType) {
-      const m = /^https:\/\/www\.melon\.com\/(album|artist|song)/.exec(url);
+      const m = /^https:\/\/www\.melon\.com\/(album|artist|song|video)/.exec(url);
       if (m) {
         const prefix = m[1];
         switch (prefix) {
@@ -3827,8 +3827,21 @@ const CLEANUPS: CleanupEntries = {
               ];
             }
             break;
-          default: // song
+          case 'song':
             if (sourceType === 'recording') {
+              return [
+                LINK_TYPES.downloadpurchase.recording,
+                LINK_TYPES.streamingpaid.recording,
+              ];
+            }
+            break;
+          default: // video
+            if (sourceType === 'release') {
+              return [
+                LINK_TYPES.downloadpurchase.release,
+                LINK_TYPES.streamingpaid.release,
+              ];
+            } else if (sourceType === 'recording') {
               return [
                 LINK_TYPES.downloadpurchase.recording,
                 LINK_TYPES.streamingpaid.recording,
@@ -3844,6 +3857,7 @@ const CLEANUPS: CleanupEntries = {
       url = url.replace(/^(https:\/\/www\.melon\.com\/album)\/(?:detail|music)\.htm\?(albumId=\d+)(?:[\/#&].*)?$/, '$1/detail.htm?$2');
       url = url.replace(/^(https:\/\/www\.melon\.com\/artist)\/(?:timeline|detail|song|album|video|photo|fan|hifi|song\/all|detail\/info|magazine)\.htm\?(artistId=\d+)(?:[\/#&].*)?$/, '$1/detail.htm?$2');
       url = url.replace(/^(https:\/\/www\.melon\.com\/song\/detail\.htm\?songId=\d+)(?:[\/#&].*)?$/, '$1');
+      url = url.replace(/^(https:\/\/www\.melon\.com\/video)\/detail2?\.htm\?(mvId=\d+)(?:[\/#&].*)?$/, '$1/detail2.htm?$2');
       return url;
     },
     validate: function (url, id) {
@@ -3854,14 +3868,14 @@ const CLEANUPS: CleanupEntries = {
           target: ERROR_TARGETS.URL,
         };
       }
-      const m = /^https:\/\/www\.melon\.com\/(album|artist|song)\/detail.htm\?(?:albumId|artistId|songId)=\d+$/.exec(url);
+      const m = /^https:\/\/www\.melon\.com\/(album|artist|song|video)\/detail.htm\?(?:albumId|artistId|songId|mvId)=\d+$/.exec(url);
       if (m) {
         const prefix = m[1];
         switch (id) {
           case LINK_TYPES.downloadpurchase.release:
           case LINK_TYPES.streamingpaid.release:
             return {
-              result: prefix === 'album',
+              result: prefix === 'album' || prefix === 'video',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.downloadpurchase.artist:
@@ -3873,7 +3887,7 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.downloadpurchase.recording:
           case LINK_TYPES.streamingpaid.recording:
             return {
-              result: prefix === 'song',
+              result: prefix === 'song' || prefix === 'video',
               target: ERROR_TARGETS.ENTITY,
             };
         }

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3627,6 +3627,16 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://www.melon.com/album/detail.htm?albumId=11074452',
   },
   {
+                     input_url: 'https://www.melon.com/video/detail2.htm?mvId=50264014&menuId=26020101',
+             input_entity_type: 'release',
+    expected_relationship_type: ['downloadpurchase', 'streamingpaid'],
+limited_link_type_combinations: [
+                                  ['downloadpurchase', 'streamingpaid'],
+                                  'streamingpaid',
+                                ],
+            expected_clean_url: 'https://www.melon.com/video/detail2.htm?mvId=50264014',
+  },
+  {
                      input_url: 'https://www.melon.com/artist/timeline.htm?artistId=1284664#params[listType]=C',
              input_entity_type: 'artist',
     expected_relationship_type: ['downloadpurchase', 'streamingpaid'],
@@ -3657,6 +3667,16 @@ limited_link_type_combinations: [
                                   target: 'url',
                                 },
        only_valid_entity_types: [],
+  },
+  {
+                     input_url: 'https://m2.melon.com/video/detail.htm?mvId=50264300',
+             input_entity_type: 'recording',
+    expected_relationship_type: ['downloadpurchase', 'streamingpaid'],
+limited_link_type_combinations: [
+                                  ['downloadpurchase', 'streamingpaid'],
+                                  'streamingpaid',
+                                ],
+            expected_clean_url: 'https://www.melon.com/video/detail2.htm?mvId=50264300',
   },
   // (The) Metal Archives
   {


### PR DESCRIPTION
# Problem MBS-13369 (2/3)

Currently, music videos on Melon are unsupported due to the existing link validation.

# Solution

This patch adds support to add those links to releases and recordings.