### PR TITLE
MBS-13370: Rewrite more artist pages for Genie

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2674,6 +2674,7 @@ const CLEANUPS: CleanupEntries = {
     },
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?(?:(?:www|mw)\.)?genie\.co\.kr\//, 'https://www.genie.co.kr/');
+      url = url.replace(/^https:\/\/www\.genie\.co\.kr\/detail\/artist(?:Info|Album|Song|Mv)\?xxnm=(\d+)(?:[&#\/].*)?$/, 'https://www.genie.co.kr/detail/artistInfo?xxnm=$1');
       url = url.replace(/^(https:\/\/www\.genie\.co\.kr\/detail\/(?:albumInfo\?ax|artistInfo\?xx|songInfo\?xg|mediaInfo\?xv)nm=\d+)(?:[&#\/].*)?$/, '$1');
       return url;
     },

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2675,7 +2675,7 @@ const CLEANUPS: CleanupEntries = {
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?(?:(?:www|mw)\.)?genie\.co\.kr\//, 'https://www.genie.co.kr/');
       url = url.replace(/^https:\/\/www\.genie\.co\.kr\/detail\/artist(?:Info|Album|Song|Mv)\?xxnm=(\d+)(?:[&#\/].*)?$/, 'https://www.genie.co.kr/detail/artistInfo?xxnm=$1');
-      url = url.replace(/^(https:\/\/www\.genie\.co\.kr\/detail\/(?:albumInfo\?ax|artistInfo\?xx|songInfo\?xg|mediaInfo\?xv)nm=\d+)(?:[&#\/].*)?$/, '$1');
+      url = url.replace(/^(https:\/\/www\.genie\.co\.kr\/detail\/(?:albumInfo\?ax|songInfo\?xg|mediaInfo\?xv)nm=\d+)(?:[&#\/].*)?$/, '$1');
       return url;
     },
     validate: function (url, id) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2547,6 +2547,16 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://www.genie.co.kr/detail/artistInfo?xxnm=80441335',
   },
   {
+                     input_url: 'https://genie.co.kr/detail/artistAlbum?xxnm=81599561',
+             input_entity_type: 'artist',
+    expected_relationship_type: ['downloadpurchase', 'streamingpaid'],
+limited_link_type_combinations: [
+                                  ['downloadpurchase', 'streamingpaid'],
+                                  'streamingpaid',
+                                ],
+            expected_clean_url: 'https://genie.co.kr/detail/artistInfo?xxnm=81599561',
+  },
+  {
                      input_url: 'https://www.genie.co.kr/search/searchMain?query=Dreamcatcher',
              input_entity_type: 'artist',
        input_relationship_type: 'streamingpaid',


### PR DESCRIPTION

# Problem

Genie has multiple tabs on their artist pages, the main artist page uses the format https://genie.co.kr/detail/artistInfo?xxnm=81599561, while other pages showing albums, songs and MVs differ slightly (e.g., https://genie.co.kr/detail/artistAlbum?xxnm=81599561).

# Solution

They should be rewritten to the (canonical) main artist page so that relationship types are auto-selected.

Closes MBS-13370.

# Testing

Added an extra test case that rewrites the albums page for an artist to their main page.