### PR TITLE
RemoveUnreferencedRows: Silence warning for already-deleted rows

### DIFF
--- a/lib/MusicBrainz/Script/RemoveUnreferencedRows.pm
+++ b/lib/MusicBrainz/Script/RemoveUnreferencedRows.pm
@@ -91,7 +91,19 @@ sub run {
                         $id,
                     );
 
-                    if ($ref_count == 0) {
+                    if (!defined $ref_count) {
+                        # The row was deleted by some other means.
+                        # This may be normal; for artist_credit, we do delete
+                        # rows ourselves in `_swap_artist_credits`, at least.
+                        #
+                        # Since there's nothing to remove, we can safely
+                        # skip it. Log a message in case the info is useful
+                        # for debugging purposes later.
+                        log_info {
+                            sprintf "Did not find id=%s in $table_name, skipping.",
+                            $id,
+                        };
+                    } elsif ($ref_count == 0) {
                         log_info {
                             sprintf "Will remove id=%s from $table_name.",
                             $id,


### PR DESCRIPTION
# Problem

We have the following useless warnings in our daily cron log:
```
2023-11-18T00:16:37.053937Z Use of uninitialized value $ref_count in numeric eq (==) at
/home/musicbrainz/musicbrainz-server/admin/cleanup/../../lib/MusicBrainz/Script/RemoveUnreferencedRows.pm line 94.
```

# Solution

If `$ref_count` is `undef`, then it means the row was already removed. This may be normal, as in the case of artist credits, but it's safe to skip here in any case. Log a message about it just in case it helps with debugging something later.