### PR TITLE
MBS-13300: Delete RG cover art if release is moved

### DIFF
--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -866,7 +866,7 @@ sub update {
     );
     if (
         defined $new_release_group_id &&
-        $new_release_group_id eq $old_release_group_id
+        $new_release_group_id == $old_release_group_id
     ) {
         $new_release_group_id = undef;
     }

--- a/t/lib/t/MusicBrainz/Server/Edit/Release/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Release/Edit.pm
@@ -175,7 +175,7 @@ test 'A missing comment does not clear an existing one' => sub {
     is($release->comment, 'hello', 'comment is left unchanged');
 };
 
-test 'MBS-13300: Release group cover art is deleted if the release is moved' => sub {
+test 'MBS-13300: Release group cover art is unset if the release is moved' => sub {
     my $test = shift;
     my $c = $test->c;
 


### PR DESCRIPTION
# Problem

MBS-13300

If a release group has manually set cover art, and the release from which the cover art was taken is moved to another RG, then the leftover entry in the `release_group_cover_art` table which we fail to delete prevents the otherwise-empty RG from being deleted.

# Solution

Delete unused rows from the `release_group_cover_art` table in `Data::Release::update`.

# Testing

Just the added automated test.