### PR TITLE
MBS-13310: Add new empty artist credits to unreferenced_row_log

### DIFF
--- a/lib/MusicBrainz/Server/Data/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Data/ArtistCredit.pm
@@ -340,6 +340,22 @@ sub _swap_artist_credits {
         $old_credit_id
     );
 
+    $self->c->sql->do(<<~'SQL', $new_credit_id, $old_credit_id);
+        UPDATE unreferenced_row_log l
+           SET row_id = $1
+          FROM artist_credit ac
+         WHERE ac.id = $1
+           AND ac.ref_count = 0
+           AND l.table_name = 'artist_credit'
+           AND l.row_id = $2
+        SQL
+
+    $self->c->sql->do(<<~'SQL', $old_credit_id);
+        DELETE FROM unreferenced_row_log
+              WHERE table_name = 'artist_credit'
+                AND row_id = ?
+        SQL
+
     $self->_delete_from_cache($old_credit_id);
 }
 


### PR DESCRIPTION
# Problem

MBS-13310

When artists are merged, `Data::ArtistCredit::merge_artists` is called, which inserts new artist credits: each appearance of the old artist is replaced by the new one.  If the old AC had no references, it will have had an entry in the `unreferenced_row_log` table already; we should make sure to update that to point to the new AC, if the new one also has no references.

# Solution

In `_swap_artist_credits`, update `unreferenced_row_log` to point to the new AC if it's unreferenced.

Remember that because artist credits have MBIDs, we'd like to preserve them from deletion where possible: there's a 2-day delay before we cleanup empty ACs, allowing time for them to be re-used with their original MBIDs intact. This applies to redirected MBIDs too; so while inserting empty artist credits may seem silly, these empty ACs are in fact redirected to from a (now-deleted) empty AC which hadn't been cleaned up yet.

# Testing

Just the added automated test.