### PR TITLE
MBS-13364 / MBS-13377 / MBS-13378: Fixes / improvements for editor mailing preferences 

### DIFF
--- a/lib/MusicBrainz/Server/Data/EditNote.pm
+++ b/lib/MusicBrainz/Server/Data/EditNote.pm
@@ -99,8 +99,13 @@ sub add_note
         (map { $_->editor_id } @{ $edit->edit_notes }));
     $self->c->model('Editor')->load_preferences(values %$editors);
 
+    my @to_email;
+
     # Inform the edit's author that a note was left, unless this is their own edit.
     if ($note_hash->{editor_id} != $edit->editor_id) {
+        # Send email to the author
+        push(@to_email, $edit->editor_id);
+        # Add notes received notification banner
         my $edit_author = $editors->{$edit->editor_id}->name;
         my $notes_updated_key = "edit_notes_received_last_updated:$edit_author";
         $self->c->store->set($notes_updated_key, time);
@@ -108,14 +113,14 @@ sub add_note
         $self->c->store->expire($notes_updated_key, 60 * 60 * 24 * 30);
     }
 
-    my @to_email = grep { $_ != $note_hash->{editor_id} }
+    push(@to_email, grep { $_ != $note_hash->{editor_id} }
         map { $_->id } grep { $_->preferences->email_on_notes }
         map { $editors->{$_->editor_id} }
             @{ $edit->edit_notes },
             (grep { my $editor = $_->editor_id;
                     !(grep { $editor == $_ } (53705, 326637, 295208)) || $_->vote != $VOTE_ABSTAIN
                   } @{ $edit->votes }),
-            $edit;
+            $edit);
 
     my $from = $editors->{ $note_hash->{editor_id} };
     for my $editor_id (uniq @to_email) {

--- a/lib/MusicBrainz/Server/Data/EditNote.pm
+++ b/lib/MusicBrainz/Server/Data/EditNote.pm
@@ -114,13 +114,17 @@ sub add_note
     }
 
     push(@to_email, grep { $_ != $note_hash->{editor_id} }
-        map { $_->id } grep { $_->preferences->email_on_notes }
-        map { $editors->{$_->editor_id} }
-            @{ $edit->edit_notes },
-            (grep { my $editor = $_->editor_id;
-                    !(grep { $editor == $_ } (53705, 326637, 295208)) || $_->vote != $VOTE_ABSTAIN
-                  } @{ $edit->votes }),
-            $edit);
+                    map { $_->id } grep { $_->preferences->email_on_notes }
+                    map { $editors->{$_->editor_id} }
+                    @{ $edit->edit_notes });
+
+    push(@to_email, grep { $_ != $note_hash->{editor_id} }
+                    map { $_->id } grep { $_->preferences->email_on_vote }
+                    map { $editors->{$_->editor_id} }
+                    grep { my $editor_id = $_->editor_id;
+                        !(grep { $editor_id == $_ } (53705, 326637, 295208)) ||
+                        $_->vote != $VOTE_ABSTAIN
+                    } @{ $edit->votes });
 
     my $from = $editors->{ $note_hash->{editor_id} };
     for my $editor_id (uniq @to_email) {

--- a/lib/MusicBrainz/Server/Entity/Preferences.pm
+++ b/lib/MusicBrainz/Server/Entity/Preferences.pm
@@ -44,6 +44,13 @@ has [qw(email_on_no_vote email_on_notes email_on_vote)] => (
     lazy => 1,
 );
 
+has 'email_on_abstain' => (
+    isa => 'Bool',
+    default => sub { shift->email_on_vote },
+    is =>'rw',
+    lazy => 1,
+);
+
 has [qw( subscribe_to_created_artists
          subscribe_to_created_labels
          subscribe_to_created_series )] => (
@@ -67,6 +74,7 @@ sub TO_JSON {
         datetime_format => $self->datetime_format,
         subscriptions_email_period => $self->subscriptions_email_period,
         timezone => $self->timezone,
+        email_on_abstain => boolean_to_json($self->email_on_abstain),
         email_on_no_vote => boolean_to_json($self->email_on_no_vote),
         email_on_notes => boolean_to_json($self->email_on_notes),
         email_on_vote => boolean_to_json($self->email_on_vote),

--- a/lib/MusicBrainz/Server/Entity/Preferences.pm
+++ b/lib/MusicBrainz/Server/Entity/Preferences.pm
@@ -40,14 +40,14 @@ has 'timezone' => (
 has [qw(email_on_no_vote email_on_notes email_on_vote)] => (
     isa => 'Bool',
     default => 1,
-    is =>'rw',
+    is => 'rw',
     lazy => 1,
 );
 
 has 'email_on_abstain' => (
     isa => 'Bool',
     default => sub { shift->email_on_vote },
-    is =>'rw',
+    is => 'rw',
     lazy => 1,
 );
 
@@ -56,7 +56,7 @@ has [qw( subscribe_to_created_artists
          subscribe_to_created_series )] => (
     isa => 'Bool',
     default => 1,
-    is =>'rw',
+    is => 'rw',
     lazy => 1,
 );
 

--- a/lib/MusicBrainz/Server/Form/User/Preferences.pm
+++ b/lib/MusicBrainz/Server/Form/User/Preferences.pm
@@ -16,6 +16,7 @@ has_field 'public_ratings' => ( type => 'Boolean' );
 has_field 'public_subscriptions' => ( type => 'Boolean' );
 has_field 'public_tags' => ( type => 'Boolean' );
 
+has_field 'email_on_abstain' => ( type => 'Boolean' );
 has_field 'email_on_no_vote' => ( type => 'Boolean' );
 has_field 'email_on_notes' => ( type => 'Boolean' );
 has_field 'email_on_vote' => ( type => 'Boolean' );

--- a/root/static/scripts/account/components/PreferencesForm.js
+++ b/root/static/scripts/account/components/PreferencesForm.js
@@ -189,81 +189,79 @@ class PreferencesForm extends React.Component<Props, State> {
         </fieldset>
         <fieldset>
           <legend>{l('Privacy')}</legend>
-          <FormRowCheckbox
-            field={field.public_subscriptions}
-            label={l('Allow other users to see my subscriptions')}
-            uncontrolled
-          />
-          <FormRowCheckbox
-            field={field.public_tags}
-            label={l('Allow other users to see my tags')}
-            uncontrolled
-          />
-          <FormRowCheckbox
-            field={field.public_ratings}
-            label={l('Allow other users to see my ratings')}
-            uncontrolled
-          />
+          <p>
+            {l('Allow other users to see:')}
+            <FormRowCheckbox
+              field={field.public_subscriptions}
+              label={l('My subscriptions')}
+              uncontrolled
+            />
+            <FormRowCheckbox
+              field={field.public_tags}
+              label={l('My tags and genres')}
+              uncontrolled
+            />
+            <FormRowCheckbox
+              field={field.public_ratings}
+              label={l('My ratings')}
+              uncontrolled
+            />
+          </p>
         </fieldset>
         <fieldset>
           <legend>{l('Email')}</legend>
-          <FormRowCheckbox
-            field={field.email_on_no_vote}
-            label={l(
-              `Mail me when one of my edits gets a "no" vote.
-               (Note: the email is only sent for the first "no" vote,
-               not each one)`,
-            )}
-            uncontrolled
-          />
-          <FormRowCheckbox
-            field={field.email_on_notes}
-            label={l(
-              `When I add a note to an edit,
-               mail me all future notes for that edit.`,
-            )}
-            uncontrolled
-          />
-          <FormRowCheckbox
-            field={field.email_on_vote}
-            label={l(
-              `When I vote on an edit,
-               mail me all future notes for that edit.`,
-            )}
-            uncontrolled
-          />
-          <FormRowCheckbox
-            field={field.email_on_abstain}
-            label={l(
-              `When I abstain on an edit,
-               mail me all future notes for that edit.`,
-            )}
-            uncontrolled
-          />
-          <FormRowSelect
-            field={field.subscriptions_email_period}
-            label={l('Send me mails with edits to my subscriptions:')}
-            onChange={this.handleSubscriptionsEmailPeriodChangeBound}
-            options={subscriptionsEmailPeriodOptions}
-          />
+          <p>
+            {l('Email me about:')}
+            <FormRowCheckbox
+              field={field.email_on_no_vote}
+              label={l('The first “no” vote on any of my edits')}
+              uncontrolled
+            />
+            <FormRowCheckbox
+              field={field.email_on_notes}
+              label={l('Notes on edits I have left notes on')}
+              uncontrolled
+            />
+            <FormRowCheckbox
+              field={field.email_on_vote}
+              label={l('Notes on edits I have voted on')}
+              uncontrolled
+            />
+            <FormRowCheckbox
+              field={field.email_on_abstain}
+              label={l('Notes on edits I have abstained on')}
+              uncontrolled
+            />
+          </p>
+          <p>
+            <FormRowSelect
+              field={field.subscriptions_email_period}
+              label={l('Send me mails with edits to my subscriptions:')}
+              onChange={this.handleSubscriptionsEmailPeriodChangeBound}
+              options={subscriptionsEmailPeriodOptions}
+            />
+          </p>
         </fieldset>
         <fieldset>
           <legend>{l('Editing')}</legend>
-          <FormRowCheckbox
-            field={field.subscribe_to_created_artists}
-            label={l('Automatically subscribe me to artists I add.')}
-            uncontrolled
-          />
-          <FormRowCheckbox
-            field={field.subscribe_to_created_labels}
-            label={l('Automatically subscribe me to labels I add.')}
-            uncontrolled
-          />
-          <FormRowCheckbox
-            field={field.subscribe_to_created_series}
-            label={l('Automatically subscribe me to series I add.')}
-            uncontrolled
-          />
+          <p>
+            {l('Automatically subscribe me when I add:')}
+            <FormRowCheckbox
+              field={field.subscribe_to_created_artists}
+              label={l('Artists')}
+              uncontrolled
+            />
+            <FormRowCheckbox
+              field={field.subscribe_to_created_labels}
+              label={l('Labels')}
+              uncontrolled
+            />
+            <FormRowCheckbox
+              field={field.subscribe_to_created_series}
+              label={l('Series')}
+              uncontrolled
+            />
+          </p>
         </fieldset>
         <FormRow hasNoLabel>
           <FormSubmit label={l('Save')} />

--- a/root/static/scripts/account/components/PreferencesForm.js
+++ b/root/static/scripts/account/components/PreferencesForm.js
@@ -21,6 +21,7 @@ import FormSubmit from '../../edit/components/FormSubmit.js';
 type PreferencesFormT = FormT<{
   +csrf_token: FieldT<string>,
   +datetime_format: FieldT<string>,
+  +email_on_abstain: FieldT<boolean>,
   +email_on_no_vote: FieldT<boolean>,
   +email_on_notes: FieldT<boolean>,
   +email_on_vote: FieldT<boolean>,
@@ -227,6 +228,14 @@ class PreferencesForm extends React.Component<Props, State> {
             field={field.email_on_vote}
             label={l(
               `When I vote on an edit,
+               mail me all future notes for that edit.`,
+            )}
+            uncontrolled
+          />
+          <FormRowCheckbox
+            field={field.email_on_abstain}
+            label={l(
+              `When I abstain on an edit,
                mail me all future notes for that edit.`,
             )}
             uncontrolled

--- a/root/static/scripts/tests/utility/constants.js
+++ b/root/static/scripts/tests/utility/constants.js
@@ -120,6 +120,7 @@ export const genericEditor: UnsanitizedEditorT = {
   name: 'editor1',
   preferences: {
     datetime_format: '%Y-%m-%d %H:%M %Z',
+    email_on_abstain: true,
     email_on_no_vote: true,
     email_on_notes: true,
     email_on_vote: true,

--- a/root/types/editor.js
+++ b/root/types/editor.js
@@ -50,6 +50,7 @@ declare type FluencyT =
 
 declare type UnsanitizedEditorPreferencesT = {
   +datetime_format: string,
+  +email_on_abstain: boolean,
   +email_on_no_vote: boolean,
   +email_on_notes: boolean,
   +email_on_vote: boolean,

--- a/t/lib/t/MusicBrainz/Server/Data/EditNote.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/EditNote.pm
@@ -122,8 +122,8 @@ test 'Adding edit notes works and sends emails' => sub {
     my $email_transport = MusicBrainz::Server::Email->get_test_transport;
     is($email_transport->delivery_count, 2, 'Exactly two emails sent');
 
-    my $email2 = $email_transport->shift_deliveries->{email};
     my $email = $email_transport->shift_deliveries->{email};
+    my $email2 = $email_transport->shift_deliveries->{email};
 
     note('Checking email sent to editor1 (edit creator)');
     is(

--- a/t/sql/edit_note.sql
+++ b/t/sql/edit_note.sql
@@ -39,4 +39,8 @@ INSERT INTO edit (id, editor, type, status, expire_time)
 INSERT INTO edit_data (edit, data)
     SELECT 3 + x, '{}' FROM generate_series(1, 10) x;
 
+-- editor1 does not want emails on edit notes.
+INSERT INTO editor_preference (editor, name, value)
+     VALUES (1, 'email_on_notes', '0');
+
 ALTER SEQUENCE edit_note_id_seq RESTART 4;

--- a/t/sql/edit_note.sql
+++ b/t/sql/edit_note.sql
@@ -39,8 +39,4 @@ INSERT INTO edit (id, editor, type, status, expire_time)
 INSERT INTO edit_data (edit, data)
     SELECT 3 + x, '{}' FROM generate_series(1, 10) x;
 
--- editor1 does not want emails on edit notes.
-INSERT INTO editor_preference (editor, name, value)
-     VALUES (1, 'email_on_notes', '0');
-
 ALTER SEQUENCE edit_note_id_seq RESTART 4;


### PR DESCRIPTION
### Fix MBS-13364 / MBS-13377, implement MBS-13378

# Problem
Our entire preference system for mailing editors is a horrible buggy mess. `email_on_notes` wrongly determines whether the original editor gets mailed, `email_on_vote` is completely unused and votes also depend on `email_on_notes`, and we have an undocumented hardcoded feature changing the way the email works on abstain for three specific editor IDs.

# Solution
The first commit ensures the original editor is *always* emailed notes on their edits. 

The second commit splits the checks for `email_on_notes` and `email_on_vote` so they actually affect notes and votes respectively.

The third commit gets rid of the hardcoded IDs "preference" for abstain notifications and adds an actual preference that anyone can actually use, so that editors can choose whether they want to use abstain to wait and see what else the editors have to say (send emails), or to get rid of the edit on their unvoted list and not hear about it anymore (send no emails). 

# Testing
Added extra tests that take into consideration every one of these conditions.