### PR TITLE
MBS-13392 / MBS-13393: Restore the external links editor submission upon form reload, and reduce the relationship data stored in sessionStorage

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -87,7 +87,7 @@ export type LinkStateT = $ReadOnly<{
   ...DatePeriodRoleT,
   +deleted: boolean,
   +editsPending: boolean,
-  +entity0?:
+  +entity0:
     | RelatableEntityT
     | {
         +entityType: RelatableEntityTypeT,
@@ -96,9 +96,10 @@ export type LinkStateT = $ReadOnly<{
         +name?: string,
         +orderingTypeID?: number,
         +relationships?: void,
-      },
-  +entity1?: RelatableEntityT,
-  +pendingTypes?: $ReadOnlyArray<number>,
+      }
+    | null,
+  +entity1: RelatableEntityT | null,
+  +pendingTypes: $ReadOnlyArray<number> | null,
   +rawUrl: string,
   // New relationships will use a unique string ID like "new-1".
   +relationship: StrOrNum | null,
@@ -407,7 +408,7 @@ export class _ExternalLinksEditor
     }
     this.setState(prevState => {
       let newLinks = [...prevState.links];
-      newLinks[index] = {...newLinks[index], pendingTypes: undefined};
+      newLinks[index] = {...newLinks[index], pendingTypes: null};
       const emptyLinkIndex = newLinks.findIndex(link => {
         const isNewLink = !isPositiveInteger(link.relationship);
         return isNewLink && isEmpty(link);
@@ -1336,7 +1337,7 @@ type LinkProps = {
   +relationships: $ReadOnlyArray<LinkRelationshipT>,
   +typeOptions: $ReadOnlyArray<LinkTypeOptionT>,
   +url: string,
-  +urlEntity?: RelatableEntityT,
+  +urlEntity: RelatableEntityT | null,
   +urlMatchesType: boolean,
   +validateLink: (LinkRelationshipT | LinkStateT) => ErrorT | null,
 };
@@ -1593,8 +1594,9 @@ const defaultLinkState: LinkStateT = {
   editsPending: false,
   end_date: EMPTY_PARTIAL_DATE,
   ended: false,
-  entity0: undefined,
-  entity1: undefined,
+  entity0: null,
+  entity1: null,
+  pendingTypes: null,
   rawUrl: '',
   relationship: null,
   submitted: false,
@@ -1675,8 +1677,9 @@ export function parseRelationships(
         editsPending: data.editsPending,
         end_date: data.end_date || EMPTY_PARTIAL_DATE,
         ended: data.ended || false,
-        entity0: sourceData || undefined,
+        entity0: sourceData || null,
         entity1: target,
+        pendingTypes: null,
         rawUrl: target.name,
         relationship: data.id,
         submitted: true,

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -677,6 +677,7 @@ const seleniumTests = [
     login: true,
     sql: 'mbs-13015.sql',
   },
+  {name: 'MBS-13392.json5', login: true},
   {name: 'Artist_Credit_Editor.json5', login: true},
   {name: 'Autocomplete2.json5'},
   {name: 'CAA.json5', login: true},

--- a/t/selenium/MBS-13392.json5
+++ b/t/selenium/MBS-13392.json5
@@ -1,0 +1,126 @@
+{
+  title: 'MBS-13392: External links are preserved upon form reload',
+  commands: [
+    {
+      command: 'open',
+      target: '/artist/create',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: 'https://www.discogs.com/artist/999999999${KEY_TAB}',
+    },
+    // The form is disabled because we didn't enter a name or sort name yet.
+    // Manually submit the form so we can check if external links are
+    // preserved after the form reloads due to an error.
+    {
+      command: 'runScript',
+      target: "document.getElementById('id-edit-artist.name').removeAttribute('required')",
+      value: '',
+    },
+    {
+      command: 'runScript',
+      target: "document.getElementById('id-edit-artist.sort_name').removeAttribute('required')",
+      value: '',
+    },
+    {
+      command: 'runScript',
+      target: "MB.validation.errorFields([])",
+      value: '',
+    },
+    {
+      command: 'runScriptAndWait',
+      target: "document.querySelector('form.edit-artist').requestSubmit()",
+      value: '',
+    },
+    {
+      command: 'assertLocationMatches',
+      target: '\\/artist\\/create',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=id-edit-artist.name',
+      value: 'realname',
+    },
+    {
+      command: 'type',
+      target: 'id=id-edit-artist.sort_name',
+      value: 'realname',
+    },
+    // Submit the form, this time with a name and sort name entered.
+    // We'll know if the external link was preserved and submitted by
+    // checking the edits below.
+    {
+      command: 'clickAndWait',
+      target: 'css=form.edit-artist button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 1,
+      value: {
+        type: 1,
+        status: 2,
+        data: {
+          area_id: null,
+          begin_area_id: null,
+          begin_date: {
+            day: null,
+            month: null,
+            year: null,
+          },
+          comment: '',
+          end_area_id: null,
+          end_date: {
+            day: null,
+            month: null,
+            year: null,
+          },
+          ended: 0,
+          entity_gid: '$$__IGNORE__$$',
+          entity_id: 3,
+          gender_id: null,
+          ipi_codes: [],
+          isni_codes: [],
+          name: 'realname',
+          sort_name: 'realname',
+          type_id: null,
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 2,
+      value: {
+        type: 90,
+        status: 2,
+        data: {
+          edit_version: 2,
+          ended: 0,
+          entity0: {
+            gid: '$$__IGNORE__$$',
+            id: 3,
+            name: 'realname',
+          },
+          entity1: {
+            gid: '$$__IGNORE__$$',
+            id: 1,
+            name: 'https://www.discogs.com/artist/999999999',
+          },
+          entity_id: 1,
+          link_type: {
+            id: 180,
+            link_phrase: 'Discogs',
+            long_link_phrase: 'has a Discogs page at',
+            name: 'discogs',
+            reverse_link_phrase: 'Discogs page for',
+          },
+          type0: 'artist',
+          type1: 'url',
+        },
+      },
+    },
+  ],
+}


### PR DESCRIPTION
# Problem

MBS-13392 - External links editor changes are lost if the form reloads

MBS-13393 - Can't update relationships or external links for entities with a lot of them

# Solution

For MBS-13392, instead of using `MB.formWasPosted`, which no longer exists, we can check the request method on the Catalyst context object instead.

For MBS-13393, see the associated commit.

# Testing

Tested manually. (I temporarily commented out some lines in validation.js to make submitting invalid forms easier.) Added a Selenium test for MBS-13392.