### PR TITLE
Use React$FragmentType rather than typeof React.Fragment

### DIFF
--- a/root/account/ChangePassword.js
+++ b/root/account/ChangePassword.js
@@ -37,7 +37,7 @@ const ChangePasswordPageContent = ({
   form,
   isMandatory = false,
   userExists = false,
-}: Props): React$Element<typeof React.Fragment> => (
+}: Props): React$Element<React$FragmentType> => (
   <>
     {isMandatory ? (
       <p>

--- a/root/artist/ArtistIndex.js
+++ b/root/artist/ArtistIndex.js
@@ -76,7 +76,7 @@ const FooterSwitch = ({
   hasVariousArtistsExtra,
   includingAllStatuses,
   showingVariousArtistsOnly,
-}: FooterSwitchProps): React$Element<'p' | typeof React.Fragment> => {
+}: FooterSwitchProps): React$Element<'p' | React$FragmentType> => {
   const artistLink = entityHref(artist);
 
   function buildLinks(

--- a/root/cdtoc/CDTocInfo.js
+++ b/root/cdtoc/CDTocInfo.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 import calculateFullToc
   from '../static/scripts/common/utility/calculateFullToc.js';
 import formatTrackLength
@@ -18,7 +16,7 @@ type Props = {
   +cdToc: CDTocT,
 };
 
-const CDTocInfo = ({cdToc}: Props): React$Element<typeof React.Fragment> => (
+const CDTocInfo = ({cdToc}: Props): React$Element<React$FragmentType> => (
   <>
     <h2>{l('CD TOC details')}</h2>
 

--- a/root/collection/CollectionHeader.js
+++ b/root/collection/CollectionHeader.js
@@ -25,7 +25,7 @@ type Props = {
 const CollectionHeader = ({
   collection,
   page,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const $c = React.useContext(SanitizedCatalystContext);
   const owner = collection.editor;
   const viewingOwnCollection = Boolean(

--- a/root/components/Aliases/ArtistCreditList.js
+++ b/root/components/Aliases/ArtistCreditList.js
@@ -26,7 +26,7 @@ type Props = {
 const ArtistCreditList = ({
   artistCredits,
   entity,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const $c = React.useContext(SanitizedCatalystContext);
   return (
     <>

--- a/root/components/Artwork.js
+++ b/root/components/Artwork.js
@@ -36,7 +36,7 @@ export const ArtworkImage = ({
   artwork,
   hover,
   message,
-}: Props): React$Element<typeof React.Fragment> => (
+}: Props): React$Element<React$FragmentType> => (
   <>
     <noscript>
       <img src={artwork.small_ia_thumbnail} />

--- a/root/components/EntityHeader.js
+++ b/root/components/EntityHeader.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 import EntityLink from '../static/scripts/common/components/EntityLink.js';
 
 import typeof EntityTabLink from './EntityTabLink.js';
@@ -33,7 +31,7 @@ const EntityHeader = ({
   page,
   preHeader,
   subHeading,
-}: Props): React$Element<typeof React.Fragment> => (
+}: Props): React$Element<React$FragmentType> => (
   <>
     <div className={'wrap-anywhere ' + headerClass}>
       {nonEmpty(preHeader) ? preHeader : null}

--- a/root/components/PaginatedResults.js
+++ b/root/components/PaginatedResults.js
@@ -32,7 +32,7 @@ const PaginatedResults = ({
   query,
   search = false,
   total = false,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const $c = React.useContext(CatalystContext);
   const paginator = (
     <Paginator

--- a/root/components/ReleaseLanguageScript.js
+++ b/root/components/ReleaseLanguageScript.js
@@ -7,11 +7,9 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 const ReleaseLanguageScript = ({
   release,
-}: {release: ReleaseT}): React$Element<typeof React.Fragment> => {
+}: {release: ReleaseT}): React$Element<React$FragmentType> => {
   const language = release.language;
   const script = release.script;
 

--- a/root/components/TagEntitiesList.js
+++ b/root/components/TagEntitiesList.js
@@ -45,7 +45,7 @@ const TagEntitiesList = ({
   tag,
   taggedEntities,
   user,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const $c = React.useContext(CatalystContext);
 
   const totalCount = Object.values(taggedEntities)

--- a/root/components/list/EventList.js
+++ b/root/components/list/EventList.js
@@ -57,7 +57,7 @@ const EventList = ({
   showRatings = false,
   showType = false,
   sortable,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(

--- a/root/components/list/ReleaseGroupList.js
+++ b/root/components/list/ReleaseGroupList.js
@@ -155,7 +155,7 @@ const ReleaseGroupList = ({
   seriesItemNumbers,
   showRatings,
   sortable,
-}: ReleaseGroupListProps): Array<React$Element<typeof React.Fragment>> => {
+}: ReleaseGroupListProps): Array<React$Element<React$FragmentType>> => {
   const groupedReleaseGroups = groupBy(releaseGroups, x => x.typeName ?? '');
   const tables = [];
   for (const [type, releaseGroupsOfType] of groupedReleaseGroups) {

--- a/root/components/list/WorkList.js
+++ b/root/components/list/WorkList.js
@@ -44,7 +44,7 @@ const WorkList = ({
   showRatings = false,
   sortable,
   works,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(

--- a/root/edit/components/EditList.js
+++ b/root/edit/components/EditList.js
@@ -42,7 +42,7 @@ const EditList = ({
   refineUrlArgs,
   username,
   voter,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const $c = React.useContext(SanitizedCatalystContext);
 
   /*

--- a/root/edit/components/EditSummary.js
+++ b/root/edit/components/EditSummary.js
@@ -33,7 +33,7 @@ type Props = {
 const EditSummary = ({
   edit,
   index,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const $c = React.useContext(CatalystContext);
   const user = $c.user;
   const mayAddNote = editorMayAddNote(edit, user);

--- a/root/edit/components/EditorTypeInfo.js
+++ b/root/edit/components/EditorTypeInfo.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 import bracketed from '../../static/scripts/common/utility/bracketed.js';
 import {isBot} from '../../static/scripts/common/utility/privileges.js';
 
@@ -18,7 +16,7 @@ type Props = {
 
 const EditorTypeInfo = ({
   editor,
-}: Props): React$Element<typeof React.Fragment> | null => (
+}: Props): React$Element<React$FragmentType> | null => (
   editor == null ? null : (
     <>
       {editor.is_limited ? (

--- a/root/edit/components/TrackDurationChanges.js
+++ b/root/edit/components/TrackDurationChanges.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 import formatTrackLength
   from '../../static/scripts/common/utility/formatTrackLength.js';
 import DiffSide from '../../static/scripts/edit/components/edit/DiffSide.js';
@@ -26,7 +24,7 @@ const TrackDurationChanges = ({
   newLengths,
   oldLabel,
   oldLengths,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const lengthsSize = oldLengths.length;
   const lengthComparisonTables = [];
   for (let i = 0; i < lengthsSize; i++) {

--- a/root/edit/details/AddRelationshipType.js
+++ b/root/edit/details/AddRelationshipType.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 import Cardinality
   from '../../static/scripts/common/components/Cardinality.js';
 import EntityLink from '../../static/scripts/common/components/EntityLink.js';
@@ -23,7 +21,7 @@ type Props = {
 
 const AddRelationshipType = ({
   edit,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const display = edit.display_data;
   const entity0Type = ENTITY_NAMES[display.entity0_type]();
   const entity1Type = ENTITY_NAMES[display.entity1_type]();

--- a/root/edit/details/EditRelationshipType.js
+++ b/root/edit/details/EditRelationshipType.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 import Cardinality
   from '../../static/scripts/common/components/Cardinality.js';
 import DescriptiveLink
@@ -92,7 +90,7 @@ function formatExample(
 
 const EditRelationshipType = ({
   edit,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const display = edit.display_data;
   const name = display.name;
   const oldDescription = display.description?.old ?? '';

--- a/root/edit/details/EditUrl.js
+++ b/root/edit/details/EditUrl.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 import {
   EDIT_STATUS_OPEN,
 } from '../../constants.js';
@@ -21,7 +19,7 @@ type Props = {
   +edit: EditUrlEditT,
 };
 
-const EditUrl = ({edit}: Props): React$Element<typeof React.Fragment> => {
+const EditUrl = ({edit}: Props): React$Element<React$FragmentType> => {
   const display = edit.display_data;
   const description = display.description;
   const uri = display.uri;

--- a/root/edit/details/MergeReleases.js
+++ b/root/edit/details/MergeReleases.js
@@ -220,7 +220,7 @@ function getHtmlVars(
 
 const MergeReleases = ({
   edit,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const display = edit.display_data;
   const emptyReleases = display.empty_releases;
   const changes = display.changes;

--- a/root/edit/details/RemoveMedium.js
+++ b/root/edit/details/RemoveMedium.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 import {EDIT_STATUS_OPEN} from '../../constants.js';
 import MediumTracklist
   from '../../medium/MediumTracklist.js';
@@ -33,7 +31,7 @@ const areTracksEqual = (a: TrackT, b: TrackT) => (
 
 const RemoveMedium = ({
   edit,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const display = edit.display_data;
   const originalTracklist = display.tracks ?? [];
   const currentTracklist = display.medium.tracks ?? [];

--- a/root/edit/details/historic/EditRelationship.js
+++ b/root/edit/details/historic/EditRelationship.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 import DescriptiveLink
   from '../../../static/scripts/common/components/DescriptiveLink.js';
 import Warning from '../../../static/scripts/common/components/Warning.js';
@@ -31,7 +29,7 @@ type Props = {
 
 const EditRelationship = ({
   edit,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const oldRels = edit.display_data.relationship.old;
   const newRels = edit.display_data.relationship.new;
   const isDataBroken = oldRels.length !== newRels.length;

--- a/root/layout/components/FaviconLinks.js
+++ b/root/layout/components/FaviconLinks.js
@@ -7,9 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
-const FaviconLinks = (): React$Element<typeof React.Fragment> => (
+const FaviconLinks = (): React$Element<React$FragmentType> => (
   <>
     <link
       href="/static/images/favicons/apple-touch-icon-57x57.png"

--- a/root/layout/components/sidebar/AnnotationLinks.js
+++ b/root/layout/components/sidebar/AnnotationLinks.js
@@ -19,7 +19,7 @@ type Props = {
 
 const AnnotationLinks = ({
   entity,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const $c = React.useContext(CatalystContext);
   const numberOfRevisions = $c.stash.number_of_revisions ?? 0;
 

--- a/root/layout/components/sidebar/EditLinks.js
+++ b/root/layout/components/sidebar/EditLinks.js
@@ -24,7 +24,7 @@ const EditLinks = ({
   children,
   entity,
   requiresPrivileges = false,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const $c = React.useContext(CatalystContext);
   return (
     <>

--- a/root/layout/components/sidebar/SidebarProperties.js
+++ b/root/layout/components/sidebar/SidebarProperties.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 type SidebarPropertyProps = {
   +children: React$Node,
   +className: string,
@@ -19,7 +17,7 @@ export const SidebarProperty = ({
   children,
   className,
   label,
-}: SidebarPropertyProps): React$Element<typeof React.Fragment> => (
+}: SidebarPropertyProps): React$Element<React$FragmentType> => (
   <>
     <dt>{label}</dt>
     <dd className={className}>

--- a/root/layout/components/sidebar/SidebarRating.js
+++ b/root/layout/components/sidebar/SidebarRating.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 import EntityLink
   from '../../../static/scripts/common/components/EntityLink.js';
 import RatingStars
@@ -22,7 +20,7 @@ type Props = {
 const SidebarRating = ({
   entity,
   heading,
-}: Props): React$Element<typeof React.Fragment> => (
+}: Props): React$Element<React$FragmentType> => (
   <>
     <h2 className="rating">{nonEmpty(heading) ? heading : l('Rating')}</h2>
     <p>

--- a/root/layout/components/sidebar/SidebarTags.js
+++ b/root/layout/components/sidebar/SidebarTags.js
@@ -55,7 +55,7 @@ const TagList = ({
 
 const SidebarTags = ({
   entity,
-}: SidebarTagsProps): React$Element<typeof React.Fragment> | null => {
+}: SidebarTagsProps): React$Element<React$FragmentType> | null => {
   const $c = React.useContext(CatalystContext);
   const aggregatedTags = $c.stash.top_tags;
   const more = Boolean($c.stash.more_tags);

--- a/root/layout/components/sidebar/SubscriptionLinks.js
+++ b/root/layout/components/sidebar/SubscriptionLinks.js
@@ -20,7 +20,7 @@ type Props = {
 
 const SubscriptionLinks = ({
   entity,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const $c = React.useContext(CatalystContext);
   const entityType = entity.entityType;
   const id = encodeURIComponent(String(entity.id));

--- a/root/main/error/components/ErrorEnvironment.js
+++ b/root/main/error/components/ErrorEnvironment.js
@@ -19,7 +19,7 @@ type Props = {
 const ErrorEnvironment = ({
   hostname,
   useLanguages = false,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const $c = React.useContext(CatalystContext);
   return (
     <>

--- a/root/release/CoverArt.js
+++ b/root/release/CoverArt.js
@@ -25,7 +25,7 @@ type Props = {
 
 const CoverArtLinks = ({
   artwork,
-}: {artwork: ArtworkT}): React$Element<typeof React.Fragment> => (
+}: {artwork: ArtworkT}): React$Element<React$FragmentType> => (
   <>
     {artwork.small_thumbnail ? (
       <>

--- a/root/release/CoverArtFields.js
+++ b/root/release/CoverArtFields.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 import {unwrapNl} from '../static/scripts/common/i18n.js';
 import FormRow from '../static/scripts/edit/components/FormRow.js';
 import FormRowTextLong
@@ -28,7 +26,7 @@ type Props = {
 const CoverArtFields = ({
   form,
   typeIdOptions,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const typeIdField = form.field.type_id;
   const selectedTypeIds = new Set(typeIdField.value.map(
     value => String(value),

--- a/root/search/components/SearchForm.js
+++ b/root/search/components/SearchForm.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 import DBDefs from '../../static/scripts/common/DBDefs.mjs';
 import FormRowRadio
   from '../../static/scripts/edit/components/FormRowRadio.js';
@@ -69,7 +67,7 @@ const methodOptions = [
 
 const SearchForm = ({
   form,
-}: Props): React$Element<typeof React.Fragment> => (
+}: Props): React$Element<React$FragmentType> => (
   <>
     <div className="searchform">
       <form action="/search" method="get">

--- a/root/static/scripts/alias/AliasEditForm.js
+++ b/root/static/scripts/alias/AliasEditForm.js
@@ -200,7 +200,7 @@ const AliasEditForm = ({
   form: initialForm,
   locales,
   searchHintType,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const localeOptions = {
     grouped: false,
     options: locales,

--- a/root/static/scripts/common/components/AcoustIdCell.js
+++ b/root/static/scripts/common/components/AcoustIdCell.js
@@ -89,7 +89,7 @@ function loadAcoustIdData(
 
 const AcoustIdCell = ({
   recordingMbid,
-}: PropsT): React$Element<typeof React.Fragment> => {
+}: PropsT): React$Element<React$FragmentType> => {
   const [acoustIdTracks, setAcoustIdTracks] = React.useState<
     $ReadOnlyArray<AcoustIdTrackT> | null,
   >(null);

--- a/root/static/scripts/common/components/Relationships.js
+++ b/root/static/scripts/common/components/Relationships.js
@@ -70,7 +70,7 @@ const Relationships = (React.memo<PropsT>(({
   relationships: passedRelationships,
   showIfEmpty = false,
   source,
-}: PropsT): React$Element<typeof React.Fragment> => {
+}: PropsT): React$Element<React$FragmentType> => {
   let srcRels = source.relationships;
   let relationships = passedRelationships;
   if (!relationships) {

--- a/root/static/scripts/common/components/ReleaseEvent.js
+++ b/root/static/scripts/common/components/ReleaseEvent.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 import formatDate from '../utility/formatDate.js';
 import isDateEmpty from '../utility/isDateEmpty.js';
 
@@ -20,7 +18,7 @@ type Props = {
 
 const ReleaseEvent = ({
   event,
-}: Props): React$Element<typeof React.Fragment> => (
+}: Props): React$Element<React$FragmentType> => (
   <>
     {isDateEmpty(event.date) ? null : (
       <>

--- a/root/static/scripts/common/components/WorkListEntry.js
+++ b/root/static/scripts/common/components/WorkListEntry.js
@@ -48,7 +48,7 @@ export const WorkListRow = ({
   showIswcs = false,
   showRatings = false,
   work,
-}: WorkListRowProps): React$Element<typeof React.Fragment> => {
+}: WorkListRowProps): React$Element<React$FragmentType> => {
   const $c = React.useContext(CatalystContext);
 
   return (

--- a/root/static/scripts/edit/components/EntityPendingEditsWarning.js
+++ b/root/static/scripts/edit/components/EntityPendingEditsWarning.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 import openEditsForEntityIconUrl
   from '../../../images/icons/open_edits_for_entity.svg';
 import entityHref from '../../common/utility/entityHref.js';
@@ -21,7 +19,7 @@ type PropsT = {
 
 const EntityPendingEditsWarning = ({
   entity,
-}: PropsT): React$Element<typeof React.Fragment> | null => {
+}: PropsT): React$Element<React$FragmentType> | null => {
   const hasPendingEdits = Boolean(entity.editsPending);
   const openEditsLink = entityHref(entity, '/open_edits');
 

--- a/root/static/scripts/edit/components/InlineSubmitButton.js
+++ b/root/static/scripts/edit/components/InlineSubmitButton.js
@@ -7,15 +7,13 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 type PropsT = {
   +label?: string,
 };
 
 const InlineSubmitButton = ({
   label,
-}: PropsT): React$Element<typeof React.Fragment> => (
+}: PropsT): React$Element<React$FragmentType> => (
   <>
     {' '}
     <span className="buttons inline">

--- a/root/static/scripts/edit/components/RelationshipPendingEditsWarning.js
+++ b/root/static/scripts/edit/components/RelationshipPendingEditsWarning.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import * as React from 'react';
-
 import openEditsForRelIconUrl
   from '../../../images/icons/open_edits_for_rel.svg';
 import type {
@@ -28,7 +26,7 @@ type PropsT = {
 
 const RelationshipPendingEditsWarning = ({
   relationship,
-}: PropsT): React$Element<typeof React.Fragment> | null => {
+}: PropsT): React$Element<React$FragmentType> | null => {
   const hasPendingEdits = relationship.editsPending;
   const openEditsLink = getOpenEditsLink(relationship);
 

--- a/root/static/scripts/edit/components/edit/RelationshipDiff.js
+++ b/root/static/scripts/edit/components/edit/RelationshipDiff.js
@@ -66,7 +66,7 @@ const RelationshipDiff = (React.memo(({
   newRelationship,
   oldRelationship,
   makeEntityLink = makeDescriptiveLink,
-}: Props): React$Element<typeof React.Fragment> => {
+}: Props): React$Element<React$FragmentType> => {
   const oldAttrs = keyBy(oldRelationship.attributes, getTypeId);
   const newAttrs = keyBy(newRelationship.attributes, getTypeId);
 

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -1351,7 +1351,7 @@ export class ExternalLink extends React.Component<LinkProps> {
     setTimeout(() => target.style.backgroundColor = 'initial', 1000);
   }
 
-  render(): React$Element<typeof React.Fragment> {
+  render(): React$Element<React$FragmentType> {
     const props = this.props;
     const notEmpty = props.relationships.some(link => {
       return !isEmpty(link);

--- a/root/tag/EntityList.js
+++ b/root/tag/EntityList.js
@@ -136,7 +136,7 @@ export const EntityListContent = ({
   showVotesSelect = false,
   tag,
   user,
-}: EntityListContentProps): React$Element<typeof React.Fragment> => {
+}: EntityListContentProps): React$Element<React$FragmentType> => {
   const $c = React.useContext(CatalystContext);
   return (
     <>


### PR DESCRIPTION
# Description
We had already gotten rid of most `React.` types, but we had kept `typeof React.Fragment` because I didn't know there was a better option. `React$FragmentType` exists though, and we were even using it already in at least one file, so this gets rid of some more unneeded React imports and adds consistency.