### PR TITLE
MBS-13397: Support video pages for jazzmusic/metalmusic/progarchives

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3249,6 +3249,11 @@ const CLEANUPS: CleanupEntries = {
               result: type === 'artist',
               target: ERROR_TARGETS.ENTITY,
             };
+          case LINK_TYPES.otherdatabases.recording:
+            return {
+              result: type === 'video',
+              target: ERROR_TARGETS.ENTITY,
+            };
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: type === 'album',
@@ -3977,6 +3982,11 @@ const CLEANUPS: CleanupEntries = {
               result: type === 'artist',
               target: ERROR_TARGETS.ENTITY,
             };
+          case LINK_TYPES.otherdatabases.recording:
+            return {
+              result: type === 'video',
+              target: ERROR_TARGETS.ENTITY,
+            };
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: type === 'album',
@@ -4666,6 +4676,11 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: type === 'artist',
+              target: ERROR_TARGETS.ENTITY,
+            };
+          case LINK_TYPES.otherdatabases.recording:
+            return {
+              result: type === 'video',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release_group:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3108,6 +3108,12 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://www.jazzmusicarchives.com/album/rita-marcotulli(italy)/summer',
        only_valid_entity_types: ['release_group'],
   },
+  {
+                     input_url: 'https://www.jazzmusicarchives.com/video/gary-wilson/34605',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'otherdatabases',
+       only_valid_entity_types: ['recording'],
+  },
   // JOYSOUND
   {
                      input_url: 'https://www.joysound.com/web/search/artist/5169?startIndex=20#songlist',
@@ -3797,6 +3803,12 @@ limited_link_type_combinations: [
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://www.metalmusicarchives.com/album/sunn-o/lxndxn-subcamden-underworld-halloween-2003(live)',
        only_valid_entity_types: ['release_group'],
+  },
+  {
+                     input_url: 'https://www.metalmusicarchives.com/video/humankind/23333',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'otherdatabases',
+       only_valid_entity_types: ['recording'],
   },
   // Migu Music
   {
@@ -4783,6 +4795,12 @@ limited_link_type_combinations: [
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://www.progarchives.com/album.asp?id=1823',
        only_valid_entity_types: ['release_group'],
+  },
+  {
+                     input_url: 'https://www.progarchives.com/video.asp?id=7855',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'otherdatabases',
+       only_valid_entity_types: ['recording'],
   },
   {
                      input_url: 'https://www.progarchives.com/Collaborators.asp?id=9702',


### PR DESCRIPTION
### Implement MBS-13397

# Description
The three sister sites progarchives.com / jazzmusicarchives.com / metalmusicarchives.com support video links, which we had missed before so we were blocking. It makes sense to allow these to be linked to recordings.

Documented with https://wiki.musicbrainz.org/index.php?title=Other_Databases_Relationship_Type%2FWhitelist&type=revision&diff=77212&oldid=77195 (we don't have per-entity info for progarchives).

# Testing
Added tests for these as usual.