### PR TITLE
MBS-13117 (II): Make more admin strings untranslatable

### DIFF
--- a/root/area/edit_form.tt
+++ b/root/area/edit_form.tt
@@ -5,21 +5,21 @@
 
   <div class="half-width">
     <fieldset>
-      <legend>[%- l('Area details') -%]</legend>
+      <legend>[%- 'Area details' -%]</legend>
       [%- form_row_name_with_guesscase(r) -%]
-      [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
-      [%- form_row_select(r, 'type_id', l('Type:')) -%]
-      [%- form_row_text_list(r, 'iso_3166_1', add_colon(l('ISO 3166-1')), l('ISO 3166-1')) -%]
-      [%- form_row_text_list(r, 'iso_3166_2', add_colon(l('ISO 3166-2')), l('ISO 3166-2')) -%]
-      [%- form_row_text_list(r, 'iso_3166_3', add_colon(l('ISO 3166-3')), l('ISO 3166-3')) -%]
+      [%- form_row_text_long(r, 'comment', 'Disambiguation:') -%]
+      [%- form_row_select(r, 'type_id', 'Type:') -%]
+      [%- form_row_text_list(r, 'iso_3166_1', 'ISO 3166-1:', 'ISO 3166-1') -%]
+      [%- form_row_text_list(r, 'iso_3166_2', 'ISO 3166-2:', 'ISO 3166-2') -%]
+      [%- form_row_text_list(r, 'iso_3166_3', 'ISO 3166-3:', 'ISO 3166-3') -%]
     </fieldset>
 
-    [% date_range_fieldset(r, 'area', l('This area has ended.')) %]
+    [% date_range_fieldset(r, 'area', 'This area has ended.') %]
 
     [% PROCESS 'forms/relationship-editor.tt' %]
 
     <fieldset>
-      <legend>[% l('External links') %]</legend>
+      <legend>[% 'External links' %]</legend>
       [% external_links_editor() %]
     </fieldset>
 

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -43,6 +43,10 @@ two. -%]
     Translation.ln(text, plural, num, args);
 END; -%]
 
+[%~ MACRO l_admin(text) BLOCK;
+    text;
+END; -%]
+
 [%~ MACRO artwork_hover(artwork) BLOCK -%]
     [%- IF artwork.l_types; comma_only_list(artwork.l_types) | html; END %][% IF artwork.comment %] ([% artwork.comment | html%])[% END -%]
 [%- END -%]

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -397,7 +397,7 @@
 
   <select name="args" multiple="multiple">
     [%~ editor_flags = [[1, lp('Auto-editor', 'user type')], [2, lp('Bot', 'user type')]];
-        IF c.user.is_account_admin; editor_flags.push([4, l('Untrusted')]); END;
+        IF c.user.is_account_admin; editor_flags.push([4, l_admin('Untrusted')]); END;
         editor_flags.push(
           [8, lp('Relationship editor', 'user type')],
           [32, lp('Transclusion editor', 'user type')],

--- a/root/genre/CreateGenre.js
+++ b/root/genre/CreateGenre.js
@@ -21,9 +21,9 @@ type Props = {
 const CreateGenre = ({
   form,
 }: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Add a new genre')}>
+  <Layout fullWidth title="Add a new genre">
     <div id="content">
-      <h1>{l('Add a new genre')}</h1>
+      <h1>{'Add a new genre'}</h1>
       <GenreEditForm form={form} />
     </div>
     {manifest.js('genre/components/GenreEditForm', {async: 'async'})}

--- a/root/genre/DeleteGenre.js
+++ b/root/genre/DeleteGenre.js
@@ -28,12 +28,12 @@ const DeleteGenre = ({
     entity={genre}
     fullWidth
     page="delete"
-    title={lp('Remove genre', 'header')}
+    title="Remove genre"
   >
-    <h2>{lp('Remove genre', 'header')}</h2>
+    <h2>{'Remove genre'}</h2>
     <p>
-      {exp.l('Are you sure you want to remove the genre {genre}?',
-             {genre: <EntityLink entity={genre} />})}
+      {exp.l_admin('Are you sure you want to remove the genre {genre}?',
+                   {genre: <EntityLink entity={genre} />})}
     </p>
 
     <form method="post">

--- a/root/genre/EditGenre.js
+++ b/root/genre/EditGenre.js
@@ -27,7 +27,7 @@ const EditGenre = ({
     entity={entity}
     fullWidth
     page="edit"
-    title={lp('Edit genre', 'header')}
+    title="Edit genre"
   >
     <GenreEditForm form={form} />
     {manifest.js('genre/components/GenreEditForm', {async: 'async'})}

--- a/root/instrument/edit_form.tt
+++ b/root/instrument/edit_form.tt
@@ -5,22 +5,22 @@
 
   <div class="half-width">
     <fieldset>
-      <legend>[%- l('Instrument details') -%]</legend>
+      <legend>[%- 'Instrument details' -%]</legend>
       [%- form_row_name_with_guesscase(r) -%]
-      [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
-      [%- form_row_select(r, 'type_id', l('Type:')) -%]
+      [%- form_row_text_long(r, 'comment', 'Disambiguation:') -%]
+      [%- form_row_select(r, 'type_id', 'Type:') -%]
       [% WRAPPER form_row %]
-          [%- r.label('description', add_colon(l('Description'))) -%]
+          [%- r.label('description', 'Description:') -%]
           [%- r.textarea('description', { rows => 5 }) -%]
           [%- field_errors(form, 'description') -%]
       [%- END -%]
       [% WRAPPER form_row %]
         <p>
           [% # When converting to React, please move the list below to expand2react.js and import from there # %]
-          [% l('HTML tags allowed in the description: {tag_list}.', 
-            {tag_list => comma_only_list(
+          [% 'HTML tags allowed in the description: ' _ 
+            comma_only_list(
               ['a', 'abbr', 'br', 'code', 'em', 'li', 'p', 'span', 'strong', 'ul'],
-            )}) %]
+            ) _ '.' %]
         </p>
       [%- END -%]
 
@@ -29,7 +29,7 @@
     [% PROCESS 'forms/relationship-editor.tt' %]
 
     <fieldset>
-      <legend>[% l('External links') %]</legend>
+      <legend>[% 'External links' %]</legend>
       [% external_links_editor() %]
     </fieldset>
 

--- a/root/relationship/linkattributetype/create.tt
+++ b/root/relationship/linkattributetype/create.tt
@@ -1,6 +1,6 @@
-[% WRAPPER "layout.tt" title=l("New Relationship Attribute") full_width=1 %]
+[% WRAPPER "layout.tt" title="New relationship attribute" full_width=1 %]
     <div id="content">
-        <h1>[% l("New Relationship Attribute") %]</h1>
+        <h1>[% 'New relationship attribute' %]</h1>
         [% INCLUDE "relationship/linkattributetype/form.tt" %]
     </div>
 [% END %]

--- a/root/relationship/linkattributetype/edit.tt
+++ b/root/relationship/linkattributetype/edit.tt
@@ -1,6 +1,6 @@
-[% WRAPPER "layout.tt" title=l("Edit Relationship Attribute") full_width=1 %]
+[% WRAPPER "layout.tt" title="Edit relationship attribute" full_width=1 %]
     <div id="content">
-        <h1>[% l("Edit Relationship Attribute") %]</h1>
+        <h1>[% 'Edit relationship attribute' %]</h1>
         [% INCLUDE "relationship/linkattributetype/form.tt" %]
     </div>
 [% END %]

--- a/root/relationship/linkattributetype/form.tt
+++ b/root/relationship/linkattributetype/form.tt
@@ -1,26 +1,26 @@
 <form action="[% c.req.uri %]" method="post">
     [%- USE r = FormRenderer(form) -%]
 
-    [% form_row_select(r, 'parent_id', add_colon(l('Parent'))) %]
+    [% form_row_select(r, 'parent_id', 'Parent:') %]
 
     [% WRAPPER form_row %]
-        [% r.label('child_order', add_colon(l('Child order'))) %]
+        [% r.label('child_order', 'Child order:') %]
         [% r.number('child_order') %]
         [% field_errors(form, 'child_order') %]
     [% END %]
 
-    [% form_row_text(r, 'name', add_colon(l('Name'))) %]
+    [% form_row_text(r, 'name', 'Name:') %]
 
     [% WRAPPER form_row %]
-        [% r.label('description', add_colon(l('Description'))) %]
+        [% r.label('description', 'Description:') %]
         [% r.textarea('description', { cols => 80, rows => 6 }) %]
         [% field_errors(form, 'description') %]
     [% END %]
 
-    [% form_row_checkbox(r, 'creditable', l('This attribute supports free text credits')) %]
-    [% form_row_checkbox(r, 'free_text', l('This attribute uses free text values')) %]
+    [% form_row_checkbox(r, 'creditable', 'This attribute supports free text credits') %]
+    [% form_row_checkbox(r, 'free_text', 'This attribute uses free text values') %]
 
     <div class="row no-label">
-        [% form_submit(l('Save')) %]
+        [% form_submit('Save') %]
     </div>
 </form>

--- a/root/relationship/linktype/create.tt
+++ b/root/relationship/linktype/create.tt
@@ -1,6 +1,6 @@
-[% WRAPPER "layout.tt" title=l("New Relationship Type") full_width=1 %]
+[% WRAPPER "layout.tt" title="New relationship type" full_width=1 %]
     <div id="content">
-        <h1>[% l("New Relationship Type") %]</h1>
+        <h1>[% 'New relationship type' %]</h1>
         [% INCLUDE "relationship/linktype/form.tt" %]
     </div>
 [% END %]

--- a/root/relationship/linktype/edit.tt
+++ b/root/relationship/linktype/edit.tt
@@ -1,6 +1,6 @@
-[% WRAPPER "layout.tt" title=l("Edit Relationship Type") full_width=1 %]
+[% WRAPPER "layout.tt" title="Edit relationship type" full_width=1 %]
     <div id="content">
-        <h1>[% l("Edit Relationship Type") %]</h1>
+        <h1>[% 'Edit relationship type' %]</h1>
         [% INCLUDE "relationship/linktype/form.tt" %]
     </div>
 [% END %]

--- a/root/relationship/linktype/form.tt
+++ b/root/relationship/linktype/form.tt
@@ -1,55 +1,55 @@
 <form action="[% c.req.uri %]" method="post" class="edit-relationship">
     [%- USE r = FormRenderer(form) -%]
 
-    [% form_row_select(r, 'parent_id', add_colon(l('Parent'))) %]
+    [% form_row_select(r, 'parent_id', 'Parent:') %]
 
     [% WRAPPER form_row %]
-        [% r.label('child_order', add_colon(l('Child order'))) %]
+        [% r.label('child_order', 'Child order:') %]
         [% r.number('child_order') %]
         [% field_errors(form, 'child_order') %]
     [% END %]
 
-    [% form_row_text_long(r, 'name', add_colon(l('Name'))) %]
-    [% form_row_text_long(r, 'link_phrase', l('Forward link phrase:')) %]
-    [% form_row_text_long(r, 'reverse_link_phrase', l('Reverse link phrase:')) %]
-    [% form_row_text_long(r, 'long_link_phrase', l('Long link phrase:')) %]
-    [% form_row_checkbox(r, 'is_deprecated', l('This relationship is deprecated')) %]
-    [% form_row_checkbox(r, 'has_dates', l('This relationship allows setting dates')) %]
+    [% form_row_text_long(r, 'name', 'Name:') %]
+    [% form_row_text_long(r, 'link_phrase', 'Forward link phrase:') %]
+    [% form_row_text_long(r, 'reverse_link_phrase', 'Reverse link phrase:') %]
+    [% form_row_text_long(r, 'long_link_phrase', 'Long link phrase:') %]
+    [% form_row_checkbox(r, 'is_deprecated', 'This relationship is deprecated') %]
+    [% form_row_checkbox(r, 'has_dates', 'This relationship allows setting dates') %]
 
     [% WRAPPER form_row %]
-        [% r.label('description', add_colon(l('Description'))) %]
+        [% r.label('description', 'Description:') %]
         [% r.textarea('description', { cols => 80, rows => 6 }) %]
         [% field_errors(form, 'description') %]
     [% END %]
 
     [% WRAPPER form_row %]
-        [% r.label('entity0_cardinality', add_colon(l('Cardinality of {entity_placeholder}', { entity_placeholder => '<code>{entity0}</code>' }))) %]
+        [% r.label('entity0_cardinality', 'Cardinality of <code>{entity0}</code>') %]
         [% r.number('entity0_cardinality') %]
         [% field_errors(form, 'entity0_cardinality') %]
     [% END %]
     [% WRAPPER form_row %]
-        [% r.label('entity1_cardinality', add_colon(l('Cardinality of {entity_placeholder}', { entity_placeholder => '<code>{entity1}</code>' }))) %]
+        [% r.label('entity1_cardinality', 'Cardinality of <code>{entity1}</code>') %]
         [% r.number('entity1_cardinality') %]
         [% field_errors(form, 'entity1_cardinality') %]
     [% END %]
 
     [% WRAPPER form_row %]
-        [% r.label('orderable_direction', l('Orderable direction:')) %]
+        [% r.label('orderable_direction', 'Orderable direction:') %]
         [% r.number('orderable_direction') %]
         <div class="no-label">
-            [% l('A value of 1 or 2 indicates that either entity1 or entity0 are orderable, respectively.') %]
+            [% 'A value of 1 or 2 indicates that either entity1 or entity0 are orderable, respectively.' %]
         </div>
         [% field_errors(form, 'orderable_direction') %]
     [% END %]
 
     [% WRAPPER form_row %]
-        [% r.label('priority', l('Priority:')) %]
+        [% r.label('priority', 'Priority:') %]
         [% r.number('priority') %]
         [% field_errors(form, 'priority') %]
     [% END %]
 
     [% WRAPPER form_row %]
-        <label>[% add_colon(l('Attributes')) %]</label>
+        <label>[% 'Attributes:' %]</label>
         [% FOR field IN form.field('attributes').fields %]
             <div class="no-label">
                     [% r.hidden(field.field('type')) %]
@@ -62,23 +62,23 @@
     [% END %]
 
     [% WRAPPER form_row %]
-      [% r.label('documentation', add_colon(l('Documentation'))) %]
+      [% r.label('documentation', 'Documentation:') %]
       [% r.textarea('documentation', { cols => 80, rows => 10 }) %]
     [% END %]
 
     [% IF form.isa('MusicBrainz::Server::Form::Admin::LinkType::Edit') %]
     <fieldset>
-        <legend>[% l('Examples') %]</legend>
+        <legend>[% 'Examples' %]</legend>
         <div data-bind="if: MB.ExampleRelationshipsEditor.viewModel.examples().length > 0">
             <div data-bind="foreach: MB.ExampleRelationshipsEditor.viewModel.examples">
                 [% WRAPPER form_row %]
                     <label class="required"
                            data-bind="attr: { for: examplePrefix($index(), 'name') }">
-                        [%- add_colon(l('Name')) -%]
+                        [%- 'Name:' -%]
                     </label>
                     <input type="text" data-bind="attr: { name: examplePrefix($index(), 'name') }, value: name" />
                     <button type="button" data-bind="click: removeExample">
-                        [% l('Remove example') %]
+                        [% 'Remove example' %]
                     </button>
                 [% END %]
 
@@ -97,19 +97,19 @@
         <div data-bind="if: MB.ExampleRelationshipsEditor.viewModel.examples().length == 0">
             [% WRAPPER form_row %]
                 <div class="no-label">
-                    [% l('This relationship type does not have any examples.') %]
+                    [% 'This relationship type does not have any examples.' %]
                 </div>
             [% END %]
         </div>
 
-        <h3>[% l('Add a new example') %]</h3>
+        <h3>[% 'Add a new example' %]</h3>
         [% WRAPPER form_row %]
-            <label>[% add_colon(l('Name')) %]</label>
+            <label>[% 'Name:' %]</label>
             <input type="text" data-bind="value: currentExample.name" />
         [% END %]
 
         [%- WRAPPER form_row -%]
-          <label class="required">[% l('Endpoint:') %]</label>
+          <label class="required">[% 'Endpoint:' %]</label>
           <select style="width: 130px; margin-right: 4px;"
               data-bind="options: availableEntityTypes, value: selectedEntityType,
                          optionsText: 'text', optionsValue: 'value'">
@@ -123,7 +123,7 @@
           </span>
           <button type="button" data-bind="click: currentExample.possibleRelationships.search,
                              enable: currentExample.possibleRelationships.query">
-                [% l('Find relationships') %]</button>
+                [% 'Find relationships' %]</button>
         [%- END -%]
 
         <div class="row" data-bind="visible: currentExample.possibleRelationships.error">
@@ -151,7 +151,7 @@
         [% WRAPPER form_row %]
             <div class="no-label">
                 <button type="button" data-bind="click: currentExample.add, enable: currentExample.relationship()">
-                    [% l('Add example') %]
+                    [% 'Add example' %]
                 </button>
             </div>
         [% END %]
@@ -197,6 +197,6 @@ function examplePrefix(i, s) {
     [% END %]
 
     <div class="row no-label">
-        [% form_submit(l('Save')) %]
+        [% form_submit('Save') %]
     </div>
 </form>

--- a/root/static/scripts/genre/components/GenreEditForm.js
+++ b/root/static/scripts/genre/components/GenreEditForm.js
@@ -133,18 +133,18 @@ const GenreEditForm = ({
     >
       <div className="half-width">
         <fieldset>
-          <legend>{l('Genre details')}</legend>
+          <legend>{'Genre details'}</legend>
           <FormRowNameWithGuessCase
             dispatch={nameDispatch}
             entity={genre}
             field={state.form.field.name}
             guessCaseOptions={state.guessCaseOptions}
             isGuessCaseOptionsOpen={state.isGuessCaseOptionsOpen}
-            label={addColonText(l('Name'))}
+            label="Name:"
           />
           <FormRowTextLong
             field={state.form.field.comment}
-            label={addColonText(l('Disambiguation'))}
+            label="Disambiguation:"
             uncontrolled
           />
         </fieldset>
@@ -153,7 +153,7 @@ const GenreEditForm = ({
           seededRelationships={$c.stash.seeded_relationships}
         />
         <fieldset>
-          <legend>{l('External links')}</legend>
+          <legend>{'External links'}</legend>
           <ExternalLinksEditor
             isNewEntity={!genre.id}
             ref={externalLinksEditorRef}


### PR DESCRIPTION
Implement (more of) MBS-13117

# Description
A few admin-only files (mostly TT ones) were forgotten with https://github.com/metabrainz/musicbrainz-server/pull/3091 so this makes those also untranslatable. I also found one admin-only string in an otherwise standard file so I used `l_admin` for that one.

# Testing
Some manual testing to make sure the changes to the instrument page and the `l_admin` call both work.