### PR TITLE
MBS-13404: Avoid duplicating feat. artists

### DIFF
--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -16,6 +16,7 @@ import {
   reduceArtistCreditNames,
 } from '../common/immutable-entities.js';
 import MB from '../common/MB.js';
+import {arraysEqual} from '../common/utility/arrays.js';
 import {getSourceEntityData} from '../common/utility/catalyst.js';
 import clean from '../common/utility/clean.js';
 import {
@@ -202,13 +203,25 @@ releaseEditor.init = function (options) {
         const savedReleaseACLength = savedReleaseAC.names.length;
         const savedReleaseACReduced = reduceArtistCredit(savedReleaseAC);
 
+        /*
+         * Returns true if the supplied ArtistCreditNameT arrays include the
+         * same underlying artists.
+         */
+        const sameArtists = (a, b) => arraysEqual(a, b,
+          (a, b) => a.artist && b.artist && a.artist.gid === b.artist.gid);
+
         for (const medium of release.mediums()) {
           for (const track of medium.tracks()) {
             const trackAC = track.artistCredit();
-            if (reduceArtistCredit(trackAC) === savedReleaseACReduced) {
+            if (
+              reduceArtistCredit(trackAC) === savedReleaseACReduced ||
+              sameArtists(trackAC.names, releaseAC.names)
+            ) {
               /*
-               * If the track credits exactly match the old release credits,
-               * update them to use the new release credits.
+               * If the track credits exactly match the old release credits
+               * or the track credits include the same artists as the new
+               * release credits, update them to use the new release
+               * credits.
                */
               track.artistCredit(releaseAC);
               track.artistCreditEditorInst?.current?.setState({
@@ -225,11 +238,23 @@ releaseEditor.init = function (options) {
                * length of the release credits) track artists match the
                * release artists. This handles renaming primary artists on
                * tracks that also include featured artists (MBS-13273).
+               *
+               * Don't do anything if the track credits already start with
+               * the same artists as the new release credits to avoid
+               * duplicating artists in the case where the track is
+               * credited to "A & B feat. C" and the release is updated
+               * from "A" to "A & B" or "A feat. B".
                */
               const trackPrefix = reduceArtistCreditNames(
                 trackAC.names.slice(0, savedReleaseACLength), true,
               );
-              if (trackPrefix === savedReleaseACReduced) {
+              if (
+                trackPrefix === savedReleaseACReduced &&
+                !sameArtists(
+                  trackAC.names.slice(0, releaseAC.names.length),
+                  releaseAC.names,
+                )
+              ) {
                 /*
                  * Replace the old release artist(s) with the new one(s) and
                  * restore the old join phrase following the release artist.

--- a/root/static/scripts/tests/release-editor/seeds/mbs-13273.html
+++ b/root/static/scripts/tests/release-editor/seeds/mbs-13273.html
@@ -28,6 +28,12 @@
       <input type="hidden" name="mediums.0.track.4.name" value="Different Artist" />
       <input type="hidden" name="mediums.0.track.4.artist_credit.names.0.name" value="Bing Crosby" />
       <input type="hidden" name="mediums.0.track.4.artist_credit.names.0.mbid" value="2437980f-513a-44fc-80f1-b90d9d7fcf8f" />
+      <input type="hidden" name="mediums.0.track.5.name" value="New Artists, Different Join Phrase" />
+      <input type="hidden" name="mediums.0.track.5.artist_credit.names.0.name" value="Lethal Bizzle" />
+      <input type="hidden" name="mediums.0.track.5.artist_credit.names.0.mbid" value="1155431a-d35e-4863-9ae0-e3c24eb61aa9" />
+      <input type="hidden" name="mediums.0.track.5.artist_credit.names.0.join_phrase" value=" feat. " />
+      <input type="hidden" name="mediums.0.track.5.artist_credit.names.1.name" value="Super Furry Animals" />
+      <input type="hidden" name="mediums.0.track.5.artist_credit.names.1.mbid" value="c5f5dc27-3059-49c0-ae45-5009a01bb9ec" />
       <input type="hidden" name="edit_note" value="Testing MBS-13273" />
       <button type="submit">Submit</button>
     </form>

--- a/t/selenium/release-editor/MBS-13273.json5
+++ b/t/selenium/release-editor/MBS-13273.json5
@@ -54,8 +54,7 @@
       value: '',
     },
     // After switching to the tracklist tab, the first two tracks' artist credits should be updated
-    // since they began with the original release credits, but the remaining tracks' credits should
-    // be unchanged.
+    // since they began with the original release credits.
     {
       command: 'click',
       target: 'css=a[href="#tracklist"]',
@@ -71,6 +70,7 @@
       target: "document.querySelectorAll('#tracklist span.artist.autocomplete input.name')[1].value",
       value: 'Lethal Bizzle & Super Furry Animals feat. Bing Crosby',
     },
+    // These tracks' credits should be unchanged.
     {
       command: 'assertEval',
       target: "document.querySelectorAll('#tracklist span.artist.autocomplete input.name')[2].value",
@@ -85,6 +85,13 @@
       command: 'assertEval',
       target: "document.querySelectorAll('#tracklist span.artist.autocomplete input.name')[4].value",
       value: 'Bing Crosby',
+    },
+    // This track was credited to the new release artists but used ' feat. ' as its join phrase.
+    // The join phrase should be updated.
+    {
+      command: 'assertEval',
+      target: "document.querySelectorAll('#tracklist span.artist.autocomplete input.name')[5].value",
+      value: 'Lethal Bizzle & Super Furry Animals',
     },
     {
       command: 'open',


### PR DESCRIPTION
# MBS-13404

Fix a bug introduced by 2d82124e where tracklist artist credits could be duplicated when changing release artists.

When changing release credits to "A & B" while a track was already credited to "A feat. B", the track credits would be changed to "A & B feat. B". This change sets track credits to the new release credits (i.e. "A & B") if they already contain the same artists as the new release credits.

# Problem

As described at [this comment](https://tickets.metabrainz.org/browse/MBS-13273?focusedCommentId=70393&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-70393), 2d82124eb732026305d74cb0074888ee460c4aa7 could result in secondary artists getting duplicated in cases where the release and track artists didn't match.

Specifically, the change was (by design) updating tracklist credits in cases where they had a prefix matching the old release credits. If the release credited "A" and the track credited "A feat. B", then changing the release credit to "C" would update the track credit to "C feat. B". The problem arose if the release was instead updated to credit "A & B": the track would end up being credited to "A & B feat. B" in that case due to the matching "A" prefix.

# Solution

This change adds an additional "do the track credits and new release credits include the same artists?" condition for setting the track credits to the new release credits. In the previous example, since "A feat. B" and "A & B" both include A and B, the track credits will be set to "A & B", which is presumably the editor's intent in this case.

It also updates the shared-prefix case to avoid updating track credits if they start with the same artists as the new release credits. When the track credits are "A & B feat. C" and the release credits are changed from "A" to "A & B", this prevents erroneous "A & B & B feat. C" track credits.

# Action

I did some manual testing by replicating the situation described in the ticket: I created a release credited to "A" with a track credited to "A & B", and checked that when I changed the release credit to "A feat. B" the track credit was updated to "A feat. B" rather than "A feat. B & B". I also checked that tracks credited to "A & B feat. C" would be left alone in this case rather than being updated to "A feat. B & B feat. C". More manual testing would be appreciated!

I also updated the existing Selenium test for MBS-13273 to include a track already credited to the new release artists to verify that it would be updated as expected. This isn't exactly the same as the situation described in the ticket (the test would probably need to create another release for that), but it should at least be exercising the new code path.

Please let me know if this seems to be getting too complicated. :-/