### PR TITLE
MBS-13401: Also load data quality for track releases

### DIFF
--- a/lib/MusicBrainz/Server/Data/Track.pm
+++ b/lib/MusicBrainz/Server/Data/Track.pm
@@ -169,6 +169,7 @@ sub find_by_recording
                 release.packaging AS r_packaging,
                 release.edits_pending AS r_edits_pending,
                 release.comment AS r_comment,
+                release.quality AS r_quality,
             date_year, date_month, date_day
           FROM track
           JOIN medium ON medium.id = track.medium


### PR DESCRIPTION
### Implement MBS-13401

# Problem
There's currently no way to see whether the releases a recording appears on are high, low or normal data quality from the recording page. This would be a useful way to see what releases might, for example, have the recording assigned wrongly.

# Solution
This loads data quality on `Track::find_by_recording`, allowing us to display the correct data quality icon in the recording index page.

# Testing
Manually, with `/recording/01a066a8-f4ec-4261-bf3e-0453c76d20b7` in main DB, which has one release with low data quality and one with normal/default data quality.