### PR TITLE
Avoid translating more messages for relationship type editors

### DIFF
--- a/root/relationship/linkattributetype/DeleteRelationshipAttributeType.js
+++ b/root/relationship/linkattributetype/DeleteRelationshipAttributeType.js
@@ -20,12 +20,12 @@ const DeleteRelationshipAttributeType = ({
 }: Props): React$Element<typeof ConfirmLayout> => (
   <ConfirmLayout
     form={form}
-    question={exp.l(
+    question={exp.l_admin(
       `Are you sure you wish to remove the
        <strong>{link_attr_type}</strong> relationship attribute?`,
       {link_attr_type: type.name},
     )}
-    title={l('Remove relationship attribute')}
+    title="Remove relationship attribute"
   />
 );
 

--- a/root/relationship/linkattributetype/RelationshipAttributeTypeInUse.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypeInUse.js
@@ -16,11 +16,11 @@ type Props = {
 const RelationshipAttributeTypeInUse = ({
   type,
 }: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Relationship attribute in use')}>
+  <Layout fullWidth title="Relationship attribute in use">
     <div className="content">
-      <h1>{l('Relationship attribute in use')}</h1>
+      <h1>{'Relationship attribute in use'}</h1>
       <p>
-        {texp.l(
+        {texp.l_admin(
           `The relationship attribute type “{type}” can’t be removed
            because it’s still in use.`,
           {type: type.name},

--- a/root/relationship/linkattributetype/RelationshipAttributeTypesList.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypesList.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import {SanitizedCatalystContext} from '../../context.mjs';
 import Layout from '../../layout/index.js';
+import {l_admin} from '../../static/scripts/common/i18n/admin.js'
 import expand2react from '../../static/scripts/common/i18n/expand2react.js';
 import bracketed, {bracketedText}
   from '../../static/scripts/common/utility/bracketed.js';
@@ -59,7 +60,7 @@ const AttributeDetails = ({
             <a
               href={'/relationship-attributes/create?parent=' + attribute.gid}
             >
-              {l('Add child')}
+              {l_admin('Add child')}
             </a>
             {' | '}
           </>
@@ -181,7 +182,7 @@ const RelationshipAttributeTypesList = ({
         {isRelationshipEditor($c.user) ? (
           <p>
             <a href="/relationship-attributes/create">
-              {l('Add a new relationship attribute')}
+              {l_admin('Add a new relationship attribute')}
             </a>
           </p>
         ) : null}

--- a/root/relationship/linktype/DeleteRelationshipType.js
+++ b/root/relationship/linktype/DeleteRelationshipType.js
@@ -20,12 +20,12 @@ const DeleteRelationshipType = ({
 }: Props): React$Element<typeof ConfirmLayout> => (
   <ConfirmLayout
     form={form}
-    question={exp.l(
+    question={exp.l_admin(
       `Are you sure you wish to remove the
        <strong>{link_type}</strong> relationship type?`,
       {link_type: type.name},
     )}
-    title={l('Remove relationship type')}
+    title="Remove relationship type"
   />
 );
 

--- a/root/relationship/linktype/RelationshipTypeInUse.js
+++ b/root/relationship/linktype/RelationshipTypeInUse.js
@@ -16,11 +16,11 @@ type Props = {
 const RelationshipTypeInUse = ({
   type,
 }: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Relationship type in use')}>
+  <Layout fullWidth title="Relationship type in use">
     <div className="content">
-      <h1>{l('Relationship type in use')}</h1>
+      <h1>{'Relationship type in use'}</h1>
       <p>
-        {texp.l(
+        {texp.l_admin(
           `The relationship type “{type}” can’t be removed
            because it’s still in use.`,
           {type: type.name},

--- a/root/relationship/linktype/RelationshipTypePairTree.js
+++ b/root/relationship/linktype/RelationshipTypePairTree.js
@@ -199,7 +199,7 @@ const RelationshipTypePairTree = ({
         {isRelationshipEditor($c.user) ? (
           <p>
             <a href={'/relationships/' + type0 + '-' + type1 + '/create'}>
-              {texp.l(
+              {texp.l_admin(
                 'Add a new {type0}-{type1} relationship type',
                 {type0: formattedType0, type1: formattedType1},
               )}


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Messages which are exclusively addressed to relationship type editors (who are required to speak English to some extent anyway) do not need to be translated in several languages and to increase the burden on translators.

This has been mostly resolved with the pull request #3120 but a few files have been left behind.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

- Drop `l` calls from files addressed to relationship type editors only
- Use `l_admin` in files addressed to normal editors too
- Use `exp.l_admin` (or `texp.l_admin`) when needed for cleanup and interpolation


# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Tested locally