### PR TITLE
MBS-13405: Also infer rel dirs when adding artists

### DIFF
--- a/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
@@ -225,6 +225,7 @@ function inferLinkDirection(
     linkTypeId !== null &&
     personGroupLinkTypeIds.has(linkTypeId)
   ) {
+    const isSourceUnset = source.typeID === null;
     const isSourcePerson = source.typeID === ARTIST_TYPE_PERSON;
     const isSourceGroup =
       source.typeID !== null && ARTIST_GROUP_TYPES.has(source.typeID);
@@ -233,10 +234,13 @@ function inferLinkDirection(
     const isTargetGroup =
       target.typeID !== null && ARTIST_GROUP_TYPES.has(target.typeID);
 
-
-    if (isSourcePerson && isTargetGroup) {
+    /*
+     * The source's type will be unset if the entity hasn't been added yet,
+     * so make an inference based on the target's type in that case.
+     */
+    if ((isSourcePerson || isSourceUnset) && isTargetGroup) {
       newState.backward = false;
-    } else if (isSourceGroup && isTargetPerson) {
+    } else if ((isSourceGroup || isSourceUnset) && isTargetPerson) {
       newState.backward = true;
     }
   }

--- a/t/selenium/Artist_Edit_Form.json5
+++ b/t/selenium/Artist_Edit_Form.json5
@@ -127,11 +127,6 @@
     },
     {
       command: 'click',
-      target: 'css=#add-relationship-dialog button.change-direction',
-      value: '',
-    },
-    {
-      command: 'click',
       target: 'css=#add-relationship-dialog button.positive',
       value: '',
     },

--- a/t/selenium/MBS-2604.json5
+++ b/t/selenium/MBS-2604.json5
@@ -55,5 +55,66 @@
       target: 'css=#add-relationship-dialog table.preview td',
       value: 'David Bowie is/was a member of Nine Inch Nails',
     },
+    // Start adding a new artist and check that relationship directions
+    // are inferred based on the target artist's type (see MBS-13405).
+    {
+      command: 'open',
+      target: '/artist/create',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=id-edit-artist.name',
+      value: 'Test Artist',
+    },
+    {
+      command: 'click',
+      target: 'css=#relationship-editor button.add-item',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-type',
+      value: 'member${KEY_ENTER}',
+    },
+    // Create a member-of/members relationship with David Bowie
+    // (type "Person").
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: '5441c29d-3602-4898-b1a1-b77fa23b8e50',
+    },
+    {
+      command: 'assertText',
+      target: 'css=#add-relationship-dialog table.preview td',
+      value: 'David Bowie is/was a member of Test Artist',
+    },
+    // Create a member-of/members relationship with Nine Inch Nails
+    // (type "Group").
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: 'b7ffd2af-418f-4be2-bdd1-22f8b48613da',
+    },
+    {
+      command: 'assertText',
+      target: 'css=#add-relationship-dialog table.preview td',
+      value: 'Test Artist is/was a member of Nine Inch Nails',
+    },
+    {
+      command: 'open',
+      target: '/',
+      value: '',
+    },
+    {
+      command: 'handleAlert',
+      target: 'accept',
+      value: '',
+    },
+    {
+      command: 'waitUntilUrlIs',
+      target: '/',
+      value: '',
+    },
   ],
 }


### PR DESCRIPTION
# MBS-13405

When adding a new artist, infer the correct direction for an individual-to-group relationship from the target artist's type.

# Problem

54f9433c39c73c4390fcca9c525789db4dc21df1 made the "Edit artist" form infer the correct direction for individual-to-group artist relationships (e.g. member-of/members) based on the types (e.g. Person, Group, etc.) of the source and target entities. This didn't work when adding a new artist, since the source type is null.

# Solution

Even if the source type is unknown, it's possible to infer the correct direction based on the target entity's type. For example, a "member of" relationship is probably correct if the target is a group, and a "members" relationship is probably correct if the target is a person.

# Action

I did some manual testing, but more is always appreciated.

I also updated the existing Selenium test that I added for MBS-2604 to exercise the new behavior.