### PR TITLE
Remove bogus evalnochange stats

### DIFF
--- a/lib/MusicBrainz/Server/Data/Statistics.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics.pm
@@ -1309,7 +1309,6 @@ my %stats = (
                 'count.edit.faileddep'      => $dist{$STATUS_FAILEDDEP}     || 0,
                 'count.edit.error'          => $dist{$STATUS_ERROR}         || 0,
                 'count.edit.failedprereq'   => $dist{$STATUS_FAILEDPREREQ}  || 0,
-                'count.edit.evalnochange'   => 0,
                 'count.edit.deleted'        => $dist{$STATUS_DELETED}       || 0,
             };
         },
@@ -1341,12 +1340,6 @@ my %stats = (
     },
     'count.edit.failedprereq' => {
         DESC => 'Count of edits which failed because a prerequisitite moderation failed',
-        PREREQ => [qw[ count.edit.open ]],
-        PREREQ_ONLY => 1,
-        NONREPLICATED => 1,
-    },
-    'count.edit.evalnochange' => {
-        DESC => 'Count of evalnochange edits',
         PREREQ => [qw[ count.edit.open ]],
         PREREQ_ONLY => 1,
         NONREPLICATED => 1,

--- a/root/statistics/stats.js
+++ b/root/statistics/stats.js
@@ -303,11 +303,6 @@ const stats = {
     color: '#ff0000',
     label: l('Error edits'),
   },
-  'count.edit.evalnochange': {
-    category: 'edit-information',
-    color: '#ff0000',
-    label: l('Evalnochange edits'),
-  },
   'count.edit.faileddep': {
     category: 'edit-information',
     color: '#ff0000',


### PR DESCRIPTION
`count.edit.evalnochange` is hardcoded as "0" in the statistics table, and doesn't appear to have any use. The string "Evalnochange edits" is confusing to translators, because it doesn't correspond to anything that exists.

I found this mention of it from 2003-12-08 (happy belated birthday!):
```
  <djce> ruaok: hmmm... somehow your server has heard about
         ModDefs::STATUS_EVALNOCHANGE, even though it doesn't exist any more,
         and isn't in the codebase.
```