### PR TITLE
MBS-13449: Reimplement transactional cache without database locks

### DIFF
--- a/docker/musicbrainz-tests/DBDefs.pm
+++ b/docker/musicbrainz-tests/DBDefs.pm
@@ -81,6 +81,7 @@ sub CACHE_MANAGER_OPTIONS {
                 options => {
                     server => 'localhost:6379',
                     namespace => $self->CACHE_NAMESPACE,
+                    database => 0,
                 },
             },
         },
@@ -104,7 +105,6 @@ sub DATASTORE_REDIS_ARGS {
         database => 0,
         namespace => $self->CACHE_NAMESPACE,
         server => 'localhost:6379',
-        test_database => 1,
     };
 }
 
@@ -134,6 +134,7 @@ sub PLUGIN_CACHE_OPTIONS {
         class => 'MusicBrainz::Server::CacheWrapper::Redis',
         server => 'localhost:6379',
         namespace => $self->CACHE_NAMESPACE . 'Catalyst:',
+        database => 0,
     };
 }
 

--- a/entities.json
+++ b/entities.json
@@ -14,9 +14,6 @@
         "annotations": {
             "edit_type": 85
         },
-        "cache": {
-            "id": 1
-        },
         "collections": true,
         "custom_tabs": [
             "artists",
@@ -50,16 +47,10 @@
         "url": "area"
     },
     "area_alias_type": {
-        "cache": {
-            "id": 39
-        },
         "model": "AreaAliasType",
         "table": "area_alias_type"
     },
     "area_type": {
-        "cache": {
-            "id": 2
-        },
         "model": "AreaType"
     },
     "artist": {
@@ -72,9 +63,6 @@
         },
         "annotations": {
             "edit_type": 5
-        },
-        "cache": {
-            "id": 3
         },
         "collections": true,
         "custom_tabs": [
@@ -128,22 +116,13 @@
         "url": "artist"
     },
     "artist_alias_type": {
-        "cache": {
-            "id": 40
-        },
         "model": "ArtistAliasType",
         "table": "artist_alias_type"
     },
     "artist_credit": {
-        "cache": {
-            "id": 4
-        },
         "model": "ArtistCredit"
     },
     "artist_type": {
-        "cache": {
-            "id": 5
-        },
         "model": "ArtistType"
     },
     "cdstub": {
@@ -172,15 +151,9 @@
         "url": "collection"
     },
     "collection_type": {
-        "cache": {
-            "id": 6
-        },
         "model": "CollectionType"
     },
     "cover_art_type": {
-        "cache": {
-            "id": 7
-        },
         "model": "CoverArtType"
     },
     "editor": {
@@ -201,9 +174,6 @@
         },
         "annotations": {
             "edit_type": 154
-        },
-        "cache": {
-            "id": 8
         },
         "collections": true,
         "date_period": true,
@@ -233,22 +203,13 @@
         "url": "event"
     },
     "event_alias_type": {
-        "cache": {
-            "id": 41
-        },
         "model": "EventAliasType",
         "table": "event_alias_type"
     },
     "event_type": {
-        "cache": {
-            "id": 9
-        },
         "model": "EventType"
     },
     "gender": {
-        "cache": {
-            "id": 10
-        },
         "model": "Gender"
     },
     "genre": {
@@ -261,9 +222,6 @@
         },
         "annotations": {
             "edit_type": 164
-        },
-        "cache": {
-            "id": 333
         },
         "disambiguation": true,
         "edit_table": true,
@@ -282,9 +240,6 @@
         "url": "genre"
     },
     "genre_alias_type": {
-        "cache": {
-            "id": 50
-        },
         "model": "GenreAliasType",
         "table": "genre_alias_type"
     },
@@ -298,9 +253,6 @@
         },
         "annotations": {
             "edit_type": 135
-        },
-        "cache": {
-            "id": 11
         },
         "collections": true,
         "custom_tabs": [
@@ -330,16 +282,10 @@
         "url": "instrument"
     },
     "instrument_alias_type": {
-        "cache": {
-            "id": 42
-        },
         "model": "InstrumentAliasType",
         "table": "instrument_alias_type"
     },
     "instrument_type": {
-        "cache": {
-            "id": 12
-        },
         "model": "InstrumentType"
     },
     "isrc": {
@@ -360,9 +306,6 @@
         },
         "annotations": {
             "edit_type": 15
-        },
-        "cache": {
-            "id": 13
         },
         "collections": true,
         "date_period": true,
@@ -407,41 +350,23 @@
         "url": "label"
     },
     "label_alias_type": {
-        "cache": {
-            "id": 43
-        },
         "model": "LabelAliasType",
         "table": "label_alias_type"
     },
     "label_type": {
-        "cache": {
-            "id": 14
-        },
         "model": "LabelType"
     },
     "language": {
-        "cache": {
-            "id": 15
-        },
         "model": "Language"
     },
     "link": {
-        "cache": {
-            "id": 16
-        },
         "model": "Link"
     },
     "link_attribute_type": {
-        "cache": {
-            "id": 17
-        },
         "last_updated_column": true,
         "model": "LinkAttributeType"
     },
     "link_type": {
-        "cache": {
-            "id": 18
-        },
         "last_updated_column": true,
         "mbid": {
             "relatable": false
@@ -456,9 +381,6 @@
         "model": "MediumCDTOC"
     },
     "medium_format": {
-        "cache": {
-            "id": 19
-        },
         "model": "MediumFormat"
     },
     "place": {
@@ -471,9 +393,6 @@
         },
         "annotations": {
             "edit_type": 65
-        },
-        "cache": {
-            "id": 20
         },
         "collections": true,
         "custom_tabs": [
@@ -507,16 +426,10 @@
         "url": "place"
     },
     "place_alias_type": {
-        "cache": {
-            "id": 44
-        },
         "model": "PlaceAliasType",
         "table": "place_alias_type"
     },
     "place_type": {
-        "cache": {
-            "id": 21
-        },
         "model": "PlaceType"
     },
     "recording": {
@@ -531,9 +444,6 @@
             "edit_type": 75
         },
         "artist_credits": true,
-        "cache": {
-            "id": 22
-        },
         "collections": true,
         "custom_tabs": [
             "fingerprints"
@@ -562,9 +472,6 @@
         "url": "recording"
     },
     "recording_alias_type": {
-        "cache": {
-            "id": 45
-        },
         "model": "RecordingAliasType",
         "table": "recording_alias_type"
     },
@@ -580,9 +487,6 @@
             "edit_type": 35
         },
         "artist_credits": true,
-        "cache": {
-            "id": 23
-        },
         "collections": true,
         "cover_art": true,
         "disambiguation": true,
@@ -608,9 +512,6 @@
         "url": "release"
     },
     "release_alias_type": {
-        "cache": {
-            "id": 46
-        },
         "model": "ReleaseAliasType",
         "table": "release_alias_type"
     },
@@ -626,9 +527,6 @@
             "edit_type": 25
         },
         "artist_credits": true,
-        "cache": {
-            "id": 24
-        },
         "collections": true,
         "disambiguation": true,
         "edit_table": true,
@@ -662,40 +560,22 @@
         "url": "release-group"
     },
     "release_group_alias_type": {
-        "cache": {
-            "id": 47
-        },
         "model": "ReleaseGroupAliasType",
         "table": "release_group_alias_type"
     },
     "release_group_secondary_type": {
-        "cache": {
-            "id": 25
-        },
         "model": "ReleaseGroupSecondaryType"
     },
     "release_group_type": {
-        "cache": {
-            "id": 26
-        },
         "model": "ReleaseGroupType"
     },
     "release_packaging": {
-        "cache": {
-            "id": 27
-        },
         "model": "ReleasePackaging"
     },
     "release_status": {
-        "cache": {
-            "id": 28
-        },
         "model": "ReleaseStatus"
     },
     "script": {
-        "cache": {
-            "id": 29
-        },
         "model": "Script"
     },
     "series": {
@@ -708,9 +588,6 @@
         },
         "annotations": {
             "edit_type": 144
-        },
-        "cache": {
-            "id": 30
         },
         "collections": true,
         "disambiguation": true,
@@ -740,28 +617,16 @@
         "url": "series"
     },
     "series_alias_type": {
-        "cache": {
-            "id": 48
-        },
         "model": "SeriesAliasType",
         "table": "series_alias_type"
     },
     "series_ordering_type": {
-        "cache": {
-            "id": 31
-        },
         "model": "SeriesOrderingType"
     },
     "series_type": {
-        "cache": {
-            "id": 32
-        },
         "model": "SeriesType"
     },
     "tag": {
-        "cache": {
-            "id": 33
-        },
         "model": "Tag"
     },
     "track": {
@@ -803,9 +668,6 @@
         "annotations": {
             "edit_type": 45
         },
-        "cache": {
-            "id": 34
-        },
         "collections": true,
         "disambiguation": true,
         "edit_table": true,
@@ -835,34 +697,19 @@
         "url": "work"
     },
     "work_alias_type": {
-        "cache": {
-            "id": 49
-        },
         "model": "WorkAliasType",
         "table": "work_alias_type"
     },
     "work_attribute": {
-        "cache": {
-            "id": 35
-        },
         "model": "WorkAttribute"
     },
     "work_attribute_type": {
-        "cache": {
-            "id": 36
-        },
         "model": "WorkAttributeType"
     },
     "work_attribute_type_allowed_value": {
-        "cache": {
-            "id": 37
-        },
         "model": "WorkAttributeTypeAllowedValue"
     },
     "work_type": {
-        "cache": {
-            "id": 38
-        },
         "model": "WorkType"
     }
 }

--- a/entities.mjs
+++ b/entities.mjs
@@ -36,9 +36,6 @@ const ENTITIES = {
     annotations: {
       edit_type: 85,
     },
-    cache: {
-      id: 1,
-    },
     collections: true,
     custom_tabs: ([
       'artists',
@@ -72,16 +69,10 @@ const ENTITIES = {
     url: 'area',
   },
   area_alias_type: {
-    cache: {
-      id: 39,
-    },
     model: 'AreaAliasType',
     table: 'area_alias_type',
   },
   area_type: {
-    cache: {
-      id: 2,
-    },
     model: 'AreaType',
   },
   artist: {
@@ -94,9 +85,6 @@ const ENTITIES = {
     },
     annotations: {
       edit_type: 5,
-    },
-    cache: {
-      id: 3,
     },
     collections: true,
     custom_tabs: ([
@@ -150,22 +138,13 @@ const ENTITIES = {
     url: 'artist',
   },
   artist_alias_type: {
-    cache: {
-      id: 40,
-    },
     model: 'ArtistAliasType',
     table: 'artist_alias_type',
   },
   artist_credit: {
-    cache: {
-      id: 4,
-    },
     model: 'ArtistCredit',
   },
   artist_type: {
-    cache: {
-      id: 5,
-    },
     model: 'ArtistType',
   },
   cdstub: {
@@ -194,15 +173,9 @@ const ENTITIES = {
     url: 'collection',
   },
   collection_type: {
-    cache: {
-      id: 6,
-    },
     model: 'CollectionType',
   },
   cover_art_type: {
-    cache: {
-      id: 7,
-    },
     model: 'CoverArtType',
   },
   editor: {
@@ -223,9 +196,6 @@ const ENTITIES = {
     },
     annotations: {
       edit_type: 154,
-    },
-    cache: {
-      id: 8,
     },
     collections: true,
     date_period: true,
@@ -255,22 +225,13 @@ const ENTITIES = {
     url: 'event',
   },
   event_alias_type: {
-    cache: {
-      id: 41,
-    },
     model: 'EventAliasType',
     table: 'event_alias_type',
   },
   event_type: {
-    cache: {
-      id: 9,
-    },
     model: 'EventType',
   },
   gender: {
-    cache: {
-      id: 10,
-    },
     model: 'Gender',
   },
   genre: {
@@ -283,9 +244,6 @@ const ENTITIES = {
     },
     annotations: {
       edit_type: 164,
-    },
-    cache: {
-      id: 333,
     },
     disambiguation: true,
     edit_table: true,
@@ -304,9 +262,6 @@ const ENTITIES = {
     url: 'genre',
   },
   genre_alias_type: {
-    cache: {
-      id: 50,
-    },
     model: 'GenreAliasType',
     table: 'genre_alias_type',
   },
@@ -320,9 +275,6 @@ const ENTITIES = {
     },
     annotations: {
       edit_type: 135,
-    },
-    cache: {
-      id: 11,
     },
     collections: true,
     custom_tabs: ([
@@ -352,16 +304,10 @@ const ENTITIES = {
     url: 'instrument',
   },
   instrument_alias_type: {
-    cache: {
-      id: 42,
-    },
     model: 'InstrumentAliasType',
     table: 'instrument_alias_type',
   },
   instrument_type: {
-    cache: {
-      id: 12,
-    },
     model: 'InstrumentType',
   },
   isrc: {
@@ -382,9 +328,6 @@ const ENTITIES = {
     },
     annotations: {
       edit_type: 15,
-    },
-    cache: {
-      id: 13,
     },
     collections: true,
     date_period: true,
@@ -429,41 +372,23 @@ const ENTITIES = {
     url: 'label',
   },
   label_alias_type: {
-    cache: {
-      id: 43,
-    },
     model: 'LabelAliasType',
     table: 'label_alias_type',
   },
   label_type: {
-    cache: {
-      id: 14,
-    },
     model: 'LabelType',
   },
   language: {
-    cache: {
-      id: 15,
-    },
     model: 'Language',
   },
   link: {
-    cache: {
-      id: 16,
-    },
     model: 'Link',
   },
   link_attribute_type: {
-    cache: {
-      id: 17,
-    },
     last_updated_column: true,
     model: 'LinkAttributeType',
   },
   link_type: {
-    cache: {
-      id: 18,
-    },
     last_updated_column: true,
     mbid: {
       relatable: false,
@@ -478,9 +403,6 @@ const ENTITIES = {
     model: 'MediumCDTOC',
   },
   medium_format: {
-    cache: {
-      id: 19,
-    },
     model: 'MediumFormat',
   },
   place: {
@@ -493,9 +415,6 @@ const ENTITIES = {
     },
     annotations: {
       edit_type: 65,
-    },
-    cache: {
-      id: 20,
     },
     collections: true,
     custom_tabs: ([
@@ -529,16 +448,10 @@ const ENTITIES = {
     url: 'place',
   },
   place_alias_type: {
-    cache: {
-      id: 44,
-    },
     model: 'PlaceAliasType',
     table: 'place_alias_type',
   },
   place_type: {
-    cache: {
-      id: 21,
-    },
     model: 'PlaceType',
   },
   recording: {
@@ -553,9 +466,6 @@ const ENTITIES = {
       edit_type: 75,
     },
     artist_credits: true,
-    cache: {
-      id: 22,
-    },
     collections: true,
     custom_tabs: ([
       'fingerprints',
@@ -584,9 +494,6 @@ const ENTITIES = {
     url: 'recording',
   },
   recording_alias_type: {
-    cache: {
-      id: 45,
-    },
     model: 'RecordingAliasType',
     table: 'recording_alias_type',
   },
@@ -602,9 +509,6 @@ const ENTITIES = {
       edit_type: 35,
     },
     artist_credits: true,
-    cache: {
-      id: 23,
-    },
     collections: true,
     cover_art: true,
     disambiguation: true,
@@ -630,9 +534,6 @@ const ENTITIES = {
     url: 'release',
   },
   release_alias_type: {
-    cache: {
-      id: 46,
-    },
     model: 'ReleaseAliasType',
     table: 'release_alias_type',
   },
@@ -648,9 +549,6 @@ const ENTITIES = {
       edit_type: 25,
     },
     artist_credits: true,
-    cache: {
-      id: 24,
-    },
     collections: true,
     disambiguation: true,
     edit_table: true,
@@ -684,40 +582,22 @@ const ENTITIES = {
     url: 'release-group',
   },
   release_group_alias_type: {
-    cache: {
-      id: 47,
-    },
     model: 'ReleaseGroupAliasType',
     table: 'release_group_alias_type',
   },
   release_group_secondary_type: {
-    cache: {
-      id: 25,
-    },
     model: 'ReleaseGroupSecondaryType',
   },
   release_group_type: {
-    cache: {
-      id: 26,
-    },
     model: 'ReleaseGroupType',
   },
   release_packaging: {
-    cache: {
-      id: 27,
-    },
     model: 'ReleasePackaging',
   },
   release_status: {
-    cache: {
-      id: 28,
-    },
     model: 'ReleaseStatus',
   },
   script: {
-    cache: {
-      id: 29,
-    },
     model: 'Script',
   },
   series: {
@@ -730,9 +610,6 @@ const ENTITIES = {
     },
     annotations: {
       edit_type: 144,
-    },
-    cache: {
-      id: 30,
     },
     collections: true,
     disambiguation: true,
@@ -762,28 +639,16 @@ const ENTITIES = {
     url: 'series',
   },
   series_alias_type: {
-    cache: {
-      id: 48,
-    },
     model: 'SeriesAliasType',
     table: 'series_alias_type',
   },
   series_ordering_type: {
-    cache: {
-      id: 31,
-    },
     model: 'SeriesOrderingType',
   },
   series_type: {
-    cache: {
-      id: 32,
-    },
     model: 'SeriesType',
   },
   tag: {
-    cache: {
-      id: 33,
-    },
     model: 'Tag',
   },
   track: {
@@ -825,9 +690,6 @@ const ENTITIES = {
     annotations: {
       edit_type: 45,
     },
-    cache: {
-      id: 34,
-    },
     collections: true,
     disambiguation: true,
     edit_table: true,
@@ -857,34 +719,19 @@ const ENTITIES = {
     url: 'work',
   },
   work_alias_type: {
-    cache: {
-      id: 49,
-    },
     model: 'WorkAliasType',
     table: 'work_alias_type',
   },
   work_attribute: {
-    cache: {
-      id: 35,
-    },
     model: 'WorkAttribute',
   },
   work_attribute_type: {
-    cache: {
-      id: 36,
-    },
     model: 'WorkAttributeType',
   },
   work_attribute_type_allowed_value: {
-    cache: {
-      id: 37,
-    },
     model: 'WorkAttributeTypeAllowedValue',
   },
   work_type: {
-    cache: {
-      id: 38,
-    },
     model: 'WorkType',
   },
 };

--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -289,21 +289,12 @@ sub WEB_SERVER                { 'www.musicbrainz.example.com' }
 # sub SESSION_STORE_ARGS { return {} }
 # sub SESSION_EXPIRE { return 36000; } # 10 hours
 
-# Redis by default has 16 numbered databases available, of which DB 0
-# is the default.  Here you can configure which of these databases are
-# used by musicbrainz-server.
-#
-# test_database will be completely erased on each test run, so make
-# sure it doesn't point at any production data you may have in your
-# redis server.
-
 # sub DATASTORE_REDIS_ARGS {
 #     my $self = shift;
 #     return {
 #         database => 0,
 #         namespace => $self->CACHE_NAMESPACE,
 #         server => '127.0.0.1:6379',
-#         test_database => 1,
 #     };
 # }
 

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -192,6 +192,21 @@ sub GOOGLE_CUSTOM_SEARCH { '' }
 # you use it in your own definitions.
 sub CACHE_NAMESPACE { 'MB:' }
 
+# Redis by default has 16 numbered databases available, of which DB 0 is the
+# default. You can configure which of these databases are used by
+# musicbrainz-server via the `database` properties in `PLUGIN_CACHE_OPTIONS`,
+# `CACHE_MANAGER_OPTIONS`, and `DATASTORE_REDIS_ARGS`. It is not recommended
+# to change the default of 0 unless you are sharing a Redis instance with
+# other services. (We do not advise this; please heed the note about
+# `REDIS_TEST_DATABASE` below, or suffer data loss.)
+#
+# `REDIS_TEST_DATABASE` indicates the minimum DB number used when running
+# tests. This is used for both the cache and the store. Note that the tests
+# may use additional DB numbers greater than or equal to
+# `REDIS_TEST_DATABASE`, and that all production DB numbers should be less
+# than it. All test databases will be completely erased on each test run.
+sub REDIS_TEST_DATABASE { 1 }
+
 # PLUGIN_CACHE_OPTIONS are the options configured for Plugin::Cache.  $c->cache
 # is provided by Plugin::Cache, and is required for HTTP Digest authentication
 # in the webservice (Catalyst::Authentication::Credential::HTTP).
@@ -201,6 +216,7 @@ sub PLUGIN_CACHE_OPTIONS {
         class => 'MusicBrainz::Server::CacheWrapper::Redis',
         server => '127.0.0.1:6379',
         namespace => $self->CACHE_NAMESPACE . 'Catalyst:',
+        database => 0,
     };
 }
 
@@ -215,6 +231,7 @@ sub CACHE_MANAGER_OPTIONS {
                 options => {
                     server => '127.0.0.1:6379',
                     namespace => $self->CACHE_NAMESPACE,
+                    database => 0,
                 },
             },
         },
@@ -248,21 +265,12 @@ sub SESSION_STORE { 'Session::Store::MusicBrainz' }
 sub SESSION_STORE_ARGS { return {} }
 sub SESSION_EXPIRE { return 36000; } # 10 hours
 
-# Redis by default has 16 numbered databases available, of which DB 0
-# is the default.  Here you can configure which of these databases are
-# used by musicbrainz-server.
-#
-# test_database will be completely erased on each test run, so make
-# sure it doesn't point at any production data you may have in your
-# redis server.
-
 sub DATASTORE_REDIS_ARGS {
     my $self = shift;
     return {
         database => 0,
         namespace => $self->CACHE_NAMESPACE,
         server => '127.0.0.1:6379',
-        test_database => 1,
     };
 }
 

--- a/lib/MusicBrainz/Server/Context.pm
+++ b/lib/MusicBrainz/Server/Context.pm
@@ -121,6 +121,14 @@ sub create_script_context
     return MusicBrainz::Server::Context->new(cache_manager => $cache_manager, database => 'MAINTENANCE', %args);
 }
 
+# `DBDefs::DETERMINE_MAX_REQUEST_TIME` must be called with a Catalyst request
+# object. This attribute stores the result of that call so it can be accessed
+# in the data layer.
+has 'max_request_time' => (
+    is => 'rw',
+    isa => 'Maybe[Int]',
+);
+
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/Context.pm
+++ b/lib/MusicBrainz/Server/Context.pm
@@ -13,8 +13,16 @@ use LWP::UserAgent;
 has 'cache_manager' => (
     is => 'ro',
     isa => 'MusicBrainz::Server::CacheManager',
+    lazy => 1,
+    builder => '_build_cache_manager',
+    clearer => 'clear_cache_manager',
     handles => [ 'cache' ],
 );
+
+sub _build_cache_manager {
+    my $cache_opts = DBDefs->CACHE_MANAGER_OPTIONS;
+    return MusicBrainz::Server::CacheManager->new($cache_opts);
+}
 
 has 'connector' => (
     is => 'ro',
@@ -84,8 +92,11 @@ has store => (
     is => 'ro',
     does => 'MusicBrainz::DataStore',
     lazy => 1,
-    default => sub { MusicBrainz::DataStore::RedisMulti->new },
+    builder => '_build_store',
+    clearer => 'clear_store',
 );
+
+sub _build_store { MusicBrainz::DataStore::RedisMulti->new }
 
 # This is not the Catalyst stash, but it's used by
 # MusicBrainz::Server::JSONLookup to trick some controller methods into

--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -339,7 +339,13 @@ sub delete
     return 1;
 }
 
-sub merge
+sub merge {
+    my ($self, $new_id, @old_ids) = @_;
+
+    $self->merge_with_opts($new_id, \@old_ids);
+}
+
+sub merge_with_opts
 {
     my ($self, $new_id, $old_ids, %opts) = @_;
 

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -1714,6 +1714,8 @@ sub update_amazon_asin {
             { id => $release->id },
         );
     }
+
+    $self->_delete_from_cache($release_id);
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
+++ b/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
@@ -31,12 +31,12 @@ around get_by_ids => sub {
     my %ids = map { $_ => 1 } @ids;
     my @keys = map { $self->_type . ':' . $_ } keys %ids;
     my $cache = $self->c->cache($self->_type);
-    my %data = %{$cache->get_multi(@keys)};
+    my %cached_data = %{ $cache->get_multi(@keys) };
     my %result;
-    foreach my $key (keys %data) {
+    foreach my $key (keys %cached_data) {
         my @key = split /:/, $key;
         my $id = $key[1];
-        $result{$id} = $data{$key};
+        $result{$id} = $cached_data{$key};
         delete $ids{$id};
     }
     if (%ids) {

--- a/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
+++ b/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
@@ -3,32 +3,67 @@ package MusicBrainz::Server::Data::Role::EntityCache;
 use DBDefs;
 use Moose::Role;
 use namespace::autoclean;
-use List::AllUtils qw( natatime uniq );
-use MusicBrainz::Server::Constants qw( %ENTITIES );
-use MusicBrainz::Server::Log qw( log_debug );
-use MusicBrainz::Server::Validation qw( is_database_row_id );
+use List::AllUtils qw( uniq );
 use Readonly;
-use Time::HiRes qw( time );
 
 requires '_type';
 
+=head1 Cache invalidation and locking
+
+In order to prevent stale entities from being repopulated in the cache after
+another process invalidates those entries (MBS-7241), we track which entity
+IDs were recently invalidated in our Redis store. (In production, MBS uses
+two Redis instances: one as an LRU cache for entity data, and another as a
+persistent data store, mainly for login sessions.) As an example, consider
+the following sequence of events:
+
+ 1. Request A updates artist ID=123 and calls _delete_from_cache(123). In our
+    persistent Redis store, we set `artist:recently_invalidated:123` to '1'.
+    In our Redis cache, we delete `artist:123`. (While cache addition is
+    delayed until after the relevant transaction commits, cache deletion is
+    performed immediately.)
+
+ 2. Request B starts before request A's database transaction commits, and
+    attempts to load artist ID=123. Since it's not in the cache, we read it
+    from the database, seeing the "old" version.
+
+ 3. Request B commits, and adds the stale artist to the cache at
+    `artist:123`.
+
+ 4. Immediately after adding it to the cache, we check for the presence of an
+    `artist:recently_invalidated:123` key in the Redis store. If it exists,
+    we remove the stale `artist:123` entry we just added to the cache.
+
+The `recently_invalidated` keys have their TTLs set to the "max request time"
+determined by `DBDefs::DETERMINE_MAX_REQUEST_TIME`. The idea behind this is
+that if the request times out, any database handles used in the request will
+be closed and all transactions will be rolled back. In case the max request
+time is undefined or 0 (indicating no limit), we set the TTL to
+`$RECENTLY_INVALIDATED_TTL`, which defaults to 10 minutes.
+
+Originally, MBS-7241 was resolved by using using database-level locks
+(`pg_advisory_xact_lock`). Lock contention and deadlocks (MBS-11345,
+MBS-12314, ...) were a persistent issue with that approach. We also hit
+limits on the number of locks being held in a single transaction (MBS-10497).
+
+=cut
+
+Readonly our $RECENTLY_INVALIDATED_TTL => 600;
+
 Readonly our $MAX_CACHE_ENTRIES => 500;
-
-sub _cache_id {
-    my ($self) = @_;
-
-    my $type = $self->_type;
-    if ($type && (my $entity_properties = $ENTITIES{$type})) {
-        if (exists $entity_properties->{cache}) {
-            return $entity_properties->{cache}{id};
-        }
-    }
-}
 
 has _cache_prefix => (
     is => 'ro',
     isa => 'Str',
+    lazy => 1,
     default => sub { shift->_type . ':' },
+);
+
+has _recently_invalidated_prefix => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    default => sub { shift->_cache_prefix . 'recently_invalidated:' },
 );
 
 around get_by_ids => sub {
@@ -48,7 +83,8 @@ around get_by_ids => sub {
         delete $ids{$id};
     }
     if (%ids) {
-        my $data = $self->$orig(keys %ids) || {};
+        my @ids_to_fetch = keys %ids;
+        my $data = $self->$orig(@ids_to_fetch) || {};
         my @ids_to_cache = keys %$data;
         foreach my $id (@ids_to_cache) {
             $result{$id} = $data->{$id};
@@ -79,64 +115,62 @@ after merge => sub {
 sub _create_cache_entries {
     my ($self, $data, $ids) = @_;
 
-    my $cache_id = $self->_cache_id;
     my $cache_prefix = $self->_cache_prefix;
-
-    my @ids = @$ids;
-    return unless @ids;
-
     my $ttl = DBDefs->ENTITY_CACHE_TTL;
 
-    if (DBDefs->DB_READ_ONLY) {
-        # There's no point in acquiring advisory locks for caching if
-        # DB_READ_ONLY is set, because there should be no concurrent
-        # writes in that case. While it's possible to have some servers
-        # set in DB_READ_ONLY and others still accepting writes, that's
-        # never done intentionally, and there's not much we can do
-        # about it: READONLY connections (which are made when
-        # DB_READ_ONLY is set) typically go to a standby server
-        # different from the master. Locks are not shared between
-        # primary and standby servers.
-        return map {
-            [$cache_prefix . $_, $data->{$_}, ($ttl ? $ttl : ())]
-        } @ids;
-    }
-
-    my @entries;
-    my $it = natatime 100, @ids;
-    while (my @next_ids = $it->()) {
-        # MBS-7241: Try to acquire deletion locks on all of the cache
-        # keys, so that we don't repopulate those which are being
-        # deleted in a concurrent transaction. (This is non-blocking;
-        # if we fail to acquire the lock for a particular id, we skip
-        # the key.)
-        #
-        # MBS-10497: `id % 50` is used to limit the number of locks
-        # obtained per entity type per transaction to be within
-        # PostgreSQL's default configuration value for
-        # max_locks_per_transaction, 64. Note that 64 is not a hard
-        # limit, just an average. A transaction can have as many locks
-        # as will fit in the lock table.
-        my $locks = $self->c->sql->select_list_of_hashes(
-            'SELECT id, pg_try_advisory_xact_lock(?, id % 50) AS got_lock ' .
-            '  FROM unnest(?::integer[]) AS id',
-            $cache_id,
-            \@next_ids,
-        );
-        push @entries, map {
-            my $id = $_->{id};
-            [$cache_prefix . $id, $data->{$id}, ($ttl ? $ttl : ())]
-        } grep { $_->{got_lock} } @$locks;
-    }
-
-    @entries;
+    return map {
+        [$cache_prefix . $_, $data->{$_}, ($ttl ? $ttl : ())]
+    } @$ids;
 }
 
 sub _add_to_cache {
     my ($self, $cache, $data, $ids) = @_;
 
     my @entries = $self->_create_cache_entries($data, $ids);
-    $cache->set_multi(@entries) if @entries;
+    return unless @entries;
+
+    my $sql = $self->c->sql;
+    if ($sql->is_in_transaction) {
+        $sql->add_post_txn_callback(sub {
+            $self->_add_to_cache_impl($cache, \@entries, $ids);
+        });
+    } else {
+        $self->_add_to_cache_impl($cache, \@entries, $ids);
+    }
+}
+
+sub _add_to_cache_impl {
+    my ($self, $cache, $entries, $ids) = @_;
+
+    $cache->set_multi(@$entries);
+
+    # Check if any entities we've just cached were recently invalidated.
+    # If so, delete them. This must be performed after the cache
+    # addition, but means there may be *very* brief intervals (between
+    # the `set_multi` call above and the `delete_multi` call below) where
+    # we return stale entities from the cache.
+    my $invalidated_prefix = $self->_recently_invalidated_prefix;
+    # Map keys like `MB:artist:recently_invalidated:123` to the entity ID
+    # they refer to (`123`).
+    my %possible_recently_invalidated_id_map = map {
+        my $key = $invalidated_prefix . $_;
+        ($key => $_)
+    } @$ids;
+    # Check which of these keys actually exist in our Redis store,
+    # indicating which entity IDs were recently-invalidated in the cache.
+    my @recently_invalidated_ids = map {
+        $possible_recently_invalidated_id_map{$_}
+    } keys %{ $self->c->store->get_multi(
+        keys %possible_recently_invalidated_id_map,
+    ) };
+    if (@recently_invalidated_ids) {
+        my $cache_prefix = $self->_cache_prefix;
+        # Delete the recently-invalidated entity IDs from the cache at
+        # their corresponding key locations, e.g., `MB:artist:123`.
+        $cache->delete_multi(
+            map { $cache_prefix . $_ } @recently_invalidated_ids,
+        );
+    }
 }
 
 sub _delete_from_cache {
@@ -145,41 +179,21 @@ sub _delete_from_cache {
     @ids = uniq grep { defined } @ids;
     return unless @ids;
 
-    my $cache_id = $self->_cache_id;
-
-    # MBS-7241: Lock cache deletions from `_create_cache_entries`
-    # above, so that these keys can't be repopulated until after the
-    # database transaction commits.
-    my @row_ids = uniq
-        # MBS-10497: Limit the number of locks obtained per cache id
-        # per transaction to 50; see the comment in
-        # `_create_cache_entries` above. This increases the chance of
-        # contention, but invalidating cache entries is infrequent
-        # enough that it shouldn't matter.
-        map { $_ % 50 }
-        grep { is_database_row_id($_) } @ids;
-    if (@row_ids) {
-        my $start_time = time;
-        $self->c->sql->do(
-            'SELECT pg_advisory_xact_lock(?, id) ' .
-            '  FROM unnest(?::integer[]) AS id',
-            $cache_id,
-            \@row_ids,
-        );
-        my $elapsed_time = (time - $start_time);
-        if ($elapsed_time > 0.01) {
-            log_debug {
-                "[$start_time] _delete_from_cache: waited $elapsed_time" .
-                ' seconds for ' . (scalar @row_ids) .
-                " locks with cache id $cache_id"
-            };
-        }
-    }
-
+    my $c = $self->c;
+    my $cache = $c->cache($self->_type);
     my $cache_prefix = $self->_cache_prefix;
-    my @keys = map { $cache_prefix . $_ } @ids;
 
-    my $cache = $self->c->cache($self->_type);
+    my $max_request_time = $c->max_request_time;
+    if (!defined($max_request_time) || $max_request_time == 0) {
+        $max_request_time = $RECENTLY_INVALIDATED_TTL;
+    }
+    my $invalidated_prefix = $self->_recently_invalidated_prefix;
+    my @invalidated_flags = map { $invalidated_prefix . $_ } @ids;
+    $c->store->set_multi(map {
+        [$_, 1, $max_request_time + 1]
+    } @invalidated_flags);
+
+    my @keys = map { $cache_prefix . $_ } @ids;
     my $method = @keys > 1 ? 'delete_multi' : 'delete';
     $cache->$method(@keys);
 }

--- a/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
+++ b/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
@@ -3,7 +3,7 @@ package MusicBrainz::Server::Data::Role::EntityCache;
 use DBDefs;
 use Moose::Role;
 use namespace::autoclean;
-use List::AllUtils qw( any natatime uniq );
+use List::AllUtils qw( natatime uniq );
 use MusicBrainz::Server::Constants qw( %ENTITIES );
 use MusicBrainz::Server::Log qw( log_debug );
 use MusicBrainz::Server::Validation qw( is_database_row_id );
@@ -33,7 +33,8 @@ has _cache_prefix => (
 
 around get_by_ids => sub {
     my ($orig, $self, @ids) = @_;
-    return {} unless any { defined && $_ } @ids;
+    @ids = grep { is_database_row_id($_) } @ids;
+    return {} unless @ids;
     my %ids = map { $_ => 1 } @ids;
     my $cache_prefix = $self->_cache_prefix;
     my @keys = map { $cache_prefix . $_ } keys %ids;

--- a/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
+++ b/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
@@ -4,6 +4,7 @@ use DBDefs;
 use Moose::Role;
 use namespace::autoclean;
 use List::AllUtils qw( uniq );
+use MusicBrainz::Server::Validation qw( is_database_row_id );
 use Readonly;
 
 requires '_type';
@@ -155,7 +156,7 @@ sub _add_to_cache_impl {
     my %possible_recently_invalidated_id_map = map {
         my $key = $invalidated_prefix . $_;
         ($key => $_)
-    } @$ids;
+    } grep { is_database_row_id($_) } @$ids;
     # Check which of these keys actually exist in our Redis store,
     # indicating which entity IDs were recently-invalidated in the cache.
     my @recently_invalidated_ids = map {

--- a/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
+++ b/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
@@ -44,7 +44,7 @@ around get_by_ids => sub {
         foreach my $id (keys %$data) {
             $result{$id} = $data->{$id};
         }
-        $self->_add_to_cache($cache, %$data);
+        $self->_add_to_cache($cache, $data);
     }
     return \%result;
 };
@@ -123,9 +123,9 @@ sub _create_cache_entries {
 }
 
 sub _add_to_cache {
-    my ($self, $cache, %data) = @_;
+    my ($self, $cache, $data) = @_;
 
-    my @entries = $self->_create_cache_entries(\%data);
+    my @entries = $self->_create_cache_entries($data);
     $cache->set_multi(@entries) if @entries;
 }
 

--- a/lib/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
+++ b/lib/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
@@ -11,7 +11,7 @@ around get_by_gid => sub {
     return undef
         unless defined $gid;
 
-    my $key = $self->_type . ':' . $gid;
+    my $key = $self->_cache_prefix . $gid;
     my $cache = $self->c->cache($self->_type);
     my $id = $cache->get($key);
     my $obj;
@@ -29,7 +29,7 @@ around get_by_gid => sub {
 around _create_cache_entries => sub {
     my ($orig, $self, $data) = @_;
 
-    my $prefix = $self->_type . ':';
+    my $prefix = $self->_cache_prefix;
     my @orig_entries = $self->$orig($data);
     my @entries = @orig_entries;
     # Only add gid entries for entities returned from $self->$orig, which

--- a/lib/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
+++ b/lib/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
@@ -20,7 +20,7 @@ around get_by_gid => sub {
     } else {
         $obj = $self->$orig($gid);
         if (defined($obj)) {
-            $self->_add_to_cache($cache, $obj->id => $obj);
+            $self->_add_to_cache($cache, { $obj->id => $obj });
         }
     }
     return $obj;

--- a/lib/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
+++ b/lib/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
@@ -32,9 +32,6 @@ around _create_cache_entries => sub {
     my $prefix = $self->_cache_prefix;
     my @orig_entries = $self->$orig($data, $ids);
     my @entries = @orig_entries;
-    # Only add gid entries for entities returned from $self->$orig, which
-    # may be a subset of $data if any are being deleted in a concurrent
-    # transaction.
     for my $entry (@orig_entries) {
         my $entity = $entry->[1];
         push @entries, [$prefix . $entity->gid, $entity->id];

--- a/lib/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
+++ b/lib/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
@@ -20,17 +20,17 @@ around get_by_gid => sub {
     } else {
         $obj = $self->$orig($gid);
         if (defined($obj)) {
-            $self->_add_to_cache($cache, { $obj->id => $obj });
+            $self->_add_to_cache($cache, { $obj->id => $obj }, [$obj->id]);
         }
     }
     return $obj;
 };
 
 around _create_cache_entries => sub {
-    my ($orig, $self, $data) = @_;
+    my ($orig, $self, $data, $ids) = @_;
 
     my $prefix = $self->_cache_prefix;
-    my @orig_entries = $self->$orig($data);
+    my @orig_entries = $self->$orig($data, $ids);
     my @entries = @orig_entries;
     # Only add gid entries for entities returned from $self->$orig, which
     # may be a subset of $data if any are being deleted in a concurrent

--- a/lib/MusicBrainz/Server/Edit/Artist/Merge.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Merge.pm
@@ -55,7 +55,7 @@ sub do_merge
     my $new_id = $self->new_entity->{id};
     my @old_ids = $self->_old_ids;
 
-    my (undef, $dropped_columns) = $self->c->model('Artist')->merge(
+    my (undef, $dropped_columns) = $self->c->model('Artist')->merge_with_opts(
         $new_id,
         \@old_ids,
         rename => $self->data->{rename},

--- a/lib/MusicBrainz/Server/Model/MB.pm
+++ b/lib/MusicBrainz/Server/Model/MB.pm
@@ -25,13 +25,9 @@ sub _build_context {
 
     if ($ENV{MUSICBRAINZ_RUNNING_TESTS}) {
         require MusicBrainz::Server::Test;
-        return MusicBrainz::Server::Test->create_test_context;
+        return MusicBrainz::Server::Test->get_test_context;
     } else {
-        my $cache_opts = DBDefs->CACHE_MANAGER_OPTIONS;
-        my $c = MusicBrainz::Server::Context->new(
-            cache_manager => MusicBrainz::Server::CacheManager->new($cache_opts),
-        );
-        return $c;
+        return MusicBrainz::Server::Context->new;
     }
 }
 

--- a/lib/Sql.pm
+++ b/lib/Sql.pm
@@ -47,6 +47,28 @@ has 'sth' => (
     clearer => 'clear_sth',
 );
 
+# Note: These callbacks run regardless of whether the transaction succeeded!
+has 'post_txn_callbacks' => (
+    traits  => ['Array'],
+    is => 'rw',
+    isa => 'ArrayRef[CodeRef]',
+    default => sub { [] },
+);
+
+sub add_post_txn_callback {
+    my ($self, $callback) = @_;
+    croak 'add_post_txn_callback called without begin'
+        unless $self->is_in_transaction;
+    my $index = $self->transaction_depth - 1;
+    push @{ $self->post_txn_callbacks->[$index] }, $callback;
+}
+
+sub _run_post_txn_callbacks {
+    my ($self) = @_;
+    my $callbacks = pop @{ $self->post_txn_callbacks };
+    $_->() for @$callbacks;
+}
+
 sub finish
 {
     my ($self) = @_;
@@ -229,6 +251,10 @@ sub delete_row
     }
 }
 
+# We don't support nested transactions (i.e., we don't make use of
+# savepoints), but we do fake them in order to allow tests that use both
+# `t::Context` and `t::Mechanize` to actually function. Besides running the
+# `post_txn_callbacks`, nested commits and rollbacks are simply ignored.
 has 'transaction_depth' => (
     isa => 'Int',
     is => 'ro',
@@ -244,8 +270,9 @@ sub begin
 {
     my $self = shift;
     $self->dbh->{AutoCommit} = 0;
-    $self->inc_transaction_depth;
-    if ($self->transaction_depth == 1) {
+    push @{ $self->post_txn_callbacks }, [];
+    my $txn_depth = $self->inc_transaction_depth;
+    if ($txn_depth == 1) {
         return Sql::Timer->new('BEGIN', []) if $self->debug;
     }
 }
@@ -254,8 +281,12 @@ sub commit
 {
     my $self = shift;
     croak 'commit called without begin' unless $self->is_in_transaction;
-    $self->dec_transaction_depth;
-    return unless $self->transaction_depth == 0;
+
+    my $txn_depth = $self->dec_transaction_depth;
+    if ($txn_depth > 0) {
+        $self->_run_post_txn_callbacks;
+        return;
+    }
 
     return try {
         my $tt;
@@ -273,6 +304,17 @@ sub commit
         cluck $err unless ($self->quiet);
         eval { $self->rollback };
         croak $err;
+    }
+    finally {
+        # Note: exceptions in `finally` blocks cannot be propagated "due to
+        # fundamental limitations of Perl."
+        #
+        # Never use `post_txn_callbacks` for anything that MUST complete
+        # to preserve database or cache consistency.
+        #
+        # Aside: we could pass any caught error here if any callback needs to
+        # determine whether the commit succeeded in the future.
+        $self->_run_post_txn_callbacks;
     };
 }
 
@@ -280,9 +322,12 @@ sub rollback
 {
     my $self = shift;
     croak 'rollback called without begin' unless $self->is_in_transaction;
-    $self->dec_transaction_depth;
 
-    return unless $self->transaction_depth == 0;
+    my $txn_depth = $self->dec_transaction_depth;
+    if ($txn_depth > 0) {
+        $self->_run_post_txn_callbacks;
+        return;
+    }
 
     return try {
         my $tt;
@@ -299,6 +344,10 @@ sub rollback
         $self->dbh->{AutoCommit} = 1;
         cluck $err unless $self->quiet;
         croak $err;
+    }
+    finally {
+        # See the comment in `commit` above.
+        $self->_run_post_txn_callbacks;
     };
 }
 

--- a/t/lib/t/Context.pm
+++ b/t/lib/t/Context.pm
@@ -11,40 +11,11 @@ use MusicBrainz::Server::Test;
 has c => (
     is => 'ro',
     builder => '_build_context',
-);
-
-has cache_aware_c => (
-    is => 'ro',
-    builder => '_build_cache_aware_context',
-    clearer => '_clear_cache_aware_c',
-    predicate => '_has_cache_aware_c',
     lazy => 1,
 );
 
 sub _build_context {
-    MusicBrainz::Server::Test->create_test_context();
-}
-
-sub _build_cache_aware_context {
-    my $test = shift;
-
-    my $cache_opts = DBDefs->CACHE_MANAGER_OPTIONS;
-    my $store_opts = DBDefs->DATASTORE_REDIS_ARGS;
-
-    $cache_opts->{profiles}{external}{options}{namespace} = 'mbtest:';
-    $cache_opts->{profiles}{external}{options}{database} =
-        DBDefs->REDIS_TEST_DATABASE;
-    $store_opts->{database} =
-        DBDefs->REDIS_TEST_DATABASE;
-
-    return $test->c->meta->clone_object(
-        $test->c,
-        cache_manager =>
-            MusicBrainz::Server::CacheManager->new(%$cache_opts),
-        store => MusicBrainz::DataStore::Redis->new(%$store_opts),
-        models => {}, # Need to reload models to use this new $c
-        fresh_connector => 1,
-    );
+    MusicBrainz::Server::Test->get_test_context;
 }
 
 around run_test => sub {
@@ -54,8 +25,6 @@ around run_test => sub {
     MusicBrainz::Server::Test->prepare_test_server;
 
     my $c = $self->c;
-
-    $c->connector->_disconnect;
 
     $c->sql->begin;
 
@@ -67,12 +36,8 @@ around run_test => sub {
     }
 
     $c->sql->rollback;
-
-    if ($self->_has_cache_aware_c) {
-        my $cache_aware_c = $self->cache_aware_c;
-        $cache_aware_c->cache->clear;
-        $cache_aware_c->store->clear;
-    }
+    $c->cache->clear;
+    $c->store->clear;
 };
 
 1;

--- a/t/lib/t/Context.pm
+++ b/t/lib/t/Context.pm
@@ -33,6 +33,7 @@ sub _build_cache_aware_context {
         $test->c,
         cache_manager => MusicBrainz::Server::CacheManager->new(%$opts),
         models => {}, # Need to reload models to use this new $c
+        fresh_connector => 1,
     );
 }
 

--- a/t/lib/t/MusicBrainz/DataStore/Redis.pm
+++ b/t/lib/t/MusicBrainz/DataStore/Redis.pm
@@ -23,7 +23,7 @@ and expiring keys.
 
 # Initialize tests
 my $args = DBDefs->DATASTORE_REDIS_ARGS;
-$args->{database} = $args->{test_database};
+$args->{database} = DBDefs->REDIS_TEST_DATABASE;
 my $redis = MusicBrainz::DataStore::Redis->new(%$args);
 
 test 'Database is still selected in new Redis copy' => sub {

--- a/t/lib/t/MusicBrainz/DataStore/RedisMulti.pm
+++ b/t/lib/t/MusicBrainz/DataStore/RedisMulti.pm
@@ -23,10 +23,10 @@ stores. Consistency among all the stores is checked after each operation.
 
 # Initialize tests
 my $args1 = DBDefs->DATASTORE_REDIS_ARGS;
-$args1->{database} = $args1->{test_database};
+$args1->{database} = DBDefs->REDIS_TEST_DATABASE;
 
 my $args2 = DBDefs->DATASTORE_REDIS_ARGS;
-$args2->{database} = $args2->{test_database} + 1;
+$args2->{database} = DBDefs->REDIS_TEST_DATABASE + 1;
 
 my $redis1 = MusicBrainz::DataStore::Redis->new($args1);
 my $redis2 = MusicBrainz::DataStore::Redis->new($args2);

--- a/t/lib/t/MusicBrainz/Server/Data/Alias.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Alias.pm
@@ -321,7 +321,7 @@ test 'Exists only checks a single entity' => sub {
 
 test 'Modifying instrument aliases invalidates the link attribute type caches' => sub {
     my $test = shift;
-    my $c = $test->cache_aware_c;
+    my $c = $test->c;
 
     my $piano_lat_id = 180;
     my $piano_via_all;

--- a/t/lib/t/MusicBrainz/Server/Data/Artist.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Artist.pm
@@ -244,7 +244,7 @@ $artist_data->update_gid_redirects(3, 4);
 $artist = $artist_data->get_by_gid('2adff2b0-5dbf-11de-8a39-0800200c9a66');
 is($artist->id, 3);
 
-$artist_data->merge(3, [ 4 ]);
+$artist_data->merge(3, 4);
 $artist = $artist_data->get_by_id(4);
 ok(!defined $artist);
 
@@ -318,7 +318,7 @@ test 'Merging with a cache' => sub {
         ok($cache->get('artist:' . $artist->id), 'caches artist via ID');
     }
 
-    $c->model('Artist')->merge($artist1->id, [ $artist2->id ]);
+    $c->model('Artist')->merge($artist1->id, $artist2->id);
 
     ok(!$cache->get('artist:' . $artist2->gid), 'artist 2 no longer in cache (by gid)');
     ok(!$cache->get('artist:' . $artist2->id), 'artist 2 no longer in cache (by id)');
@@ -367,7 +367,7 @@ test 'Merging attributes' => sub {
         );
         SQL
 
-    $c->model('Artist')->merge(3, [4, 5]);
+    $c->model('Artist')->merge(3, 4, 5);
     my $artist = $c->model('Artist')->get_by_id(3);
     is($artist->begin_date->year, 2000);
     is($artist->begin_date->month, 6);
@@ -386,7 +386,7 @@ test 'Merging "ended" flag' => sub {
                    (4, '0db63477-bc98-4aac-a76a-28d78971a07c', 'An Artist', 'Artist, An', TRUE);
         SQL
 
-    $c->model('Artist')->merge(3, [4]);
+    $c->model('Artist')->merge(3, 4);
     my $artist = $c->model('Artist')->get_by_id(3);
     ok($artist->ended, 'merge result retains "ended" flag (MBS-6763)');
 };
@@ -416,7 +416,7 @@ test 'Merging attributes for VA' => sub {
         );
         SQL
 
-    $c->model('Artist')->merge(1, [4, 5, 6]);
+    $c->model('Artist')->merge(1, 4, 5, 6);
     my $artist = $c->model('Artist')->get_by_id(1);
 
     is($artist->begin_date->year, undef, 'begin date...');
@@ -508,7 +508,7 @@ test q(Merging an artist that's in a collection) => sub {
     });
 
     $c->model('Collection')->add_entities_to_collection('artist', $collection->{id}, $artist1->{id});
-    $c->model('Artist')->merge($artist2->{id}, [$artist1->{id}]);
+    $c->model('Artist')->merge($artist2->{id}, $artist1->{id});
 
     ok($c->sql->select_single_value('SELECT 1 FROM editor_collection_artist WHERE artist = ?', $artist2->{id}));
 };

--- a/t/lib/t/MusicBrainz/Server/Data/Artist.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Artist.pm
@@ -295,7 +295,7 @@ $sql->commit;
 test 'Merging with a cache' => sub {
     my $test = shift;
 
-    my $c = $test->cache_aware_c;
+    my $c = $test->c;
     my $cache = $c->cache_manager->_get_cache('external');
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+data_artist');

--- a/t/lib/t/MusicBrainz/Server/Data/Artist.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Artist.pm
@@ -295,15 +295,7 @@ $sql->commit;
 test 'Merging with a cache' => sub {
     my $test = shift;
 
-    my $opts = DBDefs->CACHE_MANAGER_OPTIONS;
-    $opts->{profiles}{external}{options}{namespace} = 'mbtest:';
-
-    my $c = $test->c->meta->clone_object(
-        $test->c,
-        cache_manager => MusicBrainz::Server::CacheManager->new(%$opts),
-        models => {}, # Need to reload models to use this new $c
-    );
-
+    my $c = $test->cache_aware_c;
     my $cache = $c->cache_manager->_get_cache('external');
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+data_artist');

--- a/t/lib/t/MusicBrainz/Server/Data/Artist.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Artist.pm
@@ -301,21 +301,21 @@ test 'Merging with a cache' => sub {
     MusicBrainz::Server::Test->prepare_test_database($c, '+data_artist');
 
     $c->sql->begin;
-
     my $artist1 = $c->model('Artist')->get_by_gid('745c079d-374e-4436-9448-da92dedef3ce');
     my $artist2 = $c->model('Artist')->get_by_gid('945c079d-374e-4436-9448-da92dedef3cf');
+    $c->sql->commit;
 
     for my $artist ($artist1, $artist2) {
         ok($cache->get('artist:' . $artist->gid), 'caches artist via GID');
         ok($cache->get('artist:' . $artist->id), 'caches artist via ID');
     }
 
+    $c->sql->begin;
     $c->model('Artist')->merge($artist1->id, $artist2->id);
+    $c->sql->commit;
 
     ok(!$cache->get('artist:' . $artist2->gid), 'artist 2 no longer in cache (by gid)');
     ok(!$cache->get('artist:' . $artist2->id), 'artist 2 no longer in cache (by id)');
-
-    $c->sql->commit;
 };
 
 test 'Deny delete "Various Artists" trigger' => sub {

--- a/t/lib/t/MusicBrainz/Server/Data/ArtistCredit.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/ArtistCredit.pm
@@ -181,7 +181,7 @@ test 'Merging updates matching names' => sub {
 
 test 'Merging clears the cache' => sub {
     my $test = shift;
-    my $c = $test->cache_aware_c;
+    my $c = $test->c;
     my $cache = $c->cache_manager->_get_cache('external');
     my $artist_credit_data = $c->model('ArtistCredit');
 

--- a/t/lib/t/MusicBrainz/Server/Data/ArtistCredit.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/ArtistCredit.pm
@@ -187,7 +187,10 @@ test 'Merging clears the cache' => sub {
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+artistcredit');
 
+    $c->sql->begin;
     $artist_credit_data->get_by_ids(1);
+    $c->sql->commit;
+
     ok($cache->get('artist_credit:1'), 'cache contains artist credit #1');
 
     $c->sql->begin;

--- a/t/lib/t/MusicBrainz/Server/Data/ArtistCredit.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/ArtistCredit.pm
@@ -336,7 +336,7 @@ test 'MBS-13310: Merging artists updates empty artist_credit IDs in unreferenced
         'unreferenced_row_log table was updated correctly',
     );
 
-    $c->model('Artist')->merge(10, [11], rename => 1);
+    $c->model('Artist')->merge_with_opts(10, [11], rename => 1);
 
     cmp_deeply(
         $c->sql->select_list_of_hashes('SELECT * FROM artist_credit'),

--- a/t/lib/t/MusicBrainz/Server/Data/EntityCache.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/EntityCache.pm
@@ -5,110 +5,41 @@ use warnings;
 use Test::Routine;
 use Test::Moose;
 use Test::More;
-
-{
-    package MyEntityData;
-    use Moose;
-    use namespace::autoclean;
-
-    extends 'MusicBrainz::Server::Data::Entity';
-    sub _type { 'my_entity_data' }
-    sub get_by_ids
-    {
-        my $self = shift;
-        $self->get_called(1);
-        return { 1 => 'data' };
-    }
-
-    package MyCachedEntityData;
-    use Moose;
-    use namespace::autoclean;
-
-    extends 'MyEntityData';
-    with 'MusicBrainz::Server::Data::Role::EntityCache';
-    has 'get_called' => ( is => 'rw', isa => 'Bool', default => 0 );
-
-    package MockCache;
-    use Moose;
-    use namespace::autoclean;
-
-    has 'data' => ( is => 'rw', isa => 'HashRef', default => sub { +{} } );
-    has 'get_called' => ( is => 'rw', isa => 'Bool', default => 0 );
-    has 'set_called' => ( is => 'rw', isa => 'Bool', default => 0 );
-    sub get
-    {
-        my ($self, $key) = @_;
-        $self->get_called(1);
-        return $self->data->{$key};
-    }
-    sub set
-    {
-        my ($self, $key, $data) = @_;
-        $self->set_called(1);
-        $self->data->{$key} = $data;
-    }
-}
-
-use MusicBrainz::Server::CacheManager;
 use MusicBrainz::Server::Context;
 
-with 't::Context' => { -excludes => '_build_context' };
-
-sub _build_context {
-    my $cache_manager = MusicBrainz::Server::CacheManager->new(
-        profiles => {
-            test => {
-                class => 'MockCache',
-                wrapped => 1,
-                keys => ['my_entity_data'],
-            },
-        },
-        default_profile => 'test',
-    );
-
-    return MusicBrainz::Server::Context->new(cache_manager => $cache_manager);
-}
+with 't::Context';
 
 test all => sub {
+    my $test = shift;
+    my $c = $test->c;
+    my $sql = $c->sql;
+    my $cache = $c->cache('artist');
+    my $artist_data = $c->model('Artist');
 
-my $test = shift;
-my $c = $test->c;
-my $sql = $c->sql;
-my $entity_data = MyCachedEntityData->new(c => $c);
+    $sql->auto_commit(1);
+    $sql->do(<<~'SQL');
+        INSERT INTO artist (id, gid, name, sort_name)
+            VALUES (3, 'e7717242-d43f-46e0-b5ef-9a46ca4d458a', 'Test', 'Test');
+        SQL
 
-$sql->begin;
-my $entity = $entity_data->get_by_id(1);
-$sql->commit;
-is ( $entity, 'data' );
-is ( $entity_data->get_called, 1 );
-is ( $test->c->cache->_orig->get_called, 1 );
-is ( $test->c->cache->_orig->set_called, 1 );
-ok ( $test->c->cache->_orig->data->{'my_entity_data:1'} =~ 'data' );
+    ok(!$cache->exists('artist:3'),
+       'artist is not in the cache');
 
+    $sql->begin;
+    my $artist = $artist_data->get_by_id(3);
+    $sql->commit;
 
-$entity_data->get_called(0);
-$test->c->cache->_orig->get_called(0);
-$test->c->cache->_orig->set_called(0);
+    is($artist->id, 3,
+       'get_by_id returns artist with id=3 before caching');
+    ok($cache->get('artist:3')->isa('MusicBrainz::Server::Entity::Artist'),
+       'cache contains artist for id');
 
-$sql->begin;
-$entity = $entity_data->get_by_id(1);
-$sql->commit;
-is ( $entity, 'data' );
-is ( $entity_data->get_called, 0 );
-is ( $test->c->cache->_orig->get_called, 1 );
-is ( $test->c->cache->_orig->set_called, 0 );
+    $sql->begin;
+    $artist = $artist_data->get_by_id(3);
+    $sql->commit;
 
-
-delete $test->c->cache->_orig->data->{'my_entity_data:1'};
-$sql->begin;
-$entity = $entity_data->get_by_id(1);
-$sql->commit;
-is ( $entity, 'data' );
-is ( $entity_data->get_called, 1 );
-is ( $test->c->cache->_orig->get_called, 1 );
-is ( $test->c->cache->_orig->set_called, 1 );
-ok ( $test->c->cache->_orig->data->{'my_entity_data:1'} =~ 'data' );
-
+    is($artist->id, 3,
+       'get_by_id returns artist with id=3 after caching');
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Data/Instrument.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Instrument.pm
@@ -51,7 +51,7 @@ test 'Load basic data' => sub {
 
 test 'Create, update, delete instruments' => sub {
     my $test = shift;
-    my $c = $test->cache_aware_c;
+    my $c = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+data_instrument');
 

--- a/t/lib/t/MusicBrainz/Server/Data/LinkAttributeType.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/LinkAttributeType.pm
@@ -71,7 +71,7 @@ test 'get_by_gid with non existent GID' => sub {
 
 test 'Updating a link attribute invalidates cache entries for links' => sub {
     my $test = shift;
-    my $c = $test->cache_aware_c;
+    my $c = $test->c;
 
     $c->sql->do(<<~'SQL');
         INSERT INTO link (id, link_type, attribute_count)

--- a/t/lib/t/MusicBrainz/Server/Data/Role/Collection.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Role/Collection.pm
@@ -91,8 +91,6 @@ for my $entity_type (entities_with('collections')) {
                 medium_positions => {},
                 merge_strategy => $MusicBrainz::Server::Data::Release::MERGE_MERGE,
             );
-        } elsif ($entity_type eq 'artist') {
-            $model->merge($entity2->{id}, [$entity1->{id}]);
         } else {
             $model->merge($entity2->{id}, $entity1->{id});
         }

--- a/t/lib/t/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
@@ -12,6 +12,8 @@ use MusicBrainz::Server::Context;
 
 with 't::Context' => { -excludes => '_build_context' };
 
+our $gid1 = '3f8c4788-d193-4931-b6b7-3aa7bf64ac33';
+
 {
     package t::GIDEntityCache::MyEntity;
     use Moose;
@@ -30,13 +32,13 @@ with 't::Context' => { -excludes => '_build_context' };
     {
         my $self = shift;
         $self->get_by_id_called(1);
-        return { 1 => t::GIDEntityCache::MyEntity->new(id => 1, gid => 'abc') };
+        return { 1 => t::GIDEntityCache::MyEntity->new(id => 1, gid => $gid1) };
     }
     sub get_by_gid
     {
         my $self = shift;
         $self->get_by_gid_called(1);
-        return t::GIDEntityCache::MyEntity->new(id => 1, gid => 'abc');
+        return t::GIDEntityCache::MyEntity->new(id => 1, gid => $gid1);
     }
 
     package t::GIDEntityCache::MyCachedEntityData;
@@ -87,14 +89,14 @@ test all => sub {
 my $test = shift;
 my $entity_data = t::GIDEntityCache::MyCachedEntityData->new(c => $test->c);
 
-my $entity = $entity_data->get_by_gid('abc');
+my $entity = $entity_data->get_by_gid($gid1);
 is ( $entity->id, 1 );
 is ( $entity_data->get_by_gid_called, 1 );
 is ( $entity_data->get_by_id_called, 0 );
 is ( $test->c->cache->_orig->get_called, 1 );
 is ( $test->c->cache->_orig->set_called, 2 );
 ok ( $test->c->cache->_orig->data->{'my_cached_entity_data:1'} =~ '1' );
-ok ( $test->c->cache->_orig->data->{'my_cached_entity_data:abc'} =~ '1' );
+ok ( $test->c->cache->_orig->data->{"my_cached_entity_data:$gid1"} =~ '1' );
 
 
 $entity_data->get_by_gid_called(0);
@@ -102,7 +104,7 @@ $entity_data->get_by_id_called(0);
 $test->c->cache->_orig->get_called(0);
 $test->c->cache->_orig->set_called(0);
 
-$entity = $entity_data->get_by_gid('abc');
+$entity = $entity_data->get_by_gid($gid1);
 is ( $entity->id, 1 );
 is ( $entity_data->get_by_gid_called, 0 );
 is ( $entity_data->get_by_id_called, 0 );
@@ -117,7 +119,7 @@ $test->c->cache->_orig->set_called(0);
 
 delete $test->c->cache->_orig->data->{'my_cached_entity_data:1'};
 
-$entity = $entity_data->get_by_gid('abc');
+$entity = $entity_data->get_by_gid($gid1);
 is ( $entity->id, 1 );
 is ( $entity_data->get_by_gid_called, 0 );
 is ( $entity_data->get_by_id_called, 1 );

--- a/t/lib/t/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
@@ -6,9 +6,14 @@ use warnings;
 use Test::Routine;
 use Test::Moose;
 use Test::More;
+use Try::Tiny;
 
+use DBDefs;
 use MusicBrainz::Server::CacheManager;
+use MusicBrainz::Server::CacheWrapper::Redis;
 use MusicBrainz::Server::Context;
+use MusicBrainz::Server::Data::Artist;
+use Sql;
 
 with 't::Context' => { -excludes => '_build_context' };
 
@@ -47,7 +52,6 @@ our $gid1 = '3f8c4788-d193-4931-b6b7-3aa7bf64ac33';
     extends 't::GIDEntityCache::MyEntityData';
     with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
     sub _type { 'my_cached_entity_data' }
-    sub _cache_id { 1 }
 
     package t::GIDEntityCache::MockCache;
     use Moose;
@@ -87,9 +91,13 @@ sub _build_context {
 test all => sub {
 
 my $test = shift;
-my $entity_data = t::GIDEntityCache::MyCachedEntityData->new(c => $test->c);
+my $c = $test->c;
+my $sql = $c->sql;
+my $entity_data = t::GIDEntityCache::MyCachedEntityData->new(c => $c);
 
+$sql->begin;
 my $entity = $entity_data->get_by_gid($gid1);
+$sql->commit;
 is ( $entity->id, 1 );
 is ( $entity_data->get_by_gid_called, 1 );
 is ( $entity_data->get_by_id_called, 0 );
@@ -104,7 +112,9 @@ $entity_data->get_by_id_called(0);
 $test->c->cache->_orig->get_called(0);
 $test->c->cache->_orig->set_called(0);
 
+$sql->begin;
 $entity = $entity_data->get_by_gid($gid1);
+$sql->commit;
 is ( $entity->id, 1 );
 is ( $entity_data->get_by_gid_called, 0 );
 is ( $entity_data->get_by_id_called, 0 );
@@ -119,7 +129,9 @@ $test->c->cache->_orig->set_called(0);
 
 delete $test->c->cache->_orig->data->{'my_cached_entity_data:1'};
 
+$sql->begin;
 $entity = $entity_data->get_by_gid($gid1);
+$sql->commit;
 is ( $entity->id, 1 );
 is ( $entity_data->get_by_gid_called, 0 );
 is ( $entity_data->get_by_id_called, 1 );
@@ -130,22 +142,20 @@ is ( $test->c->cache->_orig->set_called, 2 );
 };
 
 test 'Cache is transactional (MBS-7241)' => sub {
-    # This test is of limited usefulness, since it only tests a *single* point
-    # in the transaction where an entity might be requested. But it at least
-    # detects cases where there is *no* transactionality, i.e. the situation we
-    # had before MBS-7241 was fixed.
     my $test = shift;
-
-    use DBDefs;
-    use MusicBrainz::Server::Data::Artist;
-    use MusicBrainz::Server::Context;
-    use Sql;
 
     no warnings 'redefine';
 
     # Important: each context needs a separate database connection (fresh_connector).
-    my $c1 = MusicBrainz::Server::Context->create_script_context(database => 'TEST', fresh_connector => 1);
-    my $c2 = MusicBrainz::Server::Context->create_script_context(database => 'TEST', fresh_connector => 1);
+    my $c1 = $test->_build_cache_aware_context;
+    my $c2 = $test->_build_cache_aware_context;
+
+    $c1->connector->disconnect;
+    $c1->clear_connector;
+
+    $c2->connector->disconnect;
+    $c2->clear_connector;
+
     my $_delete_from_cache = MusicBrainz::Server::Data::Artist->can('_delete_from_cache');
 
     $c1->sql->auto_commit(1);
@@ -154,59 +164,136 @@ test 'Cache is transactional (MBS-7241)' => sub {
             VALUES (3, '31456bd3-0e1a-4c47-a5cc-e147a42965f2', 'Test', 'Test');
         SQL
 
+    my $cleanup = sub {
+        $c1->sql->auto_commit(1);
+        $c1->sql->do(<<~'SQL');
+            DELETE FROM artist WHERE id = 3;
+            DELETE FROM deleted_entity WHERE gid = '31456bd3-0e1a-4c47-a5cc-e147a42965f2';
+            SQL
+        $c1->store->delete('artist:recently_invalidated:3');
+    };
+
     my $artist_gid = '31456bd3-0e1a-4c47-a5cc-e147a42965f2';
+    my $do_update = 1;
+    my $error;
+
+    # Test 1:
+    #  1. Process A fetches artist 3 (not in the cache).
+    #  2. Process B updates artist 3 and commits (deleting it from the
+    #     cache).
+    #  3. Process A finally adds artist 3 to the cache.
+    # Expectation: artist 3 should not exist in the cache.
+
+    my $set_multi = MusicBrainz::Server::CacheWrapper::Redis->can('set_multi');
+    *MusicBrainz::Server::CacheWrapper::Redis::set_multi = sub {
+        if ($do_update) {
+            $do_update = 0;
+            $c2->sql->begin;
+            $c2->model('Artist')->update(3, {name => 'COOL'});
+            $c2->sql->commit;
+        }
+        $set_multi->(@_);
+    };
+
+    try {
+        $c1->sql->begin;
+        # Attempt to cache this artist. A concurrent process will update the
+        # same artist before this process adds it to the cache (see the
+        # `set_multi` redefinition above), which should prevent our stale
+        # cache addition.
+        $c1->model('Artist')->get_by_gid($artist_gid);
+        $c1->sql->commit;
+
+        ok(!$c1->cache->exists('artist:3'),
+           'artist is not cached after a concurrent update');
+
+        $c1->sql->begin;
+        my $artist = $c1->model('Artist')->get_by_gid($artist_gid);
+        is($artist->name, 'COOL', 'get_by_gid returns the latest changes');
+        $c1->sql->commit;
+    } catch {
+        $error = $_;
+    } finally {
+        *MusicBrainz::Server::CacheWrapper::Redis::set_multi = $set_multi; ## no critic (ProtectPrivateVars)
+    };
+
+    if ($error) {
+        $cleanup->();
+        die $error;
+    }
+
+    $c1->store->delete('artist:recently_invalidated:3');
+
+    # Test 2:
+    #  1. Process A deletes artist 3 (but doesn't commit yet).
+    #  2. Process B fetches artist 3:
+    #     a. before the cache deletion,
+    #     b. after the cache deletion but before process A commits,
+    #     c. and finally after process A commits.
+    # We test `get_by_gid` and the presence of artist 3 in the cache at each
+    # interval in the points above.
+
+    $c1->sql->begin;
+    $c1->model('Artist')->get_by_gid($artist_gid);
+    $c1->sql->commit;
 
     *MusicBrainz::Server::Data::Artist::_delete_from_cache = sub { ## no critic (ProtectPrivateVars)
         my $artist = $c2->model('Artist')->get_by_id(3);
+
+        my $status = 'before database deletion commits, ' .
+            'and before cache deletion';
+
         is($artist->id, 3,
-            'concurrent get_by_id returns artist before ' .
-            'database deletion commits, and before cache deletion');
+            '(a.) concurrent get_by_id returns artist ' . $status);
 
         $artist = $c2->model('Artist')->get_by_gid($artist_gid);
         is($artist->id, 3,
-            'concurrent get_by_gid returns artist before ' .
-            'database deletion commits, and before cache deletion');
+            '(a.) concurrent get_by_gid returns artist ' . $status);
 
         ok($c2->cache->get('artist:3')->isa('MusicBrainz::Server::Entity::Artist'),
-            'cache contains artist entity');
+            '(a.) cache contains artist entity ' . $status);
 
         $_delete_from_cache->(@_);
 
+        $status = 'before database deletion commits, ' .
+            'but after cache deletion';
+
         $artist = $c2->model('Artist')->get_by_id(3);
         is($artist->id, 3,
-            'concurrent get_by_id returns artist before ' .
-            'database deletion commits, but after cache deletion');
+            '(b.) concurrent get_by_id returns artist ' . $status);
 
         is($c2->cache->get('artist:3'), undef,
-            'cache is not repopulated after concurrent get_by_id');
+            '(b.) cache is not repopulated after concurrent get_by_id ' .
+            $status);
 
         $artist = $c2->model('Artist')->get_by_gid($artist_gid);
         is($artist->id, 3,
-            'concurrent get_by_gid returns artist before ' .
-            'database deletion commits, but after cache deletion');
+            '(b.) concurrent get_by_gid returns artist ' . $status);
 
         is($c2->cache->get('artist:3'), undef,
-            'cache is not repopulated after concurrent get_by_gid');
+            '(b.) cache is not repopulated after concurrent get_by_gid' .
+            $status);
     };
 
-    Sql::run_in_transaction(sub {
-        $c1->model('Artist')->delete(3);
-    }, $c1->sql);
+    try {
+        Sql::run_in_transaction(sub {
+            $c1->model('Artist')->delete(3);
+        }, $c1->sql);
 
-    my $artist = $c1->model('Artist')->get_by_id(3);
-    ok(!defined $artist,
-        'get_by_id returns undef after ' .
-        'database deletion commits, and after cache deletion');
+        my $artist = $c1->model('Artist')->get_by_id(3);
+        ok(!defined $artist,
+            '(c.) get_by_id returns undef after ' .
+            'database deletion commits, and after cache deletion');
+    } catch {
+        $error = $_;
+    } finally {
+        *MusicBrainz::Server::Data::Artist::_delete_from_cache = $_delete_from_cache; ## no critic (ProtectPrivateVars)
+        $cleanup->();
+        $c1->connector->disconnect;
+        $c2->connector->disconnect;
+    };
 
-    $c1->sql->auto_commit(1);
-    $c1->sql->do(<<~'SQL');
-        DELETE FROM artist WHERE id = 3;
-        DELETE FROM deleted_entity WHERE gid = '31456bd3-0e1a-4c47-a5cc-e147a42965f2';
-        SQL
-
-    *MusicBrainz::Server::Data::Artist::_delete_from_cache = $_delete_from_cache; ## no critic (ProtectPrivateVars)
-    $c1->connector->disconnect;
-    $c2->connector->disconnect;
+    die $error if $error;
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Edit/Medium/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Medium/Edit.pm
@@ -713,7 +713,7 @@ test 'Tracklist merging (MBS-8752 / MBS-7475)' => sub {
 
 test 'Fail edits using cached deleted recordings (MBS-8858)' => sub {
     my $test = shift;
-    my $c = $test->cache_aware_c;
+    my $c = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+edit_medium');
 

--- a/t/lib/t/MusicBrainz/Server/Edit/Relationship/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Relationship/Create.pm
@@ -114,7 +114,7 @@ test 'Entities load correctly after being merged (MBS-2477)' => sub {
     MusicBrainz::Server::Test->prepare_test_database($c, '+edit_relationship_edit');
 
     my $edit = _create_edit($c);
-    $c->model('Artist')->merge(5, [4]);
+    $c->model('Artist')->merge(5, 4);
     $c->model('Edit')->load_all($edit);
 
     is($edit->display_data->{relationship}{entity1_id}, 5);

--- a/t/lib/t/MusicBrainz/Server/Edit/Relationship/Delete.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Relationship/Delete.pm
@@ -135,7 +135,7 @@ test 'Entities load correctly after being merged (MBS-2477)' => sub {
         relationship => $relationship,
     );
 
-    $c->model('Artist')->merge(4, [3]);
+    $c->model('Artist')->merge(4, 3);
     $c->model('Edit')->load_all($edit);
 
     is($edit->display_data->{relationship}{entity0_id}, 4);

--- a/t/lib/t/MusicBrainz/Server/Edit/Relationship/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Relationship/Edit.pm
@@ -165,7 +165,7 @@ test 'Editing a relationship succeeds despite an entity being merged' => sub {
     );
 
     ok($edit->is_open);
-    $c->model('Artist')->merge(5, [4]);
+    $c->model('Artist')->merge(5, 4);
     ok !exception { $edit->accept };
 };
 
@@ -189,7 +189,7 @@ test q(Editing a relationship fails if one of the entities is merged, and the
     );
 
     ok($edit->is_open);
-    $c->model('Artist')->merge(5, [4]);
+    $c->model('Artist')->merge(5, 4);
     $c->model('Relationship')->insert('artist', 'artist', {
         entity0_id      => 3,
         entity1_id      => 5,

--- a/t/selenium/Genre_Edit_Form.json5
+++ b/t/selenium/Genre_Edit_Form.json5
@@ -34,7 +34,7 @@
     {
       command: 'type',
       target: 'css=#external-link-0 input[type=url]',
-      value: 'https://bandcamp.com/tag/newgenre',
+      value: 'https://bandcamp.com/discover/newgenre',
     },
     {
       command: 'clickAndWait',
@@ -72,7 +72,7 @@
           entity1: {
             gid: '$$__IGNORE__$$',
             id: 1,
-            name: 'https://bandcamp.com/tag/newgenre',
+            name: 'https://bandcamp.com/discover/newgenre',
           },
           entity_id: 1,
           link_type: {
@@ -152,7 +152,7 @@
     {
       command: 'type',
       target: 'css=#url-input-popover input.raw-url',
-      value: 'https://bandcamp.com/tag/newgenre2',
+      value: 'https://bandcamp.com/discover/newgenre2',
     },
     {
       command: 'sendKeys',
@@ -216,7 +216,7 @@
             entity1: {
               gid: '$$__IGNORE__$$',
               id: 1,
-              name: 'https://bandcamp.com/tag/newgenre',
+              name: 'https://bandcamp.com/discover/newgenre',
             },
             link_type: {
               id: 1092,
@@ -230,14 +230,14 @@
             entity1: {
               gid: '$$__IGNORE__$$',
               id: 2,
-              name: 'https://bandcamp.com/tag/newgenre2',
+              name: 'https://bandcamp.com/discover/newgenre2',
             },
           },
           old: {
             entity1: {
               gid: '$$__IGNORE__$$',
               id: 1,
-              name: 'https://bandcamp.com/tag/newgenre',
+              name: 'https://bandcamp.com/discover/newgenre',
             },
           },
           relationship_id: 1,
@@ -331,7 +331,7 @@
             entity1: {
               gid: '$$__IGNORE__$$',
               id: 1,
-              name: 'https://bandcamp.com/tag/newgenre',
+              name: 'https://bandcamp.com/discover/newgenre',
             },
             id: 1,
             link: {


### PR DESCRIPTION
# Problem

The current implementation for MBS-7241 causes deadlocks and performance issues due to lock contention (MBS-11345, MBS-12314).

# Solution

Implement a different solution that blocks cache additions using our Redis store to manage "cachelock" keys.

The new implementation is documented in `Data::Role::EntityCache`. Please review that to make sure it seems sound.

# Testing

The existing test for MBS-7241 in `GIDEntityCache` passes. However, this hasn't been tested at scale. Complicating things, it also needs to be deployed to production and beta at the same time.