### PR TITLE
Improve AC bubble wording

### DIFF
--- a/root/static/scripts/edit/components/ArtistCreditBubble.js
+++ b/root/static/scripts/edit/components/ArtistCreditBubble.js
@@ -57,7 +57,8 @@ const ArtistCreditBubble = ({
         <tr>
           <td colSpan="3" style={{paddingBottom: '1em'}}>
             {exp.l(
-              `Use the following fields to enter collaborations. See the
+              `Use the following fields to enter artist name variations
+               and multiple artist collaborations. See the
                {ac|Artist Credit} documentation for more information.`,
               {ac: '/doc/Artist_Credits'},
             )}


### PR DESCRIPTION
# Description
Artist credits are not only for collaborations, so the current help is misleading rather than useful. @Aerozol proposed adding "name variations" which I guess would now cover most cases at least.

# Testing
None, but this is just a string change.