### PR TITLE
MBS-13413: Allow using "Add/Remove note" with keyboard

### DIFF
--- a/root/edit/components/EditSummary.js
+++ b/root/edit/components/EditSummary.js
@@ -56,9 +56,9 @@ const EditSummary = ({
       ) ? (
         <div className="cancel-edit buttons">
           {mayAddNote ? (
-            <a className="positive edit-note-toggle">
+            <button className="positive edit-note-toggle" type="button">
               {lp('Add note', 'interactive')}
-            </a>
+            </button>
           ) : null}
 
           {mayApprove ? (

--- a/t/selenium/Vote_And_Note_Submission.json5
+++ b/t/selenium/Vote_And_Note_Submission.json5
@@ -21,7 +21,7 @@
     // We want to leave a valid note on the first edit
     {
       command: 'click',
-      target: 'xpath=//*[@id="edits"]/form/div[2]/div[2]/div[2]/a[1]',
+      target: 'xpath=//*[@id="edits"]/form/div[2]/div[2]/div[2]/button',
       value: '',
     },
     {
@@ -32,7 +32,7 @@
     // We want to leave an invalid note on the second edit
     {
       command: 'click',
-      target: 'xpath=//*[@id="edits"]/form/div[3]/div[2]/div[2]/a[1]',
+      target: 'xpath=//*[@id="edits"]/form/div[3]/div[2]/div[2]/button',
       value: '',
     },
     {


### PR DESCRIPTION
### Fix MBS-13413

# Problem
In edit summaries, the "Add note" / "Remove note" toggle button is not reachable with keyboard navigation (it's completely skipped when tabbing).

# Solution
Since this is an `<a>` without href, it was being skipped by the tabindex, but we want it to be tabbable. There seems to be no reason why this should not be `<button>` instead, which makes it tabbable by default. It also means it responds to Enter and Space keypresses, which is nice.

# Testing
Manually, by tabbing around a list of open edits and ensuring the button is reachable and pressing Enter opens/closes the note field.