### PR TITLE
MBS-13414: Normalize x.com URLs to twitter.com

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5791,11 +5791,11 @@ const CLEANUPS: CleanupEntries = {
     },
   },
   'twitter': {
-    match: [new RegExp('^(https?://)?([^/]+\\.)?twitter\\.com/', 'i')],
+    match: [new RegExp('^(https?://)?([^/]+\\.)?(twitter|x)\\.com/', 'i')],
     restrict: [{...LINK_TYPES.streamingfree, ...LINK_TYPES.socialnetwork}],
     clean: function (url) {
       url = url.replace(
-        /^(?:https?:\/\/)?(?:(?:www|mobile)\.)?twitter\.com(?:\/#!)?\//,
+        /^(?:https?:\/\/)?(?:(?:www|mobile)\.)?(?:twitter|x)\.com(?:\/#!)?\//,
         'https://twitter.com/',
       );
       url = url.replace(

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5794,6 +5794,12 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://twitter.com/UNIVERSAL_D',
   },
   {
+                     input_url: 'https://x.com/metabrainz',
+             input_entity_type: 'label',
+    expected_relationship_type: 'socialnetwork',
+            expected_clean_url: 'https://twitter.com/metabrainz',
+  },
+  {
                      input_url: 'https://twitter.com/mountain_goats/status/1062342708470132738',
              input_entity_type: 'recording',
     expected_relationship_type: 'streamingfree',


### PR DESCRIPTION
### Implement MBS-13414

# Description
x.com URLs are simply redirects to the equivalent twitter.com URL, so we might as well clean them up.

# Testing
Added one test