### PR TITLE
MBS-13420: Support Bandcamp /discover tag links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1122,6 +1122,7 @@ const CLEANUPS: CleanupEntries = {
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?([^\/]+\.)?bandcamp\.com(?:\/([^?#]*))?.*$/, 'https://$1bandcamp.com/$2');
       url = url.replace(/^https:\/\/([^\/]+)\.bandcamp\.com\/(?:((?:album|track)\/[^\/]+))?.*$/, 'https://$1.bandcamp.com/$2');
+      url = url.replace(/^https:\/\/bandcamp\.com\/(?:discover|tag)\/([^\/]+).*$/, 'https://bandcamp.com/discover/$1');
       return url;
     },
     validate: function (url, id) {
@@ -1140,7 +1141,7 @@ const CLEANUPS: CleanupEntries = {
           return {result: /^https:\/\/[^\/]+\.bandcamp\.com\/$/.test(url)};
         case LINK_TYPES.bandcamp.genre:
           return {
-            result: /^https:\/\/bandcamp\.com\/tag\/[\w-]+$/.test(url),
+            result: /^https:\/\/bandcamp\.com\/discover\/[\w-]+$/.test(url),
             target: ERROR_TARGETS.ENTITY,
           };
         case LINK_TYPES.bandcamp.label:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -807,7 +807,14 @@ limited_link_type_combinations: [
                      input_url: 'https://bandcamp.com/tag/ambient-noise-wall?tab=highlights',
              input_entity_type: 'genre',
     expected_relationship_type: 'bandcamp',
-            expected_clean_url: 'https://bandcamp.com/tag/ambient-noise-wall',
+            expected_clean_url: 'https://bandcamp.com/discover/ambient-noise-wall',
+       only_valid_entity_types: ['genre'],
+  },
+  {
+                     input_url: 'https://bandcamp.com/discover/maidcore/digital?tags=rock-electro',
+             input_entity_type: 'genre',
+    expected_relationship_type: 'bandcamp',
+            expected_clean_url: 'https://bandcamp.com/discover/maidcore',
        only_valid_entity_types: ['genre'],
   },
   {


### PR DESCRIPTION
### Implement MBS-13420

# Problem
Bandcamp `/tag` links now redirect to a revamped `/discover` page, links which we don't currently support.

# Solution
This cleans up `/tag` links and drops unwanted extras from `/discover` ones (see test).

# Testing
Added one test for `/discover`, changed the existing `/tag` one to check the redirect.