### PR TITLE
MBS-13327: Don't unlink recording from track when removing feat. artists

### DIFF
--- a/root/static/scripts/edit/utility/guessFeat.js
+++ b/root/static/scripts/edit/utility/guessFeat.js
@@ -30,6 +30,12 @@ import getSimilarity from './similarity.js';
 
 /* eslint-disable sort-keys */
 const featRegex = /(?:^\s*|[,，－\-]\s*|\s+)((?:ft|feat|ｆｔ|ｆｅａｔ)(?:[.．]|(?=\s))|(?:featuring|ｆｅａｔｕｒｉｎｇ)(?=\s))\s*/i;
+/*
+ * `featQuickTestRegex` is used to quickly test whether a title *might*
+ * contain featured artists. It's fine if it returns false-positives.
+ * Please keep it in sync with `featRegex` above.
+ */
+const featQuickTestRegex = /ft|feat|ｆｔ|ｆｅａｔ/i;
 const collabRegex = /([,，]?\s+(?:&|and|et|＆|ａｎｄ|ｅｔ)\s+|、|[,，;；]\s+|\s*[\/／]\s*|\s+(?:vs|ｖｓ)[.．]\s+)/i;
 const bracketPairs = [['(', ')'], ['[', ']'], ['（', '）'], ['［', '］']];
 
@@ -114,9 +120,13 @@ function extractBracketedFeatCredits(str, artists, isProbablyClassical) {
   }, {name: str, joinPhrase: '', artistCredit: []});
 }
 
-function extractFeatCredits(
+export function extractFeatCredits(
   str, artists, isProbablyClassical, allowEmptyName,
 ) {
+  if (!featQuickTestRegex.test(str)) {
+    return {name: str, joinPhrase: '', artistCredit: []};
+  }
+
   const m1 = extractBracketedFeatCredits(str, artists, isProbablyClassical);
 
   if (!m1.name && !allowEmptyName) {

--- a/root/static/scripts/release-editor/recordingAssociation.js
+++ b/root/static/scripts/release-editor/recordingAssociation.js
@@ -241,7 +241,7 @@ recordingAssociation.autocompleteHook = function (track) {
 };
 
 
-function watchTrackForChanges(track) {
+export function watchTrackForChanges(track) {
   var name = track.name();
   var length = track.length();
 
@@ -262,7 +262,7 @@ function watchTrackForChanges(track) {
   }
 
   var similarTo = function (prop) {
-    return (utils.similarNames(track.name[prop], name) &&
+    return (utils.similarTrackNames(track.name[prop], name) &&
             utils.similarLengths(track.length[prop], length));
   };
 

--- a/root/static/scripts/release-editor/utils.js
+++ b/root/static/scripts/release-editor/utils.js
@@ -18,6 +18,7 @@ import {MAX_LENGTH_DIFFERENCE, MIN_NAME_SIMILARITY}
   from '../common/constants.js';
 import escapeLuceneValue from '../common/utility/escapeLuceneValue.js';
 import request from '../common/utility/request.js';
+import {extractFeatCredits} from '../edit/utility/guessFeat.js';
 import similarity from '../edit/utility/similarity.js';
 
 import releaseEditor from './viewModel.js';
@@ -194,6 +195,18 @@ function namesAreSimilar(a, b) {
 
 utils.similarNames = function (oldName, newName) {
   return oldName == newName || namesAreSimilar(oldName, newName);
+};
+
+utils.similarTrackNames = function (oldName, newName) {
+  return utils.similarNames(oldName, newName) || namesAreSimilar(
+    /*
+     * MBS-13327: Compare track titles with featured artists removed,
+     * so that the release editor doesn't unlink recordings when such
+     * changes are made.
+     */
+    extractFeatCredits(oldName).name,
+    extractFeatCredits(newName).name,
+  );
 };
 
 utils.similarLengths = function (oldLength, newLength) {

--- a/root/static/scripts/tests/index-web.js
+++ b/root/static/scripts/tests/index-web.js
@@ -22,6 +22,7 @@ require('./release-editor/edits.js');
 require('./release-editor/fields.js');
 require('./release-editor/trackParser.js');
 require('./release-editor/utils.js');
+require('./release-editor/recordingAssociation.js');
 require('./release-editor/validation.js');
 require('./utility/age.js');
 require('./utility/areDatesEqual.js');

--- a/root/static/scripts/tests/release-editor/recordingAssociation.js
+++ b/root/static/scripts/tests/release-editor/recordingAssociation.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import ko from 'knockout';
+import test from 'tape';
+
+import '../../release-editor/actions.js';
+
+import MB from '../../common/MB.js';
+import fields from '../../release-editor/fields.js';
+import {
+  watchTrackForChanges,
+} from '../../release-editor/recordingAssociation.js';
+
+MB.mediumFormatDates = {1: 1982};
+
+test('MBS-13327: Recording is not unlinked when removing feat. artists', function (t) {
+  t.plan(1);
+
+  const release = new fields.Release({
+    name: '',
+  });
+
+  const medium = new fields.Medium({
+    name: '',
+    position: 1,
+    format_id: null,
+    tracks: [],
+  }, release);
+
+  const track = new fields.Track({
+    artistCredit: {
+      names: [
+        {
+          artist: {
+            gid: '4a3818b4-0d35-445c-988e-e62770b196d4',
+            name: 'Qaballah Steppers',
+          },
+          joinPhrase: '',
+          name: 'Qaballah Steppers',
+        },
+      ],
+    },
+    name: 'Brooklyn Rumba (feat. Dr. Israel & Marc Ribot)',
+    recording: {
+      gid: 'ce4c77f3-12f9-49d2-a8a0-8e42cbabf138',
+      name: 'Brooklyn Rumba (feat. Dr. Israel & Marc Ribot)',
+    },
+  }, medium);
+
+  ko.computed(function () {
+    watchTrackForChanges(track);
+  });
+
+  track.name('Brooklyn Rumba');
+
+  t.equal(
+    track.recordingGID(),
+    'ce4c77f3-12f9-49d2-a8a0-8e42cbabf138',
+    'recording is still linked after removing feat. artists from the title',
+  );
+});

--- a/root/static/scripts/tests/release-editor/utils.js
+++ b/root/static/scripts/tests/release-editor/utils.js
@@ -8,7 +8,7 @@
 
 import test from 'tape';
 
-import {
+import utils, {
   calculateDiscID,
   unformatTrackLength,
 } from '../../release-editor/utils.js';
@@ -58,5 +58,17 @@ test('calculateDiscID', function (t) {
       '1 9 252000 150 31615 67600 87137 108242 127110 142910 166340 231445',
     ),
     'gtWBI_F_fQFSSRt8nVChAVFaT_A-',
+  );
+});
+
+test('similarTrackNames', function (t) {
+  t.plan(1);
+
+  t.ok(
+    utils.similarTrackNames(
+      'Brooklyn Rumba (feat. Dr. Israel & Marc Ribot)',
+      'Brooklyn Rumba',
+    ),
+    'name with feat. artist is similar to name without feat. artist',
   );
 });


### PR DESCRIPTION
# Problem

MBS-13327

# Solution

When deciding whether to unlink a recording, compare track names with featured artists removed.

Since `extractFeatCredits` is a heavy function to run each time a track name is modified (and is useless except when the title contains featured artists), I added `featQuickTestRegex` so that it can bail out early if it's sure there will be no matches.

# Testing

Tested locally with http://localhost:5000/release/f04eef04-06b7-498c-ae69-9a41e4d1686c/edit (on master, it unlinks the recordings).

Also added some tests for `similarTrackNames` and `watchTrackForChanges`.