### PR TITLE
MBS-13431: Fix using translations for expanded strings in statistics

### DIFF
--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -19,6 +19,10 @@ import {
   l_admin as lAdminActual,
   ln_admin as lnAdminActual,
 } from '../i18n/admin.js';
+import {
+  l_statistics as lStatisticsActual,
+  ln_statistics as lnStatisticsActual,
+} from '../i18n/statistics.js';
 
 import expand, {
   type NO_MATCH,
@@ -420,6 +424,11 @@ export const l_admin = (
   args?: ?VarArgsObject<Input>,
 ): Output => expand2react(lAdminActual(key), args);
 
+export const l_statistics = (
+  key: string,
+  args?: ?VarArgsObject<Input>,
+): Output => expand2react(lStatisticsActual(key), args);
+
 export const ln = (
   skey: string,
   pkey: string,
@@ -433,6 +442,13 @@ export const ln_admin = (
   val: number,
   args?: ?VarArgsObject<Input>,
 ): Output => expand2react(lnAdminActual(skey, pkey, val), args);
+
+export const ln_statistics = (
+  skey: string,
+  pkey: string,
+  val: number,
+  args?: ?VarArgsObject<Input>,
+): Output => expand2react(lnStatisticsActual(skey, pkey, val), args);
 
 export const lp = (
   key: string,

--- a/root/static/scripts/common/i18n/expand2text.js
+++ b/root/static/scripts/common/i18n/expand2text.js
@@ -16,6 +16,10 @@ import {
   l_admin as lAdminActual,
   ln_admin as lnAdminActual,
 } from '../i18n/admin.js';
+import {
+  l_statistics as lStatisticsActual,
+  ln_statistics as lnStatisticsActual,
+} from '../i18n/statistics.js';
 
 import expand, {
   type NO_MATCH,
@@ -116,6 +120,11 @@ export const l_admin = (
   args: VarArgsObject<StrOrNum>,
 ): string => expand2text(lAdminActual(key), args);
 
+export const l_statistics = (
+  key: string,
+  args: VarArgsObject<StrOrNum>,
+): string => expand2text(lStatisticsActual(key), args);
+
 export const ln = (
   skey: string,
   pkey: string,
@@ -129,6 +138,13 @@ export const ln_admin = (
   val: number,
   args: VarArgsObject<StrOrNum>,
 ): string => expand2text(lnAdminActual(skey, pkey, val), args);
+
+export const ln_statistics = (
+  skey: string,
+  pkey: string,
+  val: number,
+  args: VarArgsObject<StrOrNum>,
+): string => expand2text(lnStatisticsActual(skey, pkey, val), args);
 
 export const lp = (
   key: string,

--- a/root/statistics/Countries.js
+++ b/root/statistics/Countries.js
@@ -41,8 +41,8 @@ const Countries = ({
   return (
     <StatisticsLayout fullWidth page="countries" title={l('Countries')}>
       <p>
-        {texp.l('Last updated: {date}',
-                {date: dateCollected})}
+        {texp.l_statistics('Last updated: {date}',
+                           {date: dateCollected})}
       </p>
       <table className="tbl" id="countries-table">
         <thead>

--- a/root/statistics/CoverArt.js
+++ b/root/statistics/CoverArt.js
@@ -70,7 +70,7 @@ const CoverArt = ({
       title={lp('Cover art', 'plural')}
     >
       <p>
-        {texp.l('Last updated: {date}', {date: dateCollected})}
+        {texp.l_statistics('Last updated: {date}', {date: dateCollected})}
       </p>
       <h2>{l('Basics')}</h2>
       {stats['count.release.has_caa'] < 1 ? (
@@ -340,7 +340,7 @@ const CoverArt = ({
               <tr key={number}>
                 <th />
                 <th>
-                  {texp.ln(
+                  {texp.ln_statistics(
                     'with {num} piece of cover art:',
                     'with {num} pieces of cover art:',
                     number,

--- a/root/statistics/Editors.js
+++ b/root/statistics/Editors.js
@@ -97,7 +97,7 @@ const Editors = ({
 }: EditorsStatsT): React$Element<typeof StatisticsLayout> => (
   <StatisticsLayout fullWidth page="editors" title={l('Editors')}>
     <p>
-      {texp.l('Last updated: {date}', {date: dateCollected})}
+      {texp.l_statistics('Last updated: {date}', {date: dateCollected})}
     </p>
     <p>
       {l(`For the vote statistics, only yes or no votes are counted, abstain

--- a/root/statistics/Edits.js
+++ b/root/statistics/Edits.js
@@ -37,7 +37,7 @@ const Edits = ({
   return (
     <StatisticsLayout fullWidth page="edits" title={l('Edits')}>
       <p>
-        {texp.l('Last updated: {date}', {date: dateCollected})}
+        {texp.l_statistics('Last updated: {date}', {date: dateCollected})}
       </p>
       <h2>{l('Edits')}</h2>
       {Object.keys(statsByCategory).length === 0 ? (

--- a/root/statistics/Formats.js
+++ b/root/statistics/Formats.js
@@ -45,8 +45,8 @@ const Formats = ({
       title={l('Release/Medium Formats')}
     >
       <p>
-        {texp.l('Last updated: {date}',
-                {date: dateCollected})}
+        {texp.l_statistics('Last updated: {date}',
+                           {date: dateCollected})}
       </p>
       <h2>{l('Release/Medium Formats')}</h2>
       <table className="tbl">

--- a/root/statistics/Index.js
+++ b/root/statistics/Index.js
@@ -82,7 +82,7 @@ const Index = ({
   return (
     <StatisticsLayout fullWidth page="index" title={l('Overview')}>
       <p>
-        {texp.l('Last updated: {date}', {date: dateCollected})}
+        {texp.l_statistics('Last updated: {date}', {date: dateCollected})}
       </p>
       <h2>{l('Basic metadata')}</h2>
       <table className="database-statistics">
@@ -544,7 +544,7 @@ const Index = ({
               <th />
               <th />
               <th>
-                {texp.ln(
+                {texp.ln_statistics(
                   'with {num} disc ID:',
                   'with {num} disc IDs:',
                   num,
@@ -588,7 +588,7 @@ const Index = ({
               <th />
               <th />
               <th>
-                {texp.ln(
+                {texp.ln_statistics(
                   'with {num} disc ID:',
                   'with {num} disc IDs:',
                   num,

--- a/root/statistics/LanguagesScripts.js
+++ b/root/statistics/LanguagesScripts.js
@@ -50,7 +50,7 @@ const LanguagesScripts = ({
       title={l('Languages and scripts')}
     >
       <p>
-        {texp.l('Last updated: {date}', {date: dateCollected})}
+        {texp.l_statistics('Last updated: {date}', {date: dateCollected})}
       </p>
       <p>
         {l(`All other available languages and scripts

--- a/root/statistics/MusicBrainzHistory.js
+++ b/root/statistics/MusicBrainzHistory.js
@@ -9,6 +9,7 @@
 
 import Layout from '../layout/index.js';
 import expand2react from '../static/scripts/common/i18n/expand2react.js';
+import {l_statistics as l} from '../static/scripts/common/i18n/statistics.js';
 
 type PropsT = {
   +events: $ReadOnlyArray<StatisticsEventT>,

--- a/root/statistics/MusicBrainzHistory.js
+++ b/root/statistics/MusicBrainzHistory.js
@@ -21,7 +21,7 @@ const MusicBrainzHistory = ({
     <h1>{l('Our glorious history')}</h1>
     {events.length
       ? events.map((event) => {
-        const title = exp.l(
+        const title = exp.l_statistics(
           '{date} - {title}',
           {date: event.date, title: event.title},
         );

--- a/root/statistics/NoStatistics.js
+++ b/root/statistics/NoStatistics.js
@@ -15,7 +15,7 @@ const NoStatistics = (): React$Element<typeof StatisticsLayout> => (
   <StatisticsLayout fullWidth page="index" title={l('No statistics')}>
     <h2>{l('No statistics')}</h2>
     <p>
-      {exp.l(
+      {exp.l_statistics(
         `Statistics have never been collected for this server. If you are the
          administrator for this server, you should run
          <code>./admin/CollectStats.pl</code> or import

--- a/root/statistics/Relationships.js
+++ b/root/statistics/Relationships.js
@@ -105,7 +105,7 @@ const Relationships = ({
       title={l('Relationships')}
     >
       <p>
-        {texp.l('Last updated: {date}', {date: dateCollected})}
+        {texp.l_statistics('Last updated: {date}', {date: dateCollected})}
       </p>
       <h2>{l('Relationships')}</h2>
       {stats['count.ar.links'] < 1 ? (
@@ -139,7 +139,7 @@ const Relationships = ({
                 <>
                   <tr className="thead">
                     <th colSpan="4">
-                      {texp.l(
+                      {texp.l_statistics(
                         '{type0}-{type1}',
                         {type0: type0, type1: type1},
                       )}
@@ -147,7 +147,7 @@ const Relationships = ({
                   </tr>
                   <tr>
                     <th colSpan="2">
-                      {texp.l(
+                      {texp.l_statistics(
                         '{type0}-{type1} relationships:',
                         {type0: type0, type1: type1},
                       )}

--- a/root/statistics/stats.js
+++ b/root/statistics/stats.js
@@ -919,7 +919,7 @@ for (let n = 0; n < 11; n++) {
   stats[`count.release.${n}discids`] = {
     category: 'other',
     color: '#ff0000',
-    label: texp.ln(
+    label: texp.ln_statistics(
       'Releases with 1 Disc ID',
       'Releases with {n} Disc IDs',
       n,
@@ -930,7 +930,7 @@ for (let n = 0; n < 11; n++) {
   stats[`count.medium.${n}discids`] = {
     category: 'other',
     color: '#ff0000',
-    label: texp.ln(
+    label: texp.ln_statistics(
       'Mediums with 1 Disc ID',
       'Mediums with {n} Disc IDs',
       n,
@@ -941,7 +941,7 @@ for (let n = 0; n < 11; n++) {
   stats[`count.recording.${n}releases`] = {
     category: 'other',
     color: '#ff0000',
-    label: texp.ln(
+    label: texp.ln_statistics(
       'Recordings with 1 Release',
       'Recordings with {n} Releases',
       n,
@@ -952,7 +952,7 @@ for (let n = 0; n < 11; n++) {
   stats[`count.releasegroup.${n}releases`] = {
     category: 'other',
     color: '#ff0000',
-    label: texp.ln(
+    label: texp.ln_statistics(
       'Release Groups with 1 Release',
       'Release Groups with {n} Releases',
       n,
@@ -1006,7 +1006,7 @@ export function buildTypeStats(typeData) {
     stats[`count.area.type.${key}`] = {
       category: 'area-types',
       color: '#ff0000',
-      label: texp.l('{type} areas', {type: typeName}),
+      label: texp.l_statistics('{type} areas', {type: typeName}),
     };
   }
 
@@ -1018,31 +1018,31 @@ export function buildTypeStats(typeData) {
     stats[`count.artist.country.${key}`] = {
       category: 'artist-countries',
       color: '#ff0000',
-      label: texp.l('{country} artists', countryArg),
+      label: texp.l_statistics('{country} artists', countryArg),
     };
 
     stats[`count.event.country.${key}`] = {
       category: 'event-countries',
       color: '#ff0000',
-      label: texp.l('{country} events', countryArg),
+      label: texp.l_statistics('{country} events', countryArg),
     };
 
     stats[`count.label.country.${key}`] = {
       category: 'label-countries',
       color: '#ff0000',
-      label: texp.l('{country} labels', countryArg),
+      label: texp.l_statistics('{country} labels', countryArg),
     };
 
     stats[`count.place.country.${key}`] = {
       category: 'place-countries',
       color: '#ff0000',
-      label: texp.l('{country} places', countryArg),
+      label: texp.l_statistics('{country} places', countryArg),
     };
 
     stats[`count.release.country.${key}`] = {
       category: 'release-countries',
       color: '#ff0000',
-      label: texp.l('{country} releases', countryArg),
+      label: texp.l_statistics('{country} releases', countryArg),
     };
   }
 
@@ -1053,7 +1053,7 @@ export function buildTypeStats(typeData) {
     stats[`count.edit.type.${key}`] = {
       category: 'edit-types',
       color: '#ff0000',
-      label: texp.l('{type} edits', {type: typeName}),
+      label: texp.l_statistics('{type} edits', {type: typeName}),
     };
   }
 
@@ -1064,7 +1064,7 @@ export function buildTypeStats(typeData) {
     stats[`count.event.type.${key}`] = {
       category: 'event-types',
       color: '#ff0000',
-      label: texp.l('{type} events', {type: typeName}),
+      label: texp.l_statistics('{type} events', {type: typeName}),
     };
   }
 
@@ -1075,19 +1075,19 @@ export function buildTypeStats(typeData) {
     stats[`count.release.format.${key}`] = {
       category: 'formats',
       color: '#ff0000',
-      label: texp.l('{name} releases', formatArg),
+      label: texp.l_statistics('{name} releases', formatArg),
     };
 
     stats[`count.medium.format.${key}`] = {
       category: 'formats',
       color: '#ff0000',
-      label: texp.l('{name} mediums', formatArg),
+      label: texp.l_statistics('{name} mediums', formatArg),
     };
 
     stats[`count.release.format.${encodeURI(format.name)}.has_coverart`] = {
       category: 'cover-art',
       color: '#ff0000',
-      label: texp.l(
+      label: texp.l_statistics(
         'Releases with a medium of format “{format}” that have cover art',
         {format: formatArg.name},
       ),
@@ -1101,7 +1101,7 @@ export function buildTypeStats(typeData) {
     stats[`count.instrument.type.${key}`] = {
       category: 'instrument-types',
       color: '#ff0000',
-      label: texp.l('{type} instruments', {type: typeName}),
+      label: texp.l_statistics('{type} instruments', {type: typeName}),
     };
   }
 
@@ -1112,7 +1112,7 @@ export function buildTypeStats(typeData) {
     stats[`count.label.type.${key}`] = {
       category: 'label-types',
       color: '#ff0000',
-      label: texp.l('{type} labels', {type: typeName}),
+      label: texp.l_statistics('{type} labels', {type: typeName}),
     };
   }
 
@@ -1123,13 +1123,14 @@ export function buildTypeStats(typeData) {
     stats[`count.release.language.${key}`] = {
       category: 'release-languages',
       color: '#ff0000',
-      label: texp.l('{language} releases', {language: languageName}),
+      label: texp.l_statistics('{language} releases',
+                               {language: languageName}),
     };
 
     stats[`count.work.language.${key}`] = {
       category: 'work-languages',
       color: '#ff0000',
-      label: texp.l('{language} works', {language: languageName}),
+      label: texp.l_statistics('{language} works', {language: languageName}),
     };
   }
 
@@ -1140,7 +1141,7 @@ export function buildTypeStats(typeData) {
     stats[`count.release.packaging.${key}`] = {
       category: 'release-packagings',
       color: '#ff0000',
-      label: texp.l(
+      label: texp.l_statistics(
         'Releases with packaging “{packaging}”',
         {packaging: packagingName},
       ),
@@ -1154,14 +1155,14 @@ export function buildTypeStats(typeData) {
     stats[`count.place.type.${key}`] = {
       category: 'place-types',
       color: '#ff0000',
-      label: texp.l('{type} places', {type: typeName}),
+      label: texp.l_statistics('{type} places', {type: typeName}),
     };
   }
 
   for (let i = 0; i < relationshipTables.length; i++) {
     const pair = relationshipTables[i];
     const hex = fixedWidthInteger((i + 1) * 3, 2);
-    const label = texp.l(
+    const label = texp.l_statistics(
       '{first_entity_type}-{second_entity_type} Relationships',
       {
         first_entity_type: formatEntityTypeName(pair[0]),
@@ -1180,7 +1181,7 @@ export function buildTypeStats(typeData) {
     const type = relationshipTypes[key];
     const typeName = l_relationships(type.name);
 
-    const label = texp.l(
+    const label = texp.l_statistics(
       `{first_entity_type_name}-{second_entity_type_name}
        “{relationship_type_name}” relationships`,
       {
@@ -1196,7 +1197,7 @@ export function buildTypeStats(typeData) {
       label,
     };
 
-    const labelInclusive = texp.l(
+    const labelInclusive = texp.l_statistics(
       `{first_entity_type_name}-{second_entity_type_name}
        “{relationship_type_name}” relationships
        including child relationship types`,
@@ -1220,13 +1221,13 @@ export function buildTypeStats(typeData) {
     stats[`count.releasegroup.primary_type.${key}`] = {
       category: 'release-group-types',
       color: '#ff0000',
-      label: texp.l('{type} release groups', {type: typeName}),
+      label: texp.l_statistics('{type} release groups', {type: typeName}),
     };
 
     stats[`count.release.type.${encodeURI(type.name)}.has_coverart`] = {
       category: 'cover-art',
       color: '#ff0000',
-      label: texp.l(
+      label: texp.l_statistics(
         'Releases in groups of type “{type}” with cover art',
         {type: typeName},
       ),
@@ -1240,7 +1241,7 @@ export function buildTypeStats(typeData) {
     stats[`count.releasegroup.secondary_type.${key}`] = {
       category: 'release-group-types',
       color: '#ff0000',
-      label: texp.l('{type} release groups', {type: typeName}),
+      label: texp.l_statistics('{type} release groups', {type: typeName}),
     };
   }
 
@@ -1251,7 +1252,7 @@ export function buildTypeStats(typeData) {
     stats[`count.release.script.${key}`] = {
       category: 'release-scripts',
       color: '#ff0000',
-      label: texp.l('{script} releases', {script: scriptName}),
+      label: texp.l_statistics('{script} releases', {script: scriptName}),
     };
   }
 
@@ -1262,7 +1263,7 @@ export function buildTypeStats(typeData) {
     stats[`count.series.type.${key}`] = {
       category: 'series-types',
       color: '#ff0000',
-      label: texp.l('{type} series', {type: typeName}),
+      label: texp.l_statistics('{type} series', {type: typeName}),
     };
   }
 
@@ -1273,13 +1274,13 @@ export function buildTypeStats(typeData) {
     stats[`count.release.status.${key}`] = {
       category: 'release-statuses',
       color: '#ff0000',
-      label: texp.l('{status} releases', {status: statusName}),
+      label: texp.l_statistics('{status} releases', {status: statusName}),
     };
 
     stats[`count.release.status.${encodeURI(status.name)}.has_coverart`] = {
       category: 'cover-art',
       color: '#ff0000',
-      label: texp.l(
+      label: texp.l_statistics(
         'Releases of status “{status}” with cover art',
         {status: statusName},
       ),
@@ -1296,7 +1297,7 @@ export function buildTypeStats(typeData) {
     stats[`count.work.attribute.${key}`] = {
       category: 'work-attributes',
       color: '#ff0000',
-      label: texp.l(
+      label: texp.l_statistics(
         'Works with attribute “{attribute}”',
         {attribute: attributeName},
       ),
@@ -1310,7 +1311,7 @@ export function buildTypeStats(typeData) {
     stats[`count.work.type.${key}`] = {
       category: 'work-types',
       color: '#ff0000',
-      label: texp.l('{type} works', {type: typeName}),
+      label: texp.l_statistics('{type} works', {type: typeName}),
     };
   }
 }

--- a/root/statistics/stats.js
+++ b/root/statistics/stats.js
@@ -7,6 +7,10 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import {
+  l_statistics as l,
+  lp_statistics as lp,
+} from '../static/scripts/common/i18n/statistics.js';
 import formatEntityTypeName
   from '../static/scripts/common/utility/formatEntityTypeName.js';
 import {fixedWidthInteger} from '../static/scripts/common/utility/strings.js';

--- a/root/statistics/utilities.js
+++ b/root/statistics/utilities.js
@@ -10,6 +10,7 @@
 
 import timelineIconUrl
   from '../static/images/icons/timeline.png';
+import {l_statistics as l} from '../static/scripts/common/i18n/statistics.js';
 
 export function formatPercentage(
   $c: CatalystContextT,

--- a/root/vars.js
+++ b/root/vars.js
@@ -92,6 +92,10 @@ declare var exp: {
     key: string,
     args?: ?{+[arg: string]: Expand2ReactInput, ...},
   ) => Expand2ReactOutput,
+  +l_statistics: (
+    key: string,
+    args?: ?{+[arg: string]: Expand2ReactInput, ...},
+  ) => Expand2ReactOutput,
   +ln: (
     skey: string,
     pkey: string,
@@ -99,6 +103,12 @@ declare var exp: {
     args?: ?{+[arg: string]: Expand2ReactInput, ...},
   ) => Expand2ReactOutput,
   +ln_admin: (
+    skey: string,
+    pkey: string,
+    val: number,
+    args?: ?{+[arg: string]: Expand2ReactInput, ...},
+  ) => Expand2ReactOutput,
+  +ln_statistics: (
     skey: string,
     pkey: string,
     val: number,
@@ -120,6 +130,10 @@ declare var texp: {
     key: string,
     args: {+[arg: string]: StrOrNum, ...},
   ) => string,
+  +l_statistics: (
+    key: string,
+    args: {+[arg: string]: StrOrNum, ...},
+  ) => string,
   +ln: (
     skey: string,
     pkey: string,
@@ -127,6 +141,12 @@ declare var texp: {
     args: {+[arg: string]: StrOrNum, ...},
   ) => string,
   +ln_admin: (
+    skey: string,
+    pkey: string,
+    val: number,
+    args: {+[arg: string]: StrOrNum, ...},
+  ) => string,
+  +ln_statistics: (
     skey: string,
     pkey: string,
     val: number,

--- a/script/xgettext.js
+++ b/script/xgettext.js
@@ -154,7 +154,7 @@ const catchErrors = cb => {
   };
 };
 
-const keywords = {
+let keywords = {
   l: catchErrors(function (match) {
     const [arg0] = match.arguments;
 
@@ -223,6 +223,12 @@ const keywords = {
   N_l: match => keywords.l(match),
   N_ln: match => keywords.ln(match),
   N_lp: match => keywords.lp(match),
+};
+
+keywords = {
+  ...keywords,
+  l_statistics: keywords.l,
+  ln_statistics: keywords.ln,
 };
 
 const parser = new XGettext({

--- a/webpack/providePluginConfig.mjs
+++ b/webpack/providePluginConfig.mjs
@@ -59,6 +59,12 @@ const providePluginConfig = {
 
   'texp.l_admin': [expandTextPath, 'l_admin'],
   'texp.ln_admin': [expandTextPath, 'ln_admin'],
+
+  'exp.l_statistics': [expandPath, 'l_statistics'],
+  'exp.ln_statistics': [expandPath, 'ln_statistics'],
+
+  'texp.l_statistics': [expandTextPath, 'l_statistics'],
+  'texp.ln_statistics': [expandTextPath, 'ln_statistics'],
   /* eslint-enable sort-keys */
 };
 


### PR DESCRIPTION
# Problem MBS-13431
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Text that needs to be expanded - because it contains either variables or HTML tags - is incidentally not translated when rendering statistics pages.

This is because it was using `exp.l` or `texp.l` which match the translation domain `server` instead of `statistics`.

From a discussion on IRC, I found some additional issues with rendering translations from the statistics domain.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Add `l_statistics` and `ln_statistics` to `exp` and `texp`, auto-import these new functions, parse these for string extraction, and use these instead of `l` and `ln` under `root/statistics/`.

Make use of it for rendering event descriptions.

Fix rendering translations in MusicBrainz history and statistics timeline.


# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

* [x] Using sample data (that has no statistics), open the page http://localhost:5000/statistics and check that the main paragraph is actually translated (in French, and probably in other production languages too).
* [x] Tested running `po/update_pot.sh`
* [x] Copying an event from the main database, open the page http://localhost:5000/history and check that the strings are actually translated (in Italian, which has the best coverage).
* [x] Tested Flow and ESLint on modified JS files.