### PR TITLE
Fix deleted entity spacing in subscription email

### DIFF
--- a/lib/MusicBrainz/Server/Email/Subscriptions.pm
+++ b/lib/MusicBrainz/Server/Email/Subscriptions.pm
@@ -172,7 +172,7 @@ type = sub.isa('MusicBrainz::Server::Entity::Subscription::DeletedArtist') ? 'ar
 [%- IF type == 'collection' -%]
 [%- type | ucfirst %] "[% sub.last_seen_name %]" - deleted or made private
 [% ELSE -%]
-[%- type | ucfirst %] "[% sub.last_known_name %]"[% '(' _ sub.last_known_comment _ ') ' IF sub.last_known_comment %] - [% sub.reason %] by edit #[% edit %]
+[%- type | ucfirst %] "[% sub.last_known_name %]"[% ' (' _ sub.last_known_comment _ ')' IF sub.last_known_comment %] - [% sub.reason %] by edit #[% edit %]
 [% self.server %]/edit/[% edit %]
 [% END -%]
 [%- END %]


### PR DESCRIPTION
Subscription emails are missing a space between names and disambiguation comments of deleted entities and contain an extra space after comments, e.g.

`Artist "Name"(comment)  - merged by edit #...`

Fix the spacing.

---

I didn't bother with filing an issue or filling out the PR template since this is a trivial change, but let me know if I should've.

`t/lib/t/MusicBrainz/Server/Email/Subscriptions.pm` seems like it didn't catch this since it only looks at a deleted collection.