### PR TITLE
Don't store incremental JSON dumps in a local volume

### DIFF
--- a/admin/RunIncrementalJSONDump
+++ b/admin/RunIncrementalJSONDump
@@ -23,14 +23,6 @@ source admin/config.sh
 . ./admin/functions.sh
 make_temp_dir
 
-DUMP_DIR="$JSON_DUMP_DIR"/incremental
-
-# Create necessary directories and set permissions. If we're not doing a full
-# dump then $DUMP_STAMP is empty, so that argument is ignored.
-
-mkdir -m "$JSON_DUMP_DIR_MODE" -p "$DUMP_DIR"
-chown "$JSON_DUMP_USER:$JSON_DUMP_GROUP" "$DUMP_DIR"
-
 # The database from which the dumps are generated is replicated, but created
 # as standalone - meaning it has foreign keys and triggers. Foreign keys are
 # needed for MusicBrainz::Server::Role::FollowForeignKeys to work. The
@@ -52,20 +44,22 @@ shopt -s nullglob
 DUMP_FILE=`echo -n "$TEMP_DIR"/json-dump-*/*.tar.xz`
 shopt -u nullglob
 
-# Incremental JSON dumps go to the "FTP data directory", consistent with the
-# full dumps, but they aren't synced to real FTP like the full dumps are,
-# since they require a replication token to access.
-#
-# They're synced from here to a Docker volume shared by the metabrainz.org
-# container on another server, via ./bin/rsync-incremental-json-dumps.
+# Incremental JSON dumps are synced to a Docker volume on the same host as
+# the metabrainz.org container.
 if [ "$DUMP_FILE" ]
 then
     echo Copying incremental json dumps to backup dir
     chown "$JSON_DUMP_USER:$JSON_DUMP_GROUP" "$TEMP_DIR"/json-dump-*/*
     chmod "$JSON_DUMP_FILE_MODE" "$TEMP_DIR"/json-dump-*/*
-    mv "$TEMP_DIR"/* "$DUMP_DIR"/
 
-    MBS_ADMIN_CONFIG=config.incremental-json-dump.sh ./bin/rsync-fullexport-files
+    retry rsync \
+        --archive \
+        --rsh "ssh -i $RSYNC_INCREMENTAL_JSON_DUMPS_KEY -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p $RSYNC_INCREMENTAL_JSON_DUMPS_PORT" \
+        --verbose \
+        "$TEMP_DIR"/ \
+        brainz@$RSYNC_INCREMENTAL_JSON_DUMPS_HOST:./
+
+    rm -rf "$TEMP_DIR"/*
 fi
 
 # eof

--- a/admin/config.default.sh
+++ b/admin/config.default.sh
@@ -36,3 +36,7 @@ RSYNC_FULLEXPORT_PORT='65415'
 RSYNC_FULLEXPORT_DIR="$FTP_DATA_DIR/fullexport"
 RSYNC_FULLEXPORT_KEY='~/.ssh/rsync-data-fullexport'
 RSYNC_LATEST_KEY='~/.ssh/rsync-data-latest'
+
+RSYNC_INCREMENTAL_JSON_DUMPS_HOST='mbincrementaljson.local'
+RSYNC_INCREMENTAL_JSON_DUMPS_PORT='65415'
+RSYNC_INCREMENTAL_JSON_DUMPS_KEY='~/.ssh/rsync-json-dumps-incremental'

--- a/admin/config.incremental-json-dump.sh
+++ b/admin/config.incremental-json-dump.sh
@@ -1,4 +1,0 @@
-RSYNC_FULLEXPORT_HOST='mbincrementaljson.local'
-RSYNC_FULLEXPORT_DIR="$JSON_DUMP_DIR/incremental"
-RSYNC_FULLEXPORT_KEY='~/.ssh/rsync-json-dumps-incremental'
-RSYNC_LATEST_KEY=''

--- a/docker/templates/Dockerfile.json-dump.m4
+++ b/docker/templates/Dockerfile.json-dump.m4
@@ -3,8 +3,7 @@ m4_include(`server_base.m4')m4_dnl
 install_new_xz_utils
 
 RUN chown_mb(`/home/musicbrainz/log') && \
-    chown_mb(`/home/musicbrainz/json-dumps/full') && \
-    chown_mb(`/home/musicbrainz/json-dumps/incremental')
+    chown_mb(`/home/musicbrainz/json-dumps/full')
 
 copy_common_mbs_files
 


### PR DESCRIPTION
# Problem

Currently, when incremental JSON dumps are generated, they are (1) copied to a local "FTP directory" (which, confusingly, is not our actual FTP server; it's just a local volume), and (2) rsynced to a (possibly) remote volume on the same host as the metabrainz.org container.

There is not really any reason to do (1) if (2) is succesful, because we presumably backup (2) already with borgmatic; there is no need to store these in three places.

This is more relevant now, because the incremental JSON dumps are being moved to hendrix, which is also where the metabrainz.org container is hosted. So without these changes, we'd be storing them twice on the same host!

# Solution

This updates admin/RunIncrementalJSONDump to NOT copy any dumps from the temporary dump directory to any local volume, only rsync the dumps directly from the temporary directory. This means we can no longer use rsync-fullexport-files, because that runs rsync with the `--delete` flag, and we do NOT want to delete any "remote" (but really local, now) incremental JSON dumps that do not exist in our temporary directory (read: all of them).

I've added separate `RSYNC_INCREMENTAL_JSON_DUMPS_*` environment variables to control the rsync invocation, which I think is clearer than trying to use scripts designed for fullexports anyway (which are intended to only store the few most recent dumps).

# Testing

These changes are currently applied in the musicbrainz-json-dump container on hendrix. I checked the hourly JSON dump logs for any errors and ensured the json-dump-* directories were synced to the sshd-musicbrainz-json-dumps-incremental containter correctly.