### PR TITLE
MBS-13443: Properly display HTML setlist codes

### DIFF
--- a/root/event/edit_form.tt
+++ b/root/event/edit_form.tt
@@ -23,7 +23,7 @@
                    [mbid|name] allows linking to artists and works.') -%]
         </p>
         <p>
-            [%- l('If needed, the characters "[", "]", and "&" can be escaped using the HTML entities "&lsqb;", "&rsqb;", and "&amp;" respectively.') -%]
+            [%- l('If needed, the characters "[", "]", and "&" can be escaped using the HTML entities "<code>&amp;lsqb;</code>", "<code>&amp;rsqb;</code>", and "<code>&amp;amp;</code>" respectively.') -%]
         </p>
       </fieldset>
 


### PR DESCRIPTION
### Fix MBS-13443

# Problem
The documentation for setlist formatting in the event edit form contains the following very useful line:
`If needed, the characters "[", "]", and "&" can be escaped using the HTML entities "[", "]", and "&" respectively.`
Clearly, something went wrong with the escaping.

# Solution
This turns `&lsqb;` into `&amp;lsqb;`, and so on for the others, which makes the line appear as intended:
`If needed, the characters "[", "]", and "&" can be escaped using the HTML entities "&lsqb;", "&rsqb;", and "&amp;" respectively.`
It also encloses the entities in `<code>` for consistency with the similar string in `root/annotation/EditAnnotation.js`.

# Testing
Manually, by loading the page and making sure it displays the HTML fine, and also by copy-pasting the HTML and using it in a setlist as `&lsqb;testy&rsqb;` to ensure it properly shows as `[testy]` (so it can just be copied and used as-is).