### PR TITLE
Restore failing CircleCI tests on error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@ version: 2.1
 executors:
   musicbrainz-tests:
     docker:
-      - image: metabrainz/musicbrainz-tests:v-2024-01.1
+      - image: metabrainz/musicbrainz-tests:v-2024-01.419
         user: root
     working_directory: /home/musicbrainz/musicbrainz-server
 
   musicbrainz-tests-perl-5-dot-30:
     docker:
-      - image: metabrainz/musicbrainz-tests:v-2024-01.1-perl5.30
+      - image: metabrainz/musicbrainz-tests:v-2024-01.419-perl5.30
         user: root
     working_directory: /home/musicbrainz/musicbrainz-server
 

--- a/docker/musicbrainz-tests/DBDefs.pm
+++ b/docker/musicbrainz-tests/DBDefs.pm
@@ -124,7 +124,7 @@ sub GIT_SHA { return }
 
 sub HTML_VALIDATOR { 'http://localhost:8888?out=json' }
 
-sub MB_LANGUAGES { qw( de el es et fi fr he it ja nl sq en ) }
+sub MB_LANGUAGES { qw( de el es es-419 et fi fr he it ja nl sq en ) }
 
 sub ACTIVE_SCHEMA_SEQUENCE { 28 }
 

--- a/docker/musicbrainz-tests/chrome.service
+++ b/docker/musicbrainz-tests/chrome.service
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-exec sudo -E -H -u musicbrainz google-chrome-stable \
+exec sudo -E -H -u musicbrainz /opt/chrome-linux64/chrome \
     --headless \
     --disable-dev-shm-usage \
     --disable-gpu \

--- a/docker/musicbrainz-tests/run_circleci_tests.sh
+++ b/docker/musicbrainz-tests/run_circleci_tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e -o pipefail
+
 sudo -E -H -u musicbrainz mkdir -p junit_output
 
 sudo -E -H -u musicbrainz cp docker/musicbrainz-tests/DBDefs.pm lib/

--- a/docker/musicbrainz-tests/run_circleci_tests.sh
+++ b/docker/musicbrainz-tests/run_circleci_tests.sh
@@ -2,11 +2,23 @@
 
 set -e -o pipefail
 
+function sv_start_if_down() {
+  while [[ $# -gt 0 ]]
+  do
+    if [[ -e "/etc/service/$1/down" ]]
+    then
+      rm -fv "/etc/service/$1/down"
+      sv start "$1"
+    fi
+    shift
+  done
+}
+
 sudo -E -H -u musicbrainz mkdir -p junit_output
 
 sudo -E -H -u musicbrainz cp docker/musicbrainz-tests/DBDefs.pm lib/
 
-rm /etc/service/{postgresql,redis}/down && sv start postgresql redis
+sv_start_if_down postgresql redis
 
 sudo -E -H -u musicbrainz carton exec -- ./script/create_test_db.sh
 
@@ -23,7 +35,7 @@ sudo -E -H -u musicbrainz ./node_modules/.bin/flow --quiet
 sudo -E -H -u musicbrainz ./node_modules/.bin/eslint --max-warnings 0 .
 ! git grep -Pw '(N_)?l[np]?\(' -- 'root/statistics/**.js'
 
-rm /etc/service/chrome/down && sv start chrome
+sv_start_if_down chrome
 
 sudo -E -H -u musicbrainz carton exec -- node \
     t/web.js \
@@ -38,7 +50,7 @@ sudo -u postgres createdb -O musicbrainz -T musicbrainz_test -U postgres musicbr
 sudo -u postgres createdb -O musicbrainz -T musicbrainz_test -U postgres musicbrainz_test_full_export
 sudo -u postgres createdb -O musicbrainz -T musicbrainz_test -U postgres musicbrainz_test_sitemaps
 
-rm /etc/service/{template-renderer,vnu,website}/down && sv start template-renderer vnu website
+sv_start_if_down template-renderer vnu website
 
 export MMD_SCHEMA_ROOT=/home/musicbrainz/mb-solr/mmd-schema
 export JUNIT_OUTPUT_FILE=junit_output/perl_and_pgtap.xml

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -347,7 +347,7 @@ sub with_translations {
     my $cookie_lang = Translation->instance->language_from_cookie($c->request->cookies->{lang});
     $c->set_language_cookie($c->request->cookies->{lang}->value) if defined $c->request->cookies->{lang};
     my $lang = Translation->instance->set_language($cookie_lang);
-    my $html_lang = $lang =~ s/_([A-Z]{2})/-\L$1/r;
+    my $html_lang = $lang =~ s/_([A-Z0-9]{2,})/-\L$1/r;
 
     $c->stash(
         current_language => $lang,

--- a/lib/MusicBrainz/Server/Translation.pm
+++ b/lib/MusicBrainz/Server/Translation.pm
@@ -131,7 +131,10 @@ sub set_language
     }
     my $set_lang = web_set_locale(\@avail_lang, [ 'utf-8' ], LC_MESSAGES);
     if (!defined $set_lang) {
-        return 'en';
+        # Force setting 'es_419' which seems to not be recognized by
+        # Locale::Util most likely, or I18N::LangTags::Detect maybe.
+        # A more definitive fix should be implemented for MBS-13446.
+        return contains_string(\@avail_lang, 'es_419') ? 'es_419' : 'en';
     }
     # Strip off charset
     $set_lang =~ s/\.utf-8//;
@@ -170,9 +173,9 @@ sub language_from_cookie
 {
     my ($self, $cookie) = @_;
     my $cookie_munge = defined $cookie ? $cookie->value : '';
-    $cookie_munge =~ s/-([A-Z]{2})/-\L$1/;
+    $cookie_munge =~ s/-([A-Z0-9]{2,})/-\L$1/;
     my $cookie_nocountry = defined $cookie ? $cookie->value : '';
-    $cookie_nocountry =~ s/-[A-Z]{2}//;
+    $cookie_nocountry =~ s/-[A-Z0-9]{2,}//;
     if (defined $cookie &&
         any { $cookie->value eq $_ || $cookie_munge eq $_ } DBDefs->MB_LANGUAGES) {
         return $cookie->value;

--- a/root/futureColumnLabels.js
+++ b/root/futureColumnLabels.js
@@ -12,6 +12,8 @@
  * https://tickets.metabrainz.org/browse/MBS-11178 gets resolved.
  */
 
+/* eslint-disable no-unused-vars */
+
 const collectionTypeColumnLabels = [
   N_l('Entity type'),
 ];

--- a/root/server/gettext/poFile.mjs
+++ b/root/server/gettext/poFile.mjs
@@ -15,7 +15,7 @@ import po2json from 'po2json';
 
 import MB_SERVER_ROOT from '../../utility/serverRootDir.mjs';
 
-const LOCALE_EXT = new RegExp('_[a-zA-Z]+\\.po$');
+const LOCALE_EXT = new RegExp('_[a-zA-Z0-9]+\\.po$');
 const PO_DIR = path.resolve(MB_SERVER_ROOT, 'po');
 
 function getPath(domain: string, locale: string) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4004,7 +4004,9 @@ const CLEANUPS: CleanupEntries = {
     },
   },
   'metalmusicarchives': {
-    match: [new RegExp('^(https?://)?(www\\.)?metalmusicarchives\\.com', 'i')],
+    match: [
+      new RegExp('^(https?://)?(www\\.)?metalmusicarchives\\.com', 'i'),
+    ],
     restrict: [LINK_TYPES.otherdatabases],
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?metalmusicarchives\.com\/([^#?]+).*$/, 'https://www.metalmusicarchives.com/$1');

--- a/root/static/scripts/relationship-editor/utility/compareRelationships.js
+++ b/root/static/scripts/relationship-editor/utility/compareRelationships.js
@@ -324,7 +324,7 @@ export default function compareRelationships(
     targetA.orderingTypeID === SERIES_ORDERING_TYPE_AUTOMATIC &&
     linkTypeId != null &&
     PART_OF_SERIES_LINK_TYPE_IDS.includes(linkTypeId)
-  ){
+  ) {
     const seriesItemCmp = (
       /*
        * If the number attributes are different, the relationships would

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1470,16 +1470,16 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['release'],
   },
   {
-                     input_url: 'https://m.bugs.co.kr/album/20488834?wl_ref=M_contents_01_07',
-             input_entity_type: 'release',
+                     input_url: 'https://m.bugs.co.kr/track/31247088#comments',
+             input_entity_type: 'recording',
        input_relationship_type: 'streamingpaid',
     expected_relationship_type: ['downloadpurchase', 'streamingpaid'],
 limited_link_type_combinations: [
                                   ['downloadpurchase', 'streamingpaid'],
                                   'streamingpaid',
                                 ],
-            expected_clean_url: 'https://music.bugs.co.kr/album/20488834',
-       only_valid_entity_types: ['release'],
+            expected_clean_url: 'https://music.bugs.co.kr/track/31247088',
+       only_valid_entity_types: ['recording'],
   },
   {
                      input_url: 'https://music.bugs.co.kr/mv/618959',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1460,52 +1460,62 @@ limited_link_type_combinations: [
   {
                      input_url: 'https://music.bugs.co.kr/album/20488834?wl_ref=M_contents_01_07',
              input_entity_type: 'release',
+       input_relationship_type: 'streamingpaid',
     expected_relationship_type: ['downloadpurchase', 'streamingpaid'],
 limited_link_type_combinations: [
                                   ['downloadpurchase', 'streamingpaid'],
                                   'streamingpaid',
                                 ],
             expected_clean_url: 'https://music.bugs.co.kr/album/20488834',
+       only_valid_entity_types: ['release'],
   },
   {
                      input_url: 'https://m.bugs.co.kr/album/20488834?wl_ref=M_contents_01_07',
              input_entity_type: 'release',
+       input_relationship_type: 'streamingpaid',
     expected_relationship_type: ['downloadpurchase', 'streamingpaid'],
 limited_link_type_combinations: [
                                   ['downloadpurchase', 'streamingpaid'],
                                   'streamingpaid',
                                 ],
             expected_clean_url: 'https://music.bugs.co.kr/album/20488834',
+       only_valid_entity_types: ['release'],
   },
   {
                      input_url: 'https://music.bugs.co.kr/mv/618959',
              input_entity_type: 'release',
+       input_relationship_type: 'streamingpaid',
     expected_relationship_type: ['downloadpurchase', 'streamingpaid'],
 limited_link_type_combinations: [
                                   ['downloadpurchase', 'streamingpaid'],
                                   'streamingpaid',
                                 ],
             expected_clean_url: 'https://music.bugs.co.kr/mv/618959',
+       only_valid_entity_types: ['recording', 'release'],
   },
   {
                      input_url: 'https://music.bugs.co.kr/artist/80276288?wl_ref=M_Search_01_01',
              input_entity_type: 'artist',
+       input_relationship_type: 'streamingpaid',
     expected_relationship_type: ['downloadpurchase', 'streamingpaid'],
 limited_link_type_combinations: [
                                   ['downloadpurchase', 'streamingpaid'],
                                   'streamingpaid',
                                 ],
             expected_clean_url: 'https://music.bugs.co.kr/artist/80276288',
+       only_valid_entity_types: ['artist'],
   },
   {
                      input_url: 'https://m.bugs.co.kr/artist/80276288',
              input_entity_type: 'artist',
+       input_relationship_type: 'streamingpaid',
     expected_relationship_type: ['downloadpurchase', 'streamingpaid'],
 limited_link_type_combinations: [
                                   ['downloadpurchase', 'streamingpaid'],
                                   'streamingpaid',
                                 ],
             expected_clean_url: 'https://music.bugs.co.kr/artist/80276288',
+       only_valid_entity_types: ['artist'],
   },
   {
                      input_url: 'https://music.bugs.co.kr/search/integrated?q=dreamcatcher',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1480,7 +1480,6 @@ limited_link_type_combinations: [
   {
                      input_url: 'https://music.bugs.co.kr/mv/618959',
              input_entity_type: 'release',
-       input_relationship_type: 'streamingpaid',
     expected_relationship_type: ['downloadpurchase', 'streamingpaid'],
 limited_link_type_combinations: [
                                   ['downloadpurchase', 'streamingpaid'],

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2572,7 +2572,7 @@ limited_link_type_combinations: [
                                   ['downloadpurchase', 'streamingpaid'],
                                   'streamingpaid',
                                 ],
-            expected_clean_url: 'https://genie.co.kr/detail/artistInfo?xxnm=81599561',
+            expected_clean_url: 'https://www.genie.co.kr/detail/artistInfo?xxnm=81599561',
   },
   {
                      input_url: 'https://www.genie.co.kr/search/searchMain?query=Dreamcatcher',

--- a/root/static/scripts/tests/relationship-editor/utility/compareRelationships.js
+++ b/root/static/scripts/tests/relationship-editor/utility/compareRelationships.js
@@ -19,7 +19,6 @@ import {
   createRecordingObject,
   createSeriesObject,
 } from '../../../common/entity2.js';
-import {emptyRelationship} from '../constants.js';
 import compareRelationships
   from '../../../relationship-editor/utility/compareRelationships.js';
 import {
@@ -27,6 +26,7 @@ import {
   exportLinkTypeInfo,
 } from '../../../relationship-editor/utility/exportTypeInfo.js';
 import {linkAttributeTypes, linkTypes} from '../../typeInfo.js';
+import {emptyRelationship} from '../constants.js';
 
 exportLinkTypeInfo(linkTypes);
 exportLinkAttributeTypeInfo(linkAttributeTypes);
@@ -50,7 +50,7 @@ test('compareRelationships: Basic comparisons', function (t) {
     entity1: recording,
     id: -1,
     linkTypeID: 154,
-  }
+  };
 
   t.ok(
     compareRelationships(

--- a/t/selenium/MBS-9669.json5
+++ b/t/selenium/MBS-9669.json5
@@ -1,25 +1,15 @@
 {
-  title: 'UI language menu not available in Spanish and Greek (MBS-9669)',
+  title: 'UI language menu not available in locale with variant (MBS-9669)',
   commands: [
     {
       command: 'open',
-      target: '/set-language/el-GR',
+      target: '/set-language/es-419',
       value: '',
     },
     {
       command: 'assertEval',
       target: "window.document.querySelector('.language-selector .menu-header').innerHTML",
-      value: 'Ελληνικά (Ελλάδα) ▾',
-    },
-    {
-      command: 'open',
-      target: '/set-language/es-ES',
-      value: '',
-    },
-    {
-      command: 'assertEval',
-      target: "window.document.querySelector('.language-selector .menu-header').innerHTML",
-      value: 'Español (España) ▾',
+      value: 'Español (Latinoamérica) ▾',
     },
   ],
 }

--- a/webpack/babel-ignored.cjs
+++ b/webpack/babel-ignored.cjs
@@ -10,5 +10,5 @@ module.exports = [
    */
   /node_modules\/(?!@babel\/runtime|@popperjs|jed|mutate-cow|punycode|react|weight-balanced-tree)/,
   /root\/static\/scripts\/tests\/typeInfo\.js/,
-  /root\/static\/build\/jed-[A-z_-]+?\.source\.js$/,
+  /root\/static\/build\/jed-[A-z0-9_-]+?\.source\.js$/,
 ];

--- a/webpack/client.config.mjs
+++ b/webpack/client.config.mjs
@@ -104,7 +104,7 @@ const entries = [
 }, {});
 
 function langToPosix(lang) {
-  return lang.replace(/^([a-zA-Z]+)-([a-zA-Z]+)$/, function (match, l, c) {
+  return lang.replace(/^([a-zA-Z]+)-([a-zA-Z0-9]+)$/, function (match, l, c) {
     l = l.toLowerCase();
     c = c.toUpperCase();
     return l + '_' + c.toUpperCase();
@@ -192,7 +192,7 @@ const MB_LANGUAGES = shell.exec(
   `find ${shellQuote.quote([PO_DIR])} -type f -name 'mb_server*.po'`,
   {silent: true},
 ).stdout.split('\n').reduce((accum, filePath) => {
-  const lang = filePath.replace(/^.*\/mb_server\.([A-z_]+)\.po$/, '$1');
+  const lang = filePath.replace(/^.*\/mb_server\.([A-z0-9_]+)\.po$/, '$1');
   if (lang && lang !== 'en') {
     accum.push(langToPosix(lang));
   }


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Before the commit a0b56e9f8f9729f1e0c33df799ddbdaf29d0a44b the commands in the `js-perl-and-pgtap` test were ran with these shell options:

* `-e` to exit on error status code of any command,
* `-o pipefail` to exit on error status code of any piped sub-command.

See https://circleci.com/docs/configuration-reference/#default-shell-options
    
However the new script didn’t have these options enabled, causing failures from `flow` (among others) to go unnoticed.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This patch restores the previous/wanted behavior by enabling these in the script.

I built and uploaded a new pair of test images with the version [`v-2024-01.419`](https://hub.docker.com/r/metabrainz/musicbrainz-tests/tags?page=1&name=v-2024-01.419).

I also resolved the failures that went unnoticed so far:
- ESLint errors
- Genie and Bugs! URL web tests
- MBS-9669 Selenium test

See commit messages for details.

# Further action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

Rebase on `master` any PR that need to be tested with the new images.