### PR TITLE
MBS-13432: Ignore format chars when checking for useless notes and check them in more places

### DIFF
--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -70,6 +70,7 @@ our @EXPORT_OK = qw(
     placeholders
     ref_to_type
     remove_equal
+    remove_lineformatting_characters
     sanitize
     take_while
     trim
@@ -438,6 +439,7 @@ sub remove_invalid_characters {
     =~ s/[\N{ZERO WIDTH NO-BREAK SPACE}\x{F0000}-\x{FFFFF}\x{100000}-\x{10FFFF}${noncharacter_pattern}]//gr;
 }
 
+# Keep in sync with invalidEditNote in static/scripts/release-editor/init.js
 sub remove_lineformatting_characters {
     shift
     # trim lasting line-formatting characters:

--- a/lib/MusicBrainz/Server/Form/Role/EditNote.pm
+++ b/lib/MusicBrainz/Server/Form/Role/EditNote.pm
@@ -22,11 +22,13 @@ has_field 'make_votable' => (
 after validate => sub {
     my $self = shift;
 
-    if ($self->requires_edit_note && (!defined $self->field('edit_note')->value)) {
+    my $defined_edit_note = defined $self->field('edit_note')->value;
+
+    if ($self->requires_edit_note && !$defined_edit_note) {
         $self->field('edit_note')->add_error(l('You must provide an edit note'));
     }
 
-    if ($self->requires_edit_note && (!is_valid_edit_note($self->field('edit_note')->value))) {
+    if ($defined_edit_note && !is_valid_edit_note($self->field('edit_note')->value)) {
         $self->field('edit_note')->add_error(l('Your edit note seems to have no actual content. Please provide a note that will be helpful to your fellow editors!'));
     }
 };

--- a/lib/MusicBrainz/Server/Form/Vote.pm
+++ b/lib/MusicBrainz/Server/Form/Vote.pm
@@ -4,6 +4,8 @@ use warnings;
 
 use HTML::FormHandler::Moose;
 
+use MusicBrainz::Server::Validation qw( is_valid_edit_note );
+
 extends 'MusicBrainz::Server::Form';
 
 has '+name' => ( default => 'enter-vote' );
@@ -24,6 +26,15 @@ has_field 'vote.vote' => (
 
 has_field 'vote.edit_note' => (
     type => 'Text',
+    validate_method => \&validate_note,
 );
+
+sub validate_note {
+    my ($self, $field) = @_;
+
+    if (!is_valid_edit_note($field->value)) {
+        $field->value(undef);
+    }
+}
 
 1;

--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -52,7 +52,10 @@ use Encode qw( decode encode );
 use Scalar::Util qw( looks_like_number );
 use Text::Unaccent::PurePerl qw( unac_string_utf16 );
 use MusicBrainz::Server::Constants qw( $MAX_POSTGRES_INT $MAX_POSTGRES_BIGINT );
-use MusicBrainz::Server::Data::Utils qw( contains_number );
+use MusicBrainz::Server::Data::Utils qw(
+    contains_number
+    remove_lineformatting_characters
+);
 use utf8;
 
 sub unaccent_utf16 ($)
@@ -315,6 +318,14 @@ sub is_valid_edit_note
 {
     my $edit_note = shift;
 
+    return 0 unless $edit_note;
+
+    # We don't want line format chars to stop an edit note from being "empty"
+    $edit_note = remove_lineformatting_characters($edit_note);
+    # Additional format chars that can cause unwanted negatives
+    $edit_note =~ s/[\p{Cf}\p{Mn}]//g;
+
+    # The note might now be entirely empty - if so, it is useless
     return 0 unless $edit_note;
 
     # An edit note with only spaces and / or punctuation is useless

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -345,12 +345,16 @@ releaseEditor.init = function (options) {
   // Intialize release data/view model.
 
   this.rootField.missingEditNote = function () {
-    return self.action === 'add' && !self.rootField.editNote();
+    return self.action === 'add' && empty(self.rootField.editNote());
   };
 
   // Keep in sync with is_valid_edit_note in Server::Validation
   this.rootField.invalidEditNote = function () {
     const editNote = self.rootField.editNote();
+    if (empty(editNote)) {
+      // This is missing, not invalid
+      return false;
+    }
 
     // We don't want line format chars to stop an edit note from being "empty"
     const editNoteNoLineFormat = editNote.replace(
@@ -358,6 +362,7 @@ releaseEditor.init = function (options) {
       '',
     );
     return self.action === 'add' && (
+      // If it's empty now but not earlier, it was all format characters
       empty(editNote) ||
       /^[\p{White_Space}\p{Punctuation}]+$/u.test(editNoteNoLineFormat) ||
       /^\p{ASCII}$/u.test(editNoteNoLineFormat)

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -350,10 +350,17 @@ releaseEditor.init = function (options) {
 
   // Keep in sync with is_valid_edit_note in Server::Validation
   this.rootField.invalidEditNote = function () {
+    const editNote = self.rootField.editNote();
+
+    // We don't want line format chars to stop an edit note from being "empty"
+    const editNoteNoLineFormat = editNote.replace(
+      /[\u200b\u00AD\p{Cc}\p{Cf}\p{Mn}]/ug,
+      '',
+    );
     return self.action === 'add' && (
-      empty(self.rootField.editNote()) ||
-      /^[\p{White_Space}\p{Punctuation}]+$/u.test(self.rootField.editNote()) ||
-      /^\p{ASCII}$/u.test(self.rootField.editNote())
+      empty(editNote) ||
+      /^[\p{White_Space}\p{Punctuation}]+$/u.test(editNoteNoLineFormat) ||
+      /^\p{ASCII}$/u.test(editNoteNoLineFormat)
     );
   };
 

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -29,6 +29,7 @@ use MusicBrainz::Server::Validation qw(
     is_valid_partial_date
     is_database_row_id
     is_database_bigint_id
+    is_valid_edit_note
 );
 
 test 'Test trim_in_place' => sub {
@@ -276,6 +277,31 @@ test 'Test normalise_strings' => sub {
     is(normalise_strings('！＄０５ＡＺｂｙ'), '!$05azby', 'Fullwidth Latin to ASCII');
     is(normalise_strings('｡｢･ｱﾝ'), '。「・アン', 'Halfwidth Katakana/punctuation to fullwidth');
 
+};
+
+test 'Test is_valid_edit_note' => sub {
+    ok(!is_valid_edit_note(''), 'Empty edit note is invalid');
+    ok(is_valid_edit_note('This is a note!'), 'Standard edit note is valid');
+    ok(
+        !is_valid_edit_note('a'),
+        'Note made of just one ASCII character is invalid',
+    );
+    ok(
+        is_valid_edit_note('‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏‍͏漢'),
+        'Note made of just one kanji character is valid',
+    );
+    ok(
+        !is_valid_edit_note("  \t"),
+        'Note made of spaces and tabs is invalid',
+    );
+    ok(
+        !is_valid_edit_note("\N{ZERO WIDTH JOINER}\N{COMBINING GRAPHEME JOINER}\N{ZERO WIDTH JOINER}\N{COMBINING GRAPHEME JOINER}\N{ZERO WIDTH JOINER}\N{COMBINING GRAPHEME JOINER}"),
+        'Note made of format and join characters is invalid',
+    );
+    ok(
+        is_valid_edit_note("\N{ZERO WIDTH JOINER}\N{COMBINING GRAPHEME JOINER}abc\N{ZERO WIDTH JOINER}\N{COMBINING GRAPHEME JOINER}"),
+        'Note made of format and join characters plus text is valid',
+    );
 };
 
 1;

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -743,6 +743,11 @@ const seleniumTests = [
     name: 'Recording_Edit_Form.json5',
     login: true,
   },
+  {
+    name: 'Vote_And_Note_Submission.json5',
+    login: true,
+    sql: 'vote_and_note_selenium.sql',
+  },
 ];
 /* eslint-enable sort-keys */
 

--- a/t/selenium/Vote_And_Note_Submission.json5
+++ b/t/selenium/Vote_And_Note_Submission.json5
@@ -1,0 +1,73 @@
+{
+  title: 'Vote and note submission',
+  commands: [
+    {
+      command: 'open',
+      target: '/user/editor1/edits',
+      value: '',
+    },
+    // We want to vote No on the first edit
+    {
+      command: 'click',
+      target: 'xpath=//*[@id="id-enter-vote.vote.0.vote-No"]',
+      value: '',
+    },
+    // We want to vote Yes on the second edit
+    {
+      command: 'click',
+      target: 'xpath=//*[@id="id-enter-vote.vote.1.vote-Yes"]',
+      value: '',
+    },
+    // We want to leave a valid note on the first edit
+    {
+      command: 'click',
+      target: 'xpath=//*[@id="edits"]/form/div[2]/div[2]/div[2]/a[1]',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'xpath=//*[@id="edits"]/form/div[2]/div[4]/div/div[2]/textarea',
+      value: 'This is an edit note!',
+    },
+    // We want to leave an invalid note on the second edit
+    {
+      command: 'click',
+      target: 'xpath=//*[@id="edits"]/form/div[3]/div[2]/div[2]/a[1]',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'xpath=//*[@id="edits"]/form/div[3]/div[4]/div/div[2]/textarea',
+      value: 'a',
+    },
+    // We submit the test
+    {
+      command: 'clickAndWait',
+      target: 'xpath=//button[contains(text(), "Submit votes & edit notes")]',
+      value: '',
+    },
+    // We check both votes were submitted correctly
+    {
+      command: 'assertText',
+      target: 'xpath=(//div[contains(@class, "my-vote")])[1]',
+      value: 'My vote: No',
+    },
+    {
+      command: 'assertText',
+      target: 'xpath=(//div[contains(@class, "my-vote")])[2]',
+      value: 'My vote: Yes',
+    },
+    // We check the valid note was submitted correctly
+    {
+      command: 'assertText',
+      target: 'xpath=//*[@id="note-3-1"]/div',
+      value: 'This is an edit note!',
+    },
+    // We check the invalid note was dropped and is not present
+    {
+      command: 'assertEval',
+      target: 'document.querySelector("#note-2-1 div")',
+      value: 'null',
+    },
+  ],
+}

--- a/t/sql/vote_and_note_selenium.sql
+++ b/t/sql/vote_and_note_selenium.sql
@@ -1,0 +1,39 @@
+SET client_min_messages TO 'warning';
+
+INSERT INTO artist (id, gid, name, sort_name)
+    VALUES (1, 'a9d99e40-72d7-11de-8a39-0800200c9a66', 'Name', 'Name');
+
+INSERT INTO artist_credit (id, name, artist_count, gid)
+    VALUES (1, 'Name', 1, '949a7fd5-fe73-3e8f-922e-01ff4ca958f7');
+INSERT INTO artist_credit_name (artist_credit, artist, name, position, join_phrase)
+    VALUES (1, 1, 'Name', 0, '');
+
+INSERT INTO release_group (id, gid, name, artist_credit)
+    VALUES (1, '3b4faa80-72d9-11de-8a39-0800200c9a66', 'Arrival', 1);
+
+INSERT INTO release (id, gid, name, artist_credit, release_group)
+    VALUES (1, 'f34c079d-374e-4436-9448-da92dedef3ce', 'Arrival', 1, 1),
+           (2, 'a34c079d-374e-4436-9448-da92dedef3ce', 'Arrival', 1, 1),
+           (3, 'b34c079d-374e-4436-9448-da92dedef3ce', 'Arrival', 1, 1),
+           (4, 'c34c079d-374e-4436-9448-da92dedef3ce', 'Arrival', 1, 1);
+
+INSERT INTO editor (id, name, password, ha1, email, email_confirm_date) VALUES
+(1, 'editor1', '{CLEARTEXT}pass', '16a4862191803cb596ee4b16802bb7ee', 'foo@example.com', now());
+
+INSERT INTO edit (id, editor, type, status, expire_time)
+    VALUES (1, 1, 32, 1, NOW() + interval '72 hours'),
+           (2, 1, 32, 1, NOW() + interval '72 hours'),
+           (3, 1, 32, 1, NOW() + interval '72 hours');
+INSERT INTO edit_data (edit, data)
+    VALUES (1, '{"entity":{"name":"Arrival","id":2},"new":{"name":"Departure"},"old":{"name":"Arrival"}}'),
+           (2, '{"entity":{"name":"Arrival","id":4},"new":{"name":"Departure"},"old":{"name":"Arrival"}}'),
+           (3, '{"entity":{"name":"Arrival","id":3},"new":{"name":"Departure"},"old":{"name":"Arrival"}}');
+
+INSERT INTO edit_release (edit, release)
+    VALUES (1, 2), (2, 4), (3, 3);
+
+-- Dummy edits to allow editor 5 (from selenium.sql) to vote
+INSERT INTO edit (id, editor, type, status, expire_time)
+    SELECT 3 + x, 5, 111, 2, now() FROM generate_series(1, 10) x;
+INSERT INTO edit_data (edit, data)
+    SELECT 3 + x, '{}' FROM generate_series(1, 10) x;


### PR DESCRIPTION
### Implement MBS-13432

# Problem
Our useless edit note checks (`is_valid_edit_note` and `invalidEditNote`) only check edit notes that are required (so, release adds and destructive edits mostly), and they don't check for formatting characters, which means it's very easy to enter useless notes whether by mistake or, like in the case that prompted the ticket, as a strange attempt at vandalism.

# Solution
Three commits here that fix different parts of the problem:

The first makes the edit note checks ignore formatting characters when trying to determine whether a note contains any useful content or not. The affected characters are `ZERO WIDTH SPACE`, `SOFT HYPHEN` and the categories [`Cc`](https://www.compart.com/en/unicode/category/Cc), [`Cf`](https://www.compart.com/en/unicode/category/Cf) and [`Mn`](https://www.compart.com/en/unicode/category/Mn). These are not dropped from the notes, since in (non-empty) edit notes they can actually be perfectly fine and useful; they are only skipped when determining whether the rest of the note is useful.

The second makes it so that the validation code is not only run if the note is required, but in any case that uses `Form::Role::EditNote` (which mostly means entity edit forms) and in the release editor, as long as the note is not empty. Additionally, this fixes a kind-of-bug in the release editor where the messages for empty and invalid note would both be shown at the same time if the note was entirely empty - now only the empty note message is shown in that case.

The third also applies validation for invalid notes to the Form::Vote edit notes, which means invalid notes are also blocked when commenting on edits from edit pages or edit lists. The patch drops the invalid note, but still submits the vote, if any. This is the same as we already do for space-only notes that get trimmed to nothing, so it should at least be consistent.
Since an invalid edit note is either an honest mistake or vandalism, it seems fine not to notify the editor about the fact that it was dropped, which would be harder given that all the voting happens in `enter_votes` rather than the actual edit page or edit list itself.

# Testing
Manually, making sure that the invalid edits are blocked/ignored as intended, votes are still entered properly, and that notes that are valid are still submitted even if some notes in the same `enter_votes` call are invalid.

# Draft progress
* [x] Add some tests for `is_valid_edit_note` in `t/lib/t/MusicBrainz/Server/Validation.pm`
* [x] Add a test to make sure voting while submitting invalid notes does not break in the future.