### PR TITLE
MBS-13463: Report for bootleg releases on non-bootleg label

### DIFF
--- a/lib/MusicBrainz/Server/Report/BootlegsOnNonBootlegLabels.pm
+++ b/lib/MusicBrainz/Server/Report/BootlegsOnNonBootlegLabels.pm
@@ -1,0 +1,40 @@
+package MusicBrainz::Server::Report::BootlegsOnNonBootlegLabels;
+use Moose;
+
+use MusicBrainz::Server::Constants qw( $NOLABEL_ID );
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub query {<<~"SQL"}
+    SELECT DISTINCT ON (r.id)
+        r.id AS release_id,
+        row_number() OVER (ORDER BY r.artist_credit, r.name)
+    FROM
+    ( SELECT id, artist_credit, name
+      FROM release
+      WHERE status = 3 -- bootleg
+      AND EXISTS (
+        SELECT 1
+        FROM release_label rl
+        JOIN label ON label.id = rl.label
+        WHERE rl.release = release.id
+        AND label.type != 5 -- bootleg production
+        AND label.id != $NOLABEL_ID
+      )
+    ) r
+    SQL
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2024 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -24,6 +24,7 @@ my @all = qw(
     ArtistsThatMayBePersons
     ArtistsWithNoSubscribers
     BadAmazonURLs
+    BootlegsOnNonBootlegLabels
     CatNoLooksLikeASIN
     CatNoLooksLikeISRC
     CatNoLooksLikeLabelCode
@@ -125,6 +126,7 @@ use MusicBrainz::Server::Report::ArtistsThatMayBePersons;
 use MusicBrainz::Server::Report::ArtistsWithMultipleOccurrencesInArtistCredits;
 use MusicBrainz::Server::Report::ArtistsWithNoSubscribers;
 use MusicBrainz::Server::Report::BadAmazonURLs;
+use MusicBrainz::Server::Report::BootlegsOnNonBootlegLabels;
 use MusicBrainz::Server::Report::CatNoLooksLikeASIN;
 use MusicBrainz::Server::Report::CatNoLooksLikeISRC;
 use MusicBrainz::Server::Report::CatNoLooksLikeLabelCode;

--- a/root/report/BootlegsOnNonBootlegLabels.js
+++ b/root/report/BootlegsOnNonBootlegLabels.js
@@ -1,0 +1,40 @@
+/*
+ * @flow strict
+ * Copyright (C) 2024 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import ReleaseList from './components/ReleaseList.js';
+import ReportLayout from './components/ReportLayout.js';
+import type {ReportDataT, ReportReleaseT} from './types.js';
+
+const BootlegsOnNonBootlegLabels = ({
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
+  <ReportLayout
+    canBeFiltered={canBeFiltered}
+    description={l(
+      `This report shows releases that are set to status “Bootleg”, but have
+       at least one label in their labels list which is not “[no label]” nor
+       has the type “Bootleg Production”.
+       Other types of labels pretty much never release bootleg releases,
+       so chances are that either the label or the status are wrong.`,
+    )}
+    entityType="release"
+    filtered={filtered}
+    generated={generated}
+    title={l('Releases on non-bootleg labels set to bootleg')}
+    totalEntries={pager.total_entries}
+  >
+    <ReleaseList items={items} pager={pager} />
+  </ReportLayout>
+);
+
+export default BootlegsOnNonBootlegLabels;

--- a/root/report/BootlegsOnNonBootlegLabels.js
+++ b/root/report/BootlegsOnNonBootlegLabels.js
@@ -25,7 +25,7 @@ const BootlegsOnNonBootlegLabels = ({
        at least one label in their labels list which is not “[no label]” nor
        has the type “Bootleg Production”.
        Other types of labels pretty much never release bootleg releases,
-       so chances are that either the label or the status are wrong.`,
+       so chances are that either the label or the status is wrong.`,
     )}
     entityType="release"
     filtered={filtered}

--- a/root/report/NonBootlegsOnBootlegLabels.js
+++ b/root/report/NonBootlegsOnBootlegLabels.js
@@ -24,7 +24,7 @@ const NonBootlegsOnBootlegLabels = ({
       `This report shows releases that have at least one “Bootleg Production”
        label in their labels list, but are not set to status “Bootleg”.
        These labels pretty much never release non-bootleg releases,
-       so chances are that either the label or the status are wrong.`,
+       so chances are that either the label or the status is wrong.`,
     )}
     entityType="release"
     filtered={filtered}

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -463,6 +463,12 @@ const ReportsIndex = (): React$Element<typeof Layout> => {
           />
           <ReportsIndexEntry
             content={l(
+              'Releases on non-bootleg labels set to bootleg',
+            )}
+            reportName="BootlegsOnNonBootlegLabels"
+          />
+          <ReportsIndexEntry
+            content={l(
               'Non-broadcast releases with linked show notes',
             )}
             reportName="ShowNotesButNotBroadcast"

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -218,6 +218,7 @@ export default {
   'report/ArtistsWithNoSubscribers': (): Promise<mixed> => import('../report/ArtistsWithNoSubscribers.js'),
   'report/AsinsWithMultipleReleases': (): Promise<mixed> => import('../report/AsinsWithMultipleReleases.js'),
   'report/BadAmazonUrls': (): Promise<mixed> => import('../report/BadAmazonUrls.js'),
+  'report/BootlegsOnNonBootlegLabels': (): Promise<mixed> => import('../report/BootlegsOnNonBootlegLabels.js'),
   'report/CatNoLooksLikeAsin': (): Promise<mixed> => import('../report/CatNoLooksLikeAsin.js'),
   'report/CatNoLooksLikeIsrc': (): Promise<mixed> => import('../report/CatNoLooksLikeIsrc.js'),
   'report/CatNoLooksLikeLabelCode': (): Promise<mixed> => import('../report/CatNoLooksLikeLabelCode.js'),


### PR DESCRIPTION
### Implement MBS-13463

# Reasoning
Non-bootleg labels pretty much never put out bootlegs. As such, this report lets editors find bootleg releases which have a non bootleg label as a release label, which should almost always be wrong in some way.

[no label] can of course also apply to bootlegs, so it is ignored.

This is basically the opposite of https://github.com/metabrainz/musicbrainz-server/pull/2874

# Testing
With sample data, which had 31 matches.