### PR TITLE
MBS-13438: Restrict and validate Qobuz URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4771,6 +4771,57 @@ const CLEANUPS: CleanupEntries = {
     match: [new RegExp('^(https?://)?([^/]+\\.)?purevolume\\.com', 'i')],
     restrict: [LINK_TYPES.purevolume],
   },
+  'qobuz': {
+    match: [
+      new RegExp('^(https?://)?(www\\.)?qobuz\\.com/', 'i'),
+    ],
+    restrict: [
+      LINK_TYPES.streamingpaid,
+      multiple(LINK_TYPES.downloadpurchase, LINK_TYPES.streamingpaid),
+    ],
+    select: function (url, sourceType) {
+      switch (sourceType) {
+        case 'artist':
+          return LINK_TYPES.streamingpaid.artist;
+        case 'label':
+          return LINK_TYPES.streamingpaid.label;
+        case 'release':
+          return LINK_TYPES.streamingpaid.release;
+      }
+      return false;
+    },
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?qobuz\.com\//, 'https://www.qobuz.com/');
+      return url;
+    },
+    validate: function (url, id) {
+      const m = /^https:\/\/www\.qobuz\.com\/(?:[a-z]{2}-[a-z]{2}\/)?(album|interpreter|label)\/[\w\d-]+\/(?:[\w\d-]+\/)?[\w\d]+$/.exec(url);
+      if (m) {
+        const prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.downloadpurchase.artist:
+          case LINK_TYPES.streamingpaid.artist:
+            return {
+              result: prefix === 'interpreter',
+              target: ERROR_TARGETS.ENTITY,
+            };
+          case LINK_TYPES.downloadpurchase.label:
+          case LINK_TYPES.streamingpaid.label:
+            return {
+              result: prefix === 'label',
+              target: ERROR_TARGETS.ENTITY,
+            };
+          case LINK_TYPES.downloadpurchase.release:
+          case LINK_TYPES.streamingpaid.release:
+            return {
+              result: prefix === 'album',
+              target: ERROR_TARGETS.ENTITY,
+            };
+        }
+      }
+      return {result: false, target: ERROR_TARGETS.URL};
+    },
+  },
   'quebecinfomusique': {
     match: [new RegExp(
       '^(https?://)?(www\\.)?(qim|quebecinfomusique)\\.com',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4866,6 +4866,40 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://www.progarchives.com/Collaborators.asp?id=9702',
        only_valid_entity_types: [],
   },
+  // Qobuz
+  {
+                     input_url: 'https://www.qobuz.com/gb-en/interpreter/nitepunk/3241976',
+             input_entity_type: 'artist',
+       input_relationship_type: 'streamingpaid',
+limited_link_type_combinations: [
+                                  'streamingpaid',
+                                  ['downloadpurchase', 'streamingpaid'],
+                                ],
+            expected_clean_url: 'https://www.qobuz.com/gb-en/interpreter/nitepunk/3241976',
+       only_valid_entity_types: ['artist'],
+  },
+  {
+                     input_url: 'https://www.qobuz.com/fr-fr/label/ecm/download-streaming-albums/92473',
+             input_entity_type: 'label',
+       input_relationship_type: 'streamingpaid',
+limited_link_type_combinations: [
+                                  'streamingpaid',
+                                  ['downloadpurchase', 'streamingpaid'],
+                                ],
+            expected_clean_url: 'https://www.qobuz.com/fr-fr/label/ecm/download-streaming-albums/92473',
+       only_valid_entity_types: ['label'],
+  },
+  {
+                     input_url: 'https://www.qobuz.com/es-es/album/the-koln-concert-live-at-the-opera-koln-1975-keith-jarrett/0060254707654',
+             input_entity_type: 'release',
+       input_relationship_type: 'streamingpaid',
+limited_link_type_combinations: [
+                                  'streamingpaid',
+                                  ['downloadpurchase', 'streamingpaid'],
+                                ],
+            expected_clean_url: 'https://www.qobuz.com/es-es/album/the-koln-concert-live-at-the-opera-koln-1975-keith-jarrett/0060254707654',
+       only_valid_entity_types: ['release'],
+  },
   // Rock.com.ar
   {
                      input_url: 'http://rock.com.ar/artistas/200',


### PR DESCRIPTION
### Implement MBS-13438

# Description
We supported Qobuz URLs inasmuch as we showed them on the sidebar with their favicon, but we were not autoselecting them, since we couldn't until recently allow more than one option, and as such we were not validating them, since that was not possible without the selection.

Now we can offer the following options for selection: paid streaming (always available) or both paid streaming and download purchase (available in some markets, but not in LATAM for example).

We can also validate per entity: artists get /interpreter, labels get, well, /label, and releases get /album.

# Testing
Added some tests, plus some manual testing too ensuring the autoselection for streaming works and download is still available to select on top of it.