### PR TITLE
MBS-13402: Unbreak unsetting work order in release rel editor

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -204,7 +204,7 @@ our $data_processors = {
         for my $ordering (@{ $data->{relationship_order} }) {
             my $relationship = $ordering->{relationship};
             my $new_order = delete $ordering->{link_order};
-            unless (is_database_row_id($new_order)) {
+            unless ($new_order == 0 || is_database_row_id($new_order)) {
                 $c->forward('/ws/js/detach_with_error', [
                     'EDIT_RELATIONSHIPS_REORDER: invalid link_order',
                 ]);


### PR DESCRIPTION
### Fix MBS-13402

# Problem
When trying to unset work orders by unchecking the "These relationships have a specific ordering" checkbox in the release relationship editor, it triggers the error `EDIT_RELATIONSHIPS_REORDER: invalid link_order`.

# Solution
Unsetting ordering sets orders to 0, but this only accepted positive integers with `is_database_row_id`. We could use `is_non_negative_integer` but I guess it was intentional to limit this to at most `MAX_POSTGRES_INT`, so this just allows 0 in addition to `is_database_row_id`.

# Testing
Manually, making sure the orders can now be unset (and set again).