### PR TITLE
MBS-13346 (amend): Improve GTIN barcode handling

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
@@ -13,7 +13,7 @@ use MusicBrainz::Server::Constants qw(
 );
 use List::AllUtils qw( natatime partition_by uniq uniq_by );
 use MusicBrainz::Server::WebService::XML::XPath;
-use MusicBrainz::Server::Validation qw( is_guid is_valid_ean );
+use MusicBrainz::Server::Validation qw( is_guid is_valid_gtin );
 use Readonly;
 use Try::Tiny;
 
@@ -328,7 +328,7 @@ sub release_submit : Private
         my $barcode = $xp->find('mb:barcode', $node)->string_value or next;
 
         $self->_error($c, "$barcode is not a valid barcode")
-            unless is_valid_ean($barcode);
+            unless is_valid_gtin($barcode);
 
         push @submit, { release => $id, barcode => $barcode };
     }

--- a/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
@@ -13,7 +13,7 @@ use MusicBrainz::Server::Constants qw(
 );
 use List::AllUtils qw( natatime partition_by uniq uniq_by );
 use MusicBrainz::Server::WebService::XML::XPath;
-use MusicBrainz::Server::Validation qw( is_guid is_valid_gtin );
+use MusicBrainz::Server::Validation qw( is_guid is_valid_barcode is_valid_gtin );
 use Readonly;
 use Try::Tiny;
 
@@ -328,6 +328,8 @@ sub release_submit : Private
         my $barcode = $xp->find('mb:barcode', $node)->string_value or next;
 
         $self->_error($c, "$barcode is not a valid barcode")
+            unless is_valid_barcode($barcode);
+        $self->_error($c, "$barcode is not a valid GTIN (EAN/UPC) barcode")
             unless is_valid_gtin($barcode);
 
         push @submit, { release => $id, barcode => $barcode };

--- a/lib/MusicBrainz/Server/Entity/Barcode.pm
+++ b/lib/MusicBrainz/Server/Entity/Barcode.pm
@@ -9,14 +9,6 @@ has 'code' => (
 
 use overload '""' => sub { shift->code }, fallback => 1;
 
-sub type {
-    my ($self) = @_;
-    return 'EAN' if length($self->code) == 8;
-    return 'UPC' if length($self->code) == 12;
-    return 'EAN' if length($self->code) == 13;
-    return 'GTIN' if length($self->code) == 14;
-}
-
 sub format
 {
     my $self = shift;

--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -222,7 +222,7 @@ sub is_valid_ean
 {
     my $ean = shift;
     my $length = length($ean);
-    if ($length == 8 || $length == 12 || $length == 13 || $length == 14 || $length == 17 || $length == 18) {
+    if ($length == 8 || $length == 12 || $length == 13 || $length == 14) {
         return has_valid_ean_check_digit($ean);
     }
     return 0;

--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -207,16 +207,23 @@ sub is_valid_barcode
     return $barcode =~ /^[0-9]+$/;
 }
 
+sub has_valid_ean_check_digit
+{
+    my $barcode = shift;
+    my $length = length($barcode);
+    my $sum = 0;
+    for (my $i = 2; $i <= $length; $i++) {
+        $sum += substr($barcode, $length - $i, 1) * ($i % 2 == 1 ? 1 : 3);
+    }
+    return ((10 - $sum % 10) % 10) == substr($barcode, $length - 1, 1);
+}
+
 sub is_valid_ean
 {
     my $ean = shift;
     my $length = length($ean);
     if ($length == 8 || $length == 12 || $length == 13 || $length == 14 || $length == 17 || $length == 18) {
-        my $sum = 0;
-        for (my $i = 2; $i <= $length; $i++) {
-                $sum += substr($ean, $length - $i, 1) * ($i % 2 == 1 ? 1 : 3);
-        }
-        return ((10 - $sum % 10) % 10) == substr($ean, $length - 1, 1);
+        return has_valid_ean_check_digit($ean);
     }
     return 0;
 }

--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -223,13 +223,7 @@ sub is_valid_gtin
     my $barcode = shift;
     my $length = length($barcode);
     if ($length == 8 || $length == 12 || $length == 13 || $length == 14) {
-        return 1 if has_valid_gtin_check_digit($barcode);
-    }
-    if ($length == 14 || $length == 15) {
-        return 1 if has_valid_gtin_check_digit(substr($barcode, 0, -2));
-    }
-    if ($length == 17 || $length == 18) {
-        return 1 if has_valid_gtin_check_digit(substr($barcode, 0, -5));
+        return has_valid_gtin_check_digit($barcode);
     }
     return 0;
 }

--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -223,7 +223,13 @@ sub is_valid_gtin
     my $barcode = shift;
     my $length = length($barcode);
     if ($length == 8 || $length == 12 || $length == 13 || $length == 14) {
-        return has_valid_gtin_check_digit($barcode);
+        return 1 if has_valid_gtin_check_digit($barcode);
+    }
+    if ($length == 14 || $length == 15) {
+        return 1 if has_valid_gtin_check_digit(substr($barcode, 0, -2));
+    }
+    if ($length == 17 || $length == 18) {
+        return 1 if has_valid_gtin_check_digit(substr($barcode, 0, -5));
     }
     return 0;
 }

--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -27,7 +27,7 @@ use base 'Exporter';
         is_freedb_id
         is_valid_discid
         is_valid_barcode
-        is_valid_ean
+        is_valid_gtin
         is_valid_isrc
         format_isrc
         is_valid_time
@@ -207,7 +207,7 @@ sub is_valid_barcode
     return $barcode =~ /^[0-9]+$/;
 }
 
-sub has_valid_ean_check_digit
+sub has_valid_gtin_check_digit
 {
     my $barcode = shift;
     my $length = length($barcode);
@@ -218,12 +218,12 @@ sub has_valid_ean_check_digit
     return ((10 - $sum % 10) % 10) == substr($barcode, $length - 1, 1);
 }
 
-sub is_valid_ean
+sub is_valid_gtin
 {
-    my $ean = shift;
-    my $length = length($ean);
+    my $barcode = shift;
+    my $length = length($barcode);
     if ($length == 8 || $length == 12 || $length == 13 || $length == 14) {
-        return has_valid_ean_check_digit($ean);
+        return has_valid_gtin_check_digit($barcode);
     }
     return 0;
 }

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -932,23 +932,18 @@ class Barcode {
     });
   }
 
-  checkDigit(barcode) {
-    if (barcode.length !== 13) {
-      return false;
-    }
-
+  checkDigit(barcodeTrunk) {
+    const iMax = barcodeTrunk.length - 1;
     let calc = 0;
-    for (let i = 0; i < 13; i++) {
-      calc += parseInt(barcode[i], 10) * this.weights[i];
+    for (let i = 0; i <= iMax; i++) {
+      calc += parseInt(barcodeTrunk[iMax - i], 10) * (i % 2 === 1 ? 1 : 3);
     }
-
-    var digit = 10 - (calc % 10);
-    return digit === 10 ? 0 : digit;
+    return (10 - (calc % 10)) % 10;
   }
 
   validateCheckDigit(barcode) {
-    return this.checkDigit(barcode.slice(0, 13)) ===
-            parseInt(barcode[13], 10);
+    return this.checkDigit(barcode.slice(0, -1)) ===
+            parseInt(barcode.slice(-1), 10);
   }
 
   writeBarcode(barcode) {
@@ -956,8 +951,6 @@ class Barcode {
     this.confirmed(false);
   }
 }
-
-Barcode.prototype.weights = [3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3];
 
 fields.Barcode = Barcode;
 

--- a/root/static/scripts/release-editor/validation.js
+++ b/root/static/scripts/release-editor/validation.js
@@ -186,11 +186,11 @@ utils.withRelease(function (release) {
       ) +
       ' ' +
       expand2text(
-        checkDigitText, {checkdigit: field.checkDigit('0' + barcode)},
+        checkDigitText, {checkdigit: field.checkDigit(barcode)},
       ),
     );
   } else if (barcode.length === 12) {
-    if (field.validateCheckDigit('00' + barcode)) {
+    if (field.validateCheckDigit(barcode)) {
       field.message(l('The barcode you entered is a valid UPC code.'));
       searchExistingBarcode(field, barcode, release.gid());
     } else {
@@ -209,7 +209,7 @@ utils.withRelease(function (release) {
       );
     }
   } else if (barcode.length === 13) {
-    if (field.validateCheckDigit('0' + barcode)) {
+    if (field.validateCheckDigit(barcode)) {
       field.message(l('The barcode you entered is a valid EAN code.'));
       searchExistingBarcode(field, barcode, release.gid());
     } else {

--- a/root/static/scripts/release-editor/validation.js
+++ b/root/static/scripts/release-editor/validation.js
@@ -178,7 +178,18 @@ utils.withRelease(function (release) {
   var checkDigitText = l('The check digit would be {checkdigit}.');
   var doubleCheckText = l('Please double-check the barcode on the release.');
 
-  if (barcode.length === 11) {
+  if (barcode.length === 8) {
+    if (field.validateCheckDigit(barcode)) {
+      field.message(l('The barcode you entered is a valid EAN code.'));
+      searchExistingBarcode(field, barcode, release.gid());
+    } else {
+      field.error(
+        l('The barcode you entered is not a valid EAN code.') +
+        ' ' +
+        doubleCheckText,
+      );
+    }
+  } else if (barcode.length === 11) {
     field.error(
       l(
         `The barcode you entered looks like a UPC code

--- a/root/static/scripts/release-editor/validation.js
+++ b/root/static/scripts/release-editor/validation.js
@@ -234,9 +234,45 @@ utils.withRelease(function (release) {
     if (field.validateCheckDigit(barcode)) {
       field.message(l('The barcode you entered is a valid GTIN code.'));
       searchExistingBarcode(field, barcode, release.gid());
+    } else if (field.validateCheckDigit(barcode.slice(0, -2))) {
+      field.message(l('The barcode you entered is a valid UPC code.'));
+      searchExistingBarcode(field, barcode, release.gid());
     } else {
       field.error(
         l('The barcode you entered is not a valid GTIN code.') +
+        ' ' +
+        doubleCheckText,
+      );
+    }
+  } else if (barcode.length === 15) {
+    if (field.validateCheckDigit(barcode.slice(0, -2))) {
+      field.message(l('The barcode you entered is a valid EAN code.'));
+      searchExistingBarcode(field, barcode, release.gid());
+    } else {
+      field.error(
+        l('The barcode you entered is not a valid EAN code.') +
+        ' ' +
+        doubleCheckText,
+      );
+    }
+  } else if (barcode.length === 17) {
+    if (field.validateCheckDigit(barcode.slice(0, -5))) {
+      field.message(l('The barcode you entered is a valid UPC code.'));
+      searchExistingBarcode(field, barcode, release.gid());
+    } else {
+      field.error(
+        l('The barcode you entered is not a valid UPC code.') +
+        ' ' +
+        doubleCheckText,
+      );
+    }
+  } else if (barcode.length === 18) {
+    if (field.validateCheckDigit(barcode.slice(0, -5))) {
+      field.message(l('The barcode you entered is a valid EAN code.'));
+      searchExistingBarcode(field, barcode, release.gid());
+    } else {
+      field.error(
+        l('The barcode you entered is not a valid EAN code.') +
         ' ' +
         doubleCheckText,
       );

--- a/root/static/scripts/release-editor/validation.js
+++ b/root/static/scripts/release-editor/validation.js
@@ -235,8 +235,19 @@ utils.withRelease(function (release) {
       field.message(l('The barcode you entered is a valid GTIN code.'));
       searchExistingBarcode(field, barcode, release.gid());
     } else if (field.validateCheckDigit(barcode.slice(0, -2))) {
-      field.message(l('The barcode you entered is a valid UPC code.'));
-      searchExistingBarcode(field, barcode, release.gid());
+      field.error(
+        l('The barcode you entered is a valid UPC code.') +
+        ' ' +
+        texp.l(
+          `However it ends with an add-on code.
+           Please add it as “{annotation_text}” to the annotation field below,
+           and keep the main code “{main_digits}” only in the barcode field.`,
+          {
+            annotation_text: 'UPC-2: ' + barcode.slice(-2),
+            main_digits: barcode.slice(0, -2),
+          },
+        ),
+      );
     } else {
       field.error(
         l('The barcode you entered is not a valid GTIN code.') +
@@ -246,8 +257,19 @@ utils.withRelease(function (release) {
     }
   } else if (barcode.length === 15) {
     if (field.validateCheckDigit(barcode.slice(0, -2))) {
-      field.message(l('The barcode you entered is a valid EAN code.'));
-      searchExistingBarcode(field, barcode, release.gid());
+      field.error(
+        l('The barcode you entered is a valid EAN code.') +
+        ' ' +
+        texp.l(
+          `However it ends with an add-on code.
+           Please add it as “{annotation_text}” to the annotation field below,
+           and keep the main code “{main_digits}” only in the barcode field.`,
+          {
+            annotation_text: 'EAN-2: ' + barcode.slice(-2),
+            main_digits: barcode.slice(0, -2),
+          },
+        ),
+      );
     } else {
       field.error(
         l('The barcode you entered is not a valid EAN code.') +
@@ -257,8 +279,19 @@ utils.withRelease(function (release) {
     }
   } else if (barcode.length === 17) {
     if (field.validateCheckDigit(barcode.slice(0, -5))) {
-      field.message(l('The barcode you entered is a valid UPC code.'));
-      searchExistingBarcode(field, barcode, release.gid());
+      field.error(
+        l('The barcode you entered is a valid UPC code.') +
+        ' ' +
+        texp.l(
+          `However it ends with an add-on code.
+           Please add it as “{annotation_text}” to the annotation field below,
+           and keep the main code “{main_digits}” only in the barcode field.`,
+          {
+            annotation_text: 'UPC-5: ' + barcode.slice(-5),
+            main_digits: barcode.slice(0, -5),
+          },
+        ),
+      );
     } else {
       field.error(
         l('The barcode you entered is not a valid UPC code.') +
@@ -268,8 +301,19 @@ utils.withRelease(function (release) {
     }
   } else if (barcode.length === 18) {
     if (field.validateCheckDigit(barcode.slice(0, -5))) {
-      field.message(l('The barcode you entered is a valid EAN code.'));
-      searchExistingBarcode(field, barcode, release.gid());
+      field.error(
+        l('The barcode you entered is a valid EAN code.') +
+        ' ' +
+        texp.l(
+          `However it ends with an add-on code.
+           Please add it as “{annotation_text}” to the annotation field below,
+           and keep the main code “{main_digits}” only in the barcode field.`,
+          {
+            annotation_text: 'EAN-5: ' + barcode.slice(-5),
+            main_digits: barcode.slice(0, -5),
+          },
+        ),
+      );
     } else {
       field.error(
         l('The barcode you entered is not a valid EAN code.') +

--- a/root/static/scripts/release-editor/validation.js
+++ b/root/static/scripts/release-editor/validation.js
@@ -161,7 +161,7 @@ function searchExistingBarcode(field, barcode, releaseId) {
   });
 }
 
-// Barcode should be a valid EAN/UPC.
+// Barcode should be a valid GTIN (EAN/UPC) or double-checked.
 
 utils.withRelease(function (release) {
   var field = release.barcode;
@@ -175,7 +175,7 @@ utils.withRelease(function (release) {
     return;
   }
 
-  var checkDigitText = l('The check digit is {checkdigit}.');
+  var checkDigitText = l('The check digit would be {checkdigit}.');
   var doubleCheckText = l('Please double-check the barcode on the release.');
 
   if (barcode.length === 11) {

--- a/root/static/scripts/tests/release-editor/validation.js
+++ b/root/static/scripts/tests/release-editor/validation.js
@@ -147,7 +147,7 @@ validationTest((
 validationTest((
   'Barcode check digit validation'
 ), function (t) {
-  t.plan(4);
+  t.plan(5);
 
   const release = releaseEditor.rootField.release();
   const field = release.barcode;
@@ -156,4 +156,5 @@ validationTest((
   t.ok(field.validateCheckDigit('0810121774182'), '13-digit 0-padded GTIN-12 (UPC-A) has valid check digit');
   t.ok(field.validateCheckDigit('9399431762528'), 'GTIN-13 (EAN-13) has valid check digit');
   t.ok(field.validateCheckDigit('810121774182'), 'GTIN-12 (UPC-A) has valid check digit');
+  t.ok(field.validateCheckDigit('07642357'), 'GTIN-8 (EAN-8) has valid check digit');
 });

--- a/root/static/scripts/tests/release-editor/validation.js
+++ b/root/static/scripts/tests/release-editor/validation.js
@@ -147,13 +147,12 @@ validationTest((
 validationTest((
   'Barcode check digit validation'
 ), function (t) {
-  t.plan(5);
+  t.plan(4);
 
   const release = releaseEditor.rootField.release();
   const field = release.barcode;
 
   t.ok(field.validateCheckDigit('00810121774182'), '14-digit 0-padded GTIN-12 (UPC-A) has valid check digit');
-  t.ok(field.validateCheckDigit('12345678901231'), 'GTIN-14 (EAN/UCC-128 or ITF-14) has valid check digit');
   t.ok(field.validateCheckDigit('0810121774182'), '13-digit 0-padded GTIN-12 (UPC-A) has valid check digit');
   t.ok(field.validateCheckDigit('9399431762528'), 'GTIN-13 (EAN-13) has valid check digit');
   t.ok(field.validateCheckDigit('810121774182'), 'GTIN-12 (UPC-A) has valid check digit');

--- a/root/static/scripts/tests/release-editor/validation.js
+++ b/root/static/scripts/tests/release-editor/validation.js
@@ -147,7 +147,7 @@ validationTest((
 validationTest((
   'Barcode check digit validation'
 ), function (t) {
-  t.plan(5);
+  t.plan(9);
 
   const release = releaseEditor.rootField.release();
   const field = release.barcode;
@@ -157,4 +157,12 @@ validationTest((
   t.ok(field.validateCheckDigit('9399431762528'), 'GTIN-13 (EAN-13) has valid check digit');
   t.ok(field.validateCheckDigit('810121774182'), 'GTIN-12 (UPC-A) has valid check digit');
   t.ok(field.validateCheckDigit('07642357'), 'GTIN-8 (EAN-8) has valid check digit');
+  /*
+   * Use slice to drop add-on like the actual release editor code does
+   * TODO: Test barcode validation rather than just the check digit validation
+   */
+  t.ok(field.validateCheckDigit('02083116542649'.slice(0, -2)), 'GTIN-12 (UPC-A) with 2-digit add-on (UPC-2) has valid check digit');
+  t.ok(field.validateCheckDigit('01501272866800084'.slice(0, -5)), 'GTIN-12 (UPC-A) with 5-digit add-on (UPC-5) has valid check digit');
+  t.ok(field.validateCheckDigit('419091010790904'.slice(0, -2)), 'GTIN-13 (EAN-13) with 2-digit add-on (EAN-2) has valid check digit');
+  t.ok(field.validateCheckDigit('842056520418700004'.slice(0, -5)), 'GTIN-13 (EAN-13) with 5-digit add-on (EAN-5) has valid check digit');
 });

--- a/root/static/scripts/tests/release-editor/validation.js
+++ b/root/static/scripts/tests/release-editor/validation.js
@@ -145,7 +145,7 @@ validationTest((
 });
 
 validationTest((
-  'Barcode validation'
+  'Barcode check digit validation'
 ), function (t) {
   t.plan(5);
 

--- a/root/static/scripts/tests/release-editor/validation.js
+++ b/root/static/scripts/tests/release-editor/validation.js
@@ -152,9 +152,9 @@ validationTest((
   const release = releaseEditor.rootField.release();
   const field = release.barcode;
 
-  t.ok(field.validateCheckDigit('00810121774182'), '0-padded GTIN-14');
-  t.ok(field.validateCheckDigit('12345678901231'), 'GTIN-14');
-  t.ok(field.validateCheckDigit('0810121774182'), '0-padded EAN-13');
-  t.ok(field.validateCheckDigit('9399431762528'), 'EAN-13');
-  t.ok(field.validateCheckDigit('810121774182'), 'UPC');
+  t.ok(field.validateCheckDigit('00810121774182'), '14-digit 0-padded GTIN-12 (UPC-A) has valid check digit');
+  t.ok(field.validateCheckDigit('12345678901231'), 'GTIN-14 (EAN/UCC-128 or ITF-14) has valid check digit');
+  t.ok(field.validateCheckDigit('0810121774182'), '13-digit 0-padded GTIN-12 (UPC-A) has valid check digit');
+  t.ok(field.validateCheckDigit('9399431762528'), 'GTIN-13 (EAN-13) has valid check digit');
+  t.ok(field.validateCheckDigit('810121774182'), 'GTIN-12 (UPC-A) has valid check digit');
 });

--- a/root/static/scripts/tests/release-editor/validation.js
+++ b/root/static/scripts/tests/release-editor/validation.js
@@ -147,16 +147,20 @@ validationTest((
 validationTest((
   'Barcode check digit validation'
 ), function (t) {
-  t.plan(9);
+  t.plan(13);
 
   const release = releaseEditor.rootField.release();
   const field = release.barcode;
 
-  t.ok(field.validateCheckDigit('00810121774182'), '14-digit 0-padded GTIN-12 (UPC-A) has valid check digit');
-  t.ok(field.validateCheckDigit('0810121774182'), '13-digit 0-padded GTIN-12 (UPC-A) has valid check digit');
-  t.ok(field.validateCheckDigit('9399431762528'), 'GTIN-13 (EAN-13) has valid check digit');
-  t.ok(field.validateCheckDigit('810121774182'), 'GTIN-12 (UPC-A) has valid check digit');
   t.ok(field.validateCheckDigit('07642357'), 'GTIN-8 (EAN-8) has valid check digit');
+  t.ok(!field.validateCheckDigit('07642358'), 'GTIN-8 (EAN-8) has invalid check digit');
+  t.ok(field.validateCheckDigit('718752155427'), 'GTIN-12 (UPC-A) has valid check digit');
+  t.ok(!field.validateCheckDigit('718752155428'), 'GTIN-12 (UPC-A) has invalid check digit');
+  t.ok(field.validateCheckDigit('0666017082523'), '13-digit 0-padded GTIN-12 (UPC-A) has valid check digit');
+  t.ok(field.validateCheckDigit('4050538793819'), 'GTIN-13 (EAN-13) has valid check digit');
+  t.ok(!field.validateCheckDigit('4050538793810'), 'GTIN-13 (EAN-13) has invalid check digit');
+  t.ok(field.validateCheckDigit('00602577318801'), '14-digit 0-padded GTIN-12 (UPC-A) has valid check digit');
+  t.ok(field.validateCheckDigit('07875354382095'), '14-digit 0-padded GTIN-13 (EAN-13) has valid check digit');
   /*
    * Use slice to drop add-on like the actual release editor code does
    * TODO: Test barcode validation rather than just the check digit validation

--- a/root/static/scripts/tests/release-editor/validation.js
+++ b/root/static/scripts/tests/release-editor/validation.js
@@ -154,8 +154,7 @@ validationTest((
 
   t.ok(field.validateCheckDigit('00810121774182'), '0-padded GTIN-14');
   t.ok(field.validateCheckDigit('12345678901231'), 'GTIN-14');
-  // Adding '0' + as it matches what the actual release editor code does
-  t.ok(field.validateCheckDigit('0' + '0810121774182'), '0-padded EAN-13');
-  t.ok(field.validateCheckDigit('0' + '9399431762528'), 'EAN-13');
-  t.ok(field.validateCheckDigit('00' + '810121774182'), 'UPC');
+  t.ok(field.validateCheckDigit('0810121774182'), '0-padded EAN-13');
+  t.ok(field.validateCheckDigit('9399431762528'), 'EAN-13');
+  t.ok(field.validateCheckDigit('810121774182'), 'UPC');
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/Aliases.pm
@@ -32,7 +32,7 @@ test 'Release alias appears on alias page content and on JSON-LD' => sub {
     $mech->text_contains('Release name', 'Alias page lists the alias type');
 
     page_test_jsonld $mech => {
-        'gtin14' => '0094634396028',
+        'gtin' => '0094634396028',
         'alternateName' => ["\N{LATIN CAPITAL LETTER AE}rial"],
         'creditedTo' => 'Kate Bush',
         'recordLabel' => {

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/Show.pm
@@ -50,7 +50,7 @@ page_test_jsonld $mech => {
         '@type' => 'MusicLabel',
     },
     '@type' => 'MusicRelease',
-    'gtin14' => '0094634396028',
+    'gtin' => '0094634396028',
     'creditedTo' => 'Kate Bush',
     'track' => [
         {

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/SubmitRelease.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/SubmitRelease.pm
@@ -29,14 +29,11 @@ test all => sub {
             VALUES ('78ad6e24-dc0a-4c20-8284-db2d44d28fb9', 49161);
         SQL
 
-    my $content = '<?xml version="1.0" encoding="UTF-8"?>
-<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
-  <release-list>
-    <release id="fbe4eb72-0f24-3875-942e-f581589713d4">
-      <barcode>5021603064126</barcode>
-    </release>
-  </release-list>
-</metadata>';
+    my $ean13 = '5021603064126';
+    my $content = _create_request_content(
+        'fbe4eb72-0f24-3875-942e-f581589713d4',
+        $ean13,
+    );
 
     my $req = xml_post('/ws/2/release?client=test-1.0', $content);
     $mech->request($req);
@@ -64,7 +61,7 @@ test all => sub {
                     id => 243064,
                     name => 'For Beginner Piano',
                 },
-                barcode => '5021603064126',
+                barcode => $ean13,
                 old_barcode => undef,
             },
         ],
@@ -84,14 +81,11 @@ test all => sub {
     my $next_edit = MusicBrainz::Server::Test->get_latest_edit($c);
     is($next_edit->id, $edit->id, 'did not submit an edit');
 
-    $content = '<?xml version="1.0" encoding="UTF-8"?>
-<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
-  <release-list>
-    <release id="78ad6e24-dc0a-4c20-8284-db2d44d28fb9">
-      <barcode>796122009228</barcode>
-    </release>
-  </release-list>
-</metadata>';
+    my $upc_a = '796122009228';
+    $content = _create_request_content(
+        '78ad6e24-dc0a-4c20-8284-db2d44d28fb9',
+        $upc_a,
+    );
 
     $req = xml_post('/ws/2/release', $content);
     $req->header('User-Agent', 'test-ua');
@@ -109,7 +103,7 @@ test all => sub {
                     id => $rel->id,
                     name => $rel->name,
                 },
-                barcode => '796122009228',
+                barcode => $upc_a,
                 old_barcode => '4942463511227',
             },
         ],
@@ -126,6 +120,20 @@ test all => sub {
     } $c;
     is(@edits => 0);
 };
+
+sub _create_request_content {
+    my ($recording_mbid, $barcode) = @_;
+    return <<~"EOXML";
+        <?xml version="1.0" encoding="UTF-8"?>
+        <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+          <release-list>
+            <release id="$recording_mbid">
+              <barcode>$barcode</barcode>
+            </release>
+          </release-list>
+        </metadata>
+        EOXML
+}
 
 1;
 

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -192,10 +192,6 @@ test 'Test is_valid_ean' => sub {
     ok(!is_valid_ean('5901234123459'), 'Invalid EAN (13 chars)');
     ok(is_valid_ean('12345678901231'), 'Valid GTIN (14 chars)');
     ok(!is_valid_ean('12345678901234'), 'Invalid GTIN (14 chars)');
-    ok(is_valid_ean('12345678912345675'), 'Valid (17 chars)');
-    ok(!is_valid_ean('12345678912345677'), 'Invalid (17 chars)');
-    ok(is_valid_ean('123456789123456789'), 'Valid SSCC (18 chars)');
-    ok(!is_valid_ean('123456789123456787'), 'Invalid SSCC (18 chars)');
 };
 
 test 'Test is_valid_partial_date' => sub {

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -190,6 +190,10 @@ test 'Test is_valid_gtin' => sub {
     ok(!is_valid_gtin('123456789997'), 'GTIN-12 (UPC-A) has invalid check digit');
     ok(is_valid_gtin('5901234123457'), 'GTIN-13 (EAN-13) is valid');
     ok(!is_valid_gtin('5901234123459'), 'GTIN-13 (EAN-13) has invalid check digit');
+    ok(is_valid_gtin('02083116542649'), 'GTIN-12 (UPC-A) with 2-digit add-on (UPC-2) is valid');
+    ok(is_valid_gtin('01501272866800084'), 'GTIN-12 (UPC-A) with 5-digit add-on (UPC-5) is valid');
+    ok(is_valid_gtin('419091010790904'), 'GTIN-13 (EAN-13) with 2-digit add-on (EAN-2) is valid');
+    ok(is_valid_gtin('842056520418700004'), 'GTIN-13 (EAN-13) with 5-digit add-on (EAN-5) is valid');
 };
 
 test 'Test is_valid_partial_date' => sub {

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -183,15 +183,15 @@ test 'Test is_valid_barcode' => sub {
 };
 
 test 'Test is_valid_gtin' => sub {
-    ok(!is_valid_gtin('1234567'), 'Invalid EAN (7 chars)');
-    ok(is_valid_gtin('96385074'), 'Valid EAN (8 chars)');
-    ok(!is_valid_gtin('96385076'), 'Invalid EAN (8 chars)');
-    ok(is_valid_gtin('123456789999'), 'Valid UPC (12 chars)');
-    ok(!is_valid_gtin('123456789997'), 'Invalid UPC (12 chars)');
-    ok(is_valid_gtin('5901234123457'), 'Valid EAN (13 chars)');
-    ok(!is_valid_gtin('5901234123459'), 'Invalid EAN (13 chars)');
-    ok(is_valid_gtin('12345678901231'), 'Valid GTIN (14 chars)');
-    ok(!is_valid_gtin('12345678901234'), 'Invalid GTIN (14 chars)');
+    ok(!is_valid_gtin('1234565'), '7-digit barcode with valid check digit has invalid length');
+    ok(is_valid_gtin('96385074'), 'GTIN-8 (EAN-8) is valid');
+    ok(!is_valid_gtin('96385076'), 'GTIN-8 (EAN-8) has invalid check digit');
+    ok(is_valid_gtin('123456789999'), 'GTIN-12 (UPC-A) is valid');
+    ok(!is_valid_gtin('123456789997'), 'GTIN-12 (UPC-A) has invalid check digit');
+    ok(is_valid_gtin('5901234123457'), 'GTIN-13 (EAN-13) is valid');
+    ok(!is_valid_gtin('5901234123459'), 'GTIN-13 (EAN-13) has invalid check digit');
+    ok(is_valid_gtin('12345678901231'), 'GTIN-14 (EAN/UCC-128 or ITF-14) is valid');
+    ok(!is_valid_gtin('12345678901234'), 'GTIN-14 (EAN/UCC-128 or ITF-14) has invalid check digit');
 };
 
 test 'Test is_valid_partial_date' => sub {

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -190,8 +190,6 @@ test 'Test is_valid_gtin' => sub {
     ok(!is_valid_gtin('123456789997'), 'GTIN-12 (UPC-A) has invalid check digit');
     ok(is_valid_gtin('5901234123457'), 'GTIN-13 (EAN-13) is valid');
     ok(!is_valid_gtin('5901234123459'), 'GTIN-13 (EAN-13) has invalid check digit');
-    ok(is_valid_gtin('12345678901231'), 'GTIN-14 (EAN/UCC-128 or ITF-14) is valid');
-    ok(!is_valid_gtin('12345678901234'), 'GTIN-14 (EAN/UCC-128 or ITF-14) has invalid check digit');
 };
 
 test 'Test is_valid_partial_date' => sub {

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -193,10 +193,10 @@ test 'Test is_valid_gtin' => sub {
     ok(!is_valid_gtin('4050538793810'), 'GTIN-13 (EAN-13) has invalid check digit');
     ok(is_valid_gtin('00602577318801'), '14-digit 0-padded GTIN-12 (UPC-A) is valid');
     ok(is_valid_gtin('07875354382095'), '14-digit 0-padded GTIN-13 (EAN-13) is valid');
-    ok(is_valid_gtin('02083116542649'), 'GTIN-12 (UPC-A) with 2-digit add-on (UPC-2) is valid');
-    ok(is_valid_gtin('01501272866800084'), 'GTIN-12 (UPC-A) with 5-digit add-on (UPC-5) is valid');
-    ok(is_valid_gtin('419091010790904'), 'GTIN-13 (EAN-13) with 2-digit add-on (EAN-2) is valid');
-    ok(is_valid_gtin('842056520418700004'), 'GTIN-13 (EAN-13) with 5-digit add-on (EAN-5) is valid');
+    ok(!is_valid_gtin('02083116542649'), 'GTIN-12 (UPC-A) with 2-digit add-on (UPC-2) is invalid (until MBS-13468)');
+    ok(!is_valid_gtin('01501272866800084'), 'GTIN-12 (UPC-A) with 5-digit add-on (UPC-5) is invalid (until MBS-13468)');
+    ok(!is_valid_gtin('419091010790904'), 'GTIN-13 (EAN-13) with 2-digit add-on (EAN-2) is invalid (until MBS-13468)');
+    ok(!is_valid_gtin('842056520418700004'), 'GTIN-13 (EAN-13) with 5-digit add-on (EAN-5) is invalid (until MBS-13468)');
 };
 
 test 'Test is_valid_partial_date' => sub {

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -184,12 +184,15 @@ test 'Test is_valid_barcode' => sub {
 
 test 'Test is_valid_gtin' => sub {
     ok(!is_valid_gtin('1234565'), '7-digit barcode with valid check digit has invalid length');
-    ok(is_valid_gtin('96385074'), 'GTIN-8 (EAN-8) is valid');
-    ok(!is_valid_gtin('96385076'), 'GTIN-8 (EAN-8) has invalid check digit');
-    ok(is_valid_gtin('123456789999'), 'GTIN-12 (UPC-A) is valid');
-    ok(!is_valid_gtin('123456789997'), 'GTIN-12 (UPC-A) has invalid check digit');
-    ok(is_valid_gtin('5901234123457'), 'GTIN-13 (EAN-13) is valid');
-    ok(!is_valid_gtin('5901234123459'), 'GTIN-13 (EAN-13) has invalid check digit');
+    ok(is_valid_gtin('07642357'), 'GTIN-8 (EAN-8) is valid');
+    ok(!is_valid_gtin('07642358'), 'GTIN-8 (EAN-8) has invalid check digit');
+    ok(is_valid_gtin('718752155427'), 'GTIN-12 (UPC-A) is valid');
+    ok(!is_valid_gtin('718752155428'), 'GTIN-12 (UPC-A) has invalid check digit');
+    ok(is_valid_gtin('0666017082523'), '13-digit 0-padded GTIN-12 (UPC-A) is valid');
+    ok(is_valid_gtin('4050538793819'), 'GTIN-13 (EAN-13) is valid');
+    ok(!is_valid_gtin('4050538793810'), 'GTIN-13 (EAN-13) has invalid check digit');
+    ok(is_valid_gtin('00602577318801'), '14-digit 0-padded GTIN-12 (UPC-A) is valid');
+    ok(is_valid_gtin('07875354382095'), '14-digit 0-padded GTIN-13 (EAN-13) is valid');
     ok(is_valid_gtin('02083116542649'), 'GTIN-12 (UPC-A) with 2-digit add-on (UPC-2) is valid');
     ok(is_valid_gtin('01501272866800084'), 'GTIN-12 (UPC-A) with 5-digit add-on (UPC-5) is valid');
     ok(is_valid_gtin('419091010790904'), 'GTIN-13 (EAN-13) with 2-digit add-on (EAN-2) is valid');

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -25,7 +25,7 @@ use MusicBrainz::Server::Validation qw(
     encode_entities
     normalise_strings
     is_valid_barcode
-    is_valid_ean
+    is_valid_gtin
     is_valid_partial_date
     is_database_row_id
     is_database_bigint_id
@@ -182,16 +182,16 @@ test 'Test is_valid_barcode' => sub {
     ok(!is_valid_barcode('129483615aaa'), 'Invalid Barcode');
 };
 
-test 'Test is_valid_ean' => sub {
-    ok(!is_valid_ean('1234567'), 'Invalid EAN (7 chars)');
-    ok(is_valid_ean('96385074'), 'Valid EAN (8 chars)');
-    ok(!is_valid_ean('96385076'), 'Invalid EAN (8 chars)');
-    ok(is_valid_ean('123456789999'), 'Valid UPC (12 chars)');
-    ok(!is_valid_ean('123456789997'), 'Invalid UPC (12 chars)');
-    ok(is_valid_ean('5901234123457'), 'Valid EAN (13 chars)');
-    ok(!is_valid_ean('5901234123459'), 'Invalid EAN (13 chars)');
-    ok(is_valid_ean('12345678901231'), 'Valid GTIN (14 chars)');
-    ok(!is_valid_ean('12345678901234'), 'Invalid GTIN (14 chars)');
+test 'Test is_valid_gtin' => sub {
+    ok(!is_valid_gtin('1234567'), 'Invalid EAN (7 chars)');
+    ok(is_valid_gtin('96385074'), 'Valid EAN (8 chars)');
+    ok(!is_valid_gtin('96385076'), 'Invalid EAN (8 chars)');
+    ok(is_valid_gtin('123456789999'), 'Valid UPC (12 chars)');
+    ok(!is_valid_gtin('123456789997'), 'Invalid UPC (12 chars)');
+    ok(is_valid_gtin('5901234123457'), 'Valid EAN (13 chars)');
+    ok(!is_valid_gtin('5901234123459'), 'Invalid EAN (13 chars)');
+    ok(is_valid_gtin('12345678901231'), 'Valid GTIN (14 chars)');
+    ok(!is_valid_gtin('12345678901234'), 'Invalid GTIN (14 chars)');
 };
 
 test 'Test is_valid_partial_date' => sub {


### PR DESCRIPTION
# Problems

A number of issues related to GTIN (EAN/UPC) barcodes have been noticed while reviewing the initial implementation of MBS-13346 with PR #3078:

1. The barcode submission API and the release editor aren’t validating the same types of barcode.
2. The JSON-LD property [`gtin14`](https://schema.org/gtin14) is misused for barcode in release’s JSON-LD serialization.
3. GTIN-14 is mistaken for fully zero-padded 14-digit GTIN, whereas GTIN-14 doesn’t start with a 0 and is for shipment only.
4. GINC/GSIN/SSCC are validated whereas these are for shipment only.
5. GTIN-8 (EAN-8) is validated by the barcode submission API only.
6.  2/5-digit add-ons (EAN-2/EAN-5) aren’t taken into account.
7. Tests are sometimes missing some real data examples.
8. Barcode documentation isn’t up-to-date.

# Solution

After checking [GS1 General Specifications](https://ref.gs1.org/standards/genspecs/) standard and actual barcodes in the database supported with scanned cover art

* Refactoring:
  * Clarify the naming of barcode formats in code and tests
  * Align GTIN checksum’s JS implementation with Perl implementation
  * Use the same actual barcodes for testing both JS and Perl
  * Drop testing GTIN-14 support (as a first step)
* Changes for users:
  * No longer accept 17-digit and 18-digit barcodes through API (so as to follow the behavior of the release editor)
  * In release editor:
    * Validate GTIN-8 (EAN-8) barcodes (so as to follow the behavior of the API)
    * Recognize 2-digit and 5-digit add-ons (EAN-2 and EAN-5) when used with a GTIN-12 (UPC-A) or a GTIN-13 (EAN-13) and suggest to move the add-on code to the annotation field
  * In release’s JSON-LD serialization (embedded in release page’ HTML), replace the inappropriate `gtin14` property (from legacy code) with either `gtin` for valid GTIN barcode or `identifier` of type `barcode` otherwise.

# Testing

Each non-refactoring change comes with updated/added CI tests.

Manually tested the following as not covered by CI tests:

* [x] Entering a not recognized barcode and checking the generated JSON-LD.
* [x] Entering a barcode with 2/5-digit add-on and checking the error field.

# Documenting

Pages to be updated (after discussion with reviewers):

* [x] https://wiki.musicbrainz.org/index.php?title=Barcode&diff=77364&oldid=77214
* [x] https://wiki.musicbrainz.org/index.php?title=Style/Release&diff=77365&oldid=77299
* [x] https://wiki.musicbrainz.org/index.php?title=MusicBrainz_API&diff=77363&oldid=77340

# Further action

1. After merging to `master`, update the related ticket MBS-13346 with full changes.
2. After releasing `production`, transclude the above documentation pages.

# Notes

These are straightforward changes only. Next changes to be discussed can be:
* Stop showing the check digit, as it isn’t supposed to be copied anyway, don’t be tempting!
* Factorize the JS validation to simplify it and make it fully testable.
* Stop recognizing GTIN-14 again, but still recognize other 14-digit zero-padded GTINs.
* Improve the messages about not recognized barcodes and link to the documentation.