### PR TITLE
Add context to "Time" strings

### DIFF
--- a/root/cdtoc/CDTocInfo.js
+++ b/root/cdtoc/CDTocInfo.js
@@ -53,11 +53,11 @@ const CDTocInfo = ({cdToc}: Props): React$Element<React$FragmentType> => (
               <th colSpan="2">{l('End')}</th>
             </tr>
             <tr>
-              <th>{l('Time')}</th>
+              <th>{lp('Time', 'CD timecode')}</th>
               <th>{l('Sectors')}</th>
-              <th>{l('Time')}</th>
+              <th>{lp('Time', 'CD timecode')}</th>
               <th>{l('Sectors')}</th>
-              <th>{l('Time')}</th>
+              <th>{lp('Time', 'CD timecode')}</th>
               <th>{l('Sectors')}</th>
             </tr>
             {cdToc.track_details.map((track, index) => (

--- a/root/components/list/EventList.js
+++ b/root/components/list/EventList.js
@@ -90,7 +90,7 @@ const EventList = ({
       const timeColumn = defineTextColumn<EventT>({
         columnName: 'time',
         getText: entity => entity.time,
-        title: l('Time'),
+        title: lp('Time', 'event'),
       });
       const rolesOnlyColumn = artist && artistRoles
         ? defineTextColumn<EventT>({

--- a/root/edit/details/EditEvent.js
+++ b/root/edit/details/EditEvent.js
@@ -85,7 +85,7 @@ const EditEvent = ({edit}: Props): React$Element<'table'> => {
       ) : null}
       {time ? (
         <FullChangeDiff
-          label={addColonText(l('Time'))}
+          label={addColonText(lp('Time', 'event'))}
           newContent={time.new ?? ''}
           oldContent={time.old ?? ''}
         />

--- a/root/event/edit_form.tt
+++ b/root/event/edit_form.tt
@@ -37,7 +37,7 @@
         [% too_short_year_error('too_short_begin_year') %]
         [% form_row_date(r, 'period.end_date', add_colon(l('End date'))) %]
         [% too_short_year_error('too_short_end_year') %]
-        [%- form_row_time(r, 'time', add_colon(l('Time'))) -%]
+        [%- form_row_time(r, 'time', add_colon(lp('Time', 'event'))) -%]
       </fieldset>
 
       [% PROCESS 'forms/relationship-editor.tt' %]

--- a/root/layout/components/sidebar/EventSidebar.js
+++ b/root/layout/components/sidebar/EventSidebar.js
@@ -75,7 +75,10 @@ const EventSidebar = ({event}: Props): React$Element<'div'> => {
         ) : null}
 
         {event.time ? (
-          <SidebarProperty className="time" label={addColonText(l('Time'))}>
+          <SidebarProperty
+            className="time"
+            label={addColonText(lp('Time', 'event'))}
+          >
             {event.time}
           </SidebarProperty>
         ) : null}

--- a/root/main/error/components/ErrorEnvironment.js
+++ b/root/main/error/components/ErrorEnvironment.js
@@ -24,7 +24,7 @@ const ErrorEnvironment = ({
   return (
     <>
       <p>
-        <strong>{addColonText(l('Time'))}</strong>
+        <strong>{addColonText(l('Date and time'))}</strong>
         {' '}
         {new Date().toISOString()}
       </p>

--- a/root/report/components/EventList.js
+++ b/root/report/components/EventList.js
@@ -74,7 +74,7 @@ const EventList = <D: {+event: ?EventT, ...}>({
       const timeColumn = defineTextColumn<D>({
         columnName: 'time',
         getText: result => result.event?.time ?? '',
-        title: l('Time'),
+        title: lp('Time', 'event'),
       });
       const dateColumn = defineDatePeriodColumn<D>({
         getEntity: result => result.event ?? null,

--- a/root/search/components/EventResults.js
+++ b/root/search/components/EventResults.js
@@ -72,7 +72,7 @@ const EventResults = ({
           <>
             <th>{l('Name')}</th>
             <th>{l('Date')}</th>
-            <th>{l('Time')}</th>
+            <th>{lp('Time', 'event')}</th>
             <th>{l('Type')}</th>
             <th>{l('Artists')}</th>
             <th>{lp('Location', 'event location')}</th>


### PR DESCRIPTION
At least in Spanish, the time of an event would generally be translated in a significantly different way than the timecodes in a CDTOC.