### PR TITLE
Remove colons from Type strings

### DIFF
--- a/root/artist/edit_form.tt
+++ b/root/artist/edit_form.tt
@@ -13,7 +13,7 @@
         [%- duplicate_entities_section() -%]
         [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
         [%- disambiguation_error() -%]
-        [%- form_row_select(r, 'type_id', l('Type:')) -%]
+        [%- form_row_select(r, 'type_id', add_colon(l('Type'))) -%]
         [%- form_row_select(r, 'gender_id', add_colon(l('Gender'))) -%]
         [% WRAPPER form_row %]
           [% area_field = form.field('area.name') %]

--- a/root/edit/details/AddAnnotation.js
+++ b/root/edit/details/AddAnnotation.js
@@ -9,7 +9,6 @@
 
 import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink.js';
-import {addColonText} from '../../static/scripts/common/i18n/addColon.js';
 import formatEntityTypeName
   from '../../static/scripts/common/utility/formatEntityTypeName.js';
 import Diff from '../../static/scripts/edit/components/edit/Diff.js';

--- a/root/event/edit_form.tt
+++ b/root/event/edit_form.tt
@@ -11,7 +11,7 @@
         <legend>[% l('Event details') %]</legend>
         [%- form_row_name_with_guesscase(r) -%]
         [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
-        [%- form_row_select(r, 'type_id', l('Type:')) -%]
+        [%- form_row_select(r, 'type_id', add_colon(l('Type'))) -%]
         [% form_row_checkbox(r, 'cancelled', l('This event was cancelled.')) %]
         [% WRAPPER form_row %]
           [% r.label('setlist', add_colon(l('Setlist'))) %]

--- a/root/label/edit_form.tt
+++ b/root/label/edit_form.tt
@@ -12,7 +12,7 @@
         [%- duplicate_entities_section() -%]
         [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
         [%- disambiguation_error() -%]
-        [%- form_row_select(r, 'type_id', l('Type:')) -%]
+        [%- form_row_select(r, 'type_id', add_colon(l('Type'))) -%]
         [% WRAPPER form_row %]
           [% area_field = form.field('area.name') %]
           <label for="id-edit-label.area.name">[% add_colon(l('Area')) %]</label>

--- a/root/layout/components/sidebar/CollectionSidebar.js
+++ b/root/layout/components/sidebar/CollectionSidebar.js
@@ -56,7 +56,7 @@ const CollectionSidebar = ({
         </SidebarProperty>
 
         {nonEmpty(typeName) ? (
-          <SidebarProperty className="type" label={l('Type:')}>
+          <SidebarProperty className="type" label={addColonText(l('Type'))}>
             {lp_attributes(typeName, 'collection_type')}
           </SidebarProperty>
         ) : null}

--- a/root/layout/components/sidebar/ReleaseGroupSidebar.js
+++ b/root/layout/components/sidebar/ReleaseGroupSidebar.js
@@ -62,7 +62,7 @@ const ReleaseGroupSidebar = ({
         </SidebarProperty>
 
         {typeName ? (
-          <SidebarProperty className="type" label={l('Type:')}>
+          <SidebarProperty className="type" label={addColonText(l('Type'))}>
             {typeName}
           </SidebarProperty>
         ) : null}

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -156,7 +156,7 @@ const ReleaseSidebar = ({release}: Props): React$Element<'div'> | null => {
 
       <SidebarProperties>
         {nonEmpty(typeName) ? (
-          <SidebarProperty className="type" label={l('Type:')}>
+          <SidebarProperty className="type" label={addColonText(l('Type'))}>
             {typeName}
           </SidebarProperty>
         ) : null}

--- a/root/layout/components/sidebar/SidebarType.js
+++ b/root/layout/components/sidebar/SidebarType.js
@@ -22,7 +22,7 @@ const SidebarType = ({
   typeType,
 }: Props): React$MixedElement | null => (
   entity.typeID == null ? null : (
-    <SidebarProperty className="type" label={l('Type:')}>
+    <SidebarProperty className="type" label={addColonText(l('Type'))}>
       {lp_attributes(
         linkedEntities[typeType][entity.typeID].name,
         typeType,

--- a/root/place/edit_form.tt
+++ b/root/place/edit_form.tt
@@ -12,7 +12,7 @@
         [%- duplicate_entities_section() -%]
         [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
         [%- disambiguation_error() -%]
-        [%- form_row_select(r, 'type_id', l('Type:')) -%]
+        [%- form_row_select(r, 'type_id', add_colon(l('Type'))) -%]
         [%- form_row_text_long(r, 'address', add_colon(l('Address'))) -%]
         [% WRAPPER form_row %]
           [% area_field = form.field('area.name') %]

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -100,7 +100,7 @@
         <!-- /ko -->
       [% ELSE %]
       <tr>
-        <td><label>[% l('Type:') %]</label></td>
+        <td><label>[% add_colon(l('Type')) %]</label></td>
         <td colspan="2">
           [% l('To edit types, please {edit_page|edit the release group}.',
                 edit_page => { href => c.uri_for_action('/release_group/edit', [ release.release_group.gid ]), target => '_blank' }) %]

--- a/root/search/components/SearchForm.js
+++ b/root/search/components/SearchForm.js
@@ -79,7 +79,7 @@ const SearchForm = ({
         />
         <FormRowSelect
           field={form.field.type}
-          label={l('Type:')}
+          label={addColonText(l('Type'))}
           options={typeOptions}
           uncontrolled
         />

--- a/root/series/edit_form.tt
+++ b/root/series/edit_form.tt
@@ -13,7 +13,7 @@
         [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
         [%- disambiguation_error() -%]
         [%# When porting this, remember no_default is equivalent to allowEmpty %]
-        [%- form_row_select(r, 'type_id', l('Type:'), undef, {no_default => 1}) -%]
+        [%- form_row_select(r, 'type_id', add_colon(l('Type')), undef, {no_default => 1}) -%]
         [%- form_row_select(r, 'ordering_type_id', add_colon(l('Ordering type'))) -%]
       </fieldset>
 

--- a/root/static/scripts/common/components/Autocomplete2/formatters.js
+++ b/root/static/scripts/common/components/Autocomplete2/formatters.js
@@ -12,7 +12,6 @@ import * as React from 'react';
 import {stripAttributes} from '../../../edit/utility/linkPhrase.js';
 import {INSTRUMENT_ROOT_ID} from '../../constants.js';
 import {unwrapNl} from '../../i18n.js';
-import {addColonText} from '../../i18n/addColon.js';
 import {commaOnlyListText} from '../../i18n/commaOnlyList.js';
 import localizeLanguageName from '../../i18n/localizeLanguageName.js';
 import localizeLinkAttributeTypeDescription

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -9,7 +9,6 @@
 
 import SelectField from '../../common/components/SelectField.js';
 import FieldErrors from '../../edit/components/FieldErrors.js';
-import {addColonText} from '../i18n/addColon.js';
 
 type GenericFilterFormFieldsT = {
   +disambiguation: FieldT<string>,

--- a/root/static/scripts/common/components/MediumDescription.js
+++ b/root/static/scripts/common/components/MediumDescription.js
@@ -7,7 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import {addColonText} from '../i18n/addColon.js';
 import isolateText from '../utility/isolateText.js';
 import mediumFormatName from '../utility/mediumFormatName.js';
 

--- a/root/work/edit_form.tt
+++ b/root/work/edit_form.tt
@@ -11,7 +11,7 @@
       <legend>[%- l('Work details') -%]</legend>
       [%- form_row_name_with_guesscase(r) -%]
       [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
-      [%- form_row_select(r, 'type_id', l('Type:')) -%]
+      [%- form_row_select(r, 'type_id', add_colon(l('Type'))) -%]
       <div id="work-languages-editor"></div>
       [%- form_row_text_list(r, 'iswcs', add_colon(l('ISWCs')), l('ISWC')) -%]
     </fieldset>


### PR DESCRIPTION
We already have a lot of Type strings without colons and these do not mean different things in different places.