### PR TITLE
Add context to [removed] strings

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Relationship/RemoveLinkType.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/RemoveLinkType.pm
@@ -5,7 +5,7 @@ use MooseX::Types::Structured qw( Dict  Optional Tuple );
 use MusicBrainz::Server::Constants qw( $EDIT_RELATIONSHIP_REMOVE_LINK_TYPE );
 use MusicBrainz::Server::Edit::Types qw( Nullable );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
-use MusicBrainz::Server::Translation qw( l N_lp );
+use MusicBrainz::Server::Translation qw( lp N_lp );
 
 extends 'MusicBrainz::Server::Edit';
 with 'MusicBrainz::Server::Edit::Relationship',
@@ -83,7 +83,7 @@ sub _build_attributes {
                 max => $_->{max},
                 type => $loaded->{LinkAttributeType}{ $_->{type} } ||
                     MusicBrainz::Server::Entity::LinkAttributeType->new(
-                        name => ($_->{name} || l('[removed]')),
+                        name => ($_->{name} || lp('[removed]', 'relationship attribute type')),
                     ),
                   ))
           } @$list,

--- a/lib/MusicBrainz/Server/Edit/Release/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Create.pm
@@ -16,7 +16,7 @@ use MusicBrainz::Server::Edit::Utils qw(
 );
 use MusicBrainz::Server::Entity::ReleaseEvent;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
-use MusicBrainz::Server::Translation qw( l N_lp );
+use MusicBrainz::Server::Translation qw( lp N_lp );
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
 with 'MusicBrainz::Server::Edit::Role::Preview',
@@ -109,7 +109,7 @@ sub build_display_data
         barcode       => $self->data->{barcode},
         release_group => (defined($self->data->{release_group_id}) &&
                            to_json_object($loaded->{ReleaseGroup}{ $self->data->{release_group_id} } ||
-                               ReleaseGroup->new( name => l('[removed]') ))),
+                               ReleaseGroup->new( name => lp('[removed]', 'release group') ))),
         release       => to_json_object(defined($self->entity_id) &&
                             $loaded->{Release}{ $self->entity_id } ||
                             Release->new( name => $self->data->{name} )),

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -191,7 +191,7 @@ END -%]
     # parameters: entity, text, no_escape
       SET text = html_escape(text) UNLESS no_escape;
       SET text = html_escape(entity.name) IF text == '';
-      SET text = html_escape(l('[removed]')) IF text == '';
+      SET text = html_escape(lp('[removed]', 'generic entity')) IF text == '';
       caption = allow_new
         ? l("This entity will be added by this edit.")
         : l("This entity has been removed, and cannot be displayed correctly.");

--- a/root/edit/details/EditAlias.js
+++ b/root/edit/details/EditAlias.js
@@ -73,7 +73,11 @@ const EditAlias = ({edit}: Props): React$Element<'table'> => {
                       : locales[aliasLocale],
                   )}
                 </>
-              ) : <span className="deleted">{l('[removed]')}</span>}
+              ) : (
+                <span className="deleted">
+                  {lp('[removed]', 'alias')}
+                </span>
+              )}
             </td>
           </tr>) : null}
 

--- a/root/edit/details/SetTrackLengths.js
+++ b/root/edit/details/SetTrackLengths.js
@@ -55,7 +55,7 @@ const SetTrackLengths = ({edit}: Props): React$Element<'table'> => {
         <td colSpan="2">
           {cdtoc ? (
             <CDTocLink cdToc={cdtoc} />
-          ) : l('[removed]')}
+          ) : lp('[removed]', 'CD TOC')}
         </td>
       </tr>
 

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -45,7 +45,9 @@ export const DeletedLink = ({
       }
       title={caption}
     >
-      {isolateText(nonEmpty(name) ? name : l('[removed]'))}
+      {isolateText(nonEmpty(name)
+        ? name
+        : lp('[removed]', 'generic entity'))}
     </span>
   );
 };

--- a/root/static/scripts/common/i18n/localizeLanguageName.js
+++ b/root/static/scripts/common/i18n/localizeLanguageName.js
@@ -12,7 +12,7 @@ function localizeLanguageName(
   isWork?: boolean = false,
 ): string {
   if (!language) {
-    return l('[removed]');
+    return lp('[removed]', 'language');
   }
   // For works, "No linguistic content" is meant as "No lyrics"
   if (isWork && language.iso_code_3 === 'zxx') {

--- a/root/static/scripts/edit/components/Multiselect.js
+++ b/root/static/scripts/edit/components/Multiselect.js
@@ -194,7 +194,7 @@ export const MultiselectValue: MultiselectValueComponentT = React.memo(<
         * lost and/or doesn't need to be shifted to an unrelated row;
         * neither situation is accessible.
         */}
-      {state.removed ? l('[removed]') : (
+      {state.removed ? lp('[removed]', 'generic row') : (
         <>
           <Autocomplete2
             dispatch={autocompleteDispatch}


### PR DESCRIPTION
This is needed to be able to use the right gender and number in translations. There's a few uses where we don't know what is going to be used for (different entities for example have different genders), so this at least specifies this is generic usage so translators can choose to use a generic string here if available.