### PR TITLE
Add context to "cancelled" for events

### DIFF
--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -108,7 +108,7 @@ END; -%]
 [%~ MACRO cancelled(entity) BLOCK -%]
     [%- IF entity.cancelled -%]
         <span class="cancelled">(<bdi>
-            [%~ l("cancelled") ~%]
+            [%~ lp("cancelled", 'event') ~%]
             </bdi>)</span>
     [%- END -%]
 [%- END -%]

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -93,7 +93,7 @@ const EventDisambiguation = ({
     <>
       {dates && showDate ? ' ' + bracketedText(dates) : null}
       {event.cancelled
-        ? <Comment className="cancelled" comment={l('cancelled')} />
+        ? <Comment className="cancelled" comment={lp('cancelled', 'event')} />
         : null}
     </>
   );


### PR DESCRIPTION
We had context for the "cancelled" string for edits, but not for events (the only uses left without context).