### PR TITLE
Drop contact email from strings

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Account.pm
+++ b/lib/MusicBrainz/Server/Controller/Account.pm
@@ -8,6 +8,7 @@ use namespace::autoclean;
 use Digest::SHA qw(sha1_base64);
 use JSON;
 use List::AllUtils qw( uniq );
+use MusicBrainz::Server::Constants qw( $CONTACT_URL );
 use MusicBrainz::Server::ControllerUtils::JSON qw( serialize_pager );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
@@ -172,8 +173,9 @@ sub _send_password_reset_email
     }
     catch {
         $c->flash->{message} = l(
-            'We were unable to send login information to your email address.  Please try again, ' .
-            'however if you continue to experience difficulty contact us at support@musicbrainz.org.',
+            'We were unable to send login information to your email address. ' .
+            'Please try again, and if that still doesn’t work, {contact_url|contact us}.',
+            {contact_url => $CONTACT_URL},
         );
     };
 }
@@ -740,12 +742,11 @@ sub _send_confirmation_email
     }
     catch {
         $c->flash->{message} = l(
-            '<strong>We were unable to send a verification email to you.</strong><br/>Please confirm that you have entered a valid ' .
-            'address by editing your {settings|account settings}. If the problem still persists, please contact us at ' .
-            '{mail|support@musicbrainz.org}.',
+            '<strong>We were unable to send you a verification email.</strong><br/>Please re-enter your address ' .
+            'in your {settings|account settings}. If that still doesn’t work, {contact_url|contact us}.',
             {
                 settings => $c->uri_for_action('/account/edit'),
-                mail => 'mailto:support@musicbrainz.org',
+                contact_url => $CONTACT_URL,
             },
         );
     };

--- a/root/main/error/Error401.js
+++ b/root/main/error/Error401.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CONTACT_URL} from '../../constants.js';
 import {CatalystContext} from '../../context.mjs';
 
 import ErrorLayout from './ErrorLayout.js';
@@ -35,9 +36,9 @@ const Error401 = (): React$Element<typeof ErrorLayout> => {
 
       <p>
         {exp.l(
-          `If you think this is a mistake, please contact
-          <code>support@musicbrainz.org</code>
-          with the name of your account.`,
+          `If you think this is a mistake, please {contact|contact us}
+           with the name of your account.`,
+          {contact: CONTACT_URL},
         )}
       </p>
     </ErrorLayout>

--- a/root/user/Login.js
+++ b/root/user/Login.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CONTACT_URL} from '../constants.js';
 import {CatalystContext} from '../context.mjs';
 import Layout from '../layout/index.js';
 import * as manifest from '../static/manifest.mjs';
@@ -86,9 +87,9 @@ const Login = ({
               </p>
               <p>
                 {exp.l(
-                  `If you think this is a mistake, please contact
-                   <code>support@musicbrainz.org</code>
+                  `If you think this is a mistake, please {contact|contact us}
                    with the name of your account.`,
+                  {contact: CONTACT_URL},
                 )}
               </p>
             </span>


### PR DESCRIPTION
We generally use `support@metabrainz` now, but in any case most of our strings direct people to the contact us page instead. Doing the same with these four stragglers. I also somewhat simplified the strings while at it, and changed some text that seemed to suggest the `account/edit` page would show the entered email (it does not, until it is verified).
