### PR TITLE
Add context to [unknown] strings

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/EditRelationships.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/EditRelationships.pm
@@ -17,7 +17,7 @@ use MusicBrainz::Server::Data::Utils qw(
     type_to_model
 );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
-use MusicBrainz::Server::Translation qw( l );
+use MusicBrainz::Server::Translation qw( lp );
 use MusicBrainz::Server::Validation qw(
     is_database_row_id
     is_non_negative_integer
@@ -219,7 +219,7 @@ role {
                 : ($source_type lt $target_type ? 0 : 1);
 
             $target //= $c->model(type_to_model($target_type))->_new_from_row({
-                name => $rel->{target_name} // l('[unknown]'),
+                name => $rel->{target_name} // lp('[unknown]', 'generic entity'),
             });
 
             my $source_credit = '';

--- a/root/layout/components/sidebar/SidebarEndDate.js
+++ b/root/layout/components/sidebar/SidebarEndDate.js
@@ -35,7 +35,7 @@ const SidebarEndDate = ({
   isDateEmpty(entity.end_date) ? (
     entity.ended ? (
       <SidebarProperty className="end-date" label={label}>
-        {l('[unknown]')}
+        {lp('[unknown]', 'date')}
       </SidebarProperty>
     ) : null
   ) : (

--- a/root/static/scripts/common/utility/formatEndDate.js
+++ b/root/static/scripts/common/utility/formatEndDate.js
@@ -15,6 +15,6 @@ export default function formatEndDate<T: $ReadOnly<{
   ...
 }>>(entity: T): null | string {
   return isDateEmpty(entity.end_date)
-    ? (entity.ended ? l('[unknown]') : null)
+    ? (entity.ended ? lp('[unknown]', 'date') : null)
     : formatDate(entity.end_date);
 }

--- a/root/static/scripts/relationship-editor/components/DialogPreview.js
+++ b/root/static/scripts/relationship-editor/components/DialogPreview.js
@@ -105,7 +105,7 @@ const DialogPreview = (React.memo<PropsT>(({
           : (
             (isDatabaseRowId(entity.id) || nonEmpty(entity.name))
               ? '' // have EntityLink determine the content
-              : l('[unknown]'))
+              : lp('[unknown]', 'generic entity'))
       }
       deletedCaption={
         (batchSelectionCount != null && entity === source)

--- a/root/static/scripts/relationship-editor/components/DialogSourceEntity.js
+++ b/root/static/scripts/relationship-editor/components/DialogSourceEntity.js
@@ -114,7 +114,7 @@ const DialogSourceEntity = (React.memo<PropsT>(({
             <EntityLink
               allowNew
               className="wrap-anywhere"
-              content={source.name || l('[unknown]')}
+              content={source.name || lp('[unknown]', 'generic entity')}
               entity={source}
               target="_blank"
             />


### PR DESCRIPTION
This is needed to use the right gender in translations. For date ones we can be specific. For the entity ones, all we can say is that it's for a generic entity for now (we could later decide to separate these into strings for every entity type based on context though).