### PR TITLE
Add context to [none] barcodes

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Barcode.pm
+++ b/lib/MusicBrainz/Server/Entity/Barcode.pm
@@ -1,6 +1,6 @@
 package MusicBrainz::Server::Entity::Barcode;
 use Moose;
-use MusicBrainz::Server::Translation qw( l );
+use MusicBrainz::Server::Translation qw( lp );
 
 has 'code' => (
     is => 'rw',
@@ -15,7 +15,7 @@ sub format
 
     return '' unless defined $self->code;
 
-    return $self->code eq '' ? l('[none]') : $self->code;
+    return $self->code eq '' ? lp('[none]', 'barcode') : $self->code;
 }
 
 around BUILDARGS => sub {

--- a/root/static/scripts/common/utility/formatBarcode.js
+++ b/root/static/scripts/common/utility/formatBarcode.js
@@ -12,7 +12,7 @@ function formatBarcode(code: string | null): string {
     return '';
   }
   if (code === '') {
-    return l('[none]');
+    return lp('[none]', 'barcode');
   }
   return code;
 }


### PR DESCRIPTION
We already have context for [none] strings for different entity types, but not when used to indicate no barcode.