### PR TITLE
MBS-13473: Don't block junodownload links with spaces (+)

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3340,7 +3340,7 @@ const CLEANUPS: CleanupEntries = {
           target: ERROR_TARGETS.URL,
         };
       }
-      const m = /^https:\/\/www\.junodownload\.com\/(artists|labels|products)\/[\w\d-]+\/$/.exec(url);
+      const m = /^https:\/\/www\.junodownload\.com\/(artists|labels|products)\/[\w\d+-]+\/$/.exec(url);
       if (m) {
         const prefix = m[1];
         switch (id) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3211,10 +3211,10 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['label'],
   },
   {
-                     input_url: 'https://www.junodownload.com/artists/Raito/?facet%5Bsubgenre_id%5D%5B0%5D=12%7C%7C3',
+                     input_url: 'https://www.junodownload.com/artists/Kurwastyle+Project/?facet%5Bsubgenre_id%5D%5B0%5D=12%7C%7C3',
              input_entity_type: 'artist',
     expected_relationship_type: 'downloadpurchase',
-            expected_clean_url: 'https://www.junodownload.com/artists/Raito/',
+            expected_clean_url: 'https://www.junodownload.com/artists/Kurwastyle+Project/',
        only_valid_entity_types: ['artist'],
   },
   {


### PR DESCRIPTION
### Fix MBS-13473


# Problem
junodownload links with spaces (`+`) were blocked as invalid because we didn't count on them using that rather than `-` for separating words on some names (label and artist, at least, such as https://www.junodownload.com/artists/Kurwastyle+Project/).

# Solution
This just allows `+` as part of the id on the validation so that the otherwise already valid link is accepted.

# Testing
Changed a test to use the artist with a space linked above.