### PR TITLE
Update react-dom libdef with flushSync type

### DIFF
--- a/flow-typed/npm/react-dom_v18.x.x.js
+++ b/flow-typed/npm/react-dom_v18.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: de0a47185086152df6ab4a598943384d
-// flow-typed version: cf9120ecbb/react-dom_v18.x.x/flow_>=v0.127.x
+// flow-typed signature: bd8a9984746306d26194a489f3aeff35
+// flow-typed version: 388e9edcf0/react-dom_v18.x.x/flow_>=v0.127.x
 
 declare module 'react-dom_shared-types' {
   /**
@@ -130,6 +130,8 @@ declare module 'react-dom' {
 
   declare function unmountComponentAtNode(container: any): boolean;
 
+  declare function flushSync(callback: () => mixed): void;
+
   declare function unstable_batchedUpdates<A, B, C, D, E>(
     callback: (a: A, b: B, c: C, d: D, e: E) => mixed,
     a: A,
@@ -158,7 +160,7 @@ declare module 'react-dom/client' {
 
   declare opaque type FiberRoot;
 
-  declare type RootType = {
+  declare export type RootType = {
     render(children: ReactNodeList): void,
     unmount(): void,
     _internalRoot: FiberRoot | null,

--- a/root/static/scripts/common/utility/focusManagement.js
+++ b/root/static/scripts/common/utility/focusManagement.js
@@ -7,7 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-// $FlowIgnore[missing-export]
 import {flushSync} from 'react-dom';
 
 function isElementVisible(element: HTMLElement) {

--- a/root/static/scripts/edit/components/FormRowNameWithGuessCase.js
+++ b/root/static/scripts/edit/components/FormRowNameWithGuessCase.js
@@ -7,10 +7,8 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-/* eslint-disable import/newline-after-import -- the FlowIgnore triggers it */
 import type {CowContext} from 'mutate-cow';
 import * as React from 'react';
-// $FlowIgnore[missing-export]
 import {flushSync} from 'react-dom';
 
 import GuessCase from '../../guess-case/MB/GuessCase/Main.js';

--- a/root/static/scripts/release/components/ReleaseRelationshipEditor.js
+++ b/root/static/scripts/release/components/ReleaseRelationshipEditor.js
@@ -7,11 +7,9 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-/* eslint-disable import/newline-after-import -- the FlowIgnore triggers it */
 import {captureException} from '@sentry/browser';
 import deepFreeze from 'deep-freeze-strict';
 import * as React from 'react';
-// $FlowIgnore[missing-export]
 import {flushSync} from 'react-dom';
 import * as tree from 'weight-balanced-tree';
 import {

--- a/root/static/scripts/work/edit.js
+++ b/root/static/scripts/work/edit.js
@@ -7,14 +7,12 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-/* eslint-disable import/newline-after-import -- the FlowIgnore triggers it */
 import $ from 'jquery';
 import ko, {
   type Observable as KnockoutObservable,
   type ObservableArray as KnockoutObservableArray,
 } from 'knockout';
 import mutate from 'mutate-cow';
-// $FlowIgnore[missing-export]
 import {flushSync} from 'react-dom';
 import * as ReactDOMClient from 'react-dom/client';
 import {legacy_createStore as createStore} from 'redux';

--- a/root/utility/hydrate.js
+++ b/root/utility/hydrate.js
@@ -7,10 +7,8 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-/* eslint-disable import/newline-after-import -- the FlowIgnore triggers it */
 import * as Sentry from '@sentry/browser';
 import * as React from 'react';
-// $FlowIgnore[missing-export]
 import {flushSync} from 'react-dom';
 import * as ReactDOMClient from 'react-dom/client';
 


### PR DESCRIPTION
# Problem

The react-dom libdef was missing a declaration for `flushSync`, which required a `$FlowIgnore` on the import, and an additional ESLint ignore for the `$FlowIgnore`. 

# Solution

I submitted a declaration upstream and synced the changes here.

# Testing

Ran `./node_modules/.bin/flow`.