### PR TITLE
MBS-13474: Allow TikTok videos on recordings

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5698,16 +5698,30 @@ const CLEANUPS: CleanupEntries = {
   },
   'tiktok': {
     match: [new RegExp('^(https?://)?(www\\.)?tiktok\\.com', 'i')],
-    restrict: [LINK_TYPES.socialnetwork],
+    restrict: [{...LINK_TYPES.streamingfree, ...LINK_TYPES.socialnetwork}],
     clean: function (url) {
       return url.replace(
-        /^(?:https?:\/\/)(?:www\.)?tiktok\.com\/@([\w.]+)(?:[\/?&#].*)?$/,
+        /^(?:https?:\/\/)(?:www\.)?tiktok\.com\/@([\w.]+(?:\/video\/\d+)?)(?:[\/?#].*)?$/,
         'https://www.tiktok.com/@$1',
       );
     },
     validate: function (url, id) {
-      const m = /^https:\/\/www\.tiktok\.com\/@[\w.]+$/.exec(url);
+      const m = /^https:\/\/www\.tiktok\.com\/@[\w.]+(\/video\/\d+)?$/.exec(url);
       if (m) {
+        const isAVideo = !!m[1];
+        if (Object.values(LINK_TYPES.streamingfree).includes(id)) {
+          return {
+            result: isAVideo &&
+              (id === LINK_TYPES.streamingfree.recording),
+            target: ERROR_TARGETS.ENTITY,
+          };
+        } else if (isAVideo) {
+          return {
+            error: l('Please link to TikTok profiles, not videos.'),
+            result: false,
+            target: ERROR_TARGETS.ENTITY,
+          };
+        }
         switch (id) {
           case LINK_TYPES.socialnetwork.artist:
           case LINK_TYPES.socialnetwork.label:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5662,6 +5662,13 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://www.tiktok.com/@officialrandl',
        only_valid_entity_types: ['artist', 'label', 'place', 'series'],
   },
+  {
+                     input_url: 'https://www.tiktok.com/@mimo_mio/video/7029807544944069894',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'streamingfree',
+            expected_clean_url: 'https://www.tiktok.com/@mimo_mio/video/7029807544944069894',
+       only_valid_entity_types: ['recording'],
+  },
   // Tipeee
   {
                      input_url: 'https://www.tipeee.com/example/news',


### PR DESCRIPTION
### Implement MBS-13474

# Description
We were turning these into profile links, but actually there's a fair amount of "TikTok music" being created that originates in and is mostly streamed at TikTok itself.
As such, it makes sense to allow linking recordings to `/video` TikTok links (/music links, which are used for videos that use licensed music, do not seem to belong in MusicBrainz).

# Testing
Added a test, plus checked manually that the links are blocked and allowed as expected.