### PR TITLE
MBS-13424: Allow Spotify shop links

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/Spotify.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Spotify.pm
@@ -12,6 +12,8 @@ sub sidebar_name {
 
     if ($self->url =~ m{^(?:https?:)?//(?:[^/]+.)?spotify.com/user/[^/?#]+/?}i) {
         return l('Playlists at Spotify');
+    } elsif ($self->url =~ m{^(?:https?:)?//shop.spotify.com/[^/?#]+/?}i) {
+        return l('Purchase at Spotify');
     } else {
         return l('Stream at Spotify');
     }

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5413,7 +5413,7 @@ const CLEANUPS: CleanupEntries = {
   },
   'spotify': {
     match: [new RegExp(
-      '^(https?://)?([^/]+\\.)?(spotify\\.(?:com|link))/' +
+      '^(https?://)?(((?!shop)[^/])+\.)?(spotify\\.(?:com|link))/' +
       '(?!(?:intl-[a-z]+/)?user)',
       'i',
     )],
@@ -5464,6 +5464,27 @@ const CLEANUPS: CleanupEntries = {
         return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       return {result: false, target: ERROR_TARGETS.URL};
+    },
+  },
+  'spotifyshop': {
+    match: [new RegExp('^(https?://)?shop\\.spotify\\.com/', 'i')],
+    restrict: [LINK_TYPES.downloadpurchase, LINK_TYPES.mailorder],
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?shop\.spotify\.com\/([^?#]+)(?:[?#].*)?$/, 'https://shop.spotify.com/$1');
+      return url;
+    },
+    validate: function (url, id) {
+      switch (id) {
+        case LINK_TYPES.downloadpurchase.recording:
+        case LINK_TYPES.downloadpurchase.release:
+        case LINK_TYPES.mailorder.recording:
+        case LINK_TYPES.mailorder.release:
+          return {
+            result: /^https:\/\/shop\.spotify\.com\/[^?#]+$/.test(url),
+            target: ERROR_TARGETS.URL,
+          };
+      }
+      return {result: false, target: ERROR_TARGETS.ENTITY};
     },
   },
   'spotifyuseraccount': {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5418,6 +5418,14 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
   },
   {
+                     input_url: 'http://shop.spotify.com/en-US/artist/4O15NlyKLIASxsJ0PrXPfz/product/pink-tape-autographed-digital-album-alternate-cover?utm_medium=&utm_source=&utm_content=artiststore&utm_term=&utm_promo=&container_platform=&utm_campaign=',
+             input_entity_type: 'release',
+limited_link_type_combinations: ['downloadpurchase', 'mailorder'],
+            expected_clean_url: 'https://shop.spotify.com/en-US/artist/4O15NlyKLIASxsJ0PrXPfz/product/pink-tape-autographed-digital-album-alternate-cover',
+       input_relationship_type: 'downloadpurchase',
+       only_valid_entity_types: ['recording', 'release'],
+  },
+  {
                      input_url: 'https://spotify.link/auVCkcbzoyb',
              input_entity_type: 'artist',
     expected_relationship_type: undefined,


### PR DESCRIPTION
### Implement MBS-13424

# Description
Much like Bandcamp, Spotify also allows selling merch now, including both physical and digital music, under https://shop.spotify.com/ (that link by itself doesn't work though, example from the ticket is https://shop.spotify.com/en-US/artist/4O15NlyKLIASxsJ0PrXPfz/store).

Only allowing these for releases and recordings since those seem like the most obviously useful options, and allowing either mail order or download purchase but not both since each item seems to be one or the other anyway.

# Testing
Added a test.