### PR TITLE
Move track-artist-updating code into testable function

### DIFF
--- a/root/static/scripts/common/immutable-entities.js
+++ b/root/static/scripts/common/immutable-entities.js
@@ -42,7 +42,7 @@ export const reduceArtistCredit =
  */
 export function reduceArtistCreditNames(
   names: $ReadOnlyArray<ArtistCreditNameT>,
-  dropFinalJoinPhrase?: false,
+  dropFinalJoinPhrase?: boolean = false,
 ): string {
   let s = names.reduce(reduceName, '');
   if (dropFinalJoinPhrase && names.length > 0) {

--- a/root/static/scripts/edit/utility/getUpdatedTrackArtists.js
+++ b/root/static/scripts/edit/utility/getUpdatedTrackArtists.js
@@ -1,0 +1,92 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2024 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import {reduceArtistCreditNames} from '../../common/immutable-entities.js';
+import {arraysEqual} from '../../common/utility/arrays.js';
+import {cloneArrayDeep} from '../../common/utility/cloneDeep.mjs';
+
+/*
+ * Returns true if the supplied credits include the same underlying artists.
+ */
+const sameArtists = (
+  a: $ReadOnlyArray<ArtistCreditNameT>,
+  b: $ReadOnlyArray<ArtistCreditNameT>,
+) => arraysEqual(a, b,
+  (a, b) => a.artist && b.artist && a.artist.gid === b.artist.gid);
+
+/*
+ * Returns updated artist credits for a track that's part of a release whose
+ * credits are being changed from oldArtists to newArtists.
+ *
+ * If the track's credits should not be changed, the original trackArtists
+ * array is returned.
+ */
+export default function getUpdatedTrackArtists(
+  trackArtists: $ReadOnlyArray<ArtistCreditNameT>,
+  oldArtists: $ReadOnlyArray<ArtistCreditNameT>,
+  newArtists: $ReadOnlyArray<ArtistCreditNameT>,
+): $ReadOnlyArray<ArtistCreditNameT> {
+  const oldArtistsReduced = reduceArtistCreditNames(oldArtists);
+
+  /*
+   * If the track credits exactly match the old release credits or the track
+   * credits include the same artists as the new release credits, update
+   * them to use the new release credits.
+   */
+  if (
+    reduceArtistCreditNames(trackArtists) === oldArtistsReduced ||
+    sameArtists(trackArtists, newArtists)
+  ) {
+    return newArtists;
+  }
+
+  /*
+   * If the track credits contain more artists than the old release credits,
+   * also check if the first N (where N is the length of the release
+   * credits) track artists match the release artists. This handles renaming
+   * primary artists on tracks that also include featured artists
+   * (MBS-13273).
+   *
+   * Don't do anything if the track credits already start with the same
+   * artists as the new release credits to avoid duplicating artists in the
+   * case where the track is credited to "A & B feat. C" and the release is
+   * updated from "A" to "A & B" or "A feat. B".
+   */
+  if (
+    oldArtists.length > 0 &&
+    newArtists.length > 0 &&
+    trackArtists.length > oldArtists.length
+  ) {
+    const trackPrefix = reduceArtistCreditNames(
+      trackArtists.slice(0, oldArtists.length), true,
+    );
+    if (
+      trackPrefix === oldArtistsReduced &&
+      !sameArtists(
+        trackArtists.slice(0, newArtists.length),
+        newArtists,
+      )
+    ) {
+      /*
+       * Replace the old release artist(s) with the new one(s) and restore
+       * the old join phrase following the release artist.
+       */
+      const names = cloneArrayDeep(newArtists)
+        .concat(trackArtists.slice(oldArtists.length));
+      names[newArtists.length - 1] = {
+        artist: names[newArtists.length - 1].artist,
+        joinPhrase: trackArtists[oldArtists.length - 1].joinPhrase,
+        name: names[newArtists.length - 1].name,
+      };
+      return names;
+    }
+  }
+
+  return trackArtists;
+}

--- a/root/static/scripts/tests/edit/utility/getUpdatedTrackArtists.js
+++ b/root/static/scripts/tests/edit/utility/getUpdatedTrackArtists.js
@@ -1,0 +1,133 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2024 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import test from 'tape';
+
+import getUpdatedTrackArtists from
+  '../../../edit/utility/getUpdatedTrackArtists.js';
+import {genericArtist} from '../../utility/constants.js';
+
+test('getUpdatedTrackArtists', function (t) {
+  const name = (
+    name: string,
+    gid: string,
+    joinPhrase: string = '',
+    creditedAs: string = '',
+  ) => {
+    const artist = {...genericArtist, name, gid};
+    return {artist, joinPhrase, name: creditedAs};
+  };
+
+  const testCases = [
+    {
+      desc: 'artist change, track matches old',
+      track: [name('Old', '1')],
+      oldRel: [name('Old', '1')],
+      newRel: [name('New', '2')],
+      want: [name('New', '2')],
+    },
+    {
+      desc: 'artist change, track doesn’t match old',
+      track: [name('Other', '3')],
+      oldRel: [name('Old', '1')],
+      newRel: [name('New', '2')],
+      want: [name('Other', '3')],
+    },
+    {
+      desc: 'added credited-as, track matches old',
+      track: [name('Old', '1')],
+      oldRel: [name('Old', '1')],
+      newRel: [name('Old', '1', '', 'Alt')],
+      want: [name('Old', '1', '', 'Alt')],
+    },
+    {
+      desc: 'removed credited-as, track matches old',
+      track: [name('Old', '1', '', 'Alt')],
+      oldRel: [name('Old', '1', '', 'Alt')],
+      newRel: [name('Old', '1')],
+      want: [name('Old', '1')],
+    },
+    {
+      desc: 'multiple artists, track matches old',
+      track: [name('A', '1', ' & '), name('B', '2')],
+      oldRel: [name('A', '1', ' & '), name('B', '2')],
+      newRel: [name('C', '3', ' feat. '), name('D', '4')],
+      want: [name('C', '3', ' feat. '), name('D', '4')],
+    },
+    {
+      desc: 'multiple artists, track matches old plus feat.',
+      track: [
+        name('A', '1', ' & '),
+        name('B', '2', ' feat. '),
+        name('E', '5'),
+      ],
+      oldRel: [name('A', '1', ' & '), name('B', '2')],
+      newRel: [name('C', '3', ' with '), name('D', '4')],
+      want: [
+        name('C', '3', ' with '),
+        name('D', '4', ' feat. '),
+        name('E', '5'),
+      ],
+    },
+    {
+      desc: 'multiple artists, track matches first old',
+      track: [name('A', '1')],
+      oldRel: [name('A', '1', ' & '), name('B', '2')],
+      newRel: [name('C', '3', ' & '), name('D', '4')],
+      want: [name('A', '1')],
+    },
+    {
+      desc: 'multiple artists, track matches second old',
+      track: [name('B', '2')],
+      oldRel: [name('A', '1', ' & '), name('B', '2')],
+      newRel: [name('C', '3', ' & '), name('D', '4')],
+      want: [name('B', '2')],
+    },
+    {
+      desc: 'track matches new with diff. join phrase',
+      track: [name('C', '3', ' feat. '), name('D', '4')],
+      oldRel: [name('A', '1', ' & '), name('B', '2')],
+      newRel: [name('C', '3', ' & '), name('D', '4')],
+      want: [name('C', '3', ' & '), name('D', '4')],
+    },
+    {
+      desc: 'multiple artists with credited-as, track matches old',
+      track: [name('A', '1', ' & ', 'a'), name('B', '2')],
+      oldRel: [name('A', '1', ' & ', 'a'), name('B', '2')],
+      newRel: [name('A', '1', ' & '), name('B', '2')],
+      want: [name('A', '1', ' & '), name('B', '2')],
+    },
+    {
+      desc: 'multiple artists with credited-as, track has feat.',
+      track: [
+        name('A', '1', ' & ', 'a'),
+        name('B', '2', ' feat. '),
+        name('C', '3'),
+      ],
+      oldRel: [name('A', '1', ' & ', 'a'), name('B', '2')],
+      newRel: [name('A', '1', ' & '), name('B', '2')],
+      want: [
+        /*
+         * TODO: As discussed in MBS-13273, the first artist's credited-as
+         * name should be removed here.
+         */
+        name('A', '1', ' & ', 'a'),
+        name('B', '2', ' feat. '),
+        name('C', '3'),
+      ],
+    },
+  ];
+
+  t.plan(testCases.length);
+
+  for (const tc of testCases) {
+    const got = getUpdatedTrackArtists(tc.track, tc.oldRel, tc.newRel);
+    t.deepEqual(got, tc.want, tc.desc);
+  }
+});

--- a/root/static/scripts/tests/index-web.js
+++ b/root/static/scripts/tests/index-web.js
@@ -5,6 +5,7 @@ require('./common/immutable-entities.js');
 require('./Control/URLCleanup.js');
 require('./CoverArt.js');
 require('./edit.js');
+require('./edit/utility/getUpdatedTrackArtists.js');
 require('./edit/utility/isUselessMediumTitle.js');
 require('./edit/utility/linkPhrase.js');
 require('./entity.js');


### PR DESCRIPTION
Move the release editor code that updates track credits when a release's credits are changed into a new standalone getUpdatedTrackArtists function, and add unit tests for it.

No functional changes are intended, but this should make it easier to make future improvements as discussed in MBS-13273.

# Problem

I'm planning to work on MBS-13273 some more, but testing the many edge cases via Selenium is painful.

# Solution

This change moves code for updating track credits out of the release editor's `init.js` file and into a separate Flow-checked utility file that can be unit-tested.

# Testing

I added a unit test that exercises a bunch of different cases. The existing release editor Selenium tests will hopefully pass, too.