### PR TITLE
MBS-13481: Invalidate release on label changes

### DIFF
--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -339,13 +339,7 @@ sub delete
     return 1;
 }
 
-sub merge {
-    my ($self, $new_id, @old_ids) = @_;
-
-    $self->merge_with_opts($new_id, \@old_ids);
-}
-
-sub merge_with_opts
+sub merge
 {
     my ($self, $new_id, $old_ids, %opts) = @_;
 

--- a/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
+++ b/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
@@ -108,11 +108,6 @@ after delete => sub {
     $self->_delete_from_cache(@ids);
 };
 
-after merge => sub {
-    my ($self, @ids) = @_;
-    $self->_delete_from_cache(@ids);
-};
-
 sub _create_cache_entries {
     my ($self, $data, $ids) = @_;
 
@@ -189,7 +184,9 @@ sub _delete_from_cache {
         $max_request_time = $RECENTLY_INVALIDATED_TTL;
     }
     my $invalidated_prefix = $self->_recently_invalidated_prefix;
-    my @invalidated_flags = map { $invalidated_prefix . $_ } @ids;
+    my @invalidated_flags = map { $invalidated_prefix . $_ } grep {
+        is_database_row_id($_)
+    } @ids;
     $c->store->set_multi(map {
         [$_, 1, $max_request_time + 1]
     } @invalidated_flags);

--- a/lib/MusicBrainz/Server/Edit/Artist/Merge.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Merge.pm
@@ -55,7 +55,7 @@ sub do_merge
     my $new_id = $self->new_entity->{id};
     my @old_ids = $self->_old_ids;
 
-    my (undef, $dropped_columns) = $self->c->model('Artist')->merge_with_opts(
+    my (undef, $dropped_columns) = $self->c->model('Artist')->merge(
         $new_id,
         \@old_ids,
         rename => $self->data->{rename},

--- a/lib/MusicBrainz/Server/Edit/Release/AddReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/AddReleaseLabel.pm
@@ -59,7 +59,7 @@ sub initialize {
     die 'Missing "release" argument' unless ($release || $self->preview);
 
     if ($release) {
-        $self->c->model('ReleaseLabel')->load($release) unless $release->all_labels;
+        $self->c->model('ReleaseLabel')->load($release);
 
         $self->throw_if_release_label_is_duplicate(
             $release,

--- a/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
@@ -207,7 +207,7 @@ sub initialize
         $self->c->model('Release')->load($release_label);
         $self->c->model('Medium')->load_for_releases($release_label->release);
         $self->c->model('MediumFormat')->load($release_label->release->all_mediums);
-        $self->c->model('ReleaseLabel')->load($release_label->release) unless $release_label->release->all_labels;
+        $self->c->model('ReleaseLabel')->load($release_label->release);
     }
 
     $self->throw_if_release_label_is_duplicate(

--- a/lib/MusicBrainz/Server/Entity/Release.pm
+++ b/lib/MusicBrainz/Server/Entity/Release.pm
@@ -128,6 +128,7 @@ has 'labels' => (
         clear_labels => 'clear',
         label_count => 'count',
     },
+    predicate => 'has_labels',
 );
 
 has 'mediums' => (

--- a/t/lib/t/MusicBrainz/Server/Data/Artist.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Artist.pm
@@ -244,7 +244,7 @@ $artist_data->update_gid_redirects(3, 4);
 $artist = $artist_data->get_by_gid('2adff2b0-5dbf-11de-8a39-0800200c9a66');
 is($artist->id, 3);
 
-$artist_data->merge(3, 4);
+$artist_data->merge(3, [ 4 ]);
 $artist = $artist_data->get_by_id(4);
 ok(!defined $artist);
 
@@ -311,7 +311,7 @@ test 'Merging with a cache' => sub {
     }
 
     $c->sql->begin;
-    $c->model('Artist')->merge($artist1->id, $artist2->id);
+    $c->model('Artist')->merge($artist1->id, [ $artist2->id ]);
     $c->sql->commit;
 
     ok(!$cache->get('artist:' . $artist2->gid), 'artist 2 no longer in cache (by gid)');
@@ -359,7 +359,7 @@ test 'Merging attributes' => sub {
         );
         SQL
 
-    $c->model('Artist')->merge(3, 4, 5);
+    $c->model('Artist')->merge(3, [4, 5]);
     my $artist = $c->model('Artist')->get_by_id(3);
     is($artist->begin_date->year, 2000);
     is($artist->begin_date->month, 6);
@@ -378,7 +378,7 @@ test 'Merging "ended" flag' => sub {
                    (4, '0db63477-bc98-4aac-a76a-28d78971a07c', 'An Artist', 'Artist, An', TRUE);
         SQL
 
-    $c->model('Artist')->merge(3, 4);
+    $c->model('Artist')->merge(3, [4]);
     my $artist = $c->model('Artist')->get_by_id(3);
     ok($artist->ended, 'merge result retains "ended" flag (MBS-6763)');
 };
@@ -408,7 +408,7 @@ test 'Merging attributes for VA' => sub {
         );
         SQL
 
-    $c->model('Artist')->merge(1, 4, 5, 6);
+    $c->model('Artist')->merge(1, [4, 5, 6]);
     my $artist = $c->model('Artist')->get_by_id(1);
 
     is($artist->begin_date->year, undef, 'begin date...');
@@ -500,7 +500,7 @@ test q(Merging an artist that's in a collection) => sub {
     });
 
     $c->model('Collection')->add_entities_to_collection('artist', $collection->{id}, $artist1->{id});
-    $c->model('Artist')->merge($artist2->{id}, $artist1->{id});
+    $c->model('Artist')->merge($artist2->{id}, [$artist1->{id}]);
 
     ok($c->sql->select_single_value('SELECT 1 FROM editor_collection_artist WHERE artist = ?', $artist2->{id}));
 };

--- a/t/lib/t/MusicBrainz/Server/Data/ArtistCredit.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/ArtistCredit.pm
@@ -339,7 +339,7 @@ test 'MBS-13310: Merging artists updates empty artist_credit IDs in unreferenced
         'unreferenced_row_log table was updated correctly',
     );
 
-    $c->model('Artist')->merge_with_opts(10, [11], rename => 1);
+    $c->model('Artist')->merge(10, [11], rename => 1);
 
     cmp_deeply(
         $c->sql->select_list_of_hashes('SELECT * FROM artist_credit'),

--- a/t/lib/t/MusicBrainz/Server/Data/Role/Collection.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Role/Collection.pm
@@ -91,6 +91,8 @@ for my $entity_type (entities_with('collections')) {
                 medium_positions => {},
                 merge_strategy => $MusicBrainz::Server::Data::Release::MERGE_MERGE,
             );
+        } elsif ($entity_type eq 'artist') {
+            $model->merge($entity2->{id}, [$entity1->{id}]);
         } else {
             $model->merge($entity2->{id}, $entity1->{id});
         }

--- a/t/lib/t/MusicBrainz/Server/Edit/Relationship/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Relationship/Create.pm
@@ -114,7 +114,7 @@ test 'Entities load correctly after being merged (MBS-2477)' => sub {
     MusicBrainz::Server::Test->prepare_test_database($c, '+edit_relationship_edit');
 
     my $edit = _create_edit($c);
-    $c->model('Artist')->merge(5, 4);
+    $c->model('Artist')->merge(5, [4]);
     $c->model('Edit')->load_all($edit);
 
     is($edit->display_data->{relationship}{entity1_id}, 5);

--- a/t/lib/t/MusicBrainz/Server/Edit/Relationship/Delete.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Relationship/Delete.pm
@@ -135,7 +135,7 @@ test 'Entities load correctly after being merged (MBS-2477)' => sub {
         relationship => $relationship,
     );
 
-    $c->model('Artist')->merge(4, 3);
+    $c->model('Artist')->merge(4, [3]);
     $c->model('Edit')->load_all($edit);
 
     is($edit->display_data->{relationship}{entity0_id}, 4);

--- a/t/lib/t/MusicBrainz/Server/Edit/Relationship/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Relationship/Edit.pm
@@ -165,7 +165,7 @@ test 'Editing a relationship succeeds despite an entity being merged' => sub {
     );
 
     ok($edit->is_open);
-    $c->model('Artist')->merge(5, 4);
+    $c->model('Artist')->merge(5, [4]);
     ok !exception { $edit->accept };
 };
 
@@ -189,7 +189,7 @@ test q(Editing a relationship fails if one of the entities is merged, and the
     );
 
     ok($edit->is_open);
-    $c->model('Artist')->merge(5, 4);
+    $c->model('Artist')->merge(5, [4]);
     $c->model('Relationship')->insert('artist', 'artist', {
         entity0_id      => 3,
         entity1_id      => 5,


### PR DESCRIPTION
# Problem

MBS-13481, plus another (pretty much harmless) issue with bogus keys being added to the cache.

# Solution

See associated commits for further details.

# Testing

Added some automated tests.