### PR TITLE
Don't delay cache additions until after the transaction ends

### DIFF
--- a/lib/MusicBrainz/Server/Data/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Data/ArtistCredit.pm
@@ -16,11 +16,14 @@ with 'MusicBrainz::Server::Data::Role::EntityCache',
      'MusicBrainz::Server::Data::Role::PendingEdits' => {
         table => 'artist_credit',
      },
-     'MusicBrainz::Server::Data::Role::GetByGID';
+     'MusicBrainz::Server::Data::Role::GetByGID',
+     'MusicBrainz::Server::Data::Role::GIDRedirect';
+
+sub _main_table { 'artist_credit' }
 
 sub _type { 'artist_credit' }
 
-sub _table { shift->_type }
+sub _table { shift->_main_table }
 
 sub _gid_redirect_table { shift->_table . '_gid_redirect' }
 
@@ -394,76 +397,6 @@ sub related_entities {
     push @{ $related->{release} }, @{ $track_ac_releases };
 
     return $related;
-}
-
-sub load_gid_redirects {
-    my ($self, @entities) = @_;
-    my $table = $self->_gid_redirect_table;
-
-    my %entities_by_id = object_to_ids(@entities);
-
-    my $query = "SELECT new_id, array_agg(gid) AS gid_redirects FROM $table WHERE new_id = any(?) GROUP BY new_id";
-    my $results = $self->c->sql->select_list_of_hashes($query, [map { $_->id } @entities]);
-
-    for my $row (@$results) {
-        for my $entity (@{ $entities_by_id{$row->{new_id}} }) {
-            $entity->gid_redirects($row->{gid_redirects});
-        }
-    }
-}
-
-sub remove_gid_redirects
-{
-    my ($self, @ids) = @_;
-    my $table = $self->_gid_redirect_table;
-    $self->sql->do("DELETE FROM $table WHERE new_id IN (" . placeholders(@ids) . ')', @ids);
-}
-
-sub add_gid_redirects
-{
-    my ($self, %redirects) = @_;
-    my $table = $self->_gid_redirect_table;
-    my $query = "INSERT INTO $table (gid, new_id) VALUES " .
-                (join ', ', ('(?, ?)') x keys %redirects);
-    $self->sql->do($query, %redirects);
-}
-
-sub update_gid_redirects
-{
-    my ($self, $new_id, @old_ids) = @_;
-    my $table = $self->_gid_redirect_table;
-    $self->sql->do("
-        UPDATE $table SET new_id = ?
-        WHERE new_id IN (".placeholders(@old_ids).')', $new_id, @old_ids);
-}
-
-sub _delete_and_redirect_gids
-{
-    my ($self, $table, $new_id, @old_ids) = @_;
-
-    # Update all GID redirects from @old_ids to $new_id
-    $self->update_gid_redirects($new_id, @old_ids);
-
-    # Delete the recording and select current GIDs
-    my $old_gids = $self->delete_returning_gids(@old_ids);
-
-    # Add redirects from GIDs of the deleted recordings to $new_id
-    $self->add_gid_redirects(map { $_ => $new_id } @$old_gids);
-
-    if ($self->can('_delete_from_cache')) {
-        $self->_delete_from_cache(
-            $new_id, @old_ids,
-            @$old_gids,
-        );
-    }
-}
-
-sub delete_returning_gids {
-    my ($self, @ids) = @_;
-    return $self->sql->select_single_column_array('
-        DELETE FROM ' . $self->_table . '
-        WHERE id IN ('.placeholders(@ids).')
-        RETURNING gid', @ids);
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MusicBrainz/Server/Data/Event.pm
+++ b/lib/MusicBrainz/Server/Data/Event.pm
@@ -78,12 +78,18 @@ sub update
 
     $self->sql->update_row('event', $row, { id => $event_id }) if %$row;
 
+    return 1;
+}
+
+# This is run `after` so that cache invalidation happens first
+# (via `Data::Role::EntityCache``).
+after update => sub {
+    my ($self, $event_id, $update) = @_;
+
     if (any { exists $update->{$_} } qw( name begin_date end_date time )) {
         $self->c->model('Series')->reorder_for_entities('event', $event_id);
     }
-
-    return 1;
-}
+};
 
 sub can_delete { 1 }
 

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -893,14 +893,20 @@ sub update {
             SQL
     }
 
-    if ($update->{events} || $update->{name}) {
-        $self->c->model('Series')->reorder_for_entities('release', $release_id);
-    }
-
     if ($update->{events} || $new_release_group_id) {
         $self->c->model('Series')->reorder_for_entities('release_group', $release_group_id);
     }
 }
+
+# This is run `after` so that cache invalidation happens first
+# (via `Data::Role::EntityCache``).
+after update => sub {
+    my ($self, $release_id, $update) = @_;
+
+    if ($update->{events} || $update->{name}) {
+        $self->c->model('Series')->reorder_for_entities('release', $release_id);
+    }
+};
 
 sub can_delete { 1 }
 

--- a/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
@@ -676,11 +676,17 @@ sub update {
     $self->sql->update_row('release_group', $row, { id => $group_id }) if %$row;
     $self->c->model('ReleaseGroupSecondaryType')->set_types($group_id, $update->{secondary_type_ids})
         if exists $update->{secondary_type_ids};
+}
+
+# This is run `after` so that cache invalidation happens first
+# (via `Data::Role::EntityCache``).
+after update => sub {
+    my ($self, $group_id, $update) = @_;
 
     if ($update->{name}) {
         $self->c->model('Series')->reorder_for_entities('release_group', $group_id);
     }
-}
+};
 
 sub can_delete
 {

--- a/lib/MusicBrainz/Server/Data/ReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseLabel.pm
@@ -136,7 +136,6 @@ sub insert
 
     my $release_id = $row->{release};
     $self->c->model('Series')->reorder_for_entities('release', $release_id);
-    $self->c->model('Release')->_delete_from_cache($release_id);
 
     return wantarray ? @created : $created[0];
 }
@@ -155,7 +154,6 @@ sub update
     );
 
     $self->c->model('Series')->reorder_for_entities('release', $release_id);
-    $self->c->model('Release')->_delete_from_cache($release_id);
 }
 
 sub delete {
@@ -167,7 +165,6 @@ sub delete {
     );
 
     $self->c->model('Series')->reorder_for_entities('release', @$release_ids);
-    $self->c->model('Release')->_delete_from_cache(@$release_ids);
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/t/lib/t/MusicBrainz/Server/Data/Release.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Release.pm
@@ -823,4 +823,20 @@ test 'Merging releases with the same date should discard unknown country events'
        'no unknown release events');
 };
 
+test 'Release events are not cached on the release' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+releaselabel');
+
+    # Ensure the release is cached.
+    $c->sql->begin;
+    my $release = $c->model('Release')->get_by_id(1);
+    $c->model('Release')->load_release_events($release);
+    $c->sql->commit;
+
+    $release = $c->cache->get('release:1'),
+    is(scalar($release->all_events), 0, 'cached release has no events');
+};
+
 1;

--- a/t/lib/t/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
@@ -186,7 +186,7 @@ test 'Cache is transactional (MBS-7241)' => sub {
             '(b.) concurrent get_by_gid returns artist ' . $status);
 
         is($c2->cache->get('artist:3'), undef,
-            '(b.) cache is not repopulated after concurrent get_by_gid' .
+            '(b.) cache is not repopulated after concurrent get_by_gid ' .
             $status);
     };
 


### PR DESCRIPTION
# Problem

After searching for issues similar to [MBS-13481](https://tickets.metabrainz.org/browse/MBS-13481) (where we load additional data onto an entity which is then entered into the cache, but where changes to that additional data do not invalidate the entity's cache entry), I believe that there are simply far too many uncovered cases which we'd have to handle.

While storing more data in the cache and having intelligent invalidation logic for all the linked data sounds desirable, it's too many changes to manage for now, so we need to restore the previous behavior.

# Solution

This partially reverts https://github.com/metabrainz/musicbrainz-server/commit/82c79f531edad396c20a2fceb45a37de9035e055 and https://github.com/metabrainz/musicbrainz-server/commit/42be4bcf01f198530789772629093d1b69b853c5.

I realized (later than I should have) that we don't need to delay cache additions until after the database transaction ends. We may have had to in a previous implementation I had, but no longer.

The `post_txn_callbacks` ran regardless of whether or not the commit succeeded, so an entity would always be cached in the state it was initially loaded in. The only difference now is when that occurs. There's no type of race condition that isn't already handled:

 * If the entity is deleted from the cache right after it's added, then there is no issue, just like before.

 * If the entity is added to the cache right after it's deleted, then there is still no issue, because our existing code to delete the added entry if there exists a `recently_invalidated` key for the same still applies.

# Testing

The existing `*EntityCache` tests pass, and I've added a couple additional tests to ensure that neither release events nor release labels are entered into the cache with a release.