### PR TITLE
MBS-13486 / MBS-13487: Small CAA for pseudo-releases improvements

### DIFF
--- a/lib/MusicBrainz/Server/Report/ReleasesWithoutCAA.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesWithoutCAA.pm
@@ -11,11 +11,12 @@ sub query {<<~'SQL'}
       FROM (
         SELECT DISTINCT r.*
           FROM release r
-         WHERE NOT EXISTS (
+         WHERE (r.status IS DISTINCT FROM 4) -- skip pseudo-releases
+           AND NOT EXISTS (
             SELECT 1
               FROM cover_art_archive.cover_art
              WHERE cover_art.release = r.id
-         )
+           )
       ) r
       JOIN artist_credit ac ON r.artist_credit = ac.id
     SQL

--- a/root/constants.js
+++ b/root/constants.js
@@ -78,3 +78,5 @@ export const PUBLIC_FLAGS: number = AUTO_EDITOR_FLAG &
                                     BANNER_EDITOR_FLAG;
 
 export const EDITOR_MODBOT = 4;
+
+export const RELEASE_STATUS_PSEUDORELEASE = 4;

--- a/root/release/CoverArt.js
+++ b/root/release/CoverArt.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import {Artwork} from '../components/Artwork.js';
 import RequestLogin from '../components/RequestLogin.js';
+import {RELEASE_STATUS_PSEUDORELEASE} from '../constants.js';
 import {SanitizedCatalystContext} from '../context.mjs';
 import EntityLink from '../static/scripts/common/components/EntityLink.js';
 import {commaOnlyListText}
@@ -132,12 +133,27 @@ const CoverArt = ({
           </p>
         </>
       ) : (
-        <p>
-          {exp.l(
-            'We do not currently have any cover art for {release}.',
-            {release: <EntityLink entity={release} />},
-          )}
-        </p>
+        <>
+          <p>
+            {exp.l(
+              'We do not currently have any cover art for {release}.',
+              {release: <EntityLink entity={release} />},
+            )}
+          </p>
+          {release.status?.id === RELEASE_STATUS_PSEUDORELEASE ? (
+            <p>
+              {exp.l(
+                `Keep in mind pseudo-releases generally shouldn’t have
+                 cover art. See {doc|the guidelines for pseudo-releases}
+                 for more info.`,
+                {
+                  doc:
+                    '/doc/Style/Specific_types_of_releases/Pseudo-Releases',
+                },
+              )}
+            </p>
+          ) : null}
+        </>
       )}
 
       {release.may_have_cover_art /*:: === true */ ? (


### PR DESCRIPTION
### Implement MBS-13486, MBS-13487

# Problem
Our [guidelines](https://musicbrainz.org/doc/Style/Specific_types_of_releases/Pseudo-Releases) say pseudo-releases shouldn't generally get cover art (the only exception is if there's no official release and it helps figure out what the official release should be, after which they should be deleted from the pseudo-release). Despite that, we were still showing pseudo-releases in the "Releases without any art in the Cover Art Archive" report, suggesting cover art should be uploaded, and we had no way for users to know this was not the case without them going searching for a fairly obscure guideline.

# Solution
This does two things: it makes it so pseudo-releases no longer show in the report, and it adds a line to their cover art tab when there's no cover art yet specifying that cover art should generally not be uploaded and linking to the guidelines.

# Testing
Manually with sample data, by changing the status of a release without cover art and making sure it appeared in the report when it had no status or a status other than pseudo-release, but not when set to pseudo-release; and that the new text showed in the CAA tab when it was set to pseudo-release, but not when it had no status or a different one.