### PR TITLE
MBS-13476: Show release label disambiguations on hover

### DIFF
--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -228,6 +228,7 @@ const ReleaseSidebar = ({release}: Props): React$Element<'div'> | null => {
                       className="wrap-anywhere"
                       entity={releaseLabel.label}
                       showDisambiguation={false}
+                      showDisambiguationOnHover
                     />
                     <br />
                   </>

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -227,8 +227,7 @@ const ReleaseSidebar = ({release}: Props): React$Element<'div'> | null => {
                     <EntityLink
                       className="wrap-anywhere"
                       entity={releaseLabel.label}
-                      showDisambiguation={false}
-                      showDisambiguationOnHover
+                      showDisambiguation="hover"
                     />
                     <br />
                   </>

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -157,6 +157,7 @@ type EntityLinkProps = {
   +showCaaPresence?: boolean,
   +showDeleted?: boolean,
   +showDisambiguation?: boolean,
+  +showDisambiguationOnHover?: boolean,
   +showEditsPending?: boolean,
   +showEventDate?: boolean,
   +showIcon?: boolean,
@@ -181,6 +182,7 @@ const EntityLink = ({
   showCaaPresence = false,
   showDeleted = true,
   showDisambiguation: passedShowDisambiguation,
+  showDisambiguationOnHover = false,
   showEditsPending = true,
   showEventDate = true,
   showIcon: passedShowIcon = false,
@@ -216,6 +218,12 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
 
   if (entity.entityType === 'artist' && empty(hover)) {
     hover = entity.sort_name + (comment ? ' ' + bracketedText(comment) : '');
+  }
+
+  if (showDisambiguationOnHover) {
+    hover = empty(hover)
+      ? comment
+      : hover + ' ' + bracketedText(comment);
   }
 
   if (entity.entityType === 'area') {

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -156,8 +156,7 @@ type EntityLinkProps = {
   +nameVariation?: boolean,
   +showCaaPresence?: boolean,
   +showDeleted?: boolean,
-  +showDisambiguation?: boolean,
-  +showDisambiguationOnHover?: boolean,
+  +showDisambiguation?: boolean | 'hover',
   +showEditsPending?: boolean,
   +showEventDate?: boolean,
   +showIcon?: boolean,
@@ -182,7 +181,6 @@ const EntityLink = ({
   showCaaPresence = false,
   showDeleted = true,
   showDisambiguation: passedShowDisambiguation,
-  showDisambiguationOnHover = false,
   showEditsPending = true,
   showEventDate = true,
   showIcon: passedShowIcon = false,
@@ -220,7 +218,7 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
     hover = entity.sort_name + (comment ? ' ' + bracketedText(comment) : '');
   }
 
-  if (showDisambiguationOnHover) {
+  if (showDisambiguation === 'hover') {
     hover = empty(hover)
       ? comment
       : hover + ' ' + bracketedText(comment);
@@ -409,7 +407,7 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
     return parts;
   }
 
-  if (showDisambiguation) {
+  if (showDisambiguation === true) {
     if (entity.entityType === 'event') {
       parts.push(
         <EventDisambiguation


### PR DESCRIPTION
### Implement MBS-13476

# Problem
We hide disambiguations for labels on the release sidebar (I assume because of the lack of space) but this can be useful to quickly check if the right label is selected, so we should at least show it on hover.

# Solution
This adds a `showDisambiguationOnHover` option to `EntityLink`, which will either show the disambiguation as the whole hover if there's nothing else there or append it in brackets if there is (for the current use case `hover` should be always empty AFAICT).

# Testing
Manually, making sure the disambiguation shows if there's one, and no empty hover tooltip shows otherwise.