### PR TITLE
MBS-13441: Also accept localized ra.co links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4967,7 +4967,7 @@ const CLEANUPS: CleanupEntries = {
   },
   'residentadvisor': {
     match: [
-      new RegExp('^(https?://)?(www\\.)?ra\\.co/(?!exchange)', 'i'),
+      new RegExp('^(https?://)?([^/]+\\.)?ra\\.co/(?!exchange)', 'i'),
       new RegExp('^(https?://)?(www\\.)?residentadvisor\\.net/', 'i'),
     ],
     restrict: [{
@@ -4976,7 +4976,7 @@ const CLEANUPS: CleanupEntries = {
       ...LINK_TYPES.discographyentry,
     }],
     clean: function (url) {
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?ra\.co\//, 'https://ra.co/');
+      url = url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?ra\.co\//, 'https://ra.co/');
       url = url.replace(/^https:\/\/ra\.co\/(clubs|dj|events|labels|podcast|reviews|tracks)\/([^\/?#]+).*$/, 'https://ra.co/$1/$2');
       return url;
     },

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4788,7 +4788,7 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['event'],
   },
   {
-                     input_url: 'http://ra.co/labels/2795',
+                     input_url: 'http://es.ra.co/labels/2795',
              input_entity_type: 'label',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://ra.co/labels/2795',


### PR DESCRIPTION
### Implement MBS-13441

# Description
RA also has localized links (see test for an example) which we were entirely ignoring. It seems that it is just a translation for the interface rather than a separate site, so it should be fine to just clean it up to the generic ra.co version.

# Testing
Changed a label link on the automated tests to the Spanish version to make sure it still gets cleaned up properly.