### PR TITLE
Amend #3091: Prevent git warning for ownership

### DIFF
--- a/docker/musicbrainz-tests/run_circleci_tests.sh
+++ b/docker/musicbrainz-tests/run_circleci_tests.sh
@@ -33,7 +33,7 @@ MUSICBRAINZ_RUNNING_TESTS=1 \
 
 sudo -E -H -u musicbrainz ./node_modules/.bin/flow --quiet
 sudo -E -H -u musicbrainz ./node_modules/.bin/eslint --max-warnings 0 .
-! git grep -Pw '(N_)?l[np]?\(' -- 'root/statistics/**.js'
+! sudo -E -H -u musicbrainz git grep -Pw '(N_)?l[np]?\(' -- 'root/statistics/**.js'
 
 sv_start_if_down chrome
 


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Since PR #3091, CircleCI tests output contains:

```
fatal: detected dubious ownership in repository at '/home/musicbrainz/musicbrainz-server'
To add an exception for this directory, call:

        git config --global --add safe.directory /home/musicbrainz/musicbrainz-server
```

This is because `git grep` is run as `root` whereas the [files are owned by `musicbrainz`](https://github.com/metabrainz/musicbrainz-server/blob/v-2024-02-16/.circleci/config.yml#L27).

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Run as `musicbrainz` just like for all other test commands.

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

Tested through SSH in CircleCI by running this modified command against `root/statistics` and `root/event`.

# Further action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

New test images must be build to make use of this change.
However, this change alone is not worth building new test images.