### PR TITLE
MBS-13492: Move beginner status to a privilege flag

### DIFF
--- a/admin/sql/updates/20240221-mbs-13492.sql
+++ b/admin/sql/updates/20240221-mbs-13492.sql
@@ -1,0 +1,22 @@
+\set ON_ERROR_STOP 1
+
+BEGIN;
+
+UPDATE editor
+   SET privs = privs | 8192 -- set new beginner flag
+ WHERE id != 4 -- avoid setting ModBot as beginner
+   AND NOT deleted
+   AND ( 
+        member_since > NOW() - INTERVAL '2 weeks'
+       OR
+        NOT EXISTS (
+          SELECT 1
+            FROM edit
+           WHERE edit.editor = editor.id
+             AND edit.autoedit = 0
+             AND edit.status = 2
+          OFFSET 9
+        )
+   );
+
+COMMIT;

--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -363,6 +363,7 @@ Readonly our $BANNER_EDITOR_FLAG            => 512;
 Readonly our $EDITING_DISABLED_FLAG         => 1024;
 Readonly our $ADDING_NOTES_DISABLED_FLAG    => 2048;
 Readonly our $SPAMMER_FLAG                  => 4096;
+Readonly our $BEGINNER_FLAG                 => 8192;
 # If you update this, also update root/utility/sanitizedEditor.js
 Readonly our $PUBLIC_PRIVILEGE_FLAGS        => $AUTO_EDITOR_FLAG |
                                                $BOT_FLAG |
@@ -370,7 +371,8 @@ Readonly our $PUBLIC_PRIVILEGE_FLAGS        => $AUTO_EDITOR_FLAG |
                                                $WIKI_TRANSCLUSION_FLAG |
                                                $ACCOUNT_ADMIN_FLAG |
                                                $LOCATION_EDITOR_FLAG |
-                                               $BANNER_EDITOR_FLAG;
+                                               $BANNER_EDITOR_FLAG |
+                                               $BEGINNER_FLAG;
 
 Readonly our $ELECTION_VOTE_NO      => -1;
 Readonly our $ELECTION_VOTE_ABSTAIN => 0;

--- a/lib/MusicBrainz/Server/Controller/Account.pm
+++ b/lib/MusicBrainz/Server/Controller/Account.pm
@@ -8,7 +8,7 @@ use namespace::autoclean;
 use Digest::SHA qw(sha1_base64);
 use JSON;
 use List::AllUtils qw( uniq );
-use MusicBrainz::Server::Constants qw( $CONTACT_URL );
+use MusicBrainz::Server::Constants qw( $BEGINNER_FLAG $CONTACT_URL );
 use MusicBrainz::Server::ControllerUtils::JSON qw( serialize_pager );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
@@ -639,6 +639,7 @@ sub register : Path('/register') ForbiddenOnMirrors RequireSSL DenyWhenReadonly 
             my $editor = $c->model('Editor')->insert({
                 name => $form->field('username')->value,
                 password => $form->field('password')->value,
+                privs => $BEGINNER_FLAG,
             });
 
             my $email = $form->field('email')->value;

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -115,7 +115,6 @@ sub serialize_user {
         entityType => 'editor',
         avatar => $user->avatar,
         id => 0 + $user->id,
-        is_limited => boolean_to_json($user->is_limited),
         name => $user->name,
         preferences => {
             public_ratings => boolean_to_json($preferences->public_ratings),

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -56,7 +56,6 @@ sub _build_columns
         'member_since',
         'email_confirm_date',
         'last_login_date',
-        "EXISTS (SELECT 1 FROM edit WHERE edit.editor = editor.id AND edit.autoedit = 0 AND edit.status = $STATUS_APPLIED OFFSET 9) AS has_ten_accepted_edits",
         'gender',
         'area',
         'birth_date',
@@ -84,7 +83,6 @@ sub _column_mapping
         privileges              => 'privs',
         website                 => 'website',
         biography               => 'bio',
-        has_ten_accepted_edits  => 'has_ten_accepted_edits',
         email_confirmation_date => 'email_confirm_date',
         registration_date       => 'member_since',
         last_login_date         => 'last_login_date',
@@ -302,6 +300,7 @@ sub insert
             id => $self->sql->insert_row('editor', $data, 'id'),
             name => $data->{name},
             password => $data->{password},
+            privs => $data->{privs} // 0,
             ha1 => $data->{ha1},
             registration_date => DateTime->now,
         );

--- a/lib/MusicBrainz/Server/EditQueue.pm
+++ b/lib/MusicBrainz/Server/EditQueue.pm
@@ -3,7 +3,15 @@ package MusicBrainz::Server::EditQueue;
 use Moose;
 use DBDefs;
 use MusicBrainz::Errors qw( capture_exceptions );
-use MusicBrainz::Server::Constants qw( :expire_action :editor :edit_status :vote $REQUIRED_VOTES $MINIMUM_RESPONSE_PERIOD $MINIMUM_VOTING_PERIOD );
+use MusicBrainz::Server::Constants qw(
+    :expire_action
+    :editor
+    :edit_status
+    :vote
+    $REQUIRED_VOTES
+    $MINIMUM_RESPONSE_PERIOD
+    $MINIMUM_VOTING_PERIOD
+);
 use DateTime::Format::Pg;
 
 use aliased 'MusicBrainz::Server::Entity::Editor';

--- a/lib/MusicBrainz/Server/Entity/Collection.pm
+++ b/lib/MusicBrainz/Server/Entity/Collection.pm
@@ -67,7 +67,6 @@ around TO_JSON => sub {
     $json->{public} = boolean_to_json($self->public);
     $json->{description} = $self->description;
     $json->{description_html} = format_wikitext($self->description);
-    $json->{editor_is_limited} = boolean_to_json(defined $editor ? $editor->is_limited : 0);
     $json->{collaborators} = to_json_array($self->collaborators);
     $json->{item_entity_type} = $self->type->item_entity_type if $self->type;
 

--- a/lib/MusicBrainz/Server/Report/LimitedEditors.pm
+++ b/lib/MusicBrainz/Server/Report/LimitedEditors.pm
@@ -1,23 +1,15 @@
 package MusicBrainz::Server::Report::LimitedEditors;
 use Moose;
 
-use MusicBrainz::Server::Constants qw( $EDITOR_MODBOT );
+use MusicBrainz::Server::Constants qw( $BEGINNER_FLAG );
 
 with 'MusicBrainz::Server::Report::EditorReport';
-
-# Please keep the logic in sync with EditSearch::Predicate::Role::User and Entity::Editor
 
 sub query { "
 SELECT id,
        row_number() OVER (ORDER BY id DESC)
   FROM editor eor
- WHERE id != $EDITOR_MODBOT
-   AND NOT deleted
-   AND   ( 
-            member_since < NOW() - INTERVAL '2 weeks'
-          OR
-            (SELECT COUNT(*) FROM edit WHERE eor.id = edit.editor AND edit.status = 2 AND edit.autoedit = 0) < 10
-         )";
+ WHERE (privs & $BEGINNER_FLAG) > 0";
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/root/collection/CollectionIndex.js
+++ b/root/collection/CollectionIndex.js
@@ -26,6 +26,7 @@ import {SanitizedCatalystContext} from '../context.mjs';
 import expand2react from '../static/scripts/common/i18n/expand2react.js';
 import {formatPluralEntityTypeName}
   from '../static/scripts/common/utility/formatEntityTypeName.js';
+import {isBeginner} from '../static/scripts/common/utility/privileges.js';
 import FormRow from '../static/scripts/edit/components/FormRow.js';
 import FormSubmit from '../static/scripts/edit/components/FormSubmit.js';
 import UserInlineList from '../user/components/UserInlineList.js';
@@ -196,7 +197,7 @@ component CollectionIndex(...props: Props) {
         {collection.description_html ? (
           <>
             <h2>{l('Description')}</h2>
-            {($c.user || !collection.editor_is_limited) ? (
+            {($c.user || !isBeginner(collection.editor)) ? (
               expand2react(collection.description_html)
             ) : (
               <p className="deleted">

--- a/root/components/UserAccountLayout.js
+++ b/root/components/UserAccountLayout.js
@@ -18,7 +18,6 @@ export type AccountLayoutUserT = {
   +deleted: boolean,
   +entityType: 'editor',
   +id: number,
-  +is_limited: boolean,
   +name: string,
   +preferences: {
     +public_ratings: boolean,

--- a/root/constants.js
+++ b/root/constants.js
@@ -69,13 +69,15 @@ export const BANNER_EDITOR_FLAG: 512 = 512;
 export const EDITING_DISABLED_FLAG: 1024 = 1024;
 export const ADDING_NOTES_DISABLED_FLAG: 2048 = 2048;
 export const SPAMMER_FLAG: 4096 = 4096;
+export const BEGINNER_FLAG: 8192 = 8192;
 export const PUBLIC_FLAGS: number = AUTO_EDITOR_FLAG &
                                     BOT_FLAG &
                                     RELATIONSHIP_EDITOR_FLAG &
                                     WIKI_TRANSCLUSION_FLAG &
                                     ACCOUNT_ADMIN_FLAG &
                                     LOCATION_EDITOR_FLAG &
-                                    BANNER_EDITOR_FLAG;
+                                    BANNER_EDITOR_FLAG &
+                                    BEGINNER_FLAG;
 
 export const EDITOR_MODBOT = 4;
 

--- a/root/edit/NotesReceived.js
+++ b/root/edit/NotesReceived.js
@@ -14,6 +14,7 @@ import {CatalystContext} from '../context.mjs';
 import Layout from '../layout/index.js';
 import manifest from '../static/manifest.mjs';
 import linkedEntities from '../static/scripts/common/linkedEntities.mjs';
+import {isBeginner} from '../static/scripts/common/utility/privileges.js';
 import NewNotesAlertCheckbox
   from '../static/scripts/edit/components/NewNotesAlertCheckbox.js';
 import getRequestCookie from '../utility/getRequestCookie.mjs';
@@ -27,7 +28,7 @@ component NotesReceived(editNotes: $ReadOnlyArray<EditNoteT>, pager: PagerT) {
     <Layout fullWidth title={l('Recent notes left on your edits')}>
       <div id="content">
         <h1>{l('Recent notes left on your edits')}</h1>
-        {$c.user?.is_limited ? null : (
+        {isBeginner($c.user) ? null : (
           <NewNotesAlertCheckbox
             checked={getRequestCookie(
               $c.req,

--- a/root/edit/components/EditorTypeInfo.js
+++ b/root/edit/components/EditorTypeInfo.js
@@ -8,13 +8,16 @@
  */
 
 import bracketed from '../../static/scripts/common/utility/bracketed.js';
-import {isBot} from '../../static/scripts/common/utility/privileges.js';
+import {
+  isBeginner,
+  isBot,
+} from '../../static/scripts/common/utility/privileges.js';
 
 component EditorTypeInfo(editor: EditorT | null) {
   return (
     editor == null ? null : (
       <>
-        {editor.is_limited ? (
+        {isBeginner(editor) ? (
           <span className="editor-class">
             {bracketed(
               <span

--- a/root/layout.tt
+++ b/root/layout.tt
@@ -74,7 +74,7 @@
 
         [%- IF new_edit_notes &&
                new_edit_notes_mtime > (c.req.cookies.new_edit_notes_dismissed_mtime.value || 0) &&
-               ((c.user && (c.user.is_limited || !c.user.has_confirmed_email_address)) ||
+               ((c.user && (c.user.is_beginner || !c.user.has_confirmed_email_address)) ||
                 (c.req.cookies.alert_new_edit_notes.value || 'true') != 'false') -%]
             <div class="banner new-edit-notes">
                 <p>

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -15,6 +15,7 @@ import DBDefs from '../static/scripts/common/DBDefs.mjs';
 import parseDate from '../static/scripts/common/utility/parseDate.js';
 import {
   isAddingNotesDisabled,
+  isBeginner,
   isEditingDisabled,
 } from '../static/scripts/common/utility/privileges.js';
 import {age} from '../utility/age.js';
@@ -178,7 +179,7 @@ component Layout(
     ($c.stash.new_edit_notes_mtime ?? Infinity) > Number(
       getRequestCookie($c.req, 'new_edit_notes_dismissed_mtime', '0'),
     ) && (($c.user &&
-      ($c.user.is_limited || !$c.user.has_confirmed_email_address)) ||
+      (isBeginner($c.user) || !$c.user.has_confirmed_email_address)) ||
       getRequestCookie($c.req, 'alert_new_edit_notes', 'true') !== 'false');
 
   return (

--- a/root/static/scripts/collection/components/CollectionEditForm.js
+++ b/root/static/scripts/collection/components/CollectionEditForm.js
@@ -74,7 +74,6 @@ function createCollaboratorAutocompleteState(
         deleted: false,
         entityType: 'editor',
         id,
-        is_limited: false,
         name,
         privileges: -1,
       },

--- a/root/static/scripts/common/utility/privileges.js
+++ b/root/static/scripts/common/utility/privileges.js
@@ -12,6 +12,7 @@ import {
   ADDING_NOTES_DISABLED_FLAG,
   AUTO_EDITOR_FLAG,
   BANNER_EDITOR_FLAG,
+  BEGINNER_FLAG,
   BOT_FLAG,
   DONT_NAG_FLAG,
   EDITING_DISABLED_FLAG,
@@ -93,6 +94,13 @@ export function isBannerEditor(editor: EditorPropT): boolean {
     return false;
   }
   return (editor.privileges & BANNER_EDITOR_FLAG) > 0;
+}
+
+export function isBeginner(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & BEGINNER_FLAG) > 0;
 }
 
 export function isEditingDisabled(editor: EditorPropT): boolean {

--- a/root/static/scripts/tests/utility/constants.js
+++ b/root/static/scripts/tests/utility/constants.js
@@ -119,7 +119,6 @@ export const genericEditor: UnsanitizedEditorT = {
   has_email_address: true,
   id: 1,
   is_charter: false,
-  is_limited: false,
   languages: [],
   last_login_date: '2023-05-16T00:20:43Z',
   name: 'editor1',

--- a/root/static/scripts/tests/utility/sanitizedEditor.js
+++ b/root/static/scripts/tests/utility/sanitizedEditor.js
@@ -18,7 +18,6 @@ const sanitizedNormalEditor = {
   deleted: false,
   entityType: 'editor',
   id: 1,
-  is_limited: false,
   name: 'editor1',
   privileges: 0,
 };
@@ -27,7 +26,6 @@ const deletedEditor = {
   ...genericEditor,
   deleted: true,
   id: 123,
-  is_limited: false,
   name: 'Deleted Editor #123',
   privileges: 0,
 };
@@ -37,7 +35,6 @@ const sanitizedDeletedEditor = {
   deleted: true,
   entityType: 'editor',
   id: 123,
-  is_limited: false,
   name: 'Deleted Editor #123',
   privileges: 0,
 };
@@ -46,7 +43,6 @@ const autoEditor = {
   ...genericEditor,
   deleted: false,
   id: 2,
-  is_limited: false,
   name: 'Priv McPrivileged',
   privileges: 1,
 };
@@ -56,7 +52,6 @@ const sanitizedAutoEditor = {
   deleted: false,
   entityType: 'editor',
   id: 2,
-  is_limited: false,
   name: 'Priv McPrivileged',
   privileges: 1,
 };
@@ -65,7 +60,6 @@ const bannedEditor = {
   ...genericEditor,
   deleted: false,
   id: 3,
-  is_limited: false,
   name: 'Gaiseric',
   privileges: 3072,
 };
@@ -75,28 +69,25 @@ const sanitizedBannedEditor = {
   deleted: false,
   entityType: 'editor',
   id: 3,
-  is_limited: false,
   name: 'Gaiseric',
   privileges: 0,
 };
 
-const limitedEditor = {
+const beginnerEditor = {
   ...genericEditor,
   deleted: false,
   id: 5,
-  is_limited: true,
   name: 'Nancy NewEditor',
-  privileges: 0,
+  privileges: 8192,
 };
 
-const sanitizedLimitedEditor = {
+const sanitizedBeginnerEditor = {
   avatar: '',
   deleted: false,
   entityType: 'editor',
   id: 5,
-  is_limited: true,
   name: 'Nancy NewEditor',
-  privileges: 0,
+  privileges: 8192,
 };
 
 test('sanitizedEditor', function (t) {
@@ -127,8 +118,8 @@ test('sanitizedEditor', function (t) {
   );
 
   t.deepEqual(
-    sanitizedEditor(limitedEditor),
-    sanitizedLimitedEditor,
+    sanitizedEditor(beginnerEditor),
+    sanitizedBeginnerEditor,
     'Beginner editor is sanitized as expected',
   );
 });

--- a/root/types/collection.js
+++ b/root/types/collection.js
@@ -17,7 +17,6 @@ declare type CollectionT = $ReadOnly<{
   +description: string,
   +description_html: string,
   +editor: EditorT | null,
-  +editor_is_limited: boolean,
   +entity_count: number,
   +gid: string,
   +item_entity_type?: CollectableEntityTypeT,

--- a/root/types/editor.js
+++ b/root/types/editor.js
@@ -37,7 +37,6 @@ declare type EditorT = {
   ...EntityRoleT<'editor'>,
   +avatar: string,
   +deleted: boolean,
-  +is_limited: boolean,
   +name: string,
   +privileges: number,
 };
@@ -79,7 +78,6 @@ declare type UnsanitizedEditorT = $ReadOnly<{
   +has_confirmed_email_address: boolean,
   +has_email_address: boolean,
   +is_charter: boolean,
-  +is_limited: boolean,
   +languages: $ReadOnlyArray<EditorLanguageT> | null,
   +last_login_date: string | null,
   +name: string,

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -32,6 +32,7 @@ import {
   isAccountAdmin,
   isAddingNotesDisabled,
   isAutoEditor,
+  isBeginner,
   isBot,
   isEditingDisabled,
   isLocationEditor,
@@ -99,7 +100,7 @@ function generateUserTypesList(
       </a>,
     );
   }
-  if (user.is_limited) {
+  if (isBeginner(user)) {
     typesList.push(
       <span
         className="tooltip"
@@ -141,7 +142,7 @@ component UserProfileInformation(
   viewingOwnProfile: boolean,
 ) {
   const $c = React.useContext(CatalystContext);
-  const showBioAndURL = !user.is_limited || $c.user != null;
+  const showBioAndURL = !isBeginner(user) || $c.user != null;
   let memberSince;
   if (user.name === 'rob') {
     memberSince = l('The dawn of the project');

--- a/root/utility/edit.js
+++ b/root/utility/edit.js
@@ -26,6 +26,7 @@ import {
 import {
   isAddingNotesDisabled,
   isAutoEditor,
+  isBeginner,
   isBot,
   isEditingEnabled,
 } from '../static/scripts/common/utility/privileges.js';
@@ -188,7 +189,7 @@ export function editorMayVote(
 ): boolean {
   return (
     editor != null &&
-    !editor.is_limited &&
+    !isBeginner(editor) &&
     nonEmpty(editor.email_confirmation_date) &&
     !isBot(editor) &&
     isEditingEnabled(editor)

--- a/root/utility/hydrate.js
+++ b/root/utility/hydrate.js
@@ -48,7 +48,6 @@ if (__DEV__) {
     'entityType',
     'avatar',
     'id',
-    'is_limited',
     'name',
     'privileges',
   ]);

--- a/root/utility/sanitizedEditor.mjs
+++ b/root/utility/sanitizedEditor.mjs
@@ -14,7 +14,8 @@ const publicFlags = 1 | // AUTO_EDITOR_FLAG
                     32 | // WIKI_TRANSCLUSION_FLAG
                     128 | // ACCOUNT_ADMIN_FLAG
                     256 | // LOCATION_EDITOR_FLAG
-                    512; // BANNER_EDITOR_FLAG
+                    512 | // BANNER_EDITOR_FLAG
+                    8192; // BEGINNER_FLAG
 
 function sanitizePrivileges(privileges: number): number {
   return (privileges & publicFlags);
@@ -34,7 +35,6 @@ export default function sanitizedEditor(
     deleted: editor.deleted,
     entityType: 'editor',
     id: editor.id,
-    is_limited: editor.is_limited,
     name: editor.name,
     privileges: sanitizePrivileges(editor.privileges),
   };

--- a/t/lib/t/MusicBrainz/Server/Controller/Collection/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Collection/Show.pm
@@ -97,20 +97,8 @@ test 'Collection descriptions are shown, but avoid spam risk' => sub {
         'The description section is marked to be displayed as deleted',
     );
 
-    $test->c->sql->do(<<~"SQL");
-        INSERT INTO edit (id, editor, type, status, expire_time, autoedit)
-            VALUES (11, 2, 1, $STATUS_APPLIED, now(), 0),
-                   (12, 2, 1, $STATUS_APPLIED, now(), 0),
-                   (13, 2, 1, $STATUS_APPLIED, now(), 0),
-                   (14, 2, 1, $STATUS_APPLIED, now(), 0),
-                   (15, 2, 1, $STATUS_APPLIED, now(), 0),
-                   (16, 2, 1, $STATUS_APPLIED, now(), 0),
-                   (17, 2, 1, $STATUS_APPLIED, now(), 0),
-                   (18, 2, 1, $STATUS_APPLIED, now(), 0),
-                   (19, 2, 1, $STATUS_APPLIED, now(), 0),
-                   (20, 2, 1, $STATUS_APPLIED, now(), 0);
-        UPDATE editor SET member_since = '2007-07-23' WHERE id = 2;
-        SQL
+    note('We remove the beginner flag from the editor');
+    $test->c->sql->do('UPDATE editor SET privs = 0 WHERE id = 2');
 
     $mech->get_ok(
         '/collection/f34c079d-374e-4436-9448-da92dedef3cb',

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Edit.pm
@@ -94,19 +94,8 @@ test 'Hide biography and website/homepage of beginners/limited users from not-lo
     $tx->ok('//tr/td[preceding-sibling::th[1][normalize-space(text())="Homepage:"]]/div[@class="deleted" and starts-with(text(), "This content is hidden to prevent spam.")]',
         'website field of beginner/limited user is hidden from not-logged-in user');
 
-    $test->c->sql->do(<<~"SQL");
-        INSERT INTO edit (id, editor, type, status, expire_time, autoedit)
-            VALUES (1, 1, 1, $STATUS_APPLIED, now(), 0),
-                   (2, 1, 1, $STATUS_APPLIED, now(), 0),
-                   (3, 1, 1, $STATUS_APPLIED, now(), 0),
-                   (4, 1, 1, $STATUS_APPLIED, now(), 0),
-                   (5, 1, 1, $STATUS_APPLIED, now(), 0),
-                   (6, 1, 1, $STATUS_APPLIED, now(), 0),
-                   (7, 1, 1, $STATUS_APPLIED, now(), 0),
-                   (8, 1, 1, $STATUS_APPLIED, now(), 0),
-                   (9, 1, 1, $STATUS_APPLIED, now(), 0),
-                   (10, 1, 1, $STATUS_APPLIED, now(), 0);
-        SQL
+    note('We remove the beginner flag from the editor');
+    $test->c->sql->do('UPDATE editor SET privs = 0 WHERE id = 1');
 
     $mech->get('/user/new_editor');
     html_ok($mech->content);

--- a/t/lib/t/MusicBrainz/Server/Data/Editor.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Editor.pm
@@ -236,7 +236,7 @@ test 'Getting/loading existing editors' => sub {
     );
     is(
         $editor->privileges,
-        1+8+32+512,
+        1+8+32+512+8192,
         'The editor has the expected privileges',
     );
 
@@ -470,7 +470,7 @@ test 'Deleting editors removes most information' => sub {
     # Ensure all other attributes are cleared
     my $exclusions = Set::Scalar->new(
         qw( id name password privileges last_login_date languages
-            registration_date preferences ha1 deleted has_ten_accepted_edits
+            registration_date preferences ha1 deleted
       ));
 
     for my $attribute (grep { !$exclusions->contains($_->name) }

--- a/t/lib/t/MusicBrainz/Server/Entity/Editor.pm
+++ b/t/lib/t/MusicBrainz/Server/Entity/Editor.pm
@@ -18,7 +18,7 @@ isa_ok($editor, 'MusicBrainz::Server::Entity::Editor', 'isa');
 
 # Main attributes
 can_ok($editor, qw( name password privileges email biography website
-                    registration_date last_login_date has_ten_accepted_edits
+                    registration_date last_login_date
                     email_confirmation_date ));
 
 # Check privileges
@@ -40,11 +40,13 @@ $editor->email_confirmation_date(DateTime->now);
 ok($editor->has_confirmed_email_address, 'should be confirmed');
 
 $editor->registration_date(DateTime->now);
-ok($editor->is_newbie);
+ok($editor->is_newbie, 'New editor is marked as a newbie');
 
 $editor->registration_date(DateTime->new(year => '1980'));
-ok(!$editor->is_newbie, 'shouldnt be a newbie');
-
+ok(
+  !$editor->is_newbie,
+  'Editor registered years ago is not marked as a newbie',
+);
 };
 
 1;

--- a/t/sql/collection.sql
+++ b/t/sql/collection.sql
@@ -27,12 +27,12 @@ INSERT INTO work (id, gid, name, type, edits_pending, comment) VALUES
     (1, '745c079d-374e-4436-9448-da92dedef3ce', 'Dancing Queen', 1, 0, 'Work'),
     (2, '755c079d-374e-4436-9448-da92dedef3cf', 'Test', 1, 0, 'Another Work');
 
-INSERT INTO editor (id, name, password, ha1, email, email_confirm_date) VALUES
-(1, 'editor1', '{CLEARTEXT}pass', '16a4862191803cb596ee4b16802bb7ee', 'foo@example.com', now()),
-(2, 'editor2', '{CLEARTEXT}pass', 'ba025a52cc5ff57d5d10f31874a83de6', 'foo@example.com', now()),
-(3, 'editor3', '{CLEARTEXT}pass', 'c096994132d53f3e1cde757943b10e7d', 'foo@example.com', now()),
+INSERT INTO editor (id, name, password, ha1, email, email_confirm_date, privs) VALUES
+(1, 'editor1', '{CLEARTEXT}pass', '16a4862191803cb596ee4b16802bb7ee', 'foo@example.com', now(), 0),
+(2, 'editor2', '{CLEARTEXT}pass', 'ba025a52cc5ff57d5d10f31874a83de6', 'foo@example.com', now(), 8192),
+(3, 'editor3', '{CLEARTEXT}pass', 'c096994132d53f3e1cde757943b10e7d', 'foo@example.com', now(), 0),
 -- Reminder: Editor #4 is ModBot
-(5, 'editor5', '{CLEARTEXT}pass', '01de7bc91330d78a6d0a84033e293f15', 'foo@example.com', now());
+(5, 'editor5', '{CLEARTEXT}pass', '01de7bc91330d78a6d0a84033e293f15', 'foo@example.com', now(), 0);
 
 INSERT INTO editor_collection (id, gid, editor, name, public, description, type)
     VALUES (1, 'f34c079d-374e-4436-9448-da92dedef3cd', 1, 'collection1', FALSE, '', 1),

--- a/t/sql/edit_note.sql
+++ b/t/sql/edit_note.sql
@@ -1,14 +1,14 @@
 SET client_min_messages TO 'warning';
 
-INSERT INTO editor (id, name, password, email, ha1, email_confirm_date, member_since) VALUES
-(1, 'editor1', '{CLEARTEXT}pass', 'editor1@example.com', '16a4862191803cb596ee4b16802bb7ee', now(), '2014-12-03'),
-(2, 'editor2', '{CLEARTEXT}pass', 'editor2@example.com', 'ba025a52cc5ff57d5d10f31874a83de6', now(), '2014-12-04'),
-(3, 'editor3', '{CLEARTEXT}pass', 'editor3@example.com', 'c096994132d53f3e1cde757943b10e7d', now(), '2014-12-05'),
+INSERT INTO editor (id, name, password, email, ha1, email_confirm_date, member_since, privs) VALUES
+(1, 'editor1', '{CLEARTEXT}pass', 'editor1@example.com', '16a4862191803cb596ee4b16802bb7ee', now(), '2014-12-03', 0),
+(2, 'editor2', '{CLEARTEXT}pass', 'editor2@example.com', 'ba025a52cc5ff57d5d10f31874a83de6', now(), '2014-12-04', 0),
+(3, 'editor3', '{CLEARTEXT}pass', 'editor3@example.com', 'c096994132d53f3e1cde757943b10e7d', now(), '2014-12-05', 0),
 -- Reminder: Editor #4 is ModBot
 -- Non-verified editor
-(5, 'editor5', '{CLEARTEXT}pass', null, '01de7bc91330d78a6d0a84033e293f15', null, '2014-12-03'),
+(5, 'editor5', '{CLEARTEXT}pass', null, '01de7bc91330d78a6d0a84033e293f15', null, '2014-12-03', 0),
 -- Beginner editor
-(6, 'editor6', '{CLEARTEXT}pass', 'editor6@example.com', '01de7bc91330d78a6d0a84033e293f11', now(), '2014-12-03');
+(6, 'editor6', '{CLEARTEXT}pass', 'editor6@example.com', '01de7bc91330d78a6d0a84033e293f11', now(), '2014-12-03', 8192);
 
 -- Test multiple edit_notes
 INSERT INTO edit (id, editor, type, status, expire_time)
@@ -32,11 +32,5 @@ INSERT INTO edit (id, editor, type, status, expire_time)
     VALUES (3, 1, 111, 1, NOW());
 
 INSERT INTO edit_data (edit, data) SELECT generate_series(1, 3), '{ "foo": "5" }';
-
--- Dummy edits to allow editor 2 to vote
-INSERT INTO edit (id, editor, type, status, expire_time)
-    SELECT 3 + x, 2, 111, 2, now() FROM generate_series(1, 10) x;
-INSERT INTO edit_data (edit, data)
-    SELECT 3 + x, '{}' FROM generate_series(1, 10) x;
 
 ALTER SEQUENCE edit_note_id_seq RESTART 4;

--- a/t/sql/editor.sql
+++ b/t/sql/editor.sql
@@ -1,6 +1,6 @@
 INSERT INTO editor (id, name, password, privs, email, website, bio, member_since,
         email_confirm_date, last_login_date, ha1)
-    VALUES (1, 'new_editor', '{CLEARTEXT}password', 1+8+32+512, 'test@email.com', 'http://test.website',
+    VALUES (1, 'new_editor', '{CLEARTEXT}password', 1+8+32+512+8192, 'test@email.com', 'http://test.website',
         'biography', '1989-07-23', '2005-10-20', '2013-04-05', 'aa550c5b01407ef1f3f0d16daf9ec3c8'),
          (2, 'Alice', '{CLEARTEXT}secret1', 0, 'alice@example.com', 'http://example.com',
         'second biography', '2007-07-23', '2007-10-20', now(), 'e7f46e4f25ae38fcc952ef2b7edf0de9'),

--- a/t/sql/vote.sql
+++ b/t/sql/vote.sql
@@ -3,24 +3,12 @@ SET client_min_messages TO 'warning';
 INSERT INTO artist (id, gid, name, sort_name)
     VALUES (1, 'a9d99e40-72d7-11de-8a39-0800200c9a66', 'Name', 1);
 
-INSERT INTO editor (id, name, password, email, ha1, email_confirm_date, member_since) VALUES
-    (1, 'editor1', '{CLEARTEXT}pass', 'editor1@example.com', '16a4862191803cb596ee4b16802bb7ee', now(), now()),
-    (2, 'editor2', '{CLEARTEXT}pass', 'editor2@example.com', 'ba025a52cc5ff57d5d10f31874a83de6', now(), '2014-12-01'),
-    (3, 'editor3', '{CLEARTEXT}pass', 'editor3@example.com', 'c096994132d53f3e1cde757943b10e7d', now(), '2014-12-02'),
+INSERT INTO editor (id, name, password, email, ha1, email_confirm_date, member_since, privs) VALUES
+    (1, 'editor1', '{CLEARTEXT}pass', 'editor1@example.com', '16a4862191803cb596ee4b16802bb7ee', now(), now(), 0),
+    (2, 'editor2', '{CLEARTEXT}pass', 'editor2@example.com', 'ba025a52cc5ff57d5d10f31874a83de6', now(), '2014-12-01', 0),
+    (3, 'editor3', '{CLEARTEXT}pass', 'editor3@example.com', 'c096994132d53f3e1cde757943b10e7d', now(), '2014-12-02', 0),
     -- Reminder: Editor #4 is ModBot
     -- Non-verified editor
-    (5, 'editor5', '{CLEARTEXT}pass', null, '01de7bc91330d78a6d0a84033e293f15', null, '2014-12-03'),
+    (5, 'editor5', '{CLEARTEXT}pass', null, '01de7bc91330d78a6d0a84033e293f15', null, '2014-12-03', 0),
     -- Beginner editor
-    (6, 'editor6', '{CLEARTEXT}pass', 'editor6@example.com', '01de7bc91330d78a6d0a84033e293f11', now(), '2014-12-03');
-
-
--- Dummy edits to allow voting
-INSERT INTO edit (id, editor, type, status, expire_time)
-    SELECT x, 2, 1, 2, now() FROM generate_series(1, 10) x;
-INSERT INTO edit_data (edit, data)
-    SELECT x, '{}' FROM generate_series(1, 10) x;
-
-INSERT INTO edit (id, editor, type, status, expire_time)
-    SELECT x, 3, 1, 2, now() FROM generate_series(11, 20) x;
-INSERT INTO edit_data (edit, data)
-    SELECT x, '{}' FROM generate_series(11, 20) x;
+    (6, 'editor6', '{CLEARTEXT}pass', 'editor6@example.com', '01de7bc91330d78a6d0a84033e293f11', now(), '2014-12-03', 8192);

--- a/t/sql/vote_and_note_selenium.sql
+++ b/t/sql/vote_and_note_selenium.sql
@@ -31,9 +31,3 @@ INSERT INTO edit_data (edit, data)
 
 INSERT INTO edit_release (edit, release)
     VALUES (1, 2), (2, 4), (3, 3);
-
--- Dummy edits to allow editor 5 (from selenium.sql) to vote
-INSERT INTO edit (id, editor, type, status, expire_time)
-    SELECT 3 + x, 5, 111, 2, now() FROM generate_series(1, 10) x;
-INSERT INTO edit_data (edit, data)
-    SELECT 3 + x, '{}' FROM generate_series(1, 10) x;


### PR DESCRIPTION
### Implement MBS-13492

# Problem
Anything that requires checking whether an editor is a beginner requires us to calculate beginnership every time, which is slow and cumbersome, and implemented in at least three different places in slightly different ways. Specifically, calculating beginnership as part of edit search conditions is awfully, terribly slow.

# Solution
Every new editor added via /register will get the `BEGINNER_FLAG` privilege by default, which will only be removed
when accepting edits once the number of edits + time passed requirements are fulfilled. The flag cannot be set/unset via Edit user, since even admins should have no reason to override the default mechanism for this.

We calculate this in `_do_accept`, rather than the edit queue itself, because approvals skip the edit queue but are still relevant for this check.

We run a one-off script to set the flag on any existing beginners.

# Testing
Registered a new user and saw it does get the Beginner flag. Added a test to make sure the `EditQueue` processing removes the beginner flag when appropriate.

# Draft progress
* [x] Add a cron job so that the beginner flag is eventually removed (@mwiencek suggested running this as part of `CheckVotes` on a per-edit basis, since we have the editor loaded and we can check their `privs` and `member_since` without having to query them, so we would only need to check if they have the required amount of edits and then unset their beginner flag).
* [x] Add a one-off script to set the beginner flag on every beginner account that already exists, after which they'll just work with the cron job like others.
* [x] Remove extra cruft from tests (such as SQL inserting 10 nonsense edits so that the editor is not a beginner anymore)