### PR TITLE
MBS-13495: Use RG table for RG disambiguation filter

### DIFF
--- a/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
@@ -92,6 +92,7 @@ sub _where_filter
             push @params, $filter->{name}, $filter->{name};
         }
         if (exists $filter->{disambiguation}) {
+            $needs_rg_table = 1 if $using_artist_release_group_table;
             push @query, q{(mb_simple_tsvector(rg.comment) @@ plainto_tsquery('mb_simple', mb_lower(?)) OR rg.comment = ?)};
             push @params, ($filter->{disambiguation}) x 2;
         }


### PR DESCRIPTION
### Fix MBS-13495

# Problem
The RG diambiguation filter tries to access a non-existent `rg` table when filtering in fast mode (using `artist_release_group`).

# Solution
Just set `$needs_rg_table` to `1`, as we do with other similar filters but seemingly I just forgot to do here.

# Testing
Manually with r-o main db access with and without this (testing with a local sample db works either way since it uses the slow mode with the `release_group` table).