### PR TITLE
Limit documentation content to viewport width

### DIFF
--- a/root/static/styles/extra/wikidocs.less
+++ b/root/static/styles/extra/wikidocs.less
@@ -109,6 +109,12 @@
         font-size: @small-text;
     }
 
+    // MediaWiki content
+    .mw-parser-output {
+        // Make pages somewhat readable on mobile devices.
+        max-width: calc(100vw - 32px);
+    }
+
     // footer section
     .wikidocs-footer {
         border-top: 2px dotted @medium-border;


### PR DESCRIPTION
Restrict MediaWiki content width to the viewport width to make it somewhat usable on mobile devices.

# Problem

Documentation pages set `min-width: 780px;` on `<body>`, which results in content being unusable on mobile devices with narrow screens -- the text is either tiny when zoomed out or multiple screen-widths wide when zoomed in. See the screenshots at <https://community.metabrainz.org/t/making-documentation-pages-usable-on-mobile-devices/602956>.

# Solution

Set `max-width: calc(100vw - 32px);` on the content so that it's limited to the viewport width even when the page itself is much wider (to accommodate the header).

![Screenshot (Feb 28, 2024 07_27_15)](https://github.com/metabrainz/musicbrainz-server/assets/40385/ddde01f8-1d6f-4fdc-b979-d309692605f7)

# Testing

Documentation pages look the same as before in wide windows, but the content is wrapped at the viewport width on mobile (in both Chrome dev tools and on a Pixel 7a).