### PR TITLE
MBS-13328: Remove medium / release edits missing from recording edit history

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Medium/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Delete.pm
@@ -36,6 +36,20 @@ has '+data' => (
     ],
 );
 
+around _build_related_entities => sub {
+    my ($orig, $self) = splice(@_, 0, 2);
+    my $related = $self->$orig(@_);
+
+    push @{ $related->{artist} }, map {
+        map { $_->{artist}{id} } @{ $_->{artist_credit}->{names} }
+    } @{ $self->data->{tracklist} };
+
+    push @{ $related->{recording} },
+        map { $_->{recording_id} } @{ $self->data->{tracklist} };
+
+    return $related;
+};
+
 sub alter_edit_pending
 {
     my $self = shift;

--- a/lib/MusicBrainz/Server/Edit/Release/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Delete.pm
@@ -13,6 +13,31 @@ sub edit_name { N_lp('Remove release', 'edit type') }
 sub _delete_model { 'Release' }
 sub release_id { shift->entity_id }
 
+around _build_related_entities => sub {
+    my ($orig, $self) = splice(@_, 0, 2);
+    my $related = $self->$orig(@_);
+
+    my $release = $self->c->model('Release')->get_by_id(
+        $self->data->{entity_id},
+    );
+    $self->c->model('Release')->load_related_info($release);
+
+    for my $medium (@{ $release->{mediums} }) {
+        $self->c->model('Track')->load_for_mediums($medium);
+        my @tracks = $medium->all_tracks;
+        $self->c->model('ArtistCredit')->load(@tracks);
+
+        push @{ $related->{artist} }, map {
+            map { $_->{artist}{id} } @{ $_->{artist_credit}->{names} }
+        } @tracks;
+
+        push @{ $related->{recording} },
+            map { $_->{recording_id} } @tracks;
+    }
+
+    return $related;
+};
+
 override 'foreign_keys' => sub {
     my $self = shift;
     my $data = super();


### PR DESCRIPTION
### Fix MBS-13328

# Problem
For some reason, when we delete a medium or a release (including all its mediums) we are not actually displaying those edits in the history of the recordings that appear on the affected mediums. Admittedly, in many cases this will lead to the recording being subsequently removed anyway and there will be no history to see, but especially for orphaned recordings which had relationships and were kept behind this would be good info to have.

# Solution
This just does the same when deleting a medium as we already do when adding and editing it, making the edits appear in the history of both the recordings in the medium and the artists in the track ACs.

For Remove release, this loads all the mediums in the release and does the same as the medium edit for each of the mediums, since it's effectively equivalent to a Remove medium edit for every medium in the release.

# Testing
Manually, by entering removals for a one-recording medium and its release and making sure that the edits do appear on the edit history for the recording and for the track artists (even ones not part of the release artist).
I did *not* test what happens if the release/medium has several hundred tracks (whether they are all loaded and edits added to their histories or whether it just loads whatever the standard loading limit we have is) since I didn't have an obvious release to test it with. @mwiencek might either know what will happen or have a good example to test.