### PR TITLE
MBS-7646: Show localized artist aliases in more places

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -146,9 +146,12 @@ after 'load' => sub
         }
     }
 
-    $c->model('ArtistType')->load($artist, map { $_->target } @{ $artist->relationships_by_type('artist') });
-    $c->model('Gender')->load($artist);
-    $c->model('Area')->load($artist);
+    my $lang = $c->stash->{current_language} // 'en';
+    # TODO: This loads the artist's aliases to look for a primary alias in the
+    # user's language, but note that aliases are also being loaded by the show
+    # subroutine to get the artist's legal name.
+    $c->model('Artist')->load_related_info([$artist], $lang);
+    $c->model('ArtistType')->load(map { $_->target } @{ $artist->relationships_by_type('artist') });
     $c->model('Area')->load_containment($artist->area, $artist->begin_area, $artist->end_area);
 };
 

--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -125,9 +125,8 @@ sub direct : Private
     my @entities = map { $_->entity } @$results;
 
     if ($type eq 'artist') {
-        $c->model('ArtistType')->load(@entities);
-        $c->model('Area')->load(@entities);
-        $c->model('Gender')->load(@entities);
+        my $lang = $c->stash->{current_language} // 'en';
+        $c->model('Artist')->load_related_info(\@entities, $lang);
     }
     elsif ($type eq 'editor') {
         $c->model('Editor')->load_preferences(@entities);
@@ -245,12 +244,15 @@ sub do_external_search {
     my $query = $opts{query};
     my $type  = $opts{type};
 
+    my $lang = $c->stash->{current_language} // 'en';
+
     my $search = $c->model('Search');
     my $ret = $search->external_search($type,
                                        $query,
                                        $limit,
                                        $page,
-                                       $advanced);
+                                       $advanced,
+                                       $lang);
 
     if (exists $ret->{error})
     {

--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -72,7 +72,7 @@ sub show : PathPart('') Chained('load') {
     }
 
     if ($series->type->item_entity_type eq 'artist') {
-        $c->model('Artist')->load_related_info(@entities);
+        $c->model('Artist')->load_related_info(\@entities);
         $c->model('Artist')->load_meta(@entities);
         $c->model('Artist')->rating->load_user_ratings($c->user->id, @entities) if $c->user_exists;
     }

--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -478,13 +478,14 @@ sub load_related_info {
     my $artist_aliases = $c->model('Artist')->alias->find_by_entity_ids(
         map { $_->id } @artists,
     );
+    my @all_aliases = map { @$_ } values %$artist_aliases;
+    $c->model('Artist')->alias_type->load(@all_aliases);
     for my $artist (@artists) {
         my @aliases = @{ $artist_aliases->{$artist->id} };
-        $c->model('Artist')->alias_type->load(@aliases);
-        $artist->{aliases} = \@aliases;
+        $artist->aliases(\@aliases);
         if (defined $user_lang) {
             my $best_alias = find_best_primary_alias(\@aliases, $user_lang);
-            $artist->{primary_alias} = $best_alias->name if defined $best_alias;
+            $artist->primary_alias($best_alias->name) if defined $best_alias;
         }
     }
 }

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -757,10 +757,10 @@ sub schema_fixup
         my $best_alias = find_best_primary_alias(\@aliases, $user_lang);
         $data->{primary_alias} = $best_alias->{name} if defined $best_alias;
 
-        # The aliases returned by the search API aren't Entity::Alias objects,
-        # so clear them to prevent validation from failing if this is an
-        # Entity::Artist.
-        $data->{aliases} = [];
+        # Save the new objects so validation will pass, but note that the search
+        # API doesn't include all attributes that are present in Entity::Alias,
+        # e.g. no IDs.
+        $data->{aliases} = \@aliases;
     }
 
     if ($type eq 'work') {

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -748,14 +748,19 @@ sub schema_fixup
     if (defined $data->{aliases}) {
         my @aliases = map {
             MusicBrainz::Server::Entity::Alias->new(
-                sort_name => $_->{sort_name} || '',
-                locale => $_->{locale} || '',
-                name => $_->{name} || '',
+                name => $_->{name} // '',
+                sort_name => $_->{sort_name} // '',
+                locale => $_->{locale} // '',
                 primary_for_locale => $_->{primary},
             )
         } @{ $data->{aliases} };
         my $best_alias = find_best_primary_alias(\@aliases, $user_lang);
         $data->{primary_alias} = $best_alias->{name} if defined $best_alias;
+
+        # The aliases returned by the search API aren't Entity::Alias objects,
+        # so clear them to prevent validation from failing if this is an
+        # Entity::Artist.
+        $data->{aliases} = [];
     }
 
     if ($type eq 'work') {

--- a/lib/MusicBrainz/Server/Entity/Artist.pm
+++ b/lib/MusicBrainz/Server/Entity/Artist.pm
@@ -27,7 +27,7 @@ has 'sort_name' => (
 
 has 'aliases' => (
     is => 'rw',
-    isa => 'ArrayRef[Any]',
+    isa => 'ArrayRef[MusicBrainz::Server::Entity::Alias]',
     default => sub { [] },
 );
 

--- a/lib/MusicBrainz/Server/Entity/Artist.pm
+++ b/lib/MusicBrainz/Server/Entity/Artist.pm
@@ -25,6 +25,11 @@ has 'sort_name' => (
     isa => 'Str',
 );
 
+has 'primary_alias' => (
+    is => 'rw',
+    isa => 'Str',
+);
+
 has 'gender_id' => (
     is => 'rw',
     isa => 'Int',
@@ -82,6 +87,7 @@ around TO_JSON => sub {
         $self->begin_area ? (begin_area => $self->begin_area->TO_JSON) : (),
         $self->end_area ? (end_area => $self->end_area->TO_JSON) : (),
         $self->gender ? (gender => $self->gender->TO_JSON) : (),
+        $self->primary_alias ? (primaryAlias => $self->primary_alias) : (),
         begin_area_id => $self->begin_area_id,
         end_area_id => $self->end_area_id,
         gender_id => $self->gender_id,

--- a/lib/MusicBrainz/Server/Entity/Artist.pm
+++ b/lib/MusicBrainz/Server/Entity/Artist.pm
@@ -25,6 +25,12 @@ has 'sort_name' => (
     isa => 'Str',
 );
 
+has 'aliases' => (
+    is => 'rw',
+    isa => 'ArrayRef[Any]',
+    default => sub { [] },
+);
+
 has 'primary_alias' => (
     is => 'rw',
     isa => 'Str',

--- a/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
@@ -221,6 +221,7 @@ sub _with_primary_alias {
 
     $renderer //= \&get_entity_json;
 
+    # TODO: Consider updating this function to call find_best_primary_alias().
     my @output;
     if (@$results) {
         my $munge_lang = sub {

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -74,13 +74,23 @@ const iconClassPicker = {
 };
 
 const Comment = ({
+  alias,
   className,
   comment,
-}: {+className: string, +comment: string}) => (
+}: {+alias?: string, +className: string, +comment: string}) => (
   <>
     {' '}
     <span className={className}>
-      {bracketed(<bdi key="comment">{comment}</bdi>)}
+      {bracketed(
+        <bdi key="comment">
+          {nonEmpty(alias) ? (
+            <i title={l('Primary alias in your language')}>
+              {alias + (nonEmpty(comment) ? ', ' : '')}
+            </i>
+          ) : null}
+          {comment}
+        </bdi>,
+      )}
     </span>
   </>
 );
@@ -428,9 +438,20 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
         />,
       );
     }
-    if (comment) {
+    const primaryAlias =
+      (entity.entityType !== 'track' &&
+        nonEmpty(entity.primaryAlias) &&
+        entity.primaryAlias !== entityName)
+        ? entity.primaryAlias
+        : '';
+    if (nonEmpty(comment) || nonEmpty(primaryAlias)) {
       parts.push(
-        <Comment className="comment" comment={comment} key="comment" />,
+        <Comment
+          alias={primaryAlias}
+          className="comment"
+          comment={comment}
+          key="comment"
+        />,
       );
     }
     if (entity.entityType === 'area') {

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -13,6 +13,7 @@ import * as React from 'react';
 
 import type {ReleaseEditorTrackT} from '../../release-editor/types.js';
 import isGreyedOut from '../../url/utility/isGreyedOut.js';
+import commaOnlyList from '../i18n/commaOnlyList.js';
 import localizeAreaName from '../i18n/localizeAreaName.js';
 import localizeInstrumentName from '../i18n/localizeInstrumentName.js';
 import bracketed, {bracketedText} from '../utility/bracketed.js';
@@ -77,23 +78,27 @@ const Comment = ({
   alias,
   className,
   comment,
-}: {+alias?: string, +className: string, +comment: string}) => (
-  <>
-    {' '}
-    <span className={className}>
-      {bracketed(
-        <bdi key="comment">
-          {nonEmpty(alias) ? (
-            <i title={l('Primary alias')}>
-              {alias + (nonEmpty(comment) ? ', ' : '')}
-            </i>
-          ) : null}
-          {comment}
-        </bdi>,
-      )}
-    </span>
-  </>
-);
+}: {+alias?: string, +className: string, +comment: string}) => {
+  const aliasElement = nonEmpty(alias)
+    ? <i title={l('Primary alias')}>{alias}</i>
+    : null;
+  return (
+    <>
+      {' '}
+      <span className={className}>
+        {bracketed(
+          <bdi key="comment">
+            {nonEmpty(aliasElement) ? (
+              nonEmpty(comment) ? (
+                commaOnlyList([aliasElement, comment])
+              ) : aliasElement
+            ) : comment}
+          </bdi>,
+        )}
+      </span>
+    </>
+  );
+};
 
 const EventDisambiguation = ({
   event,

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -84,7 +84,7 @@ const Comment = ({
       {bracketed(
         <bdi key="comment">
           {nonEmpty(alias) ? (
-            <i title={l('Primary alias in your language')}>
+            <i title={l('Primary alias')}>
               {alias + (nonEmpty(comment) ? ', ' : '')}
             </i>
           ) : null}

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -650,6 +650,7 @@ const seleniumTests = [
   {name: 'MBS-2604.json5', login: true},
   {name: 'MBS-5387.json5', login: true},
   {name: 'MBS-7456.json5', login: true},
+  {name: 'MBS-7646.json5'},
   {name: 'MBS-8952.json5', login: true},
   {name: 'MBS-9396.json5', login: true},
   {name: 'MBS-9548.json5'},

--- a/t/selenium/MBS-7646.json5
+++ b/t/selenium/MBS-7646.json5
@@ -1,0 +1,74 @@
+{
+  title: 'MBS-7646: Show localized primary aliases alongside disambiguations',
+  commands: [
+    // Perform an indexed search and check that the English alias is shown
+    // before the disambiguation comment.
+    {
+      command: 'sendKeys',
+      target: 'css=#headerid-query',
+      value: 'tchaikovsky${KEY_ENTER}',
+    },
+    {
+      command: 'waitUntilUrlIs',
+      target: '/search?query=tchaikovsky&type=artist&method=indexed',
+      value: '',
+    },
+    {
+      command: 'assertText',
+      target: 'css=#content table.tbl td a',
+      value: 'Пётр Ильич Чайковский',
+    },
+    {
+      command: 'assertText',
+      target: 'css=#content table.tbl td .comment',
+      value: '(Pyotr Ilyich Tchaikovsky, Russian romantic composer)',
+    },
+    // Check that the alias is also shown when performing a direct search.
+    {
+      command: 'click',
+      target: 'css=input[name="method"][value="direct"]',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=div.searchform button[type="submit"]',
+      value: '',
+    },
+    {
+      command: 'waitUntilUrlIs',
+      target: '/search?query=tchaikovsky&type=artist&limit=25&method=direct',
+      value: '',
+    },
+    {
+      command: 'assertText',
+      target: 'css=#content table.tbl td a',
+      value: 'Пётр Ильич Чайковский',
+    },
+    {
+      command: 'assertText',
+      target: 'css=#content table.tbl td .comment',
+      value: '(Pyotr Ilyich Tchaikovsky, Russian romantic composer)',
+    },
+    // Check that the alias is also shown on the artist page.
+    {
+      command: 'click',
+      target: 'css=#content table.tbl td a',
+      value: '',
+    },
+    {
+      command: 'waitUntilUrlIs',
+      target: '/artist/9ddd7abc-9e1b-471d-8031-583bc6bc8be9',
+      value: '',
+    },
+    {
+      command: 'assertText',
+      target: 'css=.artistheader a',
+      value: 'Пётр Ильич Чайковский',
+    },
+    {
+      command: 'assertText',
+      target: 'css=.artistheader .comment',
+      value: '(Pyotr Ilyich Tchaikovsky, Russian romantic composer)',
+    },
+  ],
+}

--- a/t/sql/selenium.sql
+++ b/t/sql/selenium.sql
@@ -14,6 +14,7 @@ INSERT INTO area (id, gid, name, type, edits_pending, last_updated, begin_date_y
     (73, '08310658-51eb-3801-80de-5a0739207115', 'France', 1, 0, '2013-05-27 12:50:32.702645+00', NULL, NULL,  NULL,  NULL,  NULL,  NULL, 'f', ''),
     (96, '0373cdff-eac8-3fbc-92dc-36a607da06d1', 'Hong Kong', 1, 0, '2013-11-03 06:25:22.345722+00', NULL, NULL, NULL, NULL, NULL, NULL, '0', ''),
     (107, '2db42837-c832-3c27-b4a3-08198f75693c', 'Japan', 1, 0, '2013-05-27 12:29:56.162248+00', NULL, NULL,  NULL,  NULL,  NULL,  NULL, 'f', ''),
+    (176, '1f1fc3a4-9500-39b8-9f10-f0a465557eef', 'Russia', 1, 0, '2015-01-01 23:56:40.841959+00', NULL, NULL, NULL, NULL, NULL, NULL, '0', ''),
     (194, '471c46a7-afc5-31c4-923c-d0444f5053a4', 'Spain', 1, 0, '2013-05-27 13:08:54.580681+00', NULL, NULL, NULL, NULL, NULL, NULL, '0', ''),
     (221, '8a754a16-0027-3a29-b6d7-2b40ea0481ed', 'United Kingdom', 1, 0, '2013-05-16 11:06:19.67235+00', NULL, NULL, NULL, NULL, NULL, NULL, '0', ''),
     (222, '489ce91b-6658-3307-9877-795b68554c98', 'United States', 1, 0, '2013-06-15 18:06:39.59323+00', NULL, NULL, NULL, NULL, NULL, NULL, '0', ''),
@@ -36,11 +37,15 @@ INSERT INTO musicbrainz.artist (id, gid, name, sort_name, begin_date_year, begin
     (347, 'b7ffd2af-418f-4be2-bdd1-22f8b48613da', 'Nine Inch Nails', 'Nine Inch Nails', 1988, NULL, NULL, NULL, NULL, NULL, 2, 222, NULL, '', 0, '2018-11-29 21:00:53.245938+00', '0', 5241, NULL),
     (956, '5441c29d-3602-4898-b1a1-b77fa23b8e50', 'David Bowie', 'Bowie, David', 1947, 1, 8, 2016, 1, 10, 1, 221, 1, '', 0, '2019-01-10 03:00:28.692936+00', '1', 39872, 7020),
     (20211, 'c5f5dc27-3059-49c0-ae45-5009a01bb9ec', 'Super Furry Animals', 'Super Furry Animals', 1995, NULL, NULL, NULL, NULL, NULL, 2, 221, NULL, '', 0, '2013-09-02 02:19:54.215306+00', '0', 3813, NULL),
+    (122653, '9ddd7abc-9e1b-471d-8031-583bc6bc8be9', 'Пётр Ильич Чайковский', 'Tchaikovsky, Pyotr Ilyich', 1840, 5, 7, 1893, 11, 6, 1, 176, 1, 'Russian romantic composer', 0, '2024-03-03 19:00:35.180814+00', '1', null, null),
     (237981, '1155431a-d35e-4863-9ae0-e3c24eb61aa9', 'Lethal Bizzle', 'Lethal Bizzle', 1984, 9, 14, NULL, NULL, NULL, 1, 221, 1, '', 0, '2016-02-07 18:20:11.786086+00', '0', 55331, NULL),
     (1647244, '4f74991f-0156-427a-88db-9b2ac293dd42', 'The David Bowie Knives', 'David Bowie Knives, The', NULL, NULL, NULL, NULL, NULL, NULL, 2, 96, NULL, '', 0, '2018-04-11 10:07:10.225834+00', '0', NULL, NULL);
 
 INSERT INTO artist_alias (id, artist, name, locale, edits_pending, last_updated, type, sort_name, begin_date_year, begin_date_month, begin_date_day, end_date_year, end_date_month, end_date_day, primary_for_locale, ended) VALUES
-  (37382, 237981, 'Lethal B', NULL, 0, '2012-05-15 18:57:13.252186+00', NULL, 'Lethal B', NULL, NULL, NULL, NULL, NULL, NULL, 'f', 'f');
+    (37382, 237981, 'Lethal B', NULL, 0, '2012-05-15 18:57:13.252186+00', NULL, 'Lethal B', NULL, NULL, NULL, NULL, NULL, NULL, 'f', 'f'),
+    (47312, 122653, 'Tchaikovsky', 'en', 0, '2023-12-16 12:19:16.654394+00', 1, 'Tchaikovsky', NULL, NULL, NULL, NULL, NULL, NULL, '0', '0'),
+    (145041, 122653, 'Pyotr Ilyich Tchaikovsky', 'en', 0, '2014-03-07 01:00:15.732186+00', 1, 'Tchaikovsky, Pyotr Ilyich', NULL, NULL, NULL, NULL, NULL, NULL, '1', '0'),
+    (300696, 122653, 'Piotr Ilitch Tchaïkovski', 'fr', 0, '2020-07-06 19:45:45.103713+00', 2, 'Tchaïkovski, Piotr Ilitch', NULL, NULL, NULL, NULL, NULL, NULL, '1', '0');
 
 INSERT INTO artist_credit (id, name, artist_count, ref_count, created, edits_pending, gid) VALUES
     (347, 'Nine Inch Nails', 1, 1, '2011-05-16 16:32:11.963929+00', 0, '19fe2154-9a0c-3ad5-a736-b46beea954d4'),
@@ -61,6 +66,7 @@ INSERT INTO country_area (area) VALUES
     (13),
     (73),
     (107),
+    (176),
     (222),
     (241);
 


### PR DESCRIPTION
# MBS-7646

Try to find artists' primary aliases in the user's locale and display them alongside disambiguation comments in search results and artist pages.

# Problem

Editors argue about whether Latin-script versions of artist names should be included in disambiguations (see e.g. https://musicbrainz.org/edit/109219215). Even when this is done, it's not a great approach since it doesn't help editors who are using UI languages based on other scripts. Without being able to see localized names in search results, editors either look at sort names (if they know about them) or end up creating duplicate entities.

# Solution

Localized versions of artist names are already stored as aliases, so automatically display those in italicized text at the beginning of the disambiguation comment when possible, e.g.

> Пётр Ильич Чайковский (_Pyotr Ilyich Tchaikovsky,_ Russian romantic composer)

I'm only including the alias when it doesn't already match the artist name, and I'm performing fallback to favor an exact language match before falling back to the generic language and then other variants (e.g. `en_UK` favors `en_UK`, then `en`, and then `en_US`). I'm not sure if the fallback is important given the current UI language options, though.

# Testing

I did manual testing by doing indexed and direct searches for `tchaikovsky` with various UI languages and checking that the appropriate alias is shown, and also checking that aliases are displayed in the header on artist pages.

I also added a new Selenium test.