### PR TITLE
MBS-12359: Refactor _columns implementation in data model

### DIFF
--- a/lib/MusicBrainz/Server/Data/Alias.pm
+++ b/lib/MusicBrainz/Server/Data/Alias.pm
@@ -33,15 +33,37 @@ sub _table
     return $self->table;
 }
 
-sub _columns
+sub _build_columns
 {
     my $self = shift;
-    return sprintf '%s.id, name, sort_name, %s, locale,
-                    edits_pending, begin_date_year, begin_date_month,
-                    begin_date_day, end_date_year, end_date_month,
-                    end_date_day, type AS type_id, primary_for_locale, ended',
-        $self->table, $self->type;
+    my $table = $self->table;
+    my $type = $self->type;
+
+    return join q(, ), (
+        "$table.id",
+        'name',
+        'sort_name',
+        $type,
+        'locale',
+        'edits_pending',
+        'begin_date_year',
+        'begin_date_month',
+        'begin_date_day',
+        'end_date_year',
+        'end_date_month',
+        'end_date_day',
+        'type AS type_id',
+        'primary_for_locale',
+        'ended',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/Annotation.pm
+++ b/lib/MusicBrainz/Server/Data/Annotation.pm
@@ -9,11 +9,23 @@ sub _table
     'annotation';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, editor AS editor_id, text, changelog,
-            created AS creation_date';
+    return join q(, ), (
+        'id',
+        'editor AS editor_id',
+        'text',
+        'changelog',
+        'created AS creation_date',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _entity_class
 {

--- a/lib/MusicBrainz/Server/Data/Application.pm
+++ b/lib/MusicBrainz/Server/Data/Application.pm
@@ -17,10 +17,24 @@ sub _table
     return 'application';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, owner, name, oauth_id, oauth_secret, oauth_redirect_uri';
+    return join q(, ), qw(
+        id
+        owner
+        name
+        oauth_id
+        oauth_secret
+        oauth_redirect_uri
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/Area.pm
+++ b/lib/MusicBrainz/Server/Data/Area.pm
@@ -37,14 +37,35 @@ Readonly my @CODE_TYPES => qw( iso_3166_1 iso_3166_2 iso_3166_3 );
 
 sub _type { 'area' }
 
-sub _columns {
-    return 'area.id, area.gid, area.name COLLATE musicbrainz, area.comment, area.type, ' .
-           'area.edits_pending, area.begin_date_year, area.begin_date_month, area.begin_date_day, ' .
-           'area.end_date_year, area.end_date_month, area.end_date_day, area.ended, area.last_updated, ' .
-           '(SELECT array_agg(code) FROM iso_3166_1 WHERE iso_3166_1.area = area.id) AS iso_3166_1, ' .
-           '(SELECT array_agg(code) FROM iso_3166_2 WHERE iso_3166_2.area = area.id) AS iso_3166_2, ' .
-           '(SELECT array_agg(code) FROM iso_3166_3 WHERE iso_3166_3.area = area.id) AS iso_3166_3';
+sub _build_columns
+{
+    return join q(, ), (
+        'area.id',
+        'area.gid',
+        'area.name COLLATE musicbrainz',
+        'area.comment',
+        'area.type',
+        'area.edits_pending',
+        'area.begin_date_year',
+        'area.begin_date_month',
+        'area.begin_date_day',
+        'area.end_date_year',
+        'area.end_date_month',
+        'area.end_date_day',
+        'area.ended',
+        'area.last_updated',
+        '(SELECT array_agg(code) FROM iso_3166_1 WHERE iso_3166_1.area = area.id) AS iso_3166_1',
+        '(SELECT array_agg(code) FROM iso_3166_2 WHERE iso_3166_2.area = area.id) AS iso_3166_2',
+        '(SELECT array_agg(code) FROM iso_3166_3 WHERE iso_3166_3.area = area.id) AS iso_3166_3',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _id_column
 {

--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -48,15 +48,37 @@ with 'MusicBrainz::Server::Data::Role::Relatable',
 
 sub _type { 'artist' }
 
-sub _columns
+sub _build_columns
 {
-    return 'artist.id, artist.gid, artist.name COLLATE musicbrainz, artist.sort_name COLLATE musicbrainz, ' .
-           'artist.type, artist.area, artist.begin_area, artist.end_area, ' .
-           'gender, artist.edits_pending, artist.comment, artist.last_updated, ' .
-           'artist.begin_date_year, artist.begin_date_month, artist.begin_date_day, ' .
-           'artist.end_date_year, artist.end_date_month, artist.end_date_day,' .
-           'artist.ended';
+    return join q(, ), (
+        'artist.id',
+        'artist.gid',
+        'artist.name COLLATE musicbrainz',
+        'artist.sort_name COLLATE musicbrainz',
+        'artist.type',
+        'artist.area',
+        'artist.begin_area',
+        'artist.end_area',
+        'artist.gender',
+        'artist.edits_pending',
+        'artist.comment',
+        'artist.last_updated',
+        'artist.begin_date_year',
+        'artist.begin_date_month',
+        'artist.begin_date_day',
+        'artist.end_date_year',
+        'artist.end_date_month',
+        'artist.end_date_day',
+        'artist.ended',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _id_column
 {

--- a/lib/MusicBrainz/Server/Data/Artwork.pm
+++ b/lib/MusicBrainz/Server/Data/Artwork.pm
@@ -19,17 +19,26 @@ sub _table
         'JOIN cover_art_archive.image_type USING (mime_type)';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'cover_art_archive.cover_art.id,
-            cover_art_archive.cover_art.release,
-            cover_art_archive.cover_art.comment,
-            cover_art_archive.cover_art.edit,
-            cover_art_archive.cover_art.ordering,
-            cover_art_archive.cover_art.edits_pending,
-            cover_art_archive.cover_art.mime_type,
-            cover_art_archive.image_type.suffix';
+    return join q(, ), qw(
+        cover_art_archive.cover_art.id
+        cover_art_archive.cover_art.release
+        cover_art_archive.cover_art.comment
+        cover_art_archive.cover_art.edit
+        cover_art_archive.cover_art.ordering
+        cover_art_archive.cover_art.edits_pending
+        cover_art_archive.cover_art.mime_type
+        cover_art_archive.image_type.suffix
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _id_column
 {

--- a/lib/MusicBrainz/Server/Data/AutoEditorElection.pm
+++ b/lib/MusicBrainz/Server/Data/AutoEditorElection.pm
@@ -17,11 +17,29 @@ sub _table
     return 'autoeditor_election';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, candidate, proposer, seconder_1, seconder_2, status,
-        yes_votes, no_votes, propose_time, open_time, close_time';
+    return join q(, ), qw(
+        id
+        candidate
+        proposer
+        seconder_1
+        seconder_2
+        status
+        yes_votes
+        no_votes
+        propose_time
+        open_time
+        close_time
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/CDStub.pm
+++ b/lib/MusicBrainz/Server/Data/CDStub.pm
@@ -17,9 +17,9 @@ sub _table
     return 'release_raw JOIN cdtoc_raw ON cdtoc_raw.release = release_raw.id';
 }
 
-sub _columns
+sub _build_columns
 {
-    return join(', ', qw(
+    return join q(, ), qw(
         release_raw.id
         title
         artist
@@ -34,8 +34,15 @@ sub _columns
         track_count
         leadout_offset
         track_offset
-    ));
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/CDStubTrack.pm
+++ b/lib/MusicBrainz/Server/Data/CDStubTrack.pm
@@ -14,10 +14,23 @@ sub _table
     return 'track_raw';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, release, title, artist, sequence';
+    return join q(, ), qw(
+        id
+        release
+        title
+        artist
+        sequence
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Data/CDTOC.pm
@@ -15,10 +15,24 @@ sub _table
     return 'cdtoc';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, discid, freedb_id, track_count, leadout_offset, track_offset';
+    return join q(, ), qw(
+        id
+        discid
+        freedb_id
+        track_count
+        leadout_offset
+        track_offset
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/Collection.pm
+++ b/lib/MusicBrainz/Server/Data/Collection.pm
@@ -29,9 +29,25 @@ with 'MusicBrainz::Server::Data::Role::EntityModelClass',
 
 sub _type { 'collection' }
 
-sub _columns {
-    return 'editor_collection.id, editor_collection.gid, editor_collection.editor, editor_collection.name, public, editor_collection.description, editor_collection.type';
+sub _build_columns
+{
+    return join q(, ), qw(
+        editor_collection.id
+        editor_collection.gid
+        editor_collection.editor
+        editor_collection.name
+        editor_collection.public
+        editor_collection.description
+        editor_collection.type
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _id_column {
     return 'id';

--- a/lib/MusicBrainz/Server/Data/CollectionType.pm
+++ b/lib/MusicBrainz/Server/Data/CollectionType.pm
@@ -16,9 +16,25 @@ sub _table {
     return 'editor_collection_type';
 }
 
-sub _columns {
-    return 'id, gid, name, entity_type, parent, child_order, description';
+sub _build_columns
+{
+    return join q(, ), qw(
+        id
+        gid
+        name
+        entity_type
+        parent
+        child_order
+        description
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping {
     return {

--- a/lib/MusicBrainz/Server/Data/CoverArtType.pm
+++ b/lib/MusicBrainz/Server/Data/CoverArtType.pm
@@ -18,11 +18,24 @@ sub _table
     return 'cover_art_archive.art_type';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'art_type.id, art_type.gid, art_type.name, art_type.parent AS parent_id,
-            art_type.child_order, art_type.description';
+    return join q(, ), (
+        'art_type.id',
+        'art_type.gid',
+        'art_type.name',
+        'art_type.parent AS parent_id',
+        'art_type.child_order',
+        'art_type.description',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _entity_class
 {

--- a/lib/MusicBrainz/Server/Data/Edit.pm
+++ b/lib/MusicBrainz/Server/Data/Edit.pm
@@ -58,12 +58,28 @@ sub _table
     return 'edit JOIN edit_data ON edit.id = edit_data.edit';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'edit.id, edit.editor, edit.open_time, edit.expire_time, edit.close_time,
-            edit_data.data, edit.language, edit.type,
-            edit.autoedit, edit.status';
+    return join q(, ), qw(
+        edit.id
+        edit.editor
+        edit.open_time
+        edit.expire_time
+        edit.close_time
+        edit_data.data
+        edit.language
+        edit.type
+        edit.autoedit
+        edit.status
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _new_from_row
 {

--- a/lib/MusicBrainz/Server/Data/EditNote.pm
+++ b/lib/MusicBrainz/Server/Data/EditNote.pm
@@ -21,10 +21,23 @@ sub _table
     return 'edit_note';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, editor, edit, text, post_time';
+    return join q(, ), qw(
+        id
+        editor
+        edit
+        text
+        post_time
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/EditNoteChange.pm
+++ b/lib/MusicBrainz/Server/Data/EditNoteChange.pm
@@ -11,11 +11,26 @@ sub _table
     return 'edit_note_change';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, edit_note AS edit_note_id, change_editor AS editor_id, ' .
-        'change_time, status, reason, old_note, new_note';
+    return join q(, ), (
+        'id',
+        'edit_note AS edit_note_id',
+        'change_editor AS editor_id',
+        'change_time',
+        'status',
+        'reason',
+        'old_note',
+        'new_note',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _entity_class
 {

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -42,14 +42,34 @@ sub _table
     return 'editor';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'editor.id, editor.name COLLATE musicbrainz, password, privs, email, website, bio,
-            member_since, email_confirm_date, last_login_date,
-            EXISTS (SELECT 1 FROM edit WHERE edit.editor = editor.id AND edit.autoedit = 0 AND edit.status = ' . $STATUS_APPLIED . ' OFFSET 9) AS has_ten_accepted_edits,
-            gender, area,
-            birth_date, ha1, deleted';
+    return join q(, ), (
+        'editor.id',
+        'editor.name COLLATE musicbrainz',
+        'password',
+        'privs',
+        'email',
+        'website',
+        'bio',
+        'member_since',
+        'email_confirm_date',
+        'last_login_date',
+        "EXISTS (SELECT 1 FROM edit WHERE edit.editor = editor.id AND edit.autoedit = 0 AND edit.status = $STATUS_APPLIED OFFSET 9) AS has_ten_accepted_edits",
+        'gender',
+        'area',
+        'birth_date',
+        'ha1',
+        'deleted',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _area_columns { [qw( area )] }
 

--- a/lib/MusicBrainz/Server/Data/EditorLanguage.pm
+++ b/lib/MusicBrainz/Server/Data/EditorLanguage.pm
@@ -12,10 +12,22 @@ sub _table
     return 'editor_language JOIN language ON language.id = editor_language.language';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'language.*, editor, fluency, language AS language_id';
+    return join q(, ), (
+        'language.*',
+        'editor',
+        'fluency',
+        'language AS language_id',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _new_from_row {
     my ($self, $row) = @_;

--- a/lib/MusicBrainz/Server/Data/EditorOAuthToken.pm
+++ b/lib/MusicBrainz/Server/Data/EditorOAuthToken.pm
@@ -17,12 +17,29 @@ sub _table
     return 'editor_oauth_token';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, editor, application, authorization_code, ' .
-           'access_token, refresh_token, expire_time, scope, ' .
-           'code_challenge, code_challenge_method, granted';
+    return join q(, ), qw(
+        id
+        editor
+        application
+        authorization_code
+        access_token
+        refresh_token
+        expire_time
+        scope
+        code_challenge
+        code_challenge_method
+        granted
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/EntityAnnotation.pm
+++ b/lib/MusicBrainz/Server/Data/EntityAnnotation.pm
@@ -26,11 +26,23 @@ sub _table
             JOIN annotation a ON ea.annotation=a.id';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, editor AS editor_id, text, changelog,
-            created AS creation_date';
+    return join q(, ), (
+        'id',
+        'editor AS editor_id',
+        'text',
+        'changelog',
+        'created AS creation_date',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _entity_class
 {

--- a/lib/MusicBrainz/Server/Data/Event.pm
+++ b/lib/MusicBrainz/Server/Data/Event.pm
@@ -38,14 +38,35 @@ sub _type {
     return 'event';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'event.id, event.gid, event.name COLLATE musicbrainz, event.type, event.time, event.cancelled,' .
-           'event.setlist, event.edits_pending, event.begin_date_year, ' .
-           'event.begin_date_month, event.begin_date_day, event.end_date_year, ' .
-           'event.end_date_month, event.end_date_day, event.ended, ' .
-           'event.comment, event.last_updated';
+    return join q(, ), (
+        'event.id',
+        'event.gid',
+        'event.name COLLATE musicbrainz',
+        'event.type',
+        'event.time',
+        'event.cancelled',
+        'event.setlist',
+        'event.edits_pending',
+        'event.begin_date_year',
+        'event.begin_date_month',
+        'event.begin_date_day',
+        'event.end_date_year',
+        'event.end_date_month',
+        'event.end_date_day',
+        'event.ended',
+        'event.comment',
+        'event.last_updated',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _area_columns { [qw( event_area.area )] }
 

--- a/lib/MusicBrainz/Server/Data/Genre.pm
+++ b/lib/MusicBrainz/Server/Data/Genre.pm
@@ -20,10 +20,24 @@ with 'MusicBrainz::Server::Data::Role::Relatable',
 
 sub _type { 'genre' }
 
-sub _columns {
-    return 'genre.id, genre.gid, genre.name COLLATE musicbrainz,
-            genre.comment, genre.edits_pending, genre.last_updated';
+sub _build_columns
+{
+    return join q(, ), (
+        'genre.id',
+        'genre.gid',
+        'genre.name COLLATE musicbrainz',
+        'genre.comment',
+        'genre.edits_pending',
+        'genre.last_updated',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping {
     return {

--- a/lib/MusicBrainz/Server/Data/ISRC.pm
+++ b/lib/MusicBrainz/Server/Data/ISRC.pm
@@ -16,10 +16,23 @@ sub _table
     return 'isrc';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, isrc, recording, source, edits_pending';
+    return join q(, ), qw(
+        id
+        isrc
+        recording
+        source
+        edits_pending
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/ISWC.pm
+++ b/lib/MusicBrainz/Server/Data/ISWC.pm
@@ -16,10 +16,23 @@ sub _table
     return 'iswc';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, iswc, work, source, edits_pending';
+    return join q(, ), qw(
+        id
+        iswc
+        work
+        source
+        edits_pending
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/Instrument.pm
+++ b/lib/MusicBrainz/Server/Data/Instrument.pm
@@ -34,10 +34,26 @@ with 'MusicBrainz::Server::Data::Role::Relatable',
 
 sub _type { 'instrument' }
 
-sub _columns {
-    return 'instrument.id, instrument.gid, instrument.type, instrument.name COLLATE musicbrainz,
-            instrument.comment, instrument.description, instrument.edits_pending, instrument.last_updated';
+sub _build_columns
+{
+    return join q(, ), (
+        'instrument.id',
+        'instrument.gid',
+        'instrument.type',
+        'instrument.name COLLATE musicbrainz',
+        'instrument.comment',
+        'instrument.description',
+        'instrument.edits_pending',
+        'instrument.last_updated',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping {
     return {

--- a/lib/MusicBrainz/Server/Data/Label.pm
+++ b/lib/MusicBrainz/Server/Data/Label.pm
@@ -45,13 +45,34 @@ with 'MusicBrainz::Server::Data::Role::Relatable',
 
 sub _type { 'label' }
 
-sub _columns
+sub _build_columns
 {
-    return 'label.id, label.gid, label.name COLLATE musicbrainz, ' .
-           'label.type, label.area, label.edits_pending, label.label_code, ' .
-           'label.begin_date_year, label.begin_date_month, label.begin_date_day, ' .
-           'label.end_date_year, label.end_date_month, label.end_date_day, label.ended, label.comment, label.last_updated';
+    return join q(, ), (
+        'label.id',
+        'label.gid',
+        'label.name COLLATE musicbrainz',
+        'label.type',
+        'label.area',
+        'label.edits_pending',
+        'label.label_code',
+        'label.begin_date_year',
+        'label.begin_date_month',
+        'label.begin_date_day',
+        'label.end_date_year',
+        'label.end_date_month',
+        'label.end_date_day',
+        'label.ended',
+        'label.comment',
+        'label.last_updated',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _id_column
 {

--- a/lib/MusicBrainz/Server/Data/Language.pm
+++ b/lib/MusicBrainz/Server/Data/Language.pm
@@ -20,11 +20,25 @@ sub _table
     return 'language';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, iso_code_3, iso_code_2t, iso_code_2b, ' .
-           'iso_code_1, name, frequency';
+    return join q(, ), qw(
+        id
+        iso_code_3
+        iso_code_2t
+        iso_code_2b
+        iso_code_1
+        name
+        frequency
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping {
     return {

--- a/lib/MusicBrainz/Server/Data/Link.pm
+++ b/lib/MusicBrainz/Server/Data/Link.pm
@@ -25,11 +25,27 @@ sub _table
     return 'link';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, link_type, begin_date_year, begin_date_month, begin_date_day,
-            end_date_year, end_date_month, end_date_day, ended';
+    return join q(, ), qw(
+        id
+        link_type
+        begin_date_year
+        begin_date_month
+        begin_date_day
+        end_date_year
+        end_date_month
+        end_date_day
+        ended
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/LinkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Data/LinkAttributeType.pm
@@ -48,28 +48,45 @@ sub _table
         ') AS ins ON ins.instrument_gid = link_attribute_type.gid';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, parent, child_order, gid, name, description, root, ' .
-           'lat_root.root_name, ' .
-           'lat_root.root_gid, ' .
-           'lat_parent.parent_name, ' .
-           'lat_parent.parent_gid, ' .
-           'COALESCE(
-                (SELECT TRUE FROM link_text_attribute_type
-                 WHERE attribute_type = link_attribute_type.id),
-                false
-            ) AS free_text, ' .
-           'COALESCE(
-                (SELECT TRUE FROM link_creditable_attribute_type
-                 WHERE attribute_type = link_attribute_type.id),
-                false
-            ) AS creditable, ' .
-           q{COALESCE(ins.instrument_comment, '') AS instrument_comment, } .
-           'ins.instrument_type_id, ' .
-           q{COALESCE(ins.instrument_type_name, '') AS instrument_type_name, } .
-           'ins.instrument_aliases';
+    return join q(, ), (
+        'id',
+        'parent',
+        'child_order',
+        'gid',
+        'name',
+        'description',
+        'root',
+        'lat_root.root_name',
+        'lat_root.root_gid',
+        'lat_parent.parent_name',
+        'lat_parent.parent_gid',
+        'COALESCE(
+            (SELECT TRUE
+               FROM link_text_attribute_type
+              WHERE attribute_type = link_attribute_type.id),
+            false
+        ) AS free_text',
+        'COALESCE(
+            (SELECT TRUE
+               FROM link_creditable_attribute_type
+              WHERE attribute_type = link_attribute_type.id),
+            false
+        ) AS creditable',
+        q{COALESCE(ins.instrument_comment, '') AS instrument_comment},
+        'ins.instrument_type_id',
+        q{COALESCE(ins.instrument_type_name, '') AS instrument_type_name},
+        'ins.instrument_aliases',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/LinkType.pm
+++ b/lib/MusicBrainz/Server/Data/LinkType.pm
@@ -27,16 +27,35 @@ sub _table
     return 'link_type';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, parent AS parent_id, gid, name, link_phrase,
-            entity_type0 AS entity0_type, entity_type1 AS entity1_type,
-            reverse_link_phrase, description, priority,
-            child_order, long_link_phrase, is_deprecated, has_dates,
-            entity0_cardinality, entity1_cardinality,
-            COALESCE((SELECT direction FROM orderable_link_type
-                      WHERE link_type = id), 0) AS orderable_direction';
+    return join q(, ), (
+        'id',
+        'parent AS parent_id',
+        'gid',
+        'name',
+        'link_phrase',
+        'entity_type0 AS entity0_type',
+        'entity_type1 AS entity1_type',
+        'reverse_link_phrase',
+        'description',
+        'priority',
+        'child_order',
+        'long_link_phrase',
+        'is_deprecated',
+        'has_dates',
+        'entity0_cardinality',
+        'entity1_cardinality',
+        'COALESCE((SELECT direction FROM orderable_link_type WHERE link_type = id), 0) AS orderable_direction',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _entity_class
 {

--- a/lib/MusicBrainz/Server/Data/Medium.pm
+++ b/lib/MusicBrainz/Server/Data/Medium.pm
@@ -20,13 +20,27 @@ sub _table
     return 'medium';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'medium.id, release, position, format, medium.name,
-            medium.edits_pending, track_count,
-            COALESCE((SELECT TRUE FROM track WHERE medium = medium.id AND position = 0), false) AS has_pregap,
-            (SELECT count(*) FROM track WHERE medium = medium.id AND position > 0 AND is_data_track = false) AS cdtoc_track_count';
+    return join q(, ), (
+        'medium.id',
+        'release',
+        'position',
+        'format',
+        'medium.name',
+        'medium.edits_pending',
+        'track_count',
+        'COALESCE((SELECT TRUE FROM track WHERE medium = medium.id AND position = 0), false) AS has_pregap',
+        '(SELECT count(*) FROM track WHERE medium = medium.id AND position > 0 AND is_data_track = false) AS cdtoc_track_count',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _id_column
 {

--- a/lib/MusicBrainz/Server/Data/MediumCDTOC.pm
+++ b/lib/MusicBrainz/Server/Data/MediumCDTOC.pm
@@ -20,10 +20,22 @@ sub _table
     return 'medium_cdtoc';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'medium_cdtoc.id, medium, cdtoc, edits_pending';
+    return join q(, ), qw(
+        medium_cdtoc.id
+        medium
+        cdtoc
+        edits_pending
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/MediumFormat.pm
+++ b/lib/MusicBrainz/Server/Data/MediumFormat.pm
@@ -17,10 +17,26 @@ sub _table
     return 'medium_format';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, gid, name, year, parent, child_order, has_discids, description';
+    return join q(, ), qw(
+        id
+        gid
+        name
+        year
+        parent
+        child_order
+        has_discids
+        description
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping {
     return {

--- a/lib/MusicBrainz/Server/Data/Place.pm
+++ b/lib/MusicBrainz/Server/Data/Place.pm
@@ -35,12 +35,36 @@ with 'MusicBrainz::Server::Data::Role::Relatable',
 
 sub _type { 'place' }
 
-sub _columns
+sub _build_columns
 {
-    return 'place.id, place.gid, place.name COLLATE musicbrainz, place.type, place.address, place.area, place.coordinates[0] as coordinates_x, ' .
-           'place.coordinates[1] as coordinates_y, place.edits_pending, place.begin_date_year, place.begin_date_month, place.begin_date_day, ' .
-           'place.end_date_year, place.end_date_month, place.end_date_day, place.ended, place.comment, place.last_updated';
+    return join q(, ), (
+        'place.id',
+        'place.gid',
+        'place.name COLLATE musicbrainz',
+        'place.type',
+        'place.address',
+        'place.area',
+        'place.coordinates[0] as coordinates_x',
+        'place.coordinates[1] as coordinates_y',
+        'place.edits_pending',
+        'place.begin_date_year',
+        'place.begin_date_month',
+        'place.begin_date_day',
+        'place.end_date_year',
+        'place.end_date_month',
+        'place.end_date_day',
+        'place.ended',
+        'place.comment',
+        'place.last_updated',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _id_column
 {

--- a/lib/MusicBrainz/Server/Data/Recording.pm
+++ b/lib/MusicBrainz/Server/Data/Recording.pm
@@ -39,13 +39,28 @@ with 'MusicBrainz::Server::Data::Role::Relatable',
 
 sub _type { 'recording' }
 
-sub _columns
+sub _build_columns
 {
-    return 'recording.id, recording.gid, recording.name COLLATE musicbrainz,
-            recording.artist_credit AS artist_credit_id,
-            recording.length, recording.comment, recording.video,
-            recording.edits_pending, recording.last_updated';
+    return join q(, ), (
+        'recording.id',
+        'recording.gid',
+        'recording.name COLLATE musicbrainz',
+        'recording.artist_credit AS artist_credit_id',
+        'recording.length',
+        'recording.comment',
+        'recording.video',
+        'recording.edits_pending',
+        'recording.last_updated',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
+
 sub _column_mapping
 {
     return {

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -61,13 +61,32 @@ Readonly::Hash our %RELEASE_MERGE_ERRORS => (
 
 sub _type { 'release' }
 
-sub _columns
+sub _build_columns
 {
-    return 'release.id, release.gid, release.name COLLATE musicbrainz, release.artist_credit AS artist_credit_id,
-            release.release_group, release.status, release.packaging,
-            release.comment, release.edits_pending, release.barcode,
-            release.script, release.language, release.quality, release.last_updated';
+    return join q(, ), (
+        'release.id',
+        'release.gid',
+        'release.name COLLATE musicbrainz',
+        'release.artist_credit AS artist_credit_id',
+        'release.release_group',
+        'release.status',
+        'release.packaging',
+        'release.comment',
+        'release.edits_pending',
+        'release.barcode',
+        'release.script',
+        'release.language',
+        'release.quality',
+        'release.last_updated',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _id_column
 {

--- a/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
@@ -49,15 +49,29 @@ sub _table
             JOIN release_group_meta rgm ON rgm.id = rg.id';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'rg.id, rg.gid, rg.type AS primary_type_id, rg.name COLLATE musicbrainz,
-            rg.artist_credit AS artist_credit_id,
-            rg.comment, rg.edits_pending, rg.last_updated,
-            rgm.first_release_date_year,
-            rgm.first_release_date_month,
-            rgm.first_release_date_day';
+    return join q(, ), (
+        'rg.id',
+        'rg.gid',
+        'rg.type AS primary_type_id',
+        'rg.name COLLATE musicbrainz',
+        'rg.artist_credit AS artist_credit_id',
+        'rg.comment',
+        'rg.edits_pending',
+        'rg.last_updated',
+        'rgm.first_release_date_year',
+        'rgm.first_release_date_month',
+        'rgm.first_release_date_day',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping {
     return {

--- a/lib/MusicBrainz/Server/Data/ReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseLabel.pm
@@ -17,11 +17,22 @@ sub _table
     return 'release_label rl';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'rl.id AS rl_id, rl.release AS rl_release, rl.label AS rl_label,
-            rl.catalog_number AS rl_catalog_number';
+    return join q(, ), (
+        'rl.id AS rl_id',
+        'rl.release AS rl_release',
+        'rl.label AS rl_label',
+        'rl.catalog_number AS rl_catalog_number',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/Role/AliasType.pm
+++ b/lib/MusicBrainz/Server/Data/Role/AliasType.pm
@@ -7,7 +7,24 @@ use MusicBrainz::Server::Data::Utils qw( load_subobjects );
 
 with 'MusicBrainz::Server::Data::Role::OptionsTree';
 
-sub _columns { 'id, gid, name, parent AS parent_id, child_order, description' }
+sub _build_columns
+{
+    return join q(, ), (
+        'id',
+        'gid',
+        'name',
+        'parent AS parent_id',
+        'child_order',
+        'description',
+    );
+}
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub load {
     my ($self, @objs) = @_;

--- a/lib/MusicBrainz/Server/Data/Role/Attribute.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Attribute.pm
@@ -4,9 +4,24 @@ use namespace::autoclean;
 
 with 'MusicBrainz::Server::Data::Role::InsertUpdateDelete';
 
-sub _columns {
-    return 'id, gid, name, parent, child_order, description';
+sub _build_columns
+{
+    return join q(, ), qw(
+        id
+        gid
+        name
+        parent
+        child_order
+        description
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping {
     return {

--- a/lib/MusicBrainz/Server/Data/Script.pm
+++ b/lib/MusicBrainz/Server/Data/Script.pm
@@ -18,10 +18,23 @@ sub _table
     return 'script';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, iso_code, iso_number, name, frequency';
+    return join q(, ), qw(
+        id
+        iso_code
+        iso_number
+        name
+        frequency
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping {
     return {

--- a/lib/MusicBrainz/Server/Data/Series.pm
+++ b/lib/MusicBrainz/Server/Data/Series.pm
@@ -39,10 +39,26 @@ with 'MusicBrainz::Server::Data::Role::Relatable',
 
 sub _type { 'series' }
 
-sub _columns {
-    return 'series.id, series.gid, series.name COLLATE musicbrainz, series.comment, ' .
-           'series.type, ordering_type, series.edits_pending, series.last_updated';
+sub _build_columns
+{
+    return join q(, ), (
+        'series.id',
+        'series.gid',
+        'series.name COLLATE musicbrainz',
+        'series.comment',
+        'series.type',
+        'series.ordering_type',
+        'series.edits_pending',
+        'series.last_updated',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping {
     return {

--- a/lib/MusicBrainz/Server/Data/SeriesType.pm
+++ b/lib/MusicBrainz/Server/Data/SeriesType.pm
@@ -14,9 +14,25 @@ sub _table {
     return 'series_type';
 }
 
-sub _columns {
-    return 'id, gid, name, entity_type, parent, child_order, description';
+sub _build_columns
+{
+    return join q(, ), qw(
+        id
+        gid
+        name
+        entity_type
+        parent
+        child_order
+        description
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping {
     return {

--- a/lib/MusicBrainz/Server/Data/Statistics/ByDate.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics/ByDate.pm
@@ -10,7 +10,22 @@ with 'MusicBrainz::Server::Data::Role::Sql';
 
 sub _table { 'statistics.statistic' }
 
-sub _columns { 'id, date_collected, name, value' }
+sub _build_columns
+{
+    return join q(, ), qw(
+        id
+        date_collected
+        name
+        value
+    );
+}
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _entity_class
 {

--- a/lib/MusicBrainz/Server/Data/Statistics/ByName.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics/ByName.pm
@@ -10,7 +10,22 @@ with 'MusicBrainz::Server::Data::Role::Sql';
 
 sub _table { 'statistics.statistic' }
 
-sub _columns { 'id, date_collected, name, value' }
+sub _build_columns
+{
+    return join q(, ), qw(
+        id
+        date_collected
+        name
+        value
+    );
+}
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _entity_class
 {

--- a/lib/MusicBrainz/Server/Data/StatisticsEvent.pm
+++ b/lib/MusicBrainz/Server/Data/StatisticsEvent.pm
@@ -21,9 +21,22 @@ sub _id_column
     return 'statistic_event.date';
 }
 
-sub _columns {
-    return 'date, title, description, link';
+sub _build_columns
+{
+    return join q(, ), qw(
+        date
+        title
+        description
+        link
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping {
     return {

--- a/lib/MusicBrainz/Server/Data/Tag.pm
+++ b/lib/MusicBrainz/Server/Data/Tag.pm
@@ -26,12 +26,21 @@ sub _id_column
     return 'tag.id';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'tag.id,
-            tag.name,
-            coalesce(genre.id, genre_alias.genre) as genre_id';
+    return join q(, ), (
+        'tag.id',
+        'tag.name',
+        'coalesce(genre.id, genre_alias.genre) as genre_id',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/Track.pm
+++ b/lib/MusicBrainz/Server/Data/Track.pm
@@ -26,12 +26,29 @@ with 'MusicBrainz::Server::Data::Role::EntityModelClass',
 
 sub _type { 'track' }
 
-sub _columns
+sub _build_columns
 {
-    return 'track.id, track.gid, track.name, track.medium, track.recording,
-            track.number, track.position, track.length, track.artist_credit,
-            track.edits_pending, track.is_data_track';
+    return join q(, ), qw(
+        track.id
+        track.gid
+        track.name
+        track.medium
+        track.recording
+        track.number
+        track.position
+        track.length
+        track.artist_credit
+        track.edits_pending
+        track.is_data_track
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping {
     return {

--- a/lib/MusicBrainz/Server/Data/URL.pm
+++ b/lib/MusicBrainz/Server/Data/URL.pm
@@ -242,10 +242,22 @@ my %URL_SPECIALIZATIONS = (
 
 );
 
-sub _columns
+sub _build_columns
 {
-    return 'id, gid, url, edits_pending';
+    return join q(, ), qw(
+        id
+        gid
+        url
+        edits_pending
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _entity_class
 {

--- a/lib/MusicBrainz/Server/Data/ValueSet.pm
+++ b/lib/MusicBrainz/Server/Data/ValueSet.pm
@@ -30,11 +30,18 @@ sub _table {
     return $self->entity_type . q(_) . $self->value_type;
 }
 
-sub _columns {
+sub _build_columns {
     my $self = shift;
 
     return $self->entity_type . q(, ) . $self->value_type;
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping {
     my $self = shift;

--- a/lib/MusicBrainz/Server/Data/Vote.pm
+++ b/lib/MusicBrainz/Server/Data/Vote.pm
@@ -12,10 +12,24 @@ use MusicBrainz::Server::Types qw( VoteOption );
 
 extends 'MusicBrainz::Server::Data::Entity';
 
-sub _columns
+sub _build_columns
 {
-    return 'id, editor, edit, vote_time, vote, superseded';
+    return join q(, ), qw(
+        id
+        editor
+        edit
+        vote_time
+        vote
+        superseded
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _table
 {

--- a/lib/MusicBrainz/Server/Data/Work.pm
+++ b/lib/MusicBrainz/Server/Data/Work.pm
@@ -38,11 +38,25 @@ with 'MusicBrainz::Server::Data::Role::Relatable',
 
 sub _type { 'work' }
 
-sub _columns
+sub _build_columns
 {
-    return 'work.id, work.gid, work.type,
-            work.name COLLATE musicbrainz, work.comment, work.edits_pending, work.last_updated';
+    return join q(, ), (
+        'work.id',
+        'work.gid',
+        'work.type',
+        'work.name COLLATE musicbrainz',
+        'work.comment',
+        'work.edits_pending',
+        'work.last_updated',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/WorkAttribute.pm
+++ b/lib/MusicBrainz/Server/Data/WorkAttribute.pm
@@ -15,12 +15,22 @@ sub _table
     return 'work_attribute';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, work_attribute_type AS type_id, ' .
-           'work_attribute_type_allowed_value AS value_id, ' .
-           'work_attribute_text AS value';
+    return join q(, ), (
+        'id',
+        'work_attribute_type AS type_id',
+        'work_attribute_type_allowed_value AS value_id',
+        'work_attribute_text AS value',
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/WorkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Data/WorkAttributeType.pm
@@ -17,10 +17,26 @@ sub _table
     return 'work_attribute_type';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, gid, name, free_text, parent, child_order, comment, description';
+    return join q(, ), qw(
+        id
+        gid
+        name
+        free_text
+        parent
+        child_order
+        comment
+        description
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {

--- a/lib/MusicBrainz/Server/Data/WorkAttributeTypeAllowedValue.pm
+++ b/lib/MusicBrainz/Server/Data/WorkAttributeTypeAllowedValue.pm
@@ -15,10 +15,25 @@ sub _table
     return 'work_attribute_type_allowed_value';
 }
 
-sub _columns
+sub _build_columns
 {
-    return 'id, gid, work_attribute_type, value, parent, child_order, description';
+    return join q(, ), qw(
+        id
+        gid
+        work_attribute_type
+        value
+        parent
+        child_order
+        description
+    );
 }
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
 
 sub _column_mapping
 {


### PR DESCRIPTION
### Implement MBS-12359

# Description
This changes the implementation of `_columns` to list each column on one row, and turns it into a lazy Moose attribute using a `builder` in order to cache the result of the `join` call.

# Testing
Only automated testing at the moment.