### PR TITLE
MBS-13505: Split relationships on task attributes

### DIFF
--- a/root/static/scripts/common/constants.js
+++ b/root/static/scripts/common/constants.js
@@ -51,6 +51,8 @@ export const INSTRUMENT_ROOT_ID = 14;
 
 export const VOCAL_ROOT_ID = 3;
 
+export const TASK_ATTRIBUTE_ID = 1150;
+
 export const AREA_TYPE_COUNTRY = 1;
 
 export const ARTIST_TYPE_PERSON = 1;

--- a/root/static/scripts/tests/relationship-editor.js
+++ b/root/static/scripts/tests/relationship-editor.js
@@ -304,7 +304,7 @@ test('merging duplicate relationships', function (t) {
 });
 
 test('splitRelationshipByAttributes', function (t) {
-  t.plan(16);
+  t.plan(19);
 
   const lyre = {
     type: {
@@ -663,6 +663,55 @@ test('splitRelationshipByAttributes', function (t) {
       },
     ),
     'second relationship contains drums',
+  );
+
+  // This test ensures tasks are treated the same as instruments and vocals.
+
+  const task = {
+    text_value: 'dancer',
+    type: {
+      gid: '39867b3b-0f1e-40d5-b602-4f3936b7f486',
+    },
+    typeID: 1150,
+    typeName: 'task',
+  };
+
+  const modifiedRelationship6 = {
+    ...existingRelationship,
+    _original: existingRelationship,
+    _status: REL_STATUS_EDIT,
+    attributes: tree.union(
+      existingRelationship.attributes,
+      tree.fromDistinctAscArray([task]),
+      compareLinkAttributeIds,
+      onConflictUseSecondValue,
+    ),
+  };
+  Object.freeze(modifiedRelationship6);
+
+  splitRelationships =
+    splitRelationshipByAttributes(modifiedRelationship6);
+
+  t.ok(
+    splitRelationships.length === 2,
+    'two relationships are returned',
+  );
+  t.ok(
+    splitRelationships[0] === existingRelationship,
+    'first relationship is the original',
+  );
+  t.ok(
+    relationshipsAreIdentical(
+      splitRelationships[1],
+      {
+        ...modifiedRelationship6,
+        _original: null,
+        _status: REL_STATUS_ADD,
+        attributes: tree.fromDistinctAscArray([task]),
+        id: splitRelationships[1].id,
+      },
+    ),
+    'second relationship only contains task',
   );
 
   /*

--- a/t/sql/initial.sql
+++ b/t/sql/initial.sql
@@ -173,6 +173,7 @@ INSERT INTO link_attribute_type VALUES (750, NULL, 750, 0, '37da3398-5d1b-4acb-b
 INSERT INTO link_attribute_type VALUES (788, NULL, 788, 0, 'a59c5830-5ec7-38fe-9a21-c7ea54f6650a', 'number', 'This attribute indicates the number of a work in a series.', '2014-05-14 16:39:54.654562+00');
 INSERT INTO link_attribute_type VALUES (830, NULL, 830, 0, 'ebd303c3-7f57-452a-aa3b-d780ebad868d', 'time', 'Local time a band''s performance is scheduled to start, formatted HH:MM.', '2014-11-18 14:34:00.964336+00');
 INSERT INTO link_attribute_type VALUES (921, NULL, 921, 0, 'efd89258-fb07-48e9-acf9-0a54ce03606d', 'cancelled', 'This indicates an artist cancelled their appearance at an event.', '2016-07-04 18:28:11.756249+00');
+INSERT INTO link_attribute_type VALUES (1150, NULL, 1150, 0, '39867b3b-0f1e-40d5-b602-4f3936b7f486', 'task', 'This specifies the credited task(s) for a relationship that can be credited in many different ways, such as "producer", or one that is otherwise generic, such as "miscellaneous support".', '2022-08-25 11:39:02.649033+00');
 
 INSERT INTO link_creditable_attribute_type VALUES (3);
 INSERT INTO link_creditable_attribute_type VALUES (14);


### PR DESCRIPTION
### Implement MBS-13505

# Problem
Task attributes, like instruments and vocals, should lead to split relationships, rather than be kept on new split relationships. This is needed for STYLE-2445 to lead to results that make sense.

If we add a new "member of" relationship with attributes "task: dancer", "instrument: piano" and "vocals: lead vocals":

* Currently, we end up with two split relationships, "task: dancer and piano" and "task: dancer and lead vocals".
* We want to end up with three split relationships, "task: dancer", "piano" and "lead vocals".

# Solution
Just add task to the list of things that we check for in `isInstrumentOrVocal` (which is changed to `isSplittableAttribute` because `isInstrumentOrTaskOrVocal` seemed too silly).

# Testing
Added a test for this case to the existing `splitRelationshipByAttributes` tests.

# Further action
Once this is released (on prod, probably) I'll actually implement STYLE-2445 adding the `task` attribute to `member of` relationships. 