### PR TITLE
MBS-13507: Load areas for events in collections

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -163,9 +163,7 @@ sub show : Chained('load') PathPart('') {
         $c->model('ReleaseGroupSecondaryType')->load_for_release_groups(@$entities);
         $c->model('ReleaseGroup')->load_has_cover_art(@$entities);
     } elsif ($entity_type eq 'event') {
-        $c->model('EventType')->load(@$entities);
-        $model->load_performers(@$entities);
-        $model->load_locations(@$entities);
+        $c->model('Event')->load_areas(@$entities);
     } elsif ($entity_type eq 'place') {
         $c->model('PlaceType')->load(@$entities);
         $c->model('Area')->load(@$entities);


### PR DESCRIPTION
### Fix MBS-13507

# Problem
Areas were not being loaded for events displayed in the collection view.

# Solution
Just load the areas. We don't need to load types, performers and locations separately since they're already loaded as part of `load_related_info` so this drops those as well.

# Testing
Manually, with the collection shown in the ticket.