### PR TITLE
Move some common database import subroutines to `Script::Utils`

### DIFF
--- a/admin/replication/ImportReplicationChanges
+++ b/admin/replication/ImportReplicationChanges
@@ -9,6 +9,7 @@ use FindBin;
 use lib "$FindBin::Bin/../../lib";
 
 use Getopt::Long;
+use MusicBrainz::Script::Utils qw( is_table_empty );
 use MusicBrainz::Server::Context;
 use DBDefs;
 use Sql;
@@ -156,7 +157,7 @@ sub ImportTable
         $sql->commit;
 
         die 'Error loading data'
-                if -f $file and empty($table);
+                if -f $file and is_table_empty($sql, $table);
 
         ++$tables;
         $totalrows += $rows;
@@ -170,17 +171,6 @@ sub ImportTable
 
     ++$errors, return 0 if $fIgnoreErrors;
     exit 1;
-}
-
-sub empty
-{
-    my $table = shift;
-
-    my $any = $sql->select_single_value(
-        "SELECT 1 FROM $table LIMIT 1",
-    );
-
-    not defined $any;
 }
 
 sub ImportReplicationTables
@@ -197,7 +187,7 @@ sub ImportReplicationTables
         my $file = find_file($table);
         $file or print("No data file found for '$table', skipping\n"), die;
 
-        if (not empty($table))
+        if (not is_table_empty($sql, $table))
         {
             die "$table already contains data; skipping\n";
             next;
@@ -226,7 +216,7 @@ sub ImportDBMirror2ReplicationTables {
         }
 
         my $qualified_table = "dbmirror2.$table";
-        if (!empty($qualified_table)) {
+        if (!is_table_empty($sql, $qualified_table)) {
             die "$qualified_table already contains data";
         }
 

--- a/admin/replication/ImportReplicationChanges
+++ b/admin/replication/ImportReplicationChanges
@@ -9,7 +9,10 @@ use FindBin;
 use lib "$FindBin::Bin/../../lib";
 
 use Getopt::Long;
-use MusicBrainz::Script::Utils qw( is_table_empty );
+use MusicBrainz::Script::Utils qw(
+    copy_table_from_file
+    is_table_empty
+);
 use MusicBrainz::Server::Context;
 use DBDefs;
 use Sql;
@@ -105,72 +108,19 @@ sub ImportTable
 {
     my ($table, $file) = @_;
 
-    print localtime() . " : load $table\n";
+    my $rows = copy_table_from_file(
+        $sql, $table, $file,
+        ignore_errors => $fIgnoreErrors,
+    );
 
-    my $rows = 0;
-
-    my $t1 = [gettimeofday];
-    my $interval;
-
-    my $size = -s($file) || 1;
-
-    my $p = sub {
-        my ($pre, $post) = @_;
-        no integer;
-        printf $pre.'%-30.30s %9d %3d%% %9d'.$post,
-                $table, $rows, int(100 * tell(LOAD) / $size),
-                $rows / ($interval||1);
-    };
-
-    $OUTPUT_AUTOFLUSH = 1;
-
-    eval
-    {
-        open(LOAD, '<:encoding(utf8)', $file) or die "open $file: $OS_ERROR";
-
-        $sql->begin;
-        my $dbh = $sql->dbh; # issues a ping, must be done before COPY
-        $sql->do("COPY $table FROM stdin");
-
-        $p->('', '');
-
-        while (<LOAD>)
-        {
-                $dbh->pg_putcopydata($_) or die;
-
-                ++$rows;
-                unless ($rows & 0xFFF)
-                {
-                        $interval = tv_interval($t1);
-                        $p->("\r", '');
-                }
-        }
-
-        $dbh->pg_putcopyend() or die;
-
-        $interval = tv_interval($t1);
-        $p->("\r", sprintf(" %.2f sec\n", $interval));
-
-        close LOAD
-                or die $OS_ERROR;
-
-        $sql->commit;
-
-        die 'Error loading data'
-                if -f $file and is_table_empty($sql, $table);
-
+    if ($rows) {
         ++$tables;
         $totalrows += $rows;
-
-        1;
-    };
-
-    return 1 unless $EVAL_ERROR;
-    warn "Error loading $file: $EVAL_ERROR";
-    $sql->rollback;
-
-    ++$errors, return 0 if $fIgnoreErrors;
-    exit 1;
+        return 1;
+    } else {
+        ++$errors;
+        return 0;
+    }
 }
 
 sub ImportReplicationTables

--- a/lib/MusicBrainz/Script/Utils.pm
+++ b/lib/MusicBrainz/Script/Utils.pm
@@ -8,7 +8,12 @@ use feature 'state';
 
 use base 'Exporter';
 
-our @EXPORT_OK = qw( get_primary_keys log retry );
+our @EXPORT_OK = qw(
+    get_primary_keys
+    is_table_empty
+    log
+    retry
+);
 
 =sub get_primary_keys
 
@@ -37,6 +42,20 @@ sub get_primary_keys($$$) {
     } @keys;
     $cache->{$table} = \@keys;
     return @keys;
+}
+
+=sub is_table_empty
+
+Returns whether C<$table> is empty.
+
+=cut
+
+sub is_table_empty {
+    my ($sql, $table) = @_;
+
+    not defined $sql->select_single_value(<<~"SQL");
+        SELECT 1 FROM $table LIMIT 1;
+        SQL
 }
 
 =sub log

--- a/lib/MusicBrainz/Script/Utils.pm
+++ b/lib/MusicBrainz/Script/Utils.pm
@@ -2,18 +2,131 @@ package MusicBrainz::Script::Utils;
 use strict;
 use warnings;
 
+use Encode;
 use English;
+use Time::HiRes qw( gettimeofday tv_interval );
 
 use feature 'state';
 
 use base 'Exporter';
 
 our @EXPORT_OK = qw(
+    copy_table_from_file
     get_primary_keys
     is_table_empty
     log
     retry
 );
+
+=sub copy_table_from_file
+
+Imports C<$file> into C<$table> via PostgreSQL's C<COPY> statement.
+
+Returns the number of rows imported.
+
+=cut
+
+sub copy_table_from_file {
+    my ($sql, $table, $file, %opts) = @_;
+
+    my $delete_first = $opts{delete_first};
+    my $fix_utf8 = $opts{fix_utf8};
+    my $ignore_errors = $opts{ignore_errors};
+    my $quiet = $opts{quiet};
+    my $show_progress = !$quiet && ($opts{show_progress} // (-t STDOUT));
+
+    print localtime() . " : load $table\n"
+        unless $quiet;
+
+    my $rows = 0;
+    my $t1 = [gettimeofday];
+    my $interval;
+
+    my $size = -s($file)
+        or return 1;
+
+    my $p = sub {
+        my ($pre, $post) = @_;
+        no integer;
+        printf $pre.'%-30.30s %9d %3d%% %9d'.$post,
+                $table, $rows, int(100 * tell(LOAD) / $size),
+                $rows / ($interval || 1);
+    };
+
+    $OUTPUT_AUTOFLUSH = 1;
+
+    eval {
+        # Open in :bytes mode (always keep byte octets), to allow fixing of
+        # invalid UTF-8 byte sequences in --fix-broken-utf8 mode.
+        # In default mode, the Pg driver will take care of the UTF-8
+        # transformation and croak on any invalid UTF-8 character.
+        open(LOAD, '<:bytes', $file) or die "open $file: $OS_ERROR";
+
+        # If you're looking at this code because your import failed, maybe
+        # with an error like this:
+        #   ERROR:  copy: line 1, Missing data for column "automodsaccepted"
+        # then the chances are it's because the data you're trying to load
+        # doesn't match the structure of the database you're trying to load
+        # it into. Please make sure you've got the right copy of the server
+        # code, as described in the INSTALL file.
+
+        $sql->begin;
+        $sql->do("DELETE FROM $table") if $delete_first;
+
+        my $dbh = $sql->dbh; # issues a ping, must be done before COPY
+        $sql->do("COPY $table FROM stdin");
+
+        $p->('', '') if $show_progress;
+
+        my $t;
+        while (<LOAD>) {
+            $t = $_;
+            if ($fix_utf8) {
+                # Replaces any invalid UTF-8 character with special 0xFFFD
+                # codepoint and warn on any such occurence.
+                $t = Encode::decode('UTF-8', $t,
+                                    Encode::FB_DEFAULT |
+                                    Encode::WARN_ON_ERR);
+            } else {
+                $t = Encode::decode('UTF-8', $t, Encode::FB_CROAK);
+            }
+            if (!$dbh->pg_putcopydata($t)) {
+                print 'ERROR while processing: ', $t;
+                die;
+            }
+
+            ++$rows;
+            unless ($rows & 0xFFF) {
+                $interval = tv_interval($t1);
+                $p->("\r", '') if $show_progress;
+            }
+        }
+
+        $dbh->pg_putcopyend or die;
+
+        $interval = tv_interval($t1);
+        $p->(($show_progress ? "\r" : ''),
+             sprintf(" %.2f sec\n", $interval))
+            unless $quiet;
+
+        close LOAD
+            or die $OS_ERROR;
+
+        $sql->commit;
+
+        die 'Error loading data'
+            if -f $file and is_table_empty($sql, $table);
+
+        1;
+    };
+
+    return $rows unless $EVAL_ERROR;
+    warn "Error loading $file: $EVAL_ERROR";
+    $sql->rollback;
+
+    return 0 if $ignore_errors;
+    exit 1;
+}
 
 =sub get_primary_keys
 


### PR DESCRIPTION
# Problem

 * We have some identical or very similar-looking subroutines duplicated between admin/MBImport.pl and admin/replication/ImportReplicationChanges: `empty` (to tell if a table is empty) and `ImportTable` (to import a table from a file). The two implementations of the latter function differ slightly.

 * For the incremental dumps (`MusicBrainz::Script::Role::IncrementalDump`), I'd like to reuse the `ImportTable` function to import a dbmirror2 packet into some temporary tables (to parse it).
   
   We currently parse the old packets by hand; I'm surprised it works at all (it probably doesn't in some cases) because I don't believe it fully or properly implement's parsing of PostgreSQL's `COPY` `text` format. dbmirror2 packets contain JSON, which may contain *JSON escape sequences* underneath `COPY`'s *`text` format escape sequences*, and the mixing of these can be tricky to parse. It's much, much easier to let PostgreSQL do the parsing!

# Solution

This just adds two shared subroutines, `is_table_empty` and `copy_table_from_file` to `Script::Utils`, and modifies admin/MBImport.pl and admin/replication/ImportReplicationChanges to use them.

# Testing

We have existing automated tests that make heavy use of these scripts.

I did not test the `--fix-broken-utf8` or `--ignore-errors` flags specifically.