### PR TITLE
MBS-13417: Allow filtering away bootleg-only recordings

### DIFF
--- a/lib/MusicBrainz/Server/Form/Filter/Recording.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Recording.pm
@@ -21,8 +21,12 @@ has_field 'video' => (
     type => 'Select',
 );
 
+has_field 'hide_bootlegs' => (
+    type => 'Checkbox',
+);
+
 sub filter_field_names {
-    return qw/ disambiguation name artist_credit_id video /;
+    return qw/ disambiguation name artist_credit_id hide_bootlegs video /;
 }
 
 sub options_artist_credit_id {

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -30,6 +30,7 @@ export type EventFilterT = $ReadOnly<{
 type RecordingFilterFormT = FormT<{
   ...GenericFilterFormFieldsT,
   +artist_credit_id: FieldT<number>,
+  +hide_bootlegs: FieldT<boolean>,
   +video: FieldT<number>,
 }>;
 
@@ -218,6 +219,23 @@ const FilterForm = ({form}: Props): React$Element<'div'> => (
                     }}
                     style={{maxWidth: '40em'}}
                     uncontrolled
+                  />
+                </td>
+              </tr>
+              <tr>
+                <td
+                  title={l(`Hide recordings that only appear
+                            on bootleg releases`)}
+                >
+                  {addColonText(l('Hide bootleg-only'))}
+                </td>
+                <td>
+                  <input
+                    defaultChecked={form.field.hide_bootlegs.value}
+                    id={'id-' + String(form.field.hide_bootlegs.html_name)}
+                    name={form.field.hide_bootlegs.html_name}
+                    type="checkbox"
+                    value="1"
                   />
                 </td>
               </tr>

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
@@ -174,8 +174,8 @@ test 'Release page filtering' => sub {
     my $tx = test_xpath_html($mech->content);
     $tx->is(
         'count(//table[@class="tbl"]/tbody/tr)',
-        '6',
-        'There are six entries in the unfiltered release table',
+        '7',
+        'There are seven entries in the unfiltered release table',
     );
 
     $mech->get_ok(
@@ -473,6 +473,18 @@ test 'Recording page filtering' => sub {
         'count(//table[@class="tbl"]/tbody/tr)',
         '2',
         'There are two entries in the recording table after filtering by disambiguation',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/recordings?filter.hide_bootlegs=1',
+        'Fetched artist recordings page with non-bootleg only option',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '3',
+        'There are three entries in the recording table after filtering by non-bootleg only',
     );
 };
 

--- a/t/sql/filtering.sql
+++ b/t/sql/filtering.sql
@@ -28,7 +28,8 @@ INSERT INTO release_group (id, gid, name, artist_credit, type)
            (3402, '98b72608-a824-40c5-b5df-81cf981faf7e', 'Symphonies / Concertos / Choral and Vocal Works', 3400, 1),
            (3403, '33d71de2-d3c6-4906-908e-df59d70b283d', 'Lutosławski', 3400, 1),
            (3404, 'fc9b775a-6c06-3828-b6a4-220b65cfef60', 'String Quartet', 3400, NULL),
-           (3405, '5a52075e-f5eb-3de5-8236-aa21cc05cb1e', 'Jeux vénetiens', 3400, 2);
+           (3405, '5a52075e-f5eb-3de5-8236-aa21cc05cb1e', 'Jeux vénetiens', 3400, 2),
+           (3406, '5a52075e-aaaa-3de5-8236-aa21cc05cb1e', 'Bootlegs vénetiens', 3400, 2);
 
 INSERT INTO release_group_secondary_type_join (release_group, secondary_type)
     VALUES (3403, 6), (3405, 6);
@@ -41,7 +42,12 @@ INSERT INTO release (id, gid, name, artist_credit, status, release_group)
            (3402, '98b72608-a824-40c5-b5df-81cf981faf7a', 'Symphonies / Concertos / Choral and Vocal Works', 3400, 1, 3402),
            (3403, '33d71de2-d3c6-4906-908e-df59d70b283a', 'Lutosławski', 3400, 1, 3403),
            (3404, 'fc9b775a-6c06-3828-b6a4-220b65cfef6a', 'String Quartet', 3400, NULL, 3404),
-           (3405, '5a52075e-f5eb-3de5-8236-aa21cc05cb1a', 'Jeux vénetiens', 3400, 5, 3405);
+           (3405, '5a52075e-f5eb-3de5-8236-aa21cc05cb1a', 'Jeux vénetiens', 3400, 5, 3405),
+           (3406, '5a52075e-aaaa-3de5-8236-aa21cc05cb1a', 'Bootlegs vénetiens', 3400, 3, 3406);
+
+INSERT INTO medium (id, release, position)
+    VALUES (3400, 3400, 1),
+           (3406, 3406, 1);
 
 INSERT INTO label (id, gid, name)
     VALUES (3400, 'ed65f6e2-5454-45a7-8607-e1106d209734', 'Erato'),
@@ -89,6 +95,11 @@ INSERT INTO recording (id, gid, name, artist_credit, video, comment)
            (3401, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c08', 'Symphony no. 3', 3401, 'f', 'Testy 2'),
            (3402, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c01', 'Brandenburg Concerto no. 5', 3401, 'f', ''),
            (3403, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c02', 'Brandenburg Concerto no. 5', 3402, 'f', '');
+
+INSERT INTO track (id, gid, recording, medium, position, number, name, artist_credit)
+    VALUES (3400, 'ce82bfa1-aaaa-494a-aaa0-fc5de79bd54f', 3400, 3400, 1, 1, 'Interludium', 3402), -- to make recording not bootleg-only
+           (3401, 'ce82bfa1-bbbb-494a-aaa0-fc5de79bd54f', 3400, 3406, 1, 1, 'Interludium', 3402),
+           (3402, 'd9c7a74e-aaaa-48b1-be2f-5d9a144f2c08', 3401, 3406, 2, 2, 'Symphony no. 3', 3401);
 
 -- Works
 


### PR DESCRIPTION
### Implement MBS-13417

# Problem
While we hide bootleg-only release groups from the overview, and we can filter releases on status to see only non-bootlegs, there's currently no way to hide unofficial recordings released only on bootlegs when looking at an artist's recording page.

# Solution
This adds a filter checkbox that provides a "hide bootleg-only" option, so that someone wanting to view or clean up an artist's official recordings does not have to deal with bootlegs at all unless they choose to.

Recordings that appear on both bootlegs and non-bootleg releases are still shown, in the same way RGs with bootleg and non-bootleg releases appear in the overview. Standalone recordings are also still displayed.

# Testing
Manually by creating bootleg and standalone recordings and making sure they still display unless they appear only on bootleg releases (even if they appear on some bootleg and some official releases).

Added a test to the `Filtering` Perl tests too.