### PR TITLE
MBS-13515: Support Bandsintown festival links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1315,7 +1315,7 @@ const CLEANUPS: CleanupEntries = {
     match: [new RegExp('^(https?://)?((m|www)\\.)?bandsintown\\.com', 'i')],
     restrict: [LINK_TYPES.bandsintown],
     clean: function (url) {
-      let m = url.match(/^(?:https?:\/\/)?(?:(?:m|www)\.)?bandsintown\.com\/(?:[a-z]{2}\/)?(a(?=rtist|\/)|e(?=vent|\/)|v(?=enue|\/))[a-z]*\/0*([1-9][0-9]*)(?:[^0-9].*)?$/);
+      let m = url.match(/^(?:https?:\/\/)?(?:(?:m|www)\.)?bandsintown\.com\/(?:[a-z]{2}\/)?(a(?=rtist|\/)|e(?=vent|\/)|f|v(?=enue|\/))[a-z]*\/0*([1-9][0-9]*)(?:[^0-9].*)?$/);
       if (m) {
         const prefix = m[1];
         const number = m[2];
@@ -1330,7 +1330,7 @@ const CLEANUPS: CleanupEntries = {
       return url;
     },
     validate: function (url, id) {
-      const m = /^https:\/\/www.bandsintown\.com\/(?:([aev])\/)?([^\/?#]+)$/.exec(url);
+      const m = /^https:\/\/www.bandsintown\.com\/(?:([aefv])\/)?([^\/?#]+)$/.exec(url);
       if (m) {
         const prefix = m[1];
         const target = m[2];
@@ -1343,7 +1343,8 @@ const CLEANUPS: CleanupEntries = {
             };
           case LINK_TYPES.bandsintown.event:
             return {
-              result: prefix === 'e' && /^[1-9][0-9]*$/.test(target),
+              result: (prefix === 'e' || prefix === 'f') &&
+                      /^[1-9][0-9]*$/.test(target),
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.bandsintown.place:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -978,6 +978,13 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://www.bandsintown.com/v/846942',
        only_valid_entity_types: ['place'],
   },
+  {
+                     input_url: 'https://www.bandsintown.com/f/133106?came_from=263&utm_medium=web&utm_source=home&utm_campaign=festival',
+             input_entity_type: 'event',
+    expected_relationship_type: 'bandsintown',
+            expected_clean_url: 'https://www.bandsintown.com/f/133106',
+       only_valid_entity_types: ['event'],
+  },
   // BBC Events
   {
                      input_url: 'http://bbc.co.uk/events/edhcd4',


### PR DESCRIPTION
### Implement MBS-13515

# Problem
Bandsintown also has `/f` (festival) links that should be allowed for events.

# Solution
Just allow `/f` as well as `/e` for events. I didn't find any examples of the style using the whole "festival" name, like the ones we have for other types of links, so not allowing those for now.

# Testing
Added a test for an example of this.