### PR TITLE
Enforce TLS for OAuth2 from beta.mb.o too

### DIFF
--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -366,7 +366,7 @@ sub WEB_SERVER                { 'www.musicbrainz.example.com' }
 # sub MAPBOX_ACCESS_TOKEN { '' }
 
 # Disallow OAuth2 requests over plain HTTP
-# sub OAUTH2_ENFORCE_TLS { my $self = shift; !$self->DB_STAGING_SERVER }
+# sub OAUTH2_ENFORCE_TLS { my $self = shift; !$self->DB_STAGING_SERVER || $self->IS_BETA }
 
 # sub USE_ETAGS { 1 }
 

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -364,7 +364,7 @@ sub MAPBOX_ACCESS_TOKEN { '' }
 sub ACTIVE_SCHEMA_SEQUENCE { 28 }
 
 # Disallow OAuth2 requests over plain HTTP
-sub OAUTH2_ENFORCE_TLS { my $self = shift; !$self->DB_STAGING_SERVER }
+sub OAUTH2_ENFORCE_TLS { my $self = shift; !$self->DB_STAGING_SERVER || $self->IS_BETA }
 
 sub USE_ETAGS { 1 }
 


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

TLS is legitimately enforced for OAuth2 from `musicbrainz.org`  since Jan 2013,
but it isn’t enforced from `beta.musicbrainz.org` which has been introduced in Feb 2013,
likely an oversight.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Enforce TLS not only from non-staging (production) server, but also from beta server.

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

Server logs have to be checked when deploying to `beta.musicbrainz.org`.