### PR TITLE
Update Flow to version 0.230.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.223.0",
+    "flow-bin": "0.223.2",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.17.1",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.229.0",
+    "flow-bin": "0.229.2",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.17.1",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.223.3",
+    "flow-bin": "0.224.0",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.17.1",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.222.0",
+    "flow-bin": "0.223.0",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.17.1",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.228.0",
+    "flow-bin": "0.229.0",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.17.1",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.220.1",
+    "flow-bin": "0.221.0",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.17.1",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.229.2",
+    "flow-bin": "0.230.0",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.17.1",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.223.2",
+    "flow-bin": "0.223.3",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.17.1",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.226.0",
+    "flow-bin": "0.227.0",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.17.1",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.225.0",
+    "flow-bin": "0.225.1",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.17.1",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.220.0",
+    "flow-bin": "0.220.1",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.17.1",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.224.0",
+    "flow-bin": "0.225.0",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.17.1",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.221.0",
+    "flow-bin": "0.222.0",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.17.1",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.227.0",
+    "flow-bin": "0.228.0",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.17.1",
     "http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.225.1",
+    "flow-bin": "0.226.0",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.17.1",
     "http-proxy": "1.18.1",

--- a/root/admin/attributes/Language.js
+++ b/root/admin/attributes/Language.js
@@ -13,9 +13,9 @@ import {compare} from '../../static/scripts/common/i18n.js';
 import loopParity from '../../utility/loopParity.js';
 
 const frequencyLabels = {
-  [0]: 'Hidden',
-  [1]: 'Other',
-  [2]: 'Frequently used',
+  0: 'Hidden',
+  1: 'Other',
+  2: 'Frequently used',
 };
 
 type Props = {

--- a/root/admin/attributes/Script.js
+++ b/root/admin/attributes/Script.js
@@ -13,10 +13,10 @@ import {compare} from '../../static/scripts/common/i18n.js';
 import loopParity from '../../utility/loopParity.js';
 
 const frequencyLabels = {
-  [1]: 'Hidden',
-  [2]: 'Other (uncommon)',
-  [3]: 'Other',
-  [4]: 'Frequently used',
+  1: 'Hidden',
+  2: 'Other (uncommon)',
+  3: 'Other',
+  4: 'Frequently used',
 };
 
 type Props = {

--- a/root/components/list/ReleaseGroupList.js
+++ b/root/components/list/ReleaseGroupList.js
@@ -157,7 +157,7 @@ const ReleaseGroupList = ({
   sortable,
 }: ReleaseGroupListProps): Array<React$Element<React$FragmentType>> => {
   const groupedReleaseGroups = groupBy(releaseGroups, x => x.typeName ?? '');
-  const tables = [];
+  const tables: Array<React$Element<React$FragmentType>> = [];
   for (const [type, releaseGroupsOfType] of groupedReleaseGroups) {
     tables.push(
       <React.Fragment key={type}>

--- a/root/static/scripts/relationship-editor/components/DialogAttribute/MultiselectAttribute.js
+++ b/root/static/scripts/relationship-editor/components/DialogAttribute/MultiselectAttribute.js
@@ -35,10 +35,16 @@ import type {
   DialogMultiselectAttributeActionT,
 } from '../../types/actions.js';
 
-const addAttributeLabels = {
-  [INSTRUMENT_ROOT_ID]: N_lp('Add instrument', 'interactive'),
-  [VOCAL_ROOT_ID]: N_l('Add vocal'),
-};
+function addAttributeLabel(attributeTypeId: ?number): string {
+  switch (attributeTypeId) {
+    case INSTRUMENT_ROOT_ID:
+      return lp('Add instrument', 'interactive');
+    case VOCAL_ROOT_ID:
+      return l('Add vocal');
+    default:
+      return lp('Add another', 'relationship attribute');
+  }
+}
 
 type PropsT = {
   +dispatch: (
@@ -177,7 +183,7 @@ const MultiselectAttribute = (React.memo<PropsT>(({
   dispatch,
 }: PropsT): React$MixedElement => {
   const linkTypeAttributeType = state.type;
-  const addLabel = addAttributeLabels[linkTypeAttributeType.id];
+  const addLabel = addAttributeLabel(linkTypeAttributeType.id);
 
   const multiselectDispatch = React.useCallback((
     action: DialogMultiselectAttributeActionT,
@@ -234,9 +240,7 @@ const MultiselectAttribute = (React.memo<PropsT>(({
 
   return (
     <LinkAttrTypeMultiselect
-      addLabel={addLabel
-        ? addLabel()
-        : lp('Add another', 'relationship attribute')}
+      addLabel={addLabel}
       buildExtraValueChildren={buildExtraValueChildren}
       dispatch={multiselectDispatch}
       state={state}

--- a/root/static/scripts/statistics.js
+++ b/root/static/scripts/statistics.js
@@ -48,13 +48,13 @@ tablesorter.addParser({
 
 $('#countries-table').tablesorter({
   headers: {
-    [0]: {sorter: false},
-    [2]: {sorter: 'fancyNumber'},
-    [3]: {sorter: 'fancyNumber'},
-    [4]: {sorter: 'fancyNumber'},
-    [5]: {sorter: 'fancyNumber'},
-    [6]: {sorter: 'fancyNumber'},
-    [7]: {sorter: 'fancyNumber'},
+    0: {sorter: false},
+    2: {sorter: 'fancyNumber'},
+    3: {sorter: 'fancyNumber'},
+    4: {sorter: 'fancyNumber'},
+    5: {sorter: 'fancyNumber'},
+    6: {sorter: 'fancyNumber'},
+    7: {sorter: 'fancyNumber'},
   },
   // order by descending number of entities, then name
   sortList: [[7, 1], [1, 0]],
@@ -63,10 +63,10 @@ $('#countries-table').tablesorter({
 
 $('#languages-table').tablesorter({
   headers: {
-    [0]: {sorter: false},
-    [2]: {sorter: 'fancyNumber'},
-    [3]: {sorter: 'fancyNumber'},
-    [4]: {sorter: 'fancyNumber'},
+    0: {sorter: false},
+    2: {sorter: 'fancyNumber'},
+    3: {sorter: 'fancyNumber'},
+    4: {sorter: 'fancyNumber'},
   },
   // order by descending number of entities, then name
   sortList: [[4, 1], [1, 0]],
@@ -74,7 +74,7 @@ $('#languages-table').tablesorter({
 });
 
 $('#scripts-table').tablesorter({
-  headers: {[0]: {sorter: false}, [2]: {sorter: 'fancyNumber'}},
+  headers: {0: {sorter: false}, 2: {sorter: 'fancyNumber'}},
   // order by descending number of entities, then name
   sortList: [[2, 1], [1, 0]],
   widgets: ['indexFirstColumn', 'loopParity'],

--- a/root/static/scripts/tests/edit/utility/linkPhrase.js
+++ b/root/static/scripts/tests/edit/utility/linkPhrase.js
@@ -33,7 +33,7 @@ test('required attributes are left with forGrouping', function (t) {
    */
   mergeLinkedEntities({
     link_attribute_type: {
-      [10000]: {
+      10000: {
         child_order: 0,
         creditable: true,
         description: 'description',
@@ -46,7 +46,7 @@ test('required attributes are left with forGrouping', function (t) {
         root_gid: 'd8c8f4d4-c7e9-4db9-93c3-319c722ddd98',
         root_id: 10000,
       },
-      [10001]: {
+      10001: {
         child_order: 0,
         creditable: true,
         description: 'description',
@@ -61,11 +61,12 @@ test('required attributes are left with forGrouping', function (t) {
       },
     },
     link_type: {
-      [10000]: {
+      10000: {
         attributes: {
-          [10000]: {
+          10000: {
             max: null,
             min: 1,
+            typeID: 10000,
           },
         },
         cardinality0: 0,
@@ -73,7 +74,9 @@ test('required attributes are left with forGrouping', function (t) {
         child_order: 1,
         deprecated: false,
         description: 'description',
+        documentation: null,
         entityType: 'link_type',
+        examples: null,
         gid: '43faf40a-281f-404f-a338-8efbe7775060',
         has_dates: true,
         id: 10000,
@@ -83,6 +86,7 @@ test('required attributes are left with forGrouping', function (t) {
         orderable_direction: 1,
         parent_id: null,
         reverse_link_phrase: 'supporting {instrument} by',
+        root_id: 10000,
         type0: 'artist',
         type1: 'artist',
       },
@@ -157,11 +161,12 @@ test('MBS-6129: Interpolating link phrases containing %', function (t) {
    */
   mergeLinkedEntities({
     link_type: {
-      [10001]: {
+      10001: {
         attributes: {
-          [3]: {
+          3: {
             max: null,
             min: 0,
+            typeID: 3,
           },
         },
         cardinality0: 0,
@@ -169,7 +174,9 @@ test('MBS-6129: Interpolating link phrases containing %', function (t) {
         child_order: 0,
         deprecated: false,
         description: '',
+        documentation: null,
         entityType: 'link_type',
+        examples: null,
         gid: 'd4013546-019d-4c59-8206-e0a6dec5d03a',
         has_dates: true,
         id: 10001,
@@ -179,6 +186,7 @@ test('MBS-6129: Interpolating link phrases containing %', function (t) {
         orderable_direction: 0,
         parent_id: null,
         reverse_link_phrase: '{vocal:%|vocals}',
+        root_id: 10001,
         type0: 'artist',
         type1: 'artist',
       },

--- a/root/types/languageandscript.js
+++ b/root/types/languageandscript.js
@@ -11,7 +11,7 @@
 
 declare type LanguageT = {
   +entityType: 'language',
-  +frequency: number,
+  +frequency: 0 | 1 | 2,
   +id: number,
   +iso_code_1: string | null,
   +iso_code_2b: string | null,
@@ -22,7 +22,7 @@ declare type LanguageT = {
 
 declare type ScriptT = {
   +entityType: 'script',
-  +frequency: number,
+  +frequency: 1 | 2 | 3 | 4,
   +id: number,
   +iso_code: string,
   +iso_number: string | null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,12 +3749,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.229.2":
-  version: 0.229.2
-  resolution: "flow-bin@npm:0.229.2"
+"flow-bin@npm:0.230.0":
+  version: 0.230.0
+  resolution: "flow-bin@npm:0.230.0"
   bin:
     flow: cli.js
-  checksum: 10845a6056c4dfe8457c2d93be85d5fbe0a110be7fff8263415be86f67f998be9a95c1f8e98934d50fb0140b620f32a83a1fcb170fb0147029c63fee948e4a67
+  checksum: f179f4b8de29ab1e3e918f64853b053116042ebba77a6e8f89310730e59d0a8e675ceeb24c3588c572369fe08a6e1319279c7c810c2a21a050f897c08fd50247
   languageName: node
   linkType: hard
 
@@ -5615,7 +5615,7 @@ __metadata:
     fast-diff: "npm:1.2.0"
     file-url: "npm:2.0.2"
     filesize: "npm:2.0.4"
-    flow-bin: "npm:0.229.2"
+    flow-bin: "npm:0.230.0"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:3.1.0"
     he: "npm:1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,12 +3749,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.221.0":
-  version: 0.221.0
-  resolution: "flow-bin@npm:0.221.0"
+"flow-bin@npm:0.222.0":
+  version: 0.222.0
+  resolution: "flow-bin@npm:0.222.0"
   bin:
     flow: cli.js
-  checksum: 78159b0fdde8b282b65924c3c8ac34778f0fcf07708f2c6a6b67c002bc7ccb066bdf6b9eabe1cb0df92f993300f7d64367a83a4dc0db8f4b957af8969cce54ae
+  checksum: c2470790bed7e347a3d4b0f16f558311a1319b35fd54790ee8154d93b559d24b000f5bb6d031f0e8567a8e45e9a51acbe5cce5ed8547370cddb38605f9d0dd6d
   languageName: node
   linkType: hard
 
@@ -5615,7 +5615,7 @@ __metadata:
     fast-diff: "npm:1.2.0"
     file-url: "npm:2.0.2"
     filesize: "npm:2.0.4"
-    flow-bin: "npm:0.221.0"
+    flow-bin: "npm:0.222.0"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:3.1.0"
     he: "npm:1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,12 +3749,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.223.0":
-  version: 0.223.0
-  resolution: "flow-bin@npm:0.223.0"
+"flow-bin@npm:0.223.2":
+  version: 0.223.2
+  resolution: "flow-bin@npm:0.223.2"
   bin:
     flow: cli.js
-  checksum: 5d51c9200ede6213a98d2fb342342031f2967dcb354d9fde4528d843a10b2e9383071b79d37fb311b10991ccd20f2d709f255badd850bb1afae9927cd4a64847
+  checksum: b1368119128142238c703bd228143929a28db84bbc6b6aa67ffd5122b99fdcb1c6b7357bb631cd78cfa672260017ae2b1b39a908ef5827e2bee1ca3afcfd55c9
   languageName: node
   linkType: hard
 
@@ -5615,7 +5615,7 @@ __metadata:
     fast-diff: "npm:1.2.0"
     file-url: "npm:2.0.2"
     filesize: "npm:2.0.4"
-    flow-bin: "npm:0.223.0"
+    flow-bin: "npm:0.223.2"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:3.1.0"
     he: "npm:1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,12 +3749,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.226.0":
-  version: 0.226.0
-  resolution: "flow-bin@npm:0.226.0"
+"flow-bin@npm:0.227.0":
+  version: 0.227.0
+  resolution: "flow-bin@npm:0.227.0"
   bin:
     flow: cli.js
-  checksum: 7f0d61701a10de48af2b2585e1ff4f296a72d451bfbc2557189bfe2943eea160f7cdcfb94e330fbe793c73788c46b1c1deb625229bcc057cee0da88c3a0a1a91
+  checksum: a90b9fcc43f9947b94dcf3935bca8f9618517b244ef5bdeececf5eaef50ca2351c0d83126d9b7b6c7d7ae7a4bea6fe6a7284d7c657250c95995e17d87cbb76d9
   languageName: node
   linkType: hard
 
@@ -5615,7 +5615,7 @@ __metadata:
     fast-diff: "npm:1.2.0"
     file-url: "npm:2.0.2"
     filesize: "npm:2.0.4"
-    flow-bin: "npm:0.226.0"
+    flow-bin: "npm:0.227.0"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:3.1.0"
     he: "npm:1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,12 +3749,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.222.0":
-  version: 0.222.0
-  resolution: "flow-bin@npm:0.222.0"
+"flow-bin@npm:0.223.0":
+  version: 0.223.0
+  resolution: "flow-bin@npm:0.223.0"
   bin:
     flow: cli.js
-  checksum: c2470790bed7e347a3d4b0f16f558311a1319b35fd54790ee8154d93b559d24b000f5bb6d031f0e8567a8e45e9a51acbe5cce5ed8547370cddb38605f9d0dd6d
+  checksum: 5d51c9200ede6213a98d2fb342342031f2967dcb354d9fde4528d843a10b2e9383071b79d37fb311b10991ccd20f2d709f255badd850bb1afae9927cd4a64847
   languageName: node
   linkType: hard
 
@@ -5615,7 +5615,7 @@ __metadata:
     fast-diff: "npm:1.2.0"
     file-url: "npm:2.0.2"
     filesize: "npm:2.0.4"
-    flow-bin: "npm:0.222.0"
+    flow-bin: "npm:0.223.0"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:3.1.0"
     he: "npm:1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,12 +3749,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.228.0":
-  version: 0.228.0
-  resolution: "flow-bin@npm:0.228.0"
+"flow-bin@npm:0.229.0":
+  version: 0.229.0
+  resolution: "flow-bin@npm:0.229.0"
   bin:
     flow: cli.js
-  checksum: 4e1cf35e32a2ca2888cade5abcc659218d7426ec8e701a0bbbf0d1f368df86f80fd1acb69f81f0e51b3a75bfcb46e7f727e5c46b3a4fc602d8043c0950934eba
+  checksum: 04aa70ffd1602870ad8730b123adca9afd03e5a74727a5f5a2c5eb7bf7daba06f0f902810ab4958879706714189a7b5012a25932649372999b6448c2d0c9ec95
   languageName: node
   linkType: hard
 
@@ -5615,7 +5615,7 @@ __metadata:
     fast-diff: "npm:1.2.0"
     file-url: "npm:2.0.2"
     filesize: "npm:2.0.4"
-    flow-bin: "npm:0.228.0"
+    flow-bin: "npm:0.229.0"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:3.1.0"
     he: "npm:1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,12 +3749,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.227.0":
-  version: 0.227.0
-  resolution: "flow-bin@npm:0.227.0"
+"flow-bin@npm:0.228.0":
+  version: 0.228.0
+  resolution: "flow-bin@npm:0.228.0"
   bin:
     flow: cli.js
-  checksum: a90b9fcc43f9947b94dcf3935bca8f9618517b244ef5bdeececf5eaef50ca2351c0d83126d9b7b6c7d7ae7a4bea6fe6a7284d7c657250c95995e17d87cbb76d9
+  checksum: 4e1cf35e32a2ca2888cade5abcc659218d7426ec8e701a0bbbf0d1f368df86f80fd1acb69f81f0e51b3a75bfcb46e7f727e5c46b3a4fc602d8043c0950934eba
   languageName: node
   linkType: hard
 
@@ -5615,7 +5615,7 @@ __metadata:
     fast-diff: "npm:1.2.0"
     file-url: "npm:2.0.2"
     filesize: "npm:2.0.4"
-    flow-bin: "npm:0.227.0"
+    flow-bin: "npm:0.228.0"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:3.1.0"
     he: "npm:1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,12 +3749,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.220.0":
-  version: 0.220.0
-  resolution: "flow-bin@npm:0.220.0"
+"flow-bin@npm:0.220.1":
+  version: 0.220.1
+  resolution: "flow-bin@npm:0.220.1"
   bin:
     flow: cli.js
-  checksum: 46d593964aa1b3a0f470ec503c12a6a3373ffb773a37e7049303ab879c77d22acc7a18c1edff6e341bddb1e4edf6b1c7539dd434941d16fa70920433b3b3daa0
+  checksum: 1a40cfdc5e80c6a91ea15c634857f0cc0717c7fc89e40475935f89d53e8ca147b0a7e798e6494dd936751e23b08430ee742b6c8e76900dcaa046d3b727408acc
   languageName: node
   linkType: hard
 
@@ -5615,7 +5615,7 @@ __metadata:
     fast-diff: "npm:1.2.0"
     file-url: "npm:2.0.2"
     filesize: "npm:2.0.4"
-    flow-bin: "npm:0.220.0"
+    flow-bin: "npm:0.220.1"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:3.1.0"
     he: "npm:1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,12 +3749,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.223.2":
-  version: 0.223.2
-  resolution: "flow-bin@npm:0.223.2"
+"flow-bin@npm:0.223.3":
+  version: 0.223.3
+  resolution: "flow-bin@npm:0.223.3"
   bin:
     flow: cli.js
-  checksum: b1368119128142238c703bd228143929a28db84bbc6b6aa67ffd5122b99fdcb1c6b7357bb631cd78cfa672260017ae2b1b39a908ef5827e2bee1ca3afcfd55c9
+  checksum: 7419c7a583710557f8288f1b6be865d4e56685bfd9fa02874bd02ada5b0795a39588d9bbc9e9adfeb99572450faef6105a28c29b00f660344dd16f96a8cf98c0
   languageName: node
   linkType: hard
 
@@ -5615,7 +5615,7 @@ __metadata:
     fast-diff: "npm:1.2.0"
     file-url: "npm:2.0.2"
     filesize: "npm:2.0.4"
-    flow-bin: "npm:0.223.2"
+    flow-bin: "npm:0.223.3"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:3.1.0"
     he: "npm:1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,12 +3749,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.220.1":
-  version: 0.220.1
-  resolution: "flow-bin@npm:0.220.1"
+"flow-bin@npm:0.221.0":
+  version: 0.221.0
+  resolution: "flow-bin@npm:0.221.0"
   bin:
     flow: cli.js
-  checksum: 1a40cfdc5e80c6a91ea15c634857f0cc0717c7fc89e40475935f89d53e8ca147b0a7e798e6494dd936751e23b08430ee742b6c8e76900dcaa046d3b727408acc
+  checksum: 78159b0fdde8b282b65924c3c8ac34778f0fcf07708f2c6a6b67c002bc7ccb066bdf6b9eabe1cb0df92f993300f7d64367a83a4dc0db8f4b957af8969cce54ae
   languageName: node
   linkType: hard
 
@@ -5615,7 +5615,7 @@ __metadata:
     fast-diff: "npm:1.2.0"
     file-url: "npm:2.0.2"
     filesize: "npm:2.0.4"
-    flow-bin: "npm:0.220.1"
+    flow-bin: "npm:0.221.0"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:3.1.0"
     he: "npm:1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,12 +3749,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.224.0":
-  version: 0.224.0
-  resolution: "flow-bin@npm:0.224.0"
+"flow-bin@npm:0.225.0":
+  version: 0.225.0
+  resolution: "flow-bin@npm:0.225.0"
   bin:
     flow: cli.js
-  checksum: 6f5821f8177d10337c7bc5b81c29e2e22ae7eb8e753bcb01d92756414c12a645c6120fc23ef60c462f9027c88fdd74c044a4352892c1fcbaad95f2a0a645031b
+  checksum: bc299ef4537685d4b3af8950c7c6363d229f40c1eac86c6bcddf029adb3ba1757bc55ad4732cfbb6ef31dca9a5fcca3886e1bd711b5985e7c096736bab711fbe
   languageName: node
   linkType: hard
 
@@ -5615,7 +5615,7 @@ __metadata:
     fast-diff: "npm:1.2.0"
     file-url: "npm:2.0.2"
     filesize: "npm:2.0.4"
-    flow-bin: "npm:0.224.0"
+    flow-bin: "npm:0.225.0"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:3.1.0"
     he: "npm:1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,12 +3749,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.225.0":
-  version: 0.225.0
-  resolution: "flow-bin@npm:0.225.0"
+"flow-bin@npm:0.225.1":
+  version: 0.225.1
+  resolution: "flow-bin@npm:0.225.1"
   bin:
     flow: cli.js
-  checksum: bc299ef4537685d4b3af8950c7c6363d229f40c1eac86c6bcddf029adb3ba1757bc55ad4732cfbb6ef31dca9a5fcca3886e1bd711b5985e7c096736bab711fbe
+  checksum: dd91973af705a33a0fea9b7171adcec1af2a5f1ed2b4bfbe5fe83337ff4d3a3f45f8a89b077ce33b9e8ce19f5785f6af75911b0428b232641deee37c23feb8a8
   languageName: node
   linkType: hard
 
@@ -5615,7 +5615,7 @@ __metadata:
     fast-diff: "npm:1.2.0"
     file-url: "npm:2.0.2"
     filesize: "npm:2.0.4"
-    flow-bin: "npm:0.225.0"
+    flow-bin: "npm:0.225.1"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:3.1.0"
     he: "npm:1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,12 +3749,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.223.3":
-  version: 0.223.3
-  resolution: "flow-bin@npm:0.223.3"
+"flow-bin@npm:0.224.0":
+  version: 0.224.0
+  resolution: "flow-bin@npm:0.224.0"
   bin:
     flow: cli.js
-  checksum: 7419c7a583710557f8288f1b6be865d4e56685bfd9fa02874bd02ada5b0795a39588d9bbc9e9adfeb99572450faef6105a28c29b00f660344dd16f96a8cf98c0
+  checksum: 6f5821f8177d10337c7bc5b81c29e2e22ae7eb8e753bcb01d92756414c12a645c6120fc23ef60c462f9027c88fdd74c044a4352892c1fcbaad95f2a0a645031b
   languageName: node
   linkType: hard
 
@@ -5615,7 +5615,7 @@ __metadata:
     fast-diff: "npm:1.2.0"
     file-url: "npm:2.0.2"
     filesize: "npm:2.0.4"
-    flow-bin: "npm:0.223.3"
+    flow-bin: "npm:0.224.0"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:3.1.0"
     he: "npm:1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,12 +3749,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.225.1":
-  version: 0.225.1
-  resolution: "flow-bin@npm:0.225.1"
+"flow-bin@npm:0.226.0":
+  version: 0.226.0
+  resolution: "flow-bin@npm:0.226.0"
   bin:
     flow: cli.js
-  checksum: dd91973af705a33a0fea9b7171adcec1af2a5f1ed2b4bfbe5fe83337ff4d3a3f45f8a89b077ce33b9e8ce19f5785f6af75911b0428b232641deee37c23feb8a8
+  checksum: 7f0d61701a10de48af2b2585e1ff4f296a72d451bfbc2557189bfe2943eea160f7cdcfb94e330fbe793c73788c46b1c1deb625229bcc057cee0da88c3a0a1a91
   languageName: node
   linkType: hard
 
@@ -5615,7 +5615,7 @@ __metadata:
     fast-diff: "npm:1.2.0"
     file-url: "npm:2.0.2"
     filesize: "npm:2.0.4"
-    flow-bin: "npm:0.225.1"
+    flow-bin: "npm:0.226.0"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:3.1.0"
     he: "npm:1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,12 +3749,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.229.0":
-  version: 0.229.0
-  resolution: "flow-bin@npm:0.229.0"
+"flow-bin@npm:0.229.2":
+  version: 0.229.2
+  resolution: "flow-bin@npm:0.229.2"
   bin:
     flow: cli.js
-  checksum: 04aa70ffd1602870ad8730b123adca9afd03e5a74727a5f5a2c5eb7bf7daba06f0f902810ab4958879706714189a7b5012a25932649372999b6448c2d0c9ec95
+  checksum: 10845a6056c4dfe8457c2d93be85d5fbe0a110be7fff8263415be86f67f998be9a95c1f8e98934d50fb0140b620f32a83a1fcb170fb0147029c63fee948e4a67
   languageName: node
   linkType: hard
 
@@ -5615,7 +5615,7 @@ __metadata:
     fast-diff: "npm:1.2.0"
     file-url: "npm:2.0.2"
     filesize: "npm:2.0.4"
-    flow-bin: "npm:0.229.0"
+    flow-bin: "npm:0.229.2"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:3.1.0"
     he: "npm:1.1.1"


### PR DESCRIPTION
Mostly trivial updates, 0.224.0 and 0.226.0 required small changes (see commit messages).

Latest version 0.231.0 causes a lot of errors, so let's do these, then that in a separate PR.