### PR TITLE
Make duplicated artist begin/end labels consistent

### DIFF
--- a/root/static/scripts/edit/MB/Control/ArtistEdit.js
+++ b/root/static/scripts/edit/MB/Control/ArtistEdit.js
@@ -70,11 +70,14 @@ MB.Control.ArtistEdit = function () {
       case '5':
       case '6':
         self.changeDateText(
-          l('Founded:'),
-          l('Dissolved:'),
+          addColonText(lp('Founded', 'group artist')),
+          addColonText(lp('Dissolved', 'group artist')),
           l('This group has dissolved.'),
         );
-        self.changeAreaText(l('Founded in:'), l('Dissolved in:'));
+        self.changeAreaText(
+          addColonText(lp('Founded in', 'group artist')),
+          addColonText(lp('Dissolved in', 'group artist')),
+        );
         self.disableGender();
         break;
     }


### PR DESCRIPTION
We had added context to these in one place but left them with a colon and no context in other. This reuses the new variants with context in `Control/ArtistEdit`.