### PR TITLE
Drop duplicate "Begin/End area:" colon strings

### DIFF
--- a/root/artist/utils.js
+++ b/root/artist/utils.js
@@ -16,7 +16,7 @@ export function artistBeginAreaLabel(typeId: ?number): string {
     case 6:
       return addColonText(lp('Founded in', 'group artist'));
     default:
-      return l('Begin area:');
+      return addColonText(l('Begin area'));
   }
 }
 
@@ -44,7 +44,7 @@ export function artistEndAreaLabel(typeId: ?number): string {
     case 6:
       return addColonText(lp('Dissolved in', 'group artist'));
     default:
-      return l('End area:');
+      return addColonText(l('End area'));
   }
 }
 

--- a/root/static/scripts/edit/MB/Control/ArtistEdit.js
+++ b/root/static/scripts/edit/MB/Control/ArtistEdit.js
@@ -52,7 +52,10 @@ MB.Control.ArtistEdit = function () {
           addColonText(lp('Ended', 'artist end date')),
           l('This artist has ended.'),
         );
-        self.changeAreaText(l('Begin area:'), l('End area:'));
+        self.changeAreaText(
+          addColonText(l('Begin area')),
+          addColonText(l('End area')),
+        );
         self.enableGender();
         break;
 


### PR DESCRIPTION
There's no difference between these and the existing labels that don't have a colon.