### PR TITLE
Add /ws/js/check-login endpoint

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/js.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js.pm
@@ -808,7 +808,7 @@ sub get_json_request_body : Private {
 sub cookie_login_or_error : Private {
     my ($self, $c, $error) = @_;
 
-    $c->forward('/user/cookie_login') unless $c->user_exists;
+    $c->forward('/user/cookie_login');
     $self->detach_with_error($c, $error) unless $c->user_exists;
 }
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -703,7 +703,7 @@ sub edit : Chained('/') PathPart('ws/js/edit') CaptureArgs(0) Edit {
         $c->forward('/ws/js/detach_with_error', ['this server is in read-only mode']);
     }
 
-    $c->forward('/ws/js/check_login', [{
+    $c->forward('/ws/js/cookie_login_or_error', [{
         errorCode => $ERROR_NOT_LOGGED_IN,
         message => l('You must be logged in to submit edits. {url|Log in} ' .
                      'first, and then try submitting your edits again.',

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -519,6 +519,7 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   'Controller::WS::js::Work::search',
   'Controller::WS::js::cdstub',
   'Controller::WS::js::cdstub_search',
+  'Controller::WS::js::check_login',
   'Controller::WS::js::cover_art_upload',
   'Controller::WS::js::default',
   'Controller::WS::js::entities',

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/CheckLogin.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/CheckLogin.pm
@@ -1,0 +1,39 @@
+package t::MusicBrainz::Server::Controller::WS::js::CheckLogin;
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Routine;
+use JSON;
+use MusicBrainz::Server::Test;
+
+with 't::Mechanize', 't::Context';
+
+test all => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c);
+
+    $mech->get_ok('/ws/js/check-login');
+    $test->mech->header_is('Cache-Control', 'no-store');
+    $test->mech->header_is('Pragma', 'no-cache');
+
+    my $json = JSON->new;
+    my $data = $json->decode($mech->content);
+    is($data->{id}, undef, 'id is null if not logged in');
+    is($data->{name}, undef, 'name is null if not logged in');
+
+    $mech->get_ok('/login');
+    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+
+    $mech->get_ok('/ws/js/check-login');
+    $test->mech->header_is('Cache-Control', 'no-store');
+    $test->mech->header_is('Pragma', 'no-cache');
+
+    $data = $json->decode($mech->content);
+    is($data->{id}, 1, 'id is set if logged in');
+    is($data->{name}, 'new_editor', 'name is set if logged in');
+};
+
+1;


### PR DESCRIPTION
# Problem

Quoting @amCap1712 AKA lucifer from IRC:

"[W]e intend to add a /oauth2 route to MB.org (exact path of the route yet to be decided). [G]ateways will route requests on this path to a new MeB.org container and that will handle OAuth stuff. It will read the cookies set by MB and then use it to determine the current user to perform relevant actions."

"We need to do this because if we run the OAuth stuff under MeB.org, they will need to have a MeB.org account and login there to perform any OAuth2 related actions, which would still be fine for creation and modification of applications but having users do that to approve access to applications would be cumbersome."

# Solution

To help resolve this, I'm exposing an endpoint, /ws/js/check-login, which can be called by the new MeB container internally with the cookies it receives to determine the logged-in user.

If the user is logged in, the response is as follows:

```JSON
{"id": 58244, "name": "Bitmap"}
```

Otherwise, both properties are `null`:

```JSON
{"id": null, "name": null}
```

A status code of 200 is returned in both cases.

# Testing

Tested locally. Added some automated tests.