### PR TITLE
MBS-13522 / MBS-13523: ReleasesSameBarcode report improvements

### DIFF
--- a/lib/MusicBrainz/Server/Report/ReleasesSameBarcode.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesSameBarcode.pm
@@ -12,7 +12,7 @@ sub query {
     q{
         SELECT DISTINCT ON (r.id)
             r.barcode AS barcode, r.id AS release_id, r.release_group AS release_group_id,
-            row_number() OVER (ORDER BY r.barcode, r.name COLLATE musicbrainz)
+            row_number() OVER (ORDER BY lpad(r.barcode, greatest(length(r.barcode), 14), '0'), r.name COLLATE musicbrainz)
         FROM
             release r
         WHERE r.barcode IS NOT NULL -- skip unset
@@ -20,7 +20,7 @@ sub query {
         AND r.status != 3 -- skip bootlegs
         AND EXISTS (
             SELECT 1 FROM release r2
-                WHERE r.barcode = r2.barcode
+                WHERE lpad(r.barcode, greatest(length(r.barcode), 14), '0') = lpad(r2.barcode, greatest(length(r2.barcode), 14), '0')
                 AND r2.status != 3 -- skip bootlegs
                 AND r.release_group != r2.release_group
         )

--- a/lib/MusicBrainz/Server/Report/ReleasesSameBarcode.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesSameBarcode.pm
@@ -17,11 +17,11 @@ sub query {
             release r
         WHERE r.barcode IS NOT NULL -- skip unset
         AND r.barcode != '' -- skip [none]
-        AND r.status != 3 -- skip bootlegs
+        AND r.status IS DISTINCT FROM 3 -- skip bootlegs
         AND EXISTS (
             SELECT 1 FROM release r2
                 WHERE lpad(r.barcode, greatest(length(r.barcode), 14), '0') = lpad(r2.barcode, greatest(length(r2.barcode), 14), '0')
-                AND r2.status != 3 -- skip bootlegs
+                AND r2.status IS DISTINCT FROM 3 -- skip bootlegs
                 AND r.release_group != r2.release_group
         )
     };


### PR DESCRIPTION
### Implement MBS-13522 / Fix MBS-13523

# Problem
The "Releases with same barcode in different RGs" report is missing positives for two reasons:
* It skips releases with status unset
* It doesn't see different zero-padding (EAN vs UPC) as the same

# Solution
Use `lpad` to compare barcodes after zero-padding them, and fix the bootleg skipping code to not also skip null values. See commit messages for details.

# Testing
Manually, by creating duplicate barcode releases and making sure they appear in the report:
* When one has no status set
* When one has extra zero padding
* When both are the same, but larger than 14 chars (made up barcode `12345615095201225`)