### PR TITLE
Update Flow to 0.231.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.230.0",
+    "flow-bin": "0.231.0",
     "gettext-parser": "3.1.0",
     "hermes-eslint": "0.20.1",
     "http-proxy": "1.18.1",

--- a/root/account/ChangePassword.js
+++ b/root/account/ChangePassword.js
@@ -37,7 +37,7 @@ const ChangePasswordPageContent = ({
   form,
   isMandatory = false,
   userExists = false,
-}: Props): React$Element<React$FragmentType> => (
+}: Props): React.MixedElement => (
   <>
     {isMandatory ? (
       <p>

--- a/root/cdtoc/CDTocInfo.js
+++ b/root/cdtoc/CDTocInfo.js
@@ -16,7 +16,7 @@ type Props = {
   +cdToc: CDTocT,
 };
 
-const CDTocInfo = ({cdToc}: Props): React$Element<React$FragmentType> => (
+const CDTocInfo = ({cdToc}: Props): React.MixedElement => (
   <>
     <h2>{l('CD TOC details')}</h2>
 

--- a/root/collection/CollectionHeader.js
+++ b/root/collection/CollectionHeader.js
@@ -25,7 +25,7 @@ type Props = {
 const CollectionHeader = ({
   collection,
   page,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const $c = React.useContext(SanitizedCatalystContext);
   const owner = collection.editor;
   const viewingOwnCollection = Boolean(

--- a/root/components/Aliases/ArtistCreditList.js
+++ b/root/components/Aliases/ArtistCreditList.js
@@ -26,7 +26,7 @@ type Props = {
 const ArtistCreditList = ({
   artistCredits,
   entity,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const $c = React.useContext(SanitizedCatalystContext);
   return (
     <>

--- a/root/components/Artwork.js
+++ b/root/components/Artwork.js
@@ -36,7 +36,7 @@ export const ArtworkImage = ({
   artwork,
   hover,
   message,
-}: Props): React$Element<React$FragmentType> => (
+}: Props): React.MixedElement => (
   <>
     <noscript>
       <img src={artwork.small_ia_thumbnail} />

--- a/root/components/EntityHeader.js
+++ b/root/components/EntityHeader.js
@@ -31,7 +31,7 @@ const EntityHeader = ({
   page,
   preHeader,
   subHeading,
-}: Props): React$Element<React$FragmentType> => (
+}: Props): React.MixedElement => (
   <>
     <div className={'wrap-anywhere ' + headerClass}>
       {nonEmpty(preHeader) ? preHeader : null}

--- a/root/components/PaginatedResults.js
+++ b/root/components/PaginatedResults.js
@@ -32,7 +32,7 @@ const PaginatedResults = ({
   query,
   search = false,
   total = false,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const $c = React.useContext(CatalystContext);
   const paginator = (
     <Paginator

--- a/root/components/ReleaseLanguageScript.js
+++ b/root/components/ReleaseLanguageScript.js
@@ -9,7 +9,7 @@
 
 const ReleaseLanguageScript = ({
   release,
-}: {release: ReleaseT}): React$Element<React$FragmentType> => {
+}: {release: ReleaseT}): React.MixedElement => {
   const language = release.language;
   const script = release.script;
 

--- a/root/components/TagEntitiesList.js
+++ b/root/components/TagEntitiesList.js
@@ -45,7 +45,7 @@ const TagEntitiesList = ({
   tag,
   taggedEntities,
   user,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const $c = React.useContext(CatalystContext);
 
   const totalCount = Object.values(taggedEntities)

--- a/root/components/list/EventList.js
+++ b/root/components/list/EventList.js
@@ -57,7 +57,7 @@ const EventList = ({
   showRatings = false,
   showType = false,
   sortable,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(

--- a/root/components/list/ReleaseGroupList.js
+++ b/root/components/list/ReleaseGroupList.js
@@ -155,9 +155,9 @@ const ReleaseGroupList = ({
   seriesItemNumbers,
   showRatings,
   sortable,
-}: ReleaseGroupListProps): Array<React$Element<React$FragmentType>> => {
+}: ReleaseGroupListProps): Array<React.MixedElement> => {
   const groupedReleaseGroups = groupBy(releaseGroups, x => x.typeName ?? '');
-  const tables: Array<React$Element<React$FragmentType>> = [];
+  const tables: Array<React.MixedElement> = [];
   for (const [type, releaseGroupsOfType] of groupedReleaseGroups) {
     tables.push(
       <React.Fragment key={type}>

--- a/root/components/list/WorkList.js
+++ b/root/components/list/WorkList.js
@@ -44,7 +44,7 @@ const WorkList = ({
   showRatings = false,
   sortable,
   works,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(

--- a/root/edit/components/EditList.js
+++ b/root/edit/components/EditList.js
@@ -42,7 +42,7 @@ const EditList = ({
   refineUrlArgs,
   username,
   voter,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const $c = React.useContext(SanitizedCatalystContext);
 
   /*

--- a/root/edit/components/EditSummary.js
+++ b/root/edit/components/EditSummary.js
@@ -33,7 +33,7 @@ type Props = {
 const EditSummary = ({
   edit,
   index,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const $c = React.useContext(CatalystContext);
   const user = $c.user;
   const mayAddNote = editorMayAddNote(edit, user);

--- a/root/edit/components/EditorTypeInfo.js
+++ b/root/edit/components/EditorTypeInfo.js
@@ -16,7 +16,7 @@ type Props = {
 
 const EditorTypeInfo = ({
   editor,
-}: Props): React$Element<React$FragmentType> | null => (
+}: Props): React.MixedElement | null => (
   editor == null ? null : (
     <>
       {editor.is_limited ? (

--- a/root/edit/components/ListHeader.js
+++ b/root/edit/components/ListHeader.js
@@ -28,7 +28,7 @@ const QuickLinks = ({
   page,
   refineUrlArgs,
   username,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const $c = React.useContext(CatalystContext);
   const isSecureConnection = $c.req.secure;
   const protocol = isSecureConnection ? 'https://' : 'http://';

--- a/root/edit/components/TrackDurationChanges.js
+++ b/root/edit/components/TrackDurationChanges.js
@@ -24,7 +24,7 @@ const TrackDurationChanges = ({
   newLengths,
   oldLabel,
   oldLengths,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const lengthsSize = oldLengths.length;
   const lengthComparisonTables = [];
   for (let i = 0; i < lengthsSize; i++) {

--- a/root/edit/details/AddRelationshipType.js
+++ b/root/edit/details/AddRelationshipType.js
@@ -21,7 +21,7 @@ type Props = {
 
 const AddRelationshipType = ({
   edit,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const display = edit.display_data;
   const entity0Type = ENTITY_NAMES[display.entity0_type]();
   const entity1Type = ENTITY_NAMES[display.entity1_type]();

--- a/root/edit/details/EditRelationshipType.js
+++ b/root/edit/details/EditRelationshipType.js
@@ -90,7 +90,7 @@ function formatExample(
 
 const EditRelationshipType = ({
   edit,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const display = edit.display_data;
   const name = display.name;
   const oldDescription = display.description?.old ?? '';

--- a/root/edit/details/EditUrl.js
+++ b/root/edit/details/EditUrl.js
@@ -19,7 +19,7 @@ type Props = {
   +edit: EditUrlEditT,
 };
 
-const EditUrl = ({edit}: Props): React$Element<React$FragmentType> => {
+const EditUrl = ({edit}: Props): React.MixedElement => {
   const display = edit.display_data;
   const description = display.description;
   const uri = display.uri;

--- a/root/edit/details/MergeReleases.js
+++ b/root/edit/details/MergeReleases.js
@@ -220,7 +220,7 @@ function getHtmlVars(
 
 const MergeReleases = ({
   edit,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const display = edit.display_data;
   const emptyReleases = display.empty_releases;
   const changes = display.changes;

--- a/root/edit/details/RemoveMedium.js
+++ b/root/edit/details/RemoveMedium.js
@@ -31,7 +31,7 @@ const areTracksEqual = (a: TrackT, b: TrackT) => (
 
 const RemoveMedium = ({
   edit,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const display = edit.display_data;
   const originalTracklist = display.tracks ?? [];
   const currentTracklist = display.medium.tracks ?? [];

--- a/root/edit/details/historic/EditRelationship.js
+++ b/root/edit/details/historic/EditRelationship.js
@@ -29,7 +29,7 @@ type Props = {
 
 const EditRelationship = ({
   edit,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const oldRels = edit.display_data.relationship.old;
   const newRels = edit.display_data.relationship.new;
   const isDataBroken = oldRels.length !== newRels.length;

--- a/root/layout/components/FaviconLinks.js
+++ b/root/layout/components/FaviconLinks.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const FaviconLinks = (): React$Element<React$FragmentType> => (
+const FaviconLinks = (): React.MixedElement => (
   <>
     <link
       href="/static/images/favicons/apple-touch-icon-57x57.png"

--- a/root/layout/components/sidebar/AnnotationLinks.js
+++ b/root/layout/components/sidebar/AnnotationLinks.js
@@ -19,7 +19,7 @@ type Props = {
 
 const AnnotationLinks = ({
   entity,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const $c = React.useContext(CatalystContext);
   const numberOfRevisions = $c.stash.number_of_revisions ?? 0;
 

--- a/root/layout/components/sidebar/EditLinks.js
+++ b/root/layout/components/sidebar/EditLinks.js
@@ -24,7 +24,7 @@ const EditLinks = ({
   children,
   entity,
   requiresPrivileges = false,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const $c = React.useContext(CatalystContext);
   return (
     <>

--- a/root/layout/components/sidebar/SidebarProperties.js
+++ b/root/layout/components/sidebar/SidebarProperties.js
@@ -17,7 +17,7 @@ export const SidebarProperty = ({
   children,
   className,
   label,
-}: SidebarPropertyProps): React$Element<React$FragmentType> => (
+}: SidebarPropertyProps): React.MixedElement => (
   <>
     <dt>{label}</dt>
     <dd className={className}>

--- a/root/layout/components/sidebar/SidebarRating.js
+++ b/root/layout/components/sidebar/SidebarRating.js
@@ -20,7 +20,7 @@ type Props = {
 const SidebarRating = ({
   entity,
   heading,
-}: Props): React$Element<React$FragmentType> => (
+}: Props): React.MixedElement => (
   <>
     <h2 className="rating">{nonEmpty(heading) ? heading : l('Rating')}</h2>
     <p>

--- a/root/layout/components/sidebar/SidebarTags.js
+++ b/root/layout/components/sidebar/SidebarTags.js
@@ -57,7 +57,7 @@ const TagList = ({
 
 const SidebarTags = ({
   entity,
-}: SidebarTagsProps): React$Element<React$FragmentType> | null => {
+}: SidebarTagsProps): React.MixedElement | null => {
   const $c = React.useContext(CatalystContext);
   const aggregatedTags = $c.stash.top_tags;
   const more = Boolean($c.stash.more_tags);

--- a/root/layout/components/sidebar/SubscriptionLinks.js
+++ b/root/layout/components/sidebar/SubscriptionLinks.js
@@ -20,7 +20,7 @@ type Props = {
 
 const SubscriptionLinks = ({
   entity,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const $c = React.useContext(CatalystContext);
   const entityType = entity.entityType;
   const id = encodeURIComponent(String(entity.id));

--- a/root/main/error/components/ErrorEnvironment.js
+++ b/root/main/error/components/ErrorEnvironment.js
@@ -19,7 +19,7 @@ type Props = {
 const ErrorEnvironment = ({
   hostname,
   useLanguages = false,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const $c = React.useContext(CatalystContext);
   return (
     <>

--- a/root/release/CoverArt.js
+++ b/root/release/CoverArt.js
@@ -26,7 +26,7 @@ type Props = {
 
 const CoverArtLinks = ({
   artwork,
-}: {artwork: ArtworkT}): React$Element<React$FragmentType> => (
+}: {artwork: ArtworkT}): React.MixedElement => (
   <>
     {artwork.small_thumbnail ? (
       <>

--- a/root/release/CoverArtFields.js
+++ b/root/release/CoverArtFields.js
@@ -26,7 +26,7 @@ type Props = {
 const CoverArtFields = ({
   form,
   typeIdOptions,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const typeIdField = form.field.type_id;
   const selectedTypeIds = new Set(typeIdField.value.map(
     value => String(value),

--- a/root/search/components/SearchForm.js
+++ b/root/search/components/SearchForm.js
@@ -67,7 +67,7 @@ const methodOptions = [
 
 const SearchForm = ({
   form,
-}: Props): React$Element<React$FragmentType> => (
+}: Props): React.MixedElement => (
   <>
     <div className="searchform">
       <form action="/search" method="get">

--- a/root/static/scripts/alias/AliasEditForm.js
+++ b/root/static/scripts/alias/AliasEditForm.js
@@ -201,7 +201,7 @@ const AliasEditForm = ({
   form: initialForm,
   locales,
   searchHintType,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const localeOptions = {
     grouped: false,
     options: locales,

--- a/root/static/scripts/common/components/AcoustIdCell.js
+++ b/root/static/scripts/common/components/AcoustIdCell.js
@@ -89,7 +89,7 @@ function loadAcoustIdData(
 
 const AcoustIdCell = ({
   recordingMbid,
-}: PropsT): React$Element<React$FragmentType> => {
+}: PropsT): React.MixedElement => {
   const [acoustIdTracks, setAcoustIdTracks] = React.useState<
     $ReadOnlyArray<AcoustIdTrackT> | null,
   >(null);

--- a/root/static/scripts/common/components/Relationships.js
+++ b/root/static/scripts/common/components/Relationships.js
@@ -70,7 +70,7 @@ const Relationships = (React.memo<PropsT>(({
   relationships: passedRelationships,
   showIfEmpty = false,
   source,
-}: PropsT): React$Element<React$FragmentType> => {
+}: PropsT): React.MixedElement => {
   let srcRels = source.relationships;
   let relationships = passedRelationships;
   if (!relationships) {

--- a/root/static/scripts/common/components/ReleaseEvent.js
+++ b/root/static/scripts/common/components/ReleaseEvent.js
@@ -18,7 +18,7 @@ type Props = {
 
 const ReleaseEvent = ({
   event,
-}: Props): React$Element<React$FragmentType> => (
+}: Props): React.MixedElement => (
   <>
     {isDateEmpty(event.date) ? null : (
       <>

--- a/root/static/scripts/common/components/WorkListEntry.js
+++ b/root/static/scripts/common/components/WorkListEntry.js
@@ -48,7 +48,7 @@ export const WorkListRow = ({
   showIswcs = false,
   showRatings = false,
   work,
-}: WorkListRowProps): React$Element<React$FragmentType> => {
+}: WorkListRowProps): React.MixedElement => {
   const $c = React.useContext(CatalystContext);
 
   return (

--- a/root/static/scripts/edit/components/DateRangeFieldset.js
+++ b/root/static/scripts/edit/components/DateRangeFieldset.js
@@ -173,7 +173,7 @@ const DateRangeFieldset = (React.memo<PropsT>(({
   dispatch,
   endedLabel,
   field,
-}: PropsT): React$Element<React$FragmentType> => {
+}: PropsT): React.MixedElement => {
   const subfields = field.field;
 
   const hooks = useDateRangeFieldset(dispatch);

--- a/root/static/scripts/edit/components/EntityPendingEditsWarning.js
+++ b/root/static/scripts/edit/components/EntityPendingEditsWarning.js
@@ -19,7 +19,7 @@ type PropsT = {
 
 const EntityPendingEditsWarning = ({
   entity,
-}: PropsT): React$Element<React$FragmentType> | null => {
+}: PropsT): React.MixedElement | null => {
   const hasPendingEdits = Boolean(entity.editsPending);
   const openEditsLink = entityHref(entity, '/open_edits');
 

--- a/root/static/scripts/edit/components/InlineSubmitButton.js
+++ b/root/static/scripts/edit/components/InlineSubmitButton.js
@@ -13,7 +13,7 @@ type PropsT = {
 
 const InlineSubmitButton = ({
   label,
-}: PropsT): React$Element<React$FragmentType> => (
+}: PropsT): React.MixedElement => (
   <>
     {' '}
     <span className="buttons inline">

--- a/root/static/scripts/edit/components/RelationshipPendingEditsWarning.js
+++ b/root/static/scripts/edit/components/RelationshipPendingEditsWarning.js
@@ -26,7 +26,7 @@ type PropsT = {
 
 const RelationshipPendingEditsWarning = ({
   relationship,
-}: PropsT): React$Element<React$FragmentType> | null => {
+}: PropsT): React.MixedElement | null => {
   const hasPendingEdits = relationship.editsPending;
   const openEditsLink = getOpenEditsLink(relationship);
 

--- a/root/static/scripts/edit/components/edit/RelationshipDiff.js
+++ b/root/static/scripts/edit/components/edit/RelationshipDiff.js
@@ -66,7 +66,7 @@ const RelationshipDiff = (React.memo(({
   newRelationship,
   oldRelationship,
   makeEntityLink = makeDescriptiveLink,
-}: Props): React$Element<React$FragmentType> => {
+}: Props): React.MixedElement => {
   const oldAttrs = keyBy(oldRelationship.attributes, getTypeId);
   const newAttrs = keyBy(newRelationship.attributes, getTypeId);
 

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -1430,7 +1430,7 @@ export class ExternalLink extends React.Component<LinkProps> {
     setTimeout(() => target.style.backgroundColor = 'initial', 1000);
   }
 
-  render(): React$Element<React$FragmentType> {
+  render(): React.MixedElement {
     const props = this.props;
     const notEmpty = props.relationships.some(link => {
       return !isEmpty(link);

--- a/root/tag/EntityList.js
+++ b/root/tag/EntityList.js
@@ -136,7 +136,7 @@ export const EntityListContent = ({
   showVotesSelect = false,
   tag,
   user,
-}: EntityListContentProps): React$Element<React$FragmentType> => {
+}: EntityListContentProps): React.MixedElement => {
   const $c = React.useContext(CatalystContext);
   return (
     <>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4284,12 +4284,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.230.0":
-  version: 0.230.0
-  resolution: "flow-bin@npm:0.230.0"
+"flow-bin@npm:0.231.0":
+  version: 0.231.0
+  resolution: "flow-bin@npm:0.231.0"
   bin:
     flow: cli.js
-  checksum: f179f4b8de29ab1e3e918f64853b053116042ebba77a6e8f89310730e59d0a8e675ceeb24c3588c572369fe08a6e1319279c7c810c2a21a050f897c08fd50247
+  checksum: 2809c1f07d3e2788f4a52c1d81c598a15662e1aee3ba337b9948e0e4f151576e140849e36ccbc6c9f7942028610813d7cd42ece57373b8e338aa5e0527481c1a
   languageName: node
   linkType: hard
 
@@ -6342,7 +6342,7 @@ __metadata:
     fast-diff: "npm:1.2.0"
     file-url: "npm:2.0.2"
     filesize: "npm:2.0.4"
-    flow-bin: "npm:0.230.0"
+    flow-bin: "npm:0.231.0"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:3.1.0"
     he: "npm:1.1.1"


### PR DESCRIPTION
This causes failures for React `Fragment` typing, but after a quick talk with @mwiencek we decided that the typing doesn't add much over simply `React.MixedElement` which makes Flow happy, and in any case many of these changes will go away once we move to component syntax.