### PR TITLE
MBS-13524: Update Operabase handling for new artist URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4528,16 +4528,19 @@ const CLEANUPS: CleanupEntries = {
     match: [new RegExp('^(https?://)?(www\\.)?operabase\\.com', 'i')],
     restrict: [LINK_TYPES.otherdatabases],
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?(?:www\.)?operabase\.com\/(artists|venues\/[\w-]+|works)\/(?:[^0-9]+)?([0-9]+).*$/, 'https://operabase.com/$1/$2');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?operabase\.com\//, 'https://operabase.com/');
+      url = url.replace(/^https:\/\/operabase\.com\/(venues\/[\w-]+|works)\/(?:[^0-9]+)?([0-9]+).*$/, 'https://operabase.com/$1/$2');
+      url = url.replace(/^https:\/\/operabase\.com\/(?:artists\/(?:[^0-9]+)?|[\w-]+a)([0-9]+).*$/, 'https://operabase.com/a$1');
+      return url;
     },
     validate: function (url, id) {
-      const m = /^https:\/\/operabase\.com\/(artists|venues|works)\//.exec(url);
+      const m = /^https:\/\/operabase\.com\/(?:(a)|(venues)\/[\w-]+\/|(works)\/)[0-9]+$/.exec(url);
       if (m) {
-        const prefix = m[1];
+        const prefix = m[1] || m[2] || m[3];
         switch (id) {
           case LINK_TYPES.otherdatabases.artist:
             return {
-              result: prefix === 'artists',
+              result: prefix === 'a',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.place:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4425,7 +4425,14 @@ limited_link_type_combinations: [
                      input_url: 'https://www.operabase.com/artists/megan-esther-grey-101303/en',
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',
-            expected_clean_url: 'https://operabase.com/artists/101303',
+            expected_clean_url: 'https://operabase.com/a101303',
+       only_valid_entity_types: ['artist'],
+  },
+  {
+                     input_url: 'https://www.operabase.com/megan-esther-grey-a101303/bio/en',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://operabase.com/a101303',
        only_valid_entity_types: ['artist'],
   },
   {


### PR DESCRIPTION
### Implement MBS-13524

# Problem
Operabase now redirects their artist URLs to the form `https://www.operabase.com/<name>-a<id>/<lang>`, which our validation rejects. Work and venue pages have not (yet?) changed their URLs.

# Solution
The id (as `a<id>`) is all that is needed for the URL to work, so it is probably the best option to clean up to. As such this updates the cleanup to strip everything else from both old and new artist URL styles.

# Testing
Added a `URLCleanup` test.

# Further action
*  Existing URLs can, luckily, be cleaned up with relative ease - added MBBE-85 for that.
