### PR TITLE
Fix instrument attribute doc wording

### DIFF
--- a/root/relationship/linkattributetype/RelationshipAttributeTypeIndex.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypeIndex.js
@@ -158,7 +158,7 @@ const RelationshipAttributeTypeIndex = ({
             {isInstrumentRoot ? (
               <p>
                 {exp.l(
-                  `The possible values for this relationship can be seen
+                  `The possible values for this attribute can be seen
                    from the {instrument_list|instrument list}.`,
                   {instrument_list: '/instruments'},
                 )}


### PR DESCRIPTION
This is not a relationship, it's an attribute, but [the doc page](https://musicbrainz.org/relationship-attribute/0abd7f04-5e28-425b-956f-94789d9bcbe2) confusingly says "The possible values for this relationship".