### PR TITLE
MBS-13558 (II): Migrate React report components to Flow component syntax

### DIFF
--- a/root/report/AnnotationsArtists.js
+++ b/root/report/AnnotationsArtists.js
@@ -13,14 +13,13 @@ import useAnnotationColumns from './hooks/useAnnotationColumns.js';
 import {ANNOTATION_REPORT_TEXT} from './constants.js';
 import type {ReportArtistAnnotationT, ReportDataT} from './types.js';
 
-const AnnotationsArtists = ({
+component AnnotationsArtists(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportArtistAnnotationT>):
-React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportArtistAnnotationT>) {
   const annotationColumns = useAnnotationColumns<ReportArtistAnnotationT>();
 
   return (
@@ -41,6 +40,6 @@ React$Element<typeof ReportLayout> => {
       />
     </ReportLayout>
   );
-};
+}
 
 export default AnnotationsArtists;

--- a/root/report/AnnotationsEvents.js
+++ b/root/report/AnnotationsEvents.js
@@ -13,14 +13,13 @@ import useAnnotationColumns from './hooks/useAnnotationColumns.js';
 import {ANNOTATION_REPORT_TEXT} from './constants.js';
 import type {ReportDataT, ReportEventAnnotationT} from './types.js';
 
-const AnnotationsEvents = ({
+component AnnotationsEvents(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportEventAnnotationT>):
-React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportEventAnnotationT>) {
   const annotationColumns = useAnnotationColumns<ReportEventAnnotationT>();
 
   return (
@@ -41,6 +40,6 @@ React$Element<typeof ReportLayout> => {
       />
     </ReportLayout>
   );
-};
+}
 
 export default AnnotationsEvents;

--- a/root/report/AnnotationsLabels.js
+++ b/root/report/AnnotationsLabels.js
@@ -13,14 +13,13 @@ import useAnnotationColumns from './hooks/useAnnotationColumns.js';
 import {ANNOTATION_REPORT_TEXT} from './constants.js';
 import type {ReportDataT, ReportLabelAnnotationT} from './types.js';
 
-const AnnotationsLabels = ({
+component AnnotationsLabels(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportLabelAnnotationT>):
-React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportLabelAnnotationT>) {
   const annotationColumns = useAnnotationColumns<ReportLabelAnnotationT>();
 
   return (
@@ -41,6 +40,6 @@ React$Element<typeof ReportLayout> => {
       />
     </ReportLayout>
   );
-};
+}
 
 export default AnnotationsLabels;

--- a/root/report/AnnotationsPlaces.js
+++ b/root/report/AnnotationsPlaces.js
@@ -13,14 +13,13 @@ import useAnnotationColumns from './hooks/useAnnotationColumns.js';
 import {ANNOTATION_REPORT_TEXT} from './constants.js';
 import type {ReportDataT, ReportPlaceAnnotationT} from './types.js';
 
-const AnnotationsPlaces = ({
+component AnnotationsPlaces(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportPlaceAnnotationT>):
-React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportPlaceAnnotationT>) {
   const annotationColumns = useAnnotationColumns<ReportPlaceAnnotationT>();
 
   return (
@@ -41,6 +40,6 @@ React$Element<typeof ReportLayout> => {
       />
     </ReportLayout>
   );
-};
+}
 
 export default AnnotationsPlaces;

--- a/root/report/AnnotationsRecordings.js
+++ b/root/report/AnnotationsRecordings.js
@@ -13,14 +13,13 @@ import useAnnotationColumns from './hooks/useAnnotationColumns.js';
 import {ANNOTATION_REPORT_TEXT} from './constants.js';
 import type {ReportDataT, ReportRecordingAnnotationT} from './types.js';
 
-const AnnotationsRecordings = ({
+component AnnotationsRecordings(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportRecordingAnnotationT>):
-React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportRecordingAnnotationT>) {
   const annotationColumns =
     useAnnotationColumns<ReportRecordingAnnotationT>();
 
@@ -42,6 +41,6 @@ React$Element<typeof ReportLayout> => {
       />
     </ReportLayout>
   );
-};
+}
 
 export default AnnotationsRecordings;

--- a/root/report/AnnotationsReleaseGroups.js
+++ b/root/report/AnnotationsReleaseGroups.js
@@ -13,14 +13,13 @@ import useAnnotationColumns from './hooks/useAnnotationColumns.js';
 import {ANNOTATION_REPORT_TEXT} from './constants.js';
 import type {ReportDataT, ReportReleaseGroupAnnotationT} from './types.js';
 
-const AnnotationsReleaseGroups = ({
+component AnnotationsReleaseGroups(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseGroupAnnotationT>):
-React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportReleaseGroupAnnotationT>) {
   const annotationColumns =
     useAnnotationColumns<ReportReleaseGroupAnnotationT>();
 
@@ -42,6 +41,6 @@ React$Element<typeof ReportLayout> => {
       />
     </ReportLayout>
   );
-};
+}
 
 export default AnnotationsReleaseGroups;

--- a/root/report/AnnotationsReleases.js
+++ b/root/report/AnnotationsReleases.js
@@ -13,14 +13,13 @@ import useAnnotationColumns from './hooks/useAnnotationColumns.js';
 import {ANNOTATION_REPORT_TEXT} from './constants.js';
 import type {ReportDataT, ReportReleaseAnnotationT} from './types.js';
 
-const AnnotationsReleases = ({
+component AnnotationsReleases(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseAnnotationT>):
-React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportReleaseAnnotationT>) {
   const annotationColumns = useAnnotationColumns<ReportReleaseAnnotationT>();
 
   return (
@@ -41,6 +40,6 @@ React$Element<typeof ReportLayout> => {
       />
     </ReportLayout>
   );
-};
+}
 
 export default AnnotationsReleases;

--- a/root/report/AnnotationsSeries.js
+++ b/root/report/AnnotationsSeries.js
@@ -13,14 +13,13 @@ import useAnnotationColumns from './hooks/useAnnotationColumns.js';
 import {ANNOTATION_REPORT_TEXT} from './constants.js';
 import type {ReportDataT, ReportSeriesAnnotationT} from './types.js';
 
-const AnnotationsSeries = ({
+component AnnotationsSeries(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportSeriesAnnotationT>):
-React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportSeriesAnnotationT>) {
   const annotationColumns = useAnnotationColumns<ReportSeriesAnnotationT>();
 
   return (
@@ -41,6 +40,6 @@ React$Element<typeof ReportLayout> => {
       />
     </ReportLayout>
   );
-};
+}
 
 export default AnnotationsSeries;

--- a/root/report/AnnotationsWorks.js
+++ b/root/report/AnnotationsWorks.js
@@ -13,14 +13,13 @@ import useAnnotationColumns from './hooks/useAnnotationColumns.js';
 import {ANNOTATION_REPORT_TEXT} from './constants.js';
 import type {ReportDataT, ReportWorkAnnotationT} from './types.js';
 
-const AnnotationsWorks = ({
+component AnnotationsWorks(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportWorkAnnotationT>):
-React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportWorkAnnotationT>) {
   const annotationColumns = useAnnotationColumns<ReportWorkAnnotationT>();
 
   return (
@@ -41,6 +40,6 @@ React$Element<typeof ReportLayout> => {
       />
     </ReportLayout>
   );
-};
+}
 
 export default AnnotationsWorks;

--- a/root/report/ArtistCreditsWithDubiousTrailingPhrases.js
+++ b/root/report/ArtistCreditsWithDubiousTrailingPhrases.js
@@ -11,28 +11,30 @@ import ArtistCreditList from './components/ArtistCreditList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportArtistCreditT, ReportDataT} from './types.js';
 
-const ArtistCreditsWithDubiousTrailingPhrases = ({
+component ArtistCreditsWithDubiousTrailingPhrases(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportArtistCreditT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists artist credits that have a trailing join phrase
-       that looks like it might have been left behind in error, such as
-       a trailing comma or “feat.”.`,
-    )}
-    entityType="artist_credit"
-    filtered={filtered}
-    generated={generated}
-    title={l('Artist credits with dubious trailing join phrases')}
-    totalEntries={pager.total_entries}
-  >
-    <ArtistCreditList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportArtistCreditT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists artist credits that have a trailing join phrase
+         that looks like it might have been left behind in error, such as
+         a trailing comma or “feat.”.`,
+      )}
+      entityType="artist_credit"
+      filtered={filtered}
+      generated={generated}
+      title={l('Artist credits with dubious trailing join phrases')}
+      totalEntries={pager.total_entries}
+    >
+      <ArtistCreditList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ArtistCreditsWithDubiousTrailingPhrases;

--- a/root/report/ArtistsContainingDisambiguationComments.js
+++ b/root/report/ArtistsContainingDisambiguationComments.js
@@ -11,27 +11,29 @@ import ArtistList from './components/ArtistList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportArtistT, ReportDataT} from './types.js';
 
-const ArtistsContainingDisambiguationComments = ({
+component ArtistsContainingDisambiguationComments(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportArtistT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists artists that may have disambiguation comments
-       in their name, rather than the actual disambiguation comment field.`,
-    )}
-    entityType="artist"
-    filtered={filtered}
-    generated={generated}
-    title={l('Artists containing disambiguation comments in their name')}
-    totalEntries={pager.total_entries}
-  >
-    <ArtistList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportArtistT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists artists that may have disambiguation comments
+         in their name, rather than the actual disambiguation comment field.`,
+      )}
+      entityType="artist"
+      filtered={filtered}
+      generated={generated}
+      title={l('Artists containing disambiguation comments in their name')}
+      totalEntries={pager.total_entries}
+    >
+      <ArtistList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ArtistsContainingDisambiguationComments;

--- a/root/report/ArtistsDisambiguationSameName.js
+++ b/root/report/ArtistsDisambiguationSameName.js
@@ -11,28 +11,30 @@ import ArtistList from './components/ArtistList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportArtistT, ReportDataT} from './types.js';
 
-const ArtistsDisambiguationSameName = ({
+component ArtistsDisambiguationSameName(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportArtistT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists artists that have their disambiguation set
-       to be the same as their name.
-       The disambiguation should be removed or, if it is needed, improved.`,
-    )}
-    entityType="artist"
-    filtered={filtered}
-    generated={generated}
-    title={l('Artists with disambiguation the same as the name')}
-    totalEntries={pager.total_entries}
-  >
-    <ArtistList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportArtistT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists artists that have their disambiguation set
+         to be the same as their name.
+         The disambiguation should be removed or, if it is needed, improved.`,
+      )}
+      entityType="artist"
+      filtered={filtered}
+      generated={generated}
+      title={l('Artists with disambiguation the same as the name')}
+      totalEntries={pager.total_entries}
+    >
+      <ArtistList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ArtistsDisambiguationSameName;

--- a/root/report/ArtistsThatMayBeGroups.js
+++ b/root/report/ArtistsThatMayBeGroups.js
@@ -11,31 +11,33 @@ import ArtistList from './components/ArtistList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportArtistT, ReportDataT} from './types.js';
 
-const ArtistsThatMayBeGroups = ({
+component ArtistsThatMayBeGroups(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportArtistT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists artists that have their type set to other
-       than Group (or a subtype of Group) but may be a group,
-       because they have other artists listed as members. If you find
-       that an artist here is indeed a group, change its type. If it is
-       not, please make sure that the “member of” relationships are
-       in the right direction and are correct.`,
-    )}
-    entityType="artist"
-    filtered={filtered}
-    generated={generated}
-    title={l('Artists that may be groups')}
-    totalEntries={pager.total_entries}
-  >
-    <ArtistList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportArtistT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists artists that have their type set to other
+         than Group (or a subtype of Group) but may be a group,
+         because they have other artists listed as members. If you find
+         that an artist here is indeed a group, change its type. If it is
+         not, please make sure that the “member of” relationships are
+         in the right direction and are correct.`,
+      )}
+      entityType="artist"
+      filtered={filtered}
+      generated={generated}
+      title={l('Artists that may be groups')}
+      totalEntries={pager.total_entries}
+    >
+      <ArtistList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ArtistsThatMayBeGroups;

--- a/root/report/ArtistsThatMayBePersons.js
+++ b/root/report/ArtistsThatMayBePersons.js
@@ -11,31 +11,34 @@ import ArtistList from './components/ArtistList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportArtistT, ReportDataT} from './types.js';
 
-const ArtistsThatMayBePersons = ({
+component ArtistsThatMayBePersons(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportArtistT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists artists that have their type set to other than Person
-       or Character, but may be a person, based on their relationships.
-       For example, an artist will appear here if it is listed
-       as a member of another. If you find that an artist here is indeed
-       a person (or a character), change its type. If it is not, please make
-       sure that all the relationships are correct and make sense.`,
-    )}
-    entityType="artist"
-    filtered={filtered}
-    generated={generated}
-    title={l('Artists that may be persons')}
-    totalEntries={pager.total_entries}
-  >
-    <ArtistList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportArtistT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists artists that have their type set to other than
+         Person or Character, but may be a person, based on their
+         relationships.
+         For example, an artist will appear here if it is listed
+         as a member of another. If you find that an artist here is indeed
+         a person (or a character), change its type. If it is not, please make
+         sure that all the relationships are correct and make sense.`,
+      )}
+      entityType="artist"
+      filtered={filtered}
+      generated={generated}
+      title={l('Artists that may be persons')}
+      totalEntries={pager.total_entries}
+    >
+      <ArtistList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ArtistsThatMayBePersons;

--- a/root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js
+++ b/root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js
@@ -11,27 +11,29 @@ import ArtistList from './components/ArtistList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportArtistT, ReportDataT} from './types.js';
 
-const ArtistsWithMultipleOccurrencesInArtistCredits = ({
+component ArtistsWithMultipleOccurrencesInArtistCredits(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportArtistT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists artists that appear more than once
-       in different positions within the same artist credit.`,
-    )}
-    entityType="artist"
-    filtered={filtered}
-    generated={generated}
-    title={l('Artists occurring multiple times in the same artist credit')}
-    totalEntries={pager.total_entries}
-  >
-    <ArtistList items={items} pager={pager} subPath="aliases" />
-  </ReportLayout>
-);
+}: ReportDataT<ReportArtistT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists artists that appear more than once
+         in different positions within the same artist credit.`,
+      )}
+      entityType="artist"
+      filtered={filtered}
+      generated={generated}
+      title={l('Artists occurring multiple times in the same artist credit')}
+      totalEntries={pager.total_entries}
+    >
+      <ArtistList items={items} pager={pager} subPath="aliases" />
+    </ReportLayout>
+  );
+}
 
 export default ArtistsWithMultipleOccurrencesInArtistCredits;

--- a/root/report/ArtistsWithNoSubscribers.js
+++ b/root/report/ArtistsWithNoSubscribers.js
@@ -11,28 +11,30 @@ import ArtistList from './components/ArtistList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportArtistT, ReportDataT} from './types.js';
 
-const ArtistsWithNoSubscribers = ({
+component ArtistsWithNoSubscribers(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportArtistT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists artists that have no editors subscribed to them,
-       and whose changes may therefore be under-reviewed. Artists with
-       more release groups and more open edits are listed first.`,
-    )}
-    entityType="artist"
-    filtered={filtered}
-    generated={generated}
-    title={l('Artists with no subscribers')}
-    totalEntries={pager.total_entries}
-  >
-    <ArtistList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportArtistT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists artists that have no editors subscribed to them,
+         and whose changes may therefore be under-reviewed. Artists with
+         more release groups and more open edits are listed first.`,
+      )}
+      entityType="artist"
+      filtered={filtered}
+      generated={generated}
+      title={l('Artists with no subscribers')}
+      totalEntries={pager.total_entries}
+    >
+      <ArtistList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ArtistsWithNoSubscribers;

--- a/root/report/AsinsWithMultipleReleases.js
+++ b/root/report/AsinsWithMultipleReleases.js
@@ -11,35 +11,37 @@ import ReleaseUrlList from './components/ReleaseUrlList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseUrlT} from './types.js';
 
-const AsinsWithMultipleReleases = ({
+component AsinsWithMultipleReleases(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseUrlT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={exp.l(
-      `This report shows Amazon URLs which are linked to multiple
-       releases. In most cases Amazon ASINs should map to MusicBrainz
-       releases 1:1, so only one of the links will be correct. Just check
-       which MusicBrainz release fits the release in Amazon (look at the
-       format, tracklist, etc). If the release has a barcode, you can also
-       search Amazon for it and see which ASIN matches.  You might also
-       find some ASINs linked to several discs of a multi-disc release:
-       just merge those (see
-       {how_to_merge_releases|How to Merge Releases}).`,
-      {how_to_merge_releases: '/doc/How_to_Merge_Releases'},
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Amazon URLs linked to multiple releases')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseUrlList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseUrlT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report shows Amazon URLs which are linked to multiple
+         releases. In most cases Amazon ASINs should map to MusicBrainz
+         releases 1:1, so only one of the links will be correct. Just check
+         which MusicBrainz release fits the release in Amazon (look at the
+         format, tracklist, etc). If the release has a barcode, you can also
+         search Amazon for it and see which ASIN matches.  You might also
+         find some ASINs linked to several discs of a multi-disc release:
+         just merge those (see
+         {how_to_merge_releases|How to Merge Releases}).`,
+        {how_to_merge_releases: '/doc/How_to_Merge_Releases'},
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Amazon URLs linked to multiple releases')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseUrlList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default AsinsWithMultipleReleases;

--- a/root/report/BadAmazonUrls.js
+++ b/root/report/BadAmazonUrls.js
@@ -15,13 +15,13 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseUrlT} from './types.js';
 
-const BadAmazonUrls = ({
+component BadAmazonUrls(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseUrlT>): React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportReleaseUrlT>) {
   const urlColumn = {
     Cell: ({row: {original}}: CellRenderProps<ReportReleaseUrlT, empty>) => {
       const url = original.url;
@@ -62,6 +62,6 @@ const BadAmazonUrls = ({
       />
     </ReportLayout>
   );
-};
+}
 
 export default BadAmazonUrls;

--- a/root/report/BootlegsOnNonBootlegLabels.js
+++ b/root/report/BootlegsOnNonBootlegLabels.js
@@ -11,30 +11,32 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const BootlegsOnNonBootlegLabels = ({
+component BootlegsOnNonBootlegLabels(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases that are set to status “Bootleg”, but have
-       at least one label in their labels list which is not “[no label]” nor
-       has the type “Bootleg Production”.
-       Other types of labels pretty much never release bootleg releases,
-       so chances are that either the label or the status is wrong.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases on non-bootleg labels set to bootleg')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases that are set to status “Bootleg”, but have
+         at least one label in their labels list which is not “[no label]” nor
+         has the type “Bootleg Production”.
+         Other types of labels pretty much never release bootleg releases,
+         so chances are that either the label or the status is wrong.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases on non-bootleg labels set to bootleg')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default BootlegsOnNonBootlegLabels;

--- a/root/report/CDTocDubiousLength.js
+++ b/root/report/CDTocDubiousLength.js
@@ -11,29 +11,31 @@ import CDTocList from './components/CDTocList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportCDTocT, ReportDataT} from './types.js';
 
-const CDTocDubiousLength = ({
+component CDTocDubiousLength(...{
   canBeFiltered,
   generated,
   filtered,
   items,
   pager,
-}: ReportDataT<ReportCDTocT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows disc IDs indicating a total duration much longer
-       than what a standard CD allows (at least 88 minutes for a CD, or 30
-       minutes for a mini-CD). This usually means a disc ID was generated for
-       the wrong format (SACD) or with a buggy tool.`,
-    )}
-    entityType="discId"
-    filtered={filtered}
-    generated={generated}
-    title={l('Disc IDs with dubious duration')}
-    totalEntries={pager.total_entries}
-  >
-    <CDTocList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportCDTocT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows disc IDs indicating a total duration much longer
+         than what a standard CD allows (at least 88 minutes for a CD, or 30
+         minutes for a mini-CD). This usually means a disc ID was generated
+         for the wrong format (SACD) or with a buggy tool.`,
+      )}
+      entityType="discId"
+      filtered={filtered}
+      generated={generated}
+      title={l('Disc IDs with dubious duration')}
+      totalEntries={pager.total_entries}
+    >
+      <CDTocList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default CDTocDubiousLength;

--- a/root/report/CDTocNotApplied.js
+++ b/root/report/CDTocNotApplied.js
@@ -11,31 +11,33 @@ import CDTocReleaseList from './components/CDTocReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportCDTocReleaseT, ReportDataT} from './types.js';
 
-const CDTocNotApplied = ({
+component CDTocNotApplied(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportCDTocReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows disc IDs attached to a release but obviously not
-       applied because at least one track length is unknown on the release.
-       The report is also restricted to mediums where only one disc ID is
-       attached, so it is highly likely that the disc ID can be applied
-       without any worries. Do make sure though that no existing lengths
-       clash with the disc ID, or that any clashes are clear mistakes.`,
-    )}
-    entityType="discId"
-    filtered={filtered}
-    generated={generated}
-    title={l('Disc IDs attached but not applied')}
-    totalEntries={pager.total_entries}
-  >
-    <CDTocReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportCDTocReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows disc IDs attached to a release but obviously not
+         applied because at least one track length is unknown on the release.
+         The report is also restricted to mediums where only one disc ID is
+         attached, so it is highly likely that the disc ID can be applied
+         without any worries. Do make sure though that no existing lengths
+         clash with the disc ID, or that any clashes are clear mistakes.`,
+      )}
+      entityType="discId"
+      filtered={filtered}
+      generated={generated}
+      title={l('Disc IDs attached but not applied')}
+      totalEntries={pager.total_entries}
+    >
+      <CDTocReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default CDTocNotApplied;

--- a/root/report/CatNoLooksLikeAsin.js
+++ b/root/report/CatNoLooksLikeAsin.js
@@ -12,13 +12,13 @@ import ReportLayout from './components/ReportLayout.js';
 import useCatNoColumn from './hooks/useCatNoColumn.js';
 import type {ReportDataT, ReportReleaseCatNoT} from './types.js';
 
-const CatNoLooksLikeAsin = ({
+component CatNoLooksLikeAsin(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseCatNoT>): React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportReleaseCatNoT>) {
   const catNoColumn = useCatNoColumn<ReportReleaseCatNoT>();
 
   return (
@@ -43,6 +43,6 @@ const CatNoLooksLikeAsin = ({
       />
     </ReportLayout>
   );
-};
+}
 
 export default CatNoLooksLikeAsin;

--- a/root/report/CatNoLooksLikeIsrc.js
+++ b/root/report/CatNoLooksLikeIsrc.js
@@ -12,13 +12,13 @@ import ReportLayout from './components/ReportLayout.js';
 import useCatNoColumn from './hooks/useCatNoColumn.js';
 import type {ReportDataT, ReportReleaseCatNoT} from './types.js';
 
-const CatNoLooksLikeIsrc = ({
+component CatNoLooksLikeIsrc(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseCatNoT>): React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportReleaseCatNoT>) {
   const catNoColumn = useCatNoColumn<ReportReleaseCatNoT>();
 
   return (
@@ -47,6 +47,6 @@ const CatNoLooksLikeIsrc = ({
       />
     </ReportLayout>
   );
-};
+}
 
 export default CatNoLooksLikeIsrc;

--- a/root/report/CatNoLooksLikeLabelCode.js
+++ b/root/report/CatNoLooksLikeLabelCode.js
@@ -12,13 +12,13 @@ import ReportLayout from './components/ReportLayout.js';
 import useCatNoColumn from './hooks/useCatNoColumn.js';
 import type {ReportDataT, ReportReleaseCatNoT} from './types.js';
 
-const CatNoLooksLikeLabelCode = ({
+component CatNoLooksLikeLabelCode(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseCatNoT>): React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportReleaseCatNoT>) {
   const catNoColumn = useCatNoColumn<ReportReleaseCatNoT>();
 
   return (
@@ -46,6 +46,6 @@ const CatNoLooksLikeLabelCode = ({
       />
     </ReportLayout>
   );
-};
+}
 
 export default CatNoLooksLikeLabelCode;

--- a/root/report/CollaborationRelationships.js
+++ b/root/report/CollaborationRelationships.js
@@ -15,13 +15,13 @@ import EntityLink from '../static/scripts/common/components/EntityLink.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportCollaborationT, ReportDataT} from './types.js';
 
-const CollaborationRelationships = ({
+component CollaborationRelationships(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportCollaborationT>): React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportCollaborationT>) {
   let lastID = 0;
   let currentID = 0;
 
@@ -88,6 +88,6 @@ const CollaborationRelationships = ({
       </PaginatedResults>
     </ReportLayout>
   );
-};
+}
 
 export default CollaborationRelationships;

--- a/root/report/DeprecatedRelationshipArtists.js
+++ b/root/report/DeprecatedRelationshipArtists.js
@@ -15,32 +15,33 @@ import ArtistList from './components/ArtistList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportArtistRelationshipT, ReportDataT} from './types.js';
 
-const DeprecatedRelationshipArtists = ({
+component DeprecatedRelationshipArtists(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportArtistRelationshipT>):
-React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists artists which have relationships using
-       deprecated and grouping-only relationship types.`,
-    )}
-    entityType="artist"
-    filtered={filtered}
-    generated={generated}
-    title={l('Artists with deprecated relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <ArtistList
-      columnsBefore={[relTypeColumn]}
-      items={items}
-      pager={pager}
-    />
-  </ReportLayout>
-);
+}: ReportDataT<ReportArtistRelationshipT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists artists which have relationships using
+         deprecated and grouping-only relationship types.`,
+      )}
+      entityType="artist"
+      filtered={filtered}
+      generated={generated}
+      title={l('Artists with deprecated relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <ArtistList
+        columnsBefore={[relTypeColumn]}
+        items={items}
+        pager={pager}
+      />
+    </ReportLayout>
+  );
+}
 
 export default DeprecatedRelationshipArtists;

--- a/root/report/DeprecatedRelationshipLabels.js
+++ b/root/report/DeprecatedRelationshipLabels.js
@@ -15,32 +15,33 @@ import LabelList from './components/LabelList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportLabelRelationshipT} from './types.js';
 
-const DeprecatedRelationshipLabels = ({
+component DeprecatedRelationshipLabels(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportLabelRelationshipT>):
-React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists labels which have relationships using
-       deprecated and grouping-only relationship types.`,
-    )}
-    entityType="label"
-    filtered={filtered}
-    generated={generated}
-    title={l('Labels with deprecated relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <LabelList
-      columnsBefore={[relTypeColumn]}
-      items={items}
-      pager={pager}
-    />
-  </ReportLayout>
-);
+}: ReportDataT<ReportLabelRelationshipT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists labels which have relationships using
+         deprecated and grouping-only relationship types.`,
+      )}
+      entityType="label"
+      filtered={filtered}
+      generated={generated}
+      title={l('Labels with deprecated relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <LabelList
+        columnsBefore={[relTypeColumn]}
+        items={items}
+        pager={pager}
+      />
+    </ReportLayout>
+  );
+}
 
 export default DeprecatedRelationshipLabels;

--- a/root/report/DeprecatedRelationshipPlaces.js
+++ b/root/report/DeprecatedRelationshipPlaces.js
@@ -15,32 +15,33 @@ import PlaceList from './components/PlaceList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportPlaceRelationshipT} from './types.js';
 
-const DeprecatedRelationshipPlaces = ({
+component DeprecatedRelationshipPlaces(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportPlaceRelationshipT>):
-React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists places which have relationships using
-       deprecated and grouping-only relationship types.`,
-    )}
-    entityType="place"
-    filtered={filtered}
-    generated={generated}
-    title={l('Places with deprecated relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <PlaceList
-      columnsBefore={[relTypeColumn]}
-      items={items}
-      pager={pager}
-    />
-  </ReportLayout>
-);
+}: ReportDataT<ReportPlaceRelationshipT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists places which have relationships using
+        deprecated and grouping-only relationship types.`,
+      )}
+      entityType="place"
+      filtered={filtered}
+      generated={generated}
+      title={l('Places with deprecated relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <PlaceList
+        columnsBefore={[relTypeColumn]}
+        items={items}
+        pager={pager}
+      />
+    </ReportLayout>
+  );
+}
 
 export default DeprecatedRelationshipPlaces;

--- a/root/report/DeprecatedRelationshipRecordings.js
+++ b/root/report/DeprecatedRelationshipRecordings.js
@@ -15,32 +15,33 @@ import RecordingList from './components/RecordingList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportRecordingRelationshipT} from './types.js';
 
-const DeprecatedRelationshipRecordings = ({
+component DeprecatedRelationshipRecordings(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportRecordingRelationshipT>):
-React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists recordings which have relationships using
-       deprecated and grouping-only relationship types.`,
-    )}
-    entityType="recording"
-    filtered={filtered}
-    generated={generated}
-    title={l('Recordings with deprecated relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <RecordingList
-      columnsBefore={[relTypeColumn]}
-      items={items}
-      pager={pager}
-    />
-  </ReportLayout>
-);
+}: ReportDataT<ReportRecordingRelationshipT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists recordings which have relationships using
+         deprecated and grouping-only relationship types.`,
+      )}
+      entityType="recording"
+      filtered={filtered}
+      generated={generated}
+      title={l('Recordings with deprecated relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <RecordingList
+        columnsBefore={[relTypeColumn]}
+        items={items}
+        pager={pager}
+      />
+    </ReportLayout>
+  );
+}
 
 export default DeprecatedRelationshipRecordings;

--- a/root/report/DeprecatedRelationshipReleaseGroups.js
+++ b/root/report/DeprecatedRelationshipReleaseGroups.js
@@ -15,32 +15,33 @@ import ReleaseGroupList from './components/ReleaseGroupList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseGroupRelationshipT} from './types.js';
 
-const DeprecatedRelationshipReleaseGroups = ({
+component DeprecatedRelationshipReleaseGroups(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseGroupRelationshipT>):
-React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists release groups which have relationships using
-       deprecated and grouping-only relationship types.`,
-    )}
-    entityType="release_group"
-    filtered={filtered}
-    generated={generated}
-    title={l('Release groups with deprecated relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseGroupList
-      columnsBefore={[relTypeColumn]}
-      items={items}
-      pager={pager}
-    />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseGroupRelationshipT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists release groups which have relationships using
+         deprecated and grouping-only relationship types.`,
+      )}
+      entityType="release_group"
+      filtered={filtered}
+      generated={generated}
+      title={l('Release groups with deprecated relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseGroupList
+        columnsBefore={[relTypeColumn]}
+        items={items}
+        pager={pager}
+      />
+    </ReportLayout>
+  );
+}
 
 export default DeprecatedRelationshipReleaseGroups;

--- a/root/report/DeprecatedRelationshipReleases.js
+++ b/root/report/DeprecatedRelationshipReleases.js
@@ -15,32 +15,33 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseRelationshipT} from './types.js';
 
-const DeprecatedRelationshipReleases = ({
+component DeprecatedRelationshipReleases(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseRelationshipT>):
-React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists releases which have relationships using
-       deprecated and grouping-only relationship types.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases with deprecated relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList
-      columnsBefore={[relTypeColumn]}
-      items={items}
-      pager={pager}
-    />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseRelationshipT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists releases which have relationships using
+         deprecated and grouping-only relationship types.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases with deprecated relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList
+        columnsBefore={[relTypeColumn]}
+        items={items}
+        pager={pager}
+      />
+    </ReportLayout>
+  );
+}
 
 export default DeprecatedRelationshipReleases;

--- a/root/report/DeprecatedRelationshipUrls.js
+++ b/root/report/DeprecatedRelationshipUrls.js
@@ -15,32 +15,33 @@ import ReportLayout from './components/ReportLayout.js';
 import UrlList from './components/UrlList.js';
 import type {ReportDataT, ReportUrlRelationshipT} from './types.js';
 
-const DeprecatedRelationshipUrls = ({
+component DeprecatedRelationshipUrls(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportUrlRelationshipT>):
-React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists URLs which have relationships using
-       deprecated and grouping-only relationship types.`,
-    )}
-    entityType="url"
-    filtered={filtered}
-    generated={generated}
-    title={l('URLs with deprecated relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <UrlList
-      columnsBefore={[relTypeColumn]}
-      items={items}
-      pager={pager}
-    />
-  </ReportLayout>
-);
+}: ReportDataT<ReportUrlRelationshipT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists URLs which have relationships using
+         deprecated and grouping-only relationship types.`,
+      )}
+      entityType="url"
+      filtered={filtered}
+      generated={generated}
+      title={l('URLs with deprecated relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <UrlList
+        columnsBefore={[relTypeColumn]}
+        items={items}
+        pager={pager}
+      />
+    </ReportLayout>
+  );
+}
 
 export default DeprecatedRelationshipUrls;

--- a/root/report/DeprecatedRelationshipWorks.js
+++ b/root/report/DeprecatedRelationshipWorks.js
@@ -15,32 +15,33 @@ import ReportLayout from './components/ReportLayout.js';
 import WorkList from './components/WorkList.js';
 import type {ReportDataT, ReportWorkRelationshipT} from './types.js';
 
-const DeprecatedRelationshipWorks = ({
+component DeprecatedRelationshipWorks(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportWorkRelationshipT>):
-React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists works which have relationships using
-       deprecated and grouping-only relationship types.`,
-    )}
-    entityType="work"
-    filtered={filtered}
-    generated={generated}
-    title={l('Works with deprecated relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <WorkList
-      columnsBefore={[relTypeColumn]}
-      items={items}
-      pager={pager}
-    />
-  </ReportLayout>
-);
+}: ReportDataT<ReportWorkRelationshipT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists works which have relationships using
+         deprecated and grouping-only relationship types.`,
+      )}
+      entityType="work"
+      filtered={filtered}
+      generated={generated}
+      title={l('Works with deprecated relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <WorkList
+        columnsBefore={[relTypeColumn]}
+        items={items}
+        pager={pager}
+      />
+    </ReportLayout>
+  );
+}
 
 export default DeprecatedRelationshipWorks;

--- a/root/report/DiscogsLinksWithMultipleArtists.js
+++ b/root/report/DiscogsLinksWithMultipleArtists.js
@@ -11,27 +11,29 @@ import ArtistUrlList from './components/ArtistUrlList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportArtistUrlT, ReportDataT} from './types.js';
 
-const DiscogsLinksWithMultipleArtists = ({
+component DiscogsLinksWithMultipleArtists(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportArtistUrlT>):
-React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows Discogs URLs which are linked to multiple artists.`,
-    )}
-    entityType="artist"
-    filtered={filtered}
-    generated={generated}
-    title={l('Discogs URLs linked to multiple artists')}
-    totalEntries={pager.total_entries}
-  >
-    <ArtistUrlList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportArtistUrlT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows Discogs URLs
+         which are linked to multiple artists.`,
+      )}
+      entityType="artist"
+      filtered={filtered}
+      generated={generated}
+      title={l('Discogs URLs linked to multiple artists')}
+      totalEntries={pager.total_entries}
+    >
+      <ArtistUrlList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default DiscogsLinksWithMultipleArtists;

--- a/root/report/DiscogsLinksWithMultipleLabels.js
+++ b/root/report/DiscogsLinksWithMultipleLabels.js
@@ -11,27 +11,28 @@ import LabelUrlList from './components/LabelUrlList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportLabelUrlT} from './types.js';
 
-const DiscogsLinksWithMultipleLabels = ({
+component DiscogsLinksWithMultipleLabels(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportLabelUrlT>):
-React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows Discogs URLs which are linked to multiple labels.`,
-    )}
-    entityType="label"
-    filtered={filtered}
-    generated={generated}
-    title={l('Discogs URLs linked to multiple labels')}
-    totalEntries={pager.total_entries}
-  >
-    <LabelUrlList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportLabelUrlT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows Discogs URLs which are linked to multiple labels.`,
+      )}
+      entityType="label"
+      filtered={filtered}
+      generated={generated}
+      title={l('Discogs URLs linked to multiple labels')}
+      totalEntries={pager.total_entries}
+    >
+      <LabelUrlList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default DiscogsLinksWithMultipleLabels;

--- a/root/report/DiscogsLinksWithMultipleReleaseGroups.js
+++ b/root/report/DiscogsLinksWithMultipleReleaseGroups.js
@@ -11,28 +11,29 @@ import ReleaseGroupUrlList from './components/ReleaseGroupUrlList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseGroupUrlT} from './types.js';
 
-const DiscogsLinksWithMultipleReleaseGroups = ({
+component DiscogsLinksWithMultipleReleaseGroups(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseGroupUrlT>):
-React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows Discogs URLs which are linked
-       to multiple release groups.`,
-    )}
-    entityType="release_group"
-    filtered={filtered}
-    generated={generated}
-    title={l('Discogs URLs linked to multiple release groups')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseGroupUrlList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseGroupUrlT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows Discogs URLs which are linked
+         to multiple release groups.`,
+      )}
+      entityType="release_group"
+      filtered={filtered}
+      generated={generated}
+      title={l('Discogs URLs linked to multiple release groups')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseGroupUrlList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default DiscogsLinksWithMultipleReleaseGroups;

--- a/root/report/DiscogsLinksWithMultipleReleases.js
+++ b/root/report/DiscogsLinksWithMultipleReleases.js
@@ -11,34 +11,35 @@ import ReleaseUrlList from './components/ReleaseUrlList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseUrlT} from './types.js';
 
-const DiscogsLinksWithMultipleReleases = ({
+component DiscogsLinksWithMultipleReleases(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseUrlT>):
-React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={exp.l(
-      `This report shows Discogs URLs which are linked to multiple
-       releases. In most cases Discogs releases should map to MusicBrainz
-       releases 1:1, so only one of the links will be correct. Just check
-       which MusicBrainz release fits the release in Discogs (look at the
-       format, tracklist, release country, etc.). You might also find some
-       Discogs URLs linked to several discs of a multi-disc release: just
-       merge those (see {how_to_merge_releases|How to Merge Releases}).`,
-      {how_to_merge_releases: '/doc/How_to_Merge_Releases'},
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Discogs URLs linked to multiple releases')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseUrlList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseUrlT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report shows Discogs URLs which are linked to multiple
+         releases. In most cases Discogs releases should map to MusicBrainz
+         releases 1:1, so only one of the links will be correct. Just check
+         which MusicBrainz release fits the release in Discogs (look at the
+         format, tracklist, release country, etc.). You might also find some
+         Discogs URLs linked to several discs of a multi-disc release: just
+         merge those (see {how_to_merge_releases|How to Merge Releases}).`,
+        {how_to_merge_releases: '/doc/How_to_Merge_Releases'},
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Discogs URLs linked to multiple releases')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseUrlList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default DiscogsLinksWithMultipleReleases;

--- a/root/report/DuplicateArtists.js
+++ b/root/report/DuplicateArtists.js
@@ -20,13 +20,13 @@ import {returnToCurrentPage} from '../utility/returnUri.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportArtistT, ReportDataT} from './types.js';
 
-const DuplicateArtists = ({
+component DuplicateArtists(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportArtistT>): React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportArtistT>) {
   const $c = React.useContext(SanitizedCatalystContext);
 
   let currentKey: ?string = '';
@@ -131,6 +131,6 @@ const DuplicateArtists = ({
       </form>
     </ReportLayout>
   );
-};
+}
 
 export default DuplicateArtists;

--- a/root/report/DuplicateEvents.js
+++ b/root/report/DuplicateEvents.js
@@ -11,29 +11,31 @@ import EventList from './components/EventList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportEventT} from './types.js';
 
-const DuplicateEvents = ({
+component DuplicateEvents(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportEventT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists events happening at the same place
-       on the same date. If there are duplicates (for example,
-       if there are separate events for headliner and supporting artist)
-       please merge them.`,
-    )}
-    entityType="event"
-    filtered={filtered}
-    generated={generated}
-    title={l('Possibly duplicate events')}
-    totalEntries={pager.total_entries}
-  >
-    <EventList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportEventT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists events happening at the same place
+         on the same date. If there are duplicates (for example,
+         if there are separate events for headliner and supporting artist)
+         please merge them.`,
+      )}
+      entityType="event"
+      filtered={filtered}
+      generated={generated}
+      title={l('Possibly duplicate events')}
+      totalEntries={pager.total_entries}
+    >
+      <EventList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default DuplicateEvents;

--- a/root/report/DuplicateRelationshipsArtists.js
+++ b/root/report/DuplicateRelationshipsArtists.js
@@ -11,29 +11,31 @@ import ArtistList from './components/ArtistList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportArtistT, ReportDataT} from './types.js';
 
-const DuplicateRelationshipsArtists = ({
+component DuplicateRelationshipsArtists(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportArtistT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists artists which have multiple relatonships to
-       the same artist, label or URL using the same relationship type.
-       For multiple relationships to release groups, recordings or works,
-       see the reports for those entities.`,
-    )}
-    entityType="artist"
-    filtered={filtered}
-    generated={generated}
-    title={l('Artists with possible duplicate relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <ArtistList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportArtistT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists artists which have multiple relatonships to
+         the same artist, label or URL using the same relationship type.
+         For multiple relationships to release groups, recordings or works,
+         see the reports for those entities.`,
+      )}
+      entityType="artist"
+      filtered={filtered}
+      generated={generated}
+      title={l('Artists with possible duplicate relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <ArtistList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default DuplicateRelationshipsArtists;

--- a/root/report/DuplicateRelationshipsLabels.js
+++ b/root/report/DuplicateRelationshipsLabels.js
@@ -11,27 +11,29 @@ import LabelList from './components/LabelList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportLabelT} from './types.js';
 
-const DuplicateRelationshipsLabels = ({
+component DuplicateRelationshipsLabels(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportLabelT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists labels which have multiple relationships
-       to the same entity using the same relationship type.`,
-    )}
-    entityType="label"
-    filtered={filtered}
-    generated={generated}
-    title={l('Labels with possible duplicate relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <LabelList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportLabelT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists labels which have multiple relationships
+         to the same entity using the same relationship type.`,
+      )}
+      entityType="label"
+      filtered={filtered}
+      generated={generated}
+      title={l('Labels with possible duplicate relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <LabelList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default DuplicateRelationshipsLabels;

--- a/root/report/DuplicateRelationshipsRecordings.js
+++ b/root/report/DuplicateRelationshipsRecordings.js
@@ -11,27 +11,29 @@ import RecordingList from './components/RecordingList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportRecordingT} from './types.js';
 
-const DuplicateRelationshipsRecordings = ({
+component DuplicateRelationshipsRecordings(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportRecordingT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists recordings which have multiple relationships
-       to the same entity using the same relationship type.`,
-    )}
-    entityType="recording"
-    filtered={filtered}
-    generated={generated}
-    title={l('Recordings with possible duplicate relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <RecordingList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportRecordingT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists recordings which have multiple relationships
+         to the same entity using the same relationship type.`,
+      )}
+      entityType="recording"
+      filtered={filtered}
+      generated={generated}
+      title={l('Recordings with possible duplicate relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <RecordingList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default DuplicateRelationshipsRecordings;

--- a/root/report/DuplicateRelationshipsReleaseGroups.js
+++ b/root/report/DuplicateRelationshipsReleaseGroups.js
@@ -11,27 +11,29 @@ import ReleaseGroupList from './components/ReleaseGroupList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseGroupT} from './types.js';
 
-const DuplicateRelationshipsReleaseGroups = ({
+component DuplicateRelationshipsReleaseGroups(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseGroupT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists release groups which have multiple relationships
-       to the same entity using the same relationship type.`,
-    )}
-    entityType="release_group"
-    filtered={filtered}
-    generated={generated}
-    title={l('Release groups with possible duplicate relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseGroupList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseGroupT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists release groups which have multiple relationships
+         to the same entity using the same relationship type.`,
+      )}
+      entityType="release_group"
+      filtered={filtered}
+      generated={generated}
+      title={l('Release groups with possible duplicate relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseGroupList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default DuplicateRelationshipsReleaseGroups;

--- a/root/report/DuplicateRelationshipsReleases.js
+++ b/root/report/DuplicateRelationshipsReleases.js
@@ -11,27 +11,29 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const DuplicateRelationshipsReleases = ({
+component DuplicateRelationshipsReleases(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists releases which have multiple relationships
-       to the same entity using the same relationship type.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases with possible duplicate relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists releases which have multiple relationships
+         to the same entity using the same relationship type.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases with possible duplicate relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default DuplicateRelationshipsReleases;

--- a/root/report/DuplicateRelationshipsWorks.js
+++ b/root/report/DuplicateRelationshipsWorks.js
@@ -11,29 +11,31 @@ import ReportLayout from './components/ReportLayout.js';
 import WorkList from './components/WorkList.js';
 import type {ReportDataT, ReportWorkT} from './types.js';
 
-const DuplicateRelationshipsWorks = ({
+component DuplicateRelationshipsWorks(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportWorkT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists works which have multiple relationships
-       to the same entity using the same relationship type.
-       This excludes recording-work relationships. See the recording
-       version of this report for those.`,
-    )}
-    entityType="work"
-    filtered={filtered}
-    generated={generated}
-    title={l('Works with possible duplicate relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <WorkList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportWorkT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists works which have multiple relationships
+         to the same entity using the same relationship type.
+         This excludes recording-work relationships. See the recording
+         version of this report for those.`,
+      )}
+      entityType="work"
+      filtered={filtered}
+      generated={generated}
+      title={l('Works with possible duplicate relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <WorkList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default DuplicateRelationshipsWorks;

--- a/root/report/DuplicateReleaseGroups.js
+++ b/root/report/DuplicateReleaseGroups.js
@@ -21,14 +21,13 @@ type ReportReleaseGroupWithKeyT = {
   +key: string,
 };
 
-const DuplicateReleaseGroups = ({
+component DuplicateReleaseGroups(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseGroupWithKeyT>):
-React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportReleaseGroupWithKeyT>) {
   let currentKey = '';
   let lastKey = '';
 
@@ -110,6 +109,6 @@ React$Element<typeof ReportLayout> => {
       </PaginatedResults>
     </ReportLayout>
   );
-};
+}
 
 export default DuplicateReleaseGroups;

--- a/root/report/EventSequenceNotInSeries.js
+++ b/root/report/EventSequenceNotInSeries.js
@@ -11,27 +11,29 @@ import EventList from './components/EventList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportEventT} from './types.js';
 
-const EventSequenceNotInSeries = ({
+component EventSequenceNotInSeries(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportEventT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists events where the event name indicates that it
-       may have to be part of a series or a larger event.`,
-    )}
-    entityType="event"
-    filtered={filtered}
-    generated={generated}
-    title={l('Events which should be part of series or larger event')}
-    totalEntries={pager.total_entries}
-  >
-    <EventList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportEventT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists events where the event name indicates that it
+         may have to be part of a series or a larger event.`,
+      )}
+      entityType="event"
+      filtered={filtered}
+      generated={generated}
+      title={l('Events which should be part of series or larger event')}
+      totalEntries={pager.total_entries}
+    >
+      <EventList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default EventSequenceNotInSeries;

--- a/root/report/FeaturingRecordings.js
+++ b/root/report/FeaturingRecordings.js
@@ -11,36 +11,38 @@ import RecordingList from './components/RecordingList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportRecordingT} from './types.js';
 
-const FeaturingRecordings = ({
+component FeaturingRecordings(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportRecordingT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={exp.l(
-      `This report shows recordings with “(feat. Artist)” 
-       (or similar) in the title. For classical recordings, 
-       consult the {CSG|classical style guidelines}. For 
-       non-classical recordings, this is usually inherited from an
-       older version of MusicBrainz and should be fixed  (both on 
-       the recordings and on the tracks!). Consult the
-       {featured_artists|page about featured artists} to know more.`,
-      {
-        CSG: '/doc/Style/Classical',
-        featured_artists: '/doc/Style/Artist_Credits#Featured_artists',
-      },
-    )}
-    entityType="recording"
-    filtered={filtered}
-    generated={generated}
-    title={l('Recordings with titles containing featuring artists')}
-    totalEntries={pager.total_entries}
-  >
-    <RecordingList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportRecordingT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report shows recordings with “(feat. Artist)” 
+         (or similar) in the title. For classical recordings, 
+         consult the {CSG|classical style guidelines}. For 
+         non-classical recordings, this is usually inherited from an
+         older version of MusicBrainz and should be fixed  (both on 
+         the recordings and on the tracks!). Consult the
+         {featured_artists|page about featured artists} to know more.`,
+        {
+          CSG: '/doc/Style/Classical',
+          featured_artists: '/doc/Style/Artist_Credits#Featured_artists',
+        },
+      )}
+      entityType="recording"
+      filtered={filtered}
+      generated={generated}
+      title={l('Recordings with titles containing featuring artists')}
+      totalEntries={pager.total_entries}
+    >
+      <RecordingList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default FeaturingRecordings;

--- a/root/report/FeaturingReleaseGroups.js
+++ b/root/report/FeaturingReleaseGroups.js
@@ -11,35 +11,37 @@ import ReleaseGroupList from './components/ReleaseGroupList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseGroupT} from './types.js';
 
-const FeaturingReleaseGroups = ({
+component FeaturingReleaseGroups(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseGroupT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={exp.l(
-      `This report shows release groups with “(feat. Artist)” 
-       (or similar) in the title. For classical release groups, 
-       consult the {CSG|classical style guidelines}. For 
-       non-classical release groups, this is usually inherited from an
-       older version of MusicBrainz and should be fixed. Consult the
-       {featured_artists|page about featured artists} to know more.`,
-      {
-        CSG: '/doc/Style/Classical',
-        featured_artists: '/doc/Style/Artist_Credits#Featured_artists',
-      },
-    )}
-    entityType="release_group"
-    filtered={filtered}
-    generated={generated}
-    title={l('Release groups with titles containing featuring artists')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseGroupList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseGroupT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report shows release groups with “(feat. Artist)” 
+         (or similar) in the title. For classical release groups, 
+         consult the {CSG|classical style guidelines}. For 
+         non-classical release groups, this is usually inherited from an
+         older version of MusicBrainz and should be fixed. Consult the
+         {featured_artists|page about featured artists} to know more.`,
+        {
+          CSG: '/doc/Style/Classical',
+          featured_artists: '/doc/Style/Artist_Credits#Featured_artists',
+        },
+      )}
+      entityType="release_group"
+      filtered={filtered}
+      generated={generated}
+      title={l('Release groups with titles containing featuring artists')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseGroupList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default FeaturingReleaseGroups;

--- a/root/report/FeaturingReleases.js
+++ b/root/report/FeaturingReleases.js
@@ -11,38 +11,40 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const FeaturingReleases = ({
+component FeaturingReleases(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={exp.l(
-      `This report shows releases with “(feat. Artist)”
-       (or similar) in the title. For classical releases, 
-       consult the {CSG|classical style guidelines}. For 
-       non-classical releases, this is usually inherited from an
-       older version of MusicBrainz and should be fixed. Consult the
-       {featured_artists|page about featured artists} to know more.
-       Don’t forget that the same generally applies to tracks, so if
-       the track titles also include featuring credits you can fix
-       them too while you edit the release!`,
-      {
-        CSG: '/doc/Style/Classical',
-        featured_artists: '/doc/Style/Artist_Credits#Featured_artists',
-      },
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases with titles containing featuring artists')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report shows releases with “(feat. Artist)”
+         (or similar) in the title. For classical releases, 
+         consult the {CSG|classical style guidelines}. For 
+         non-classical releases, this is usually inherited from an
+         older version of MusicBrainz and should be fixed. Consult the
+         {featured_artists|page about featured artists} to know more.
+         Don’t forget that the same generally applies to tracks, so if
+         the track titles also include featuring credits you can fix
+         them too while you edit the release!`,
+        {
+          CSG: '/doc/Style/Classical',
+          featured_artists: '/doc/Style/Artist_Credits#Featured_artists',
+        },
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases with titles containing featuring artists')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default FeaturingReleases;

--- a/root/report/FilterLink.js
+++ b/root/report/FilterLink.js
@@ -12,11 +12,7 @@ import * as React from 'react';
 import {SanitizedCatalystContext} from '../context.mjs';
 import uriWith from '../utility/uriWith.js';
 
-type Props = {
-  +filtered: boolean,
-};
-
-const FilterLink = ({filtered = false}: Props): React$Element<'li'> => {
+component FilterLink(filtered: boolean = false) {
   const $c = React.useContext(SanitizedCatalystContext);
   const reqUri = $c.req.uri;
 
@@ -33,6 +29,6 @@ const FilterLink = ({filtered = false}: Props): React$Element<'li'> => {
       )}
     </li>
   );
-};
+}
 
 export default FilterLink;

--- a/root/report/InstrumentsWithoutAnImage.js
+++ b/root/report/InstrumentsWithoutAnImage.js
@@ -11,27 +11,29 @@ import InstrumentList from './components/InstrumentList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportInstrumentT} from './types.js';
 
-const InstrumentsWithoutAnImage = ({
+component InstrumentsWithoutAnImage(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportInstrumentT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l_admin(
-      `This report shows instruments without an image relationship
-       to StaticBrainz (that is, without an IROMBOOK image).`,
-    )}
-    entityType="instrument"
-    filtered={filtered}
-    generated={generated}
-    title="Instruments without an image"
-    totalEntries={pager.total_entries}
-  >
-    <InstrumentList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportInstrumentT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l_admin(
+        `This report shows instruments without an image relationship
+         to StaticBrainz (that is, without an IROMBOOK image).`,
+      )}
+      entityType="instrument"
+      filtered={filtered}
+      generated={generated}
+      title="Instruments without an image"
+      totalEntries={pager.total_entries}
+    >
+      <InstrumentList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default InstrumentsWithoutAnImage;

--- a/root/report/InstrumentsWithoutWikidata.js
+++ b/root/report/InstrumentsWithoutWikidata.js
@@ -11,26 +11,28 @@ import InstrumentList from './components/InstrumentList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportInstrumentT} from './types.js';
 
-const InstrumentsWithoutWikidata = ({
+component InstrumentsWithoutWikidata(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportInstrumentT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l_admin(
-      `This report shows instruments without Wikidata relationships.`,
-    )}
-    entityType="instrument"
-    filtered={filtered}
-    generated={generated}
-    title="Instruments without a link to Wikidata"
-    totalEntries={pager.total_entries}
-  >
-    <InstrumentList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportInstrumentT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l_admin(
+        `This report shows instruments without Wikidata relationships.`,
+      )}
+      entityType="instrument"
+      filtered={filtered}
+      generated={generated}
+      title="Instruments without a link to Wikidata"
+      totalEntries={pager.total_entries}
+    >
+      <InstrumentList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default InstrumentsWithoutWikidata;

--- a/root/report/IsrcsWithManyRecordings.js
+++ b/root/report/IsrcsWithManyRecordings.js
@@ -20,13 +20,13 @@ import formatTrackLength
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportIsrcT} from './types.js';
 
-const IsrcsWithManyRecordings = ({
+component IsrcsWithManyRecordings(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportIsrcT>): React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportIsrcT>) {
   let lastIsrc: string = '';
   let currentIsrc: string = '';
 
@@ -108,6 +108,6 @@ const IsrcsWithManyRecordings = ({
       </PaginatedResults>
     </ReportLayout>
   );
-};
+}
 
 export default IsrcsWithManyRecordings;

--- a/root/report/IswcsWithManyWorks.js
+++ b/root/report/IswcsWithManyWorks.js
@@ -17,13 +17,13 @@ import {bracketedText} from '../static/scripts/common/utility/bracketed.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportIswcT} from './types.js';
 
-const IswcsWithManyWorks = ({
+component IswcsWithManyWorks(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportIswcT>): React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportIswcT>) {
   let lastIswc: string = '';
   let currentIswc: string = '';
 
@@ -93,6 +93,6 @@ const IswcsWithManyWorks = ({
       </PaginatedResults>
     </ReportLayout>
   );
-};
+}
 
 export default IswcsWithManyWorks;

--- a/root/report/LabelsDisambiguationSameName.js
+++ b/root/report/LabelsDisambiguationSameName.js
@@ -11,28 +11,30 @@ import LabelList from './components/LabelList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportLabelT} from './types.js';
 
-const LabelsDisambiguationSameName = ({
+component LabelsDisambiguationSameName(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportLabelT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists labels that have their disambiguation set
-       to be the same as their name.
-       The disambiguation should be removed or, if it is needed, improved.`,
-    )}
-    entityType="label"
-    filtered={filtered}
-    generated={generated}
-    title={l('Labels with disambiguation the same as the name')}
-    totalEntries={pager.total_entries}
-  >
-    <LabelList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportLabelT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists labels that have their disambiguation set
+         to be the same as their name.
+         The disambiguation should be removed or, if it is needed, improved.`,
+      )}
+      entityType="label"
+      filtered={filtered}
+      generated={generated}
+      title={l('Labels with disambiguation the same as the name')}
+      totalEntries={pager.total_entries}
+    >
+      <LabelList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default LabelsDisambiguationSameName;

--- a/root/report/LimitedEditors.js
+++ b/root/report/LimitedEditors.js
@@ -16,13 +16,13 @@ import EditorList from './components/EditorList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportEditorT} from './types.js';
 
-const LimitedEditors = ({
+component LimitedEditors(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportEditorT>): React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportEditorT>) {
   const $c = React.useContext(CatalystContext);
   return (
     <ReportLayout
@@ -44,6 +44,6 @@ const LimitedEditors = ({
       )}
     </ReportLayout>
   );
-};
+}
 
 export default LimitedEditors;

--- a/root/report/LinksWithMultipleEntities.js
+++ b/root/report/LinksWithMultipleEntities.js
@@ -24,13 +24,13 @@ type ReportEntryT = {
   +url_id: number,
 };
 
-const LinksWithMultipleEntities = ({
+component LinksWithMultipleEntities(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportEntryT>): React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportEntryT>) {
   const $c = React.useContext(CatalystContext);
 
   return (
@@ -93,6 +93,6 @@ const LinksWithMultipleEntities = ({
       </PaginatedResults>
     </ReportLayout>
   );
-};
+}
 
 export default LinksWithMultipleEntities;

--- a/root/report/LowDataQualityReleases.js
+++ b/root/report/LowDataQualityReleases.js
@@ -11,33 +11,35 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const LowDataQualityReleases = ({
+component LowDataQualityReleases(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React.Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases that have been marked as having low data
-       quality.
-       If you have some time, you can review them and try to improve the data
-       as much as possible before changing their data quality back to Normal
-       (or even to High, if you add all the possible data!). If a release
-       has already been improved but the data quality wasn’t changed
-       accordingly,
-       just enter a data quality change to remove it from this report.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases marked as having low data quality')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases that have been marked as having low data
+         quality.
+         If you have some time, you can review them and try to improve the
+         data as much as possible before changing their data quality back to
+         Normal (or even to High, if you add all the possible data!). If a
+         release has already been improved but the data quality wasn’t changed
+         accordingly,
+         just enter a data quality change to remove it from this report.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases marked as having low data quality')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default LowDataQualityReleases;

--- a/root/report/MediumsWithOrderInTitle.js
+++ b/root/report/MediumsWithOrderInTitle.js
@@ -11,30 +11,32 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const MediumsWithOrderInTitle = ({
+component MediumsWithOrderInTitle(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={exp.l(
-      `This report lists releases where at least one medium has a title
-       that seems to just be indicating its position (such a first medium
-       with the title “Disc 1”). These should usually be removed, as per
-       {release_style|the release guidelines}.`,
-      {release_style: '/doc/Style/Release#Medium_title'},
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases with mediums named after their position')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report lists releases where at least one medium has a title
+         that seems to just be indicating its position (such a first medium
+         with the title “Disc 1”). These should usually be removed, as per
+         {release_style|the release guidelines}.`,
+        {release_style: '/doc/Style/Release#Medium_title'},
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases with mediums named after their position')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default MediumsWithOrderInTitle;

--- a/root/report/MediumsWithSequenceIssues.js
+++ b/root/report/MediumsWithSequenceIssues.js
@@ -11,27 +11,29 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const MediumsWithSequenceIssues = ({
+component MediumsWithSequenceIssues(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists all releases with gaps in the medium numbers
-       (for example, there is a medium 1 and 3 but no medium 2).`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases with medium number issues')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists all releases with gaps in the medium numbers
+         (for example, there is a medium 1 and 3 but no medium 2).`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases with medium number issues')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default MediumsWithSequenceIssues;

--- a/root/report/MislinkedPseudoReleases.js
+++ b/root/report/MislinkedPseudoReleases.js
@@ -11,31 +11,34 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const MislinkedPseudoReleases = ({
+component MislinkedPseudoReleases(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases with status Pseudo-Release that are
-       marked as the original version of a translation/transliteration
-       relationship. The pseudo-release should be the one marked as a
-       translated/transliterated version instead. If both releases
-       are pseudo-releases, consider linking both to an official release
-       rather than to each other.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Translated/transliterated pseudo-releases marked as original')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases with status Pseudo-Release that are
+         marked as the original version of a translation/transliteration
+         relationship. The pseudo-release should be the one marked as a
+         translated/transliterated version instead. If both releases
+         are pseudo-releases, consider linking both to an official release
+         rather than to each other.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l(`Translated/transliterated pseudo-releases
+                marked as original`)}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default MislinkedPseudoReleases;

--- a/root/report/MultipleAsins.js
+++ b/root/report/MultipleAsins.js
@@ -11,31 +11,33 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const MultipleAsins = ({
+component MultipleAsins(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases that have more than one Amazon ASIN.
-       In most cases ASINs should map to MusicBrainz releases 1:1, so
-       only one of them will be correct. Just check which ones do not
-       fit the release (because of format, different number of tracks,
-       etc). If the release has a barcode, you can search Amazon for it
-       and see which ASIN matches.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases with multiple ASINs')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases that have more than one Amazon ASIN.
+         In most cases ASINs should map to MusicBrainz releases 1:1, so
+         only one of them will be correct. Just check which ones do not
+         fit the release (because of format, different number of tracks,
+         etc). If the release has a barcode, you can search Amazon for it
+         and see which ASIN matches.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases with multiple ASINs')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default MultipleAsins;

--- a/root/report/MultipleDiscogsLinks.js
+++ b/root/report/MultipleDiscogsLinks.js
@@ -11,33 +11,35 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const MultipleDiscogsLinks = ({
+component MultipleDiscogsLinks(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={exp.l(
-      `This report shows releases that have more than one link to Discogs.
-       In most cases a MusicBrainz release should have only one equivalent
-       in Discogs, so only one of them will be correct. Just check which
-       ones do not fit the release (because of format, different number of
-       tracks, etc). Any "master" Discogs page belongs at the
-       {release_group|release group level}, not at the release level, and
-       should be removed from releases too.`,
-      {release_group: '/doc/Release_Group'},
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases with multiple Discogs links')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report shows releases that have more than one link to Discogs.
+         In most cases a MusicBrainz release should have only one equivalent
+         in Discogs, so only one of them will be correct. Just check which
+         ones do not fit the release (because of format, different number of
+         tracks, etc). Any "master" Discogs page belongs at the
+         {release_group|release group level}, not at the release level, and
+         should be removed from releases too.`,
+        {release_group: '/doc/Release_Group'},
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases with multiple Discogs links')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default MultipleDiscogsLinks;

--- a/root/report/NoLanguage.js
+++ b/root/report/NoLanguage.js
@@ -12,13 +12,13 @@ import ReportLayout from './components/ReportLayout.js';
 import useReleaseLanguageColumn from './hooks/useReleaseLanguageColumn.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const NoLanguage = ({
+component NoLanguage(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportReleaseT>) {
   const releaseLanguageColumn = useReleaseLanguageColumn<ReportReleaseT>();
 
   return (
@@ -43,6 +43,6 @@ const NoLanguage = ({
       />
     </ReportLayout>
   );
-};
+}
 
 export default NoLanguage;

--- a/root/report/NoScript.js
+++ b/root/report/NoScript.js
@@ -12,13 +12,13 @@ import ReportLayout from './components/ReportLayout.js';
 import useReleaseLanguageColumn from './hooks/useReleaseLanguageColumn.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const NoScript = ({
+component NoScript(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportReleaseT>) {
   const releaseLanguageColumn = useReleaseLanguageColumn<ReportReleaseT>();
 
   return (
@@ -42,6 +42,6 @@ const NoScript = ({
       />
     </ReportLayout>
   );
-};
+}
 
 export default NoScript;

--- a/root/report/NonBootlegsOnBootlegLabels.js
+++ b/root/report/NonBootlegsOnBootlegLabels.js
@@ -11,29 +11,32 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const NonBootlegsOnBootlegLabels = ({
+component NonBootlegsOnBootlegLabels(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases that have at least one “Bootleg Production”
-       label in their labels list, but are not set to status “Bootleg”.
-       These labels pretty much never release non-bootleg releases,
-       so chances are that either the label or the status is wrong.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases on bootleg labels not set to bootleg')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases that have at least one “Bootleg
+         Production” label in their labels list, but are not set to status
+         “Bootleg”.
+         These labels pretty much never release non-bootleg releases,
+         so chances are that either the label or the status is wrong.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases on bootleg labels not set to bootleg')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default NonBootlegsOnBootlegLabels;

--- a/root/report/PartOfSetRelationships.js
+++ b/root/report/PartOfSetRelationships.js
@@ -11,33 +11,35 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const PartOfSetRelationships = ({
+component PartOfSetRelationships(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={exp.l(
-      `This report shows releases that still have the deprecated "part
-       of set" relationship and should probably be merged. For
-       instructions on how to fix them, please see the documentation
-       about {how_to_merge_releases|how to merge releases}. If the
-       releases are not really part of a set (for example, if they are
-       independently-released volumes in a series) just remove the
-       relationship.`,
-      {how_to_merge_releases: '/doc/How_to_Merge_Releases'},
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases with “part of set” relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report shows releases that still have the deprecated "part
+         of set" relationship and should probably be merged. For
+         instructions on how to fix them, please see the documentation
+         about {how_to_merge_releases|how to merge releases}. If the
+         releases are not really part of a set (for example, if they are
+         independently-released volumes in a series) just remove the
+         relationship.`,
+        {how_to_merge_releases: '/doc/How_to_Merge_Releases'},
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases with “part of set” relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default PartOfSetRelationships;

--- a/root/report/PlacesWithoutCoordinates.js
+++ b/root/report/PlacesWithoutCoordinates.js
@@ -16,120 +16,121 @@ import loopParity from '../utility/loopParity.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportPlaceRelationshipT} from './types.js';
 
-const PlacesWithoutCoordinates = ({
+component PlacesWithoutCoordinates(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportPlaceRelationshipT>):
-React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l('This report lists places without coordinates.')}
-    entityType="place"
-    filtered={filtered}
-    generated={generated}
-    title={l('Places without coordinates')}
-    totalEntries={pager.total_entries}
-  >
-    <PaginatedResults pager={pager}>
-      <table className="tbl">
-        <thead>
-          <tr>
-            <th>{l('Place')}</th>
-            <th>{l('Address')}</th>
-            <th>{l('Area')}</th>
-            <th>{l('Search for coordinates')}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((item, index) => {
-            const place = item.place;
-            const query = place ? (
-              encodeURIComponent(
-                place.name +
-                ' ' +
-                place.address +
-                (place.area ? ' ' + place.area.name : ''),
-              )
-            ) : '';
-            return (
-              <tr className={loopParity(index)} key={item.place_id}>
-                {place ? (
-                  <>
-                    <td>
-                      <EntityLink entity={place} />
+}: ReportDataT<ReportPlaceRelationshipT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l('This report lists places without coordinates.')}
+      entityType="place"
+      filtered={filtered}
+      generated={generated}
+      title={l('Places without coordinates')}
+      totalEntries={pager.total_entries}
+    >
+      <PaginatedResults pager={pager}>
+        <table className="tbl">
+          <thead>
+            <tr>
+              <th>{l('Place')}</th>
+              <th>{l('Address')}</th>
+              <th>{l('Area')}</th>
+              <th>{l('Search for coordinates')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item, index) => {
+              const place = item.place;
+              const query = place ? (
+                encodeURIComponent(
+                  place.name +
+                  ' ' +
+                  place.address +
+                  (place.area ? ' ' + place.area.name : ''),
+                )
+              ) : '';
+              return (
+                <tr className={loopParity(index)} key={item.place_id}>
+                  {place ? (
+                    <>
+                      <td>
+                        <EntityLink entity={place} />
+                      </td>
+                      <td>{place.address}</td>
+                      <td>
+                        {place.area
+                          ? <DescriptiveLink entity={place.area} />
+                          : null}
+                      </td>
+                      <td className="search-links">
+                        <span className="no-favicon">
+                          <a
+                            href={
+                              'https://www.openstreetmap.org/search?query=' + query
+                            }
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="OpenStreetMap"
+                          >
+                            {'OSM'}
+                          </a>
+                        </span>
+                        {' | '}
+                        <span>
+                          <a
+                            href={'https://www.qwant.com/local/?q=' + query}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="Qwant Local"
+                          >
+                            {'QL'}
+                          </a>
+                        </span>
+                        {' | '}
+                        <span>
+                          <a
+                            href={
+                              'https://www.mapquest.com/search/results/?query=' +
+                              query
+                            }
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="MapQuest"
+                          >
+                            {'MQ'}
+                          </a>
+                        </span>
+                        {' | '}
+                        <span>
+                          <a
+                            href={'https://www.google.com/maps/search/' + query}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="Google Maps"
+                          >
+                            {'GM'}
+                          </a>
+                        </span>
+                      </td>
+                    </>
+                  ) : (
+                    <td colSpan="4">
+                      {l('This place no longer exists.')}
                     </td>
-                    <td>{place.address}</td>
-                    <td>
-                      {place.area
-                        ? <DescriptiveLink entity={place.area} />
-                        : null}
-                    </td>
-                    <td className="search-links">
-                      <span className="no-favicon">
-                        <a
-                          href={
-                            'https://www.openstreetmap.org/search?query=' + query
-                          }
-                          rel="noopener noreferrer"
-                          target="_blank"
-                          title="OpenStreetMap"
-                        >
-                          {'OSM'}
-                        </a>
-                      </span>
-                      {' | '}
-                      <span>
-                        <a
-                          href={'https://www.qwant.com/local/?q=' + query}
-                          rel="noopener noreferrer"
-                          target="_blank"
-                          title="Qwant Local"
-                        >
-                          {'QL'}
-                        </a>
-                      </span>
-                      {' | '}
-                      <span>
-                        <a
-                          href={
-                            'https://www.mapquest.com/search/results/?query=' +
-                            query
-                          }
-                          rel="noopener noreferrer"
-                          target="_blank"
-                          title="MapQuest"
-                        >
-                          {'MQ'}
-                        </a>
-                      </span>
-                      {' | '}
-                      <span>
-                        <a
-                          href={'https://www.google.com/maps/search/' + query}
-                          rel="noopener noreferrer"
-                          target="_blank"
-                          title="Google Maps"
-                        >
-                          {'GM'}
-                        </a>
-                      </span>
-                    </td>
-                  </>
-                ) : (
-                  <td colSpan="4">
-                    {l('This place no longer exists.')}
-                  </td>
-                )}
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </PaginatedResults>
-  </ReportLayout>
-);
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </PaginatedResults>
+    </ReportLayout>
+  );
+}
 
 export default PlacesWithoutCoordinates;

--- a/root/report/PossibleCollaborations.js
+++ b/root/report/PossibleCollaborations.js
@@ -11,37 +11,38 @@ import ArtistList from './components/ArtistList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportArtistT, ReportDataT} from './types.js';
 
-const PossibleCollaborations = ({
+component PossibleCollaborations(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportArtistT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={exp.l(
-      `This report lists artists which have “&” in their names
-       but no membership-related relationships (none of member,
-       collaborator, conductor, founder nor subgroup). If the artist
-       is usually seen as an actual group, member relationships should
-       be added. If it’s a short term collaboration, it should be split
-       if possible (see {how_to_split_artists|How to Split Artists}).
-       If it is a collaboration with its own name and can’t be split,
-       collaboration relationships should be added to it. For some
-       special cases, such as “Person & His Orchestra”, conductor
-       and/or founder might be the best choice.`,
-      {how_to_split_artists: '/doc/How_to_Split_Artists'},
-    )}
-    entityType="artist"
-    filtered={filtered}
-    generated={generated}
-    title={l('Artists that may be collaborations')}
-    totalEntries={pager.total_entries}
-  >
-    <ArtistList items={items} pager={pager} />
-  </ReportLayout>
-);
-
+}: ReportDataT<ReportArtistT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report lists artists which have “&” in their names
+         but no membership-related relationships (none of member,
+         collaborator, conductor, founder nor subgroup). If the artist
+         is usually seen as an actual group, member relationships should
+         be added. If it’s a short term collaboration, it should be split
+         if possible (see {how_to_split_artists|How to Split Artists}).
+         If it is a collaboration with its own name and can’t be split,
+         collaboration relationships should be added to it. For some
+         special cases, such as “Person & His Orchestra”, conductor
+         and/or founder might be the best choice.`,
+        {how_to_split_artists: '/doc/How_to_Split_Artists'},
+      )}
+      entityType="artist"
+      filtered={filtered}
+      generated={generated}
+      title={l('Artists that may be collaborations')}
+      totalEntries={pager.total_entries}
+    >
+      <ArtistList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default PossibleCollaborations;

--- a/root/report/RecordingTrackDifferentName.js
+++ b/root/report/RecordingTrackDifferentName.js
@@ -23,33 +23,34 @@ export type ReportRecordingTrackT = {
   +track_id: number,
 };
 
-const RecordingTrackDifferentName = ({
+component RecordingTrackDifferentName(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportRecordingTrackT>):
-React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows recordings that are linked to only one track,
-        yet have a different name than the track. This might mean
-        one of the two needs to be renamed to match the other.`,
-    )}
-    entityType="recording"
-    filtered={filtered}
-    generated={generated}
-    title={l('Recordings with a different name than their only track')}
-    totalEntries={pager.total_entries}
-  >
-    <RecordingList
-      columnsBefore={[trackColumn]}
-      items={items}
-      pager={pager}
-    />
-  </ReportLayout>
-);
+}: ReportDataT<ReportRecordingTrackT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows recordings that are linked to only one track,
+         yet have a different name than the track. This might mean
+         one of the two needs to be renamed to match the other.`,
+      )}
+      entityType="recording"
+      filtered={filtered}
+      generated={generated}
+      title={l('Recordings with a different name than their only track')}
+      totalEntries={pager.total_entries}
+    >
+      <RecordingList
+        columnsBefore={[trackColumn]}
+        items={items}
+        pager={pager}
+      />
+    </ReportLayout>
+  );
+}
 
 export default RecordingTrackDifferentName;

--- a/root/report/RecordingsSameNameDifferentArtistsSameName.js
+++ b/root/report/RecordingsSameNameDifferentArtistsSameName.js
@@ -17,78 +17,80 @@ import loopParity from '../utility/loopParity.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportRecordingT} from './types.js';
 
-const RecordingsSameNameDifferentArtistsSameName = ({
+component RecordingsSameNameDifferentArtistsSameName(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportRecordingT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={exp.l(
-      `This report shows all recordings with the same name that have
-       different artists (having different MBIDs) with the same name.
-       These are most likely cases where the {ac|artist credit} is
-       incorrect for at least one of the recordings.`,
-      {ac: '/doc/Artist_Credits'},
-    )}
-    entityType="recording"
-    extraInfo={l(
-      `Currently, this report only works
-       with recordings that have one artist.`,
-    )}
-    filtered={filtered}
-    generated={generated}
-    title={l(
-      `Recordings with the same name
-       by different artists with the same name`,
-    )}
-    totalEntries={pager.total_entries}
-  >
-    <PaginatedResults pager={pager}>
-      <table className="tbl">
-        <thead>
-          <tr>
-            <th>{l('Artist')}</th>
-            <th>{l('Recording')}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((item, index) => {
-            const recording = item.recording;
-            return (
-              <tr className={loopParity(index)} key={item.recording_id}>
-                {recording ? (
-                  <>
-                    <td>
-                      <ArtistCreditLink
-                        artistCredit={recording.artistCredit}
-                      />
-                      <span className="comment">
-                        <bdi key="comment">
-                          {' ' + bracketedText(
-                            recording.artistCredit.names[0].artist.comment,
-                          )}
-                        </bdi>
-                      </span>
+}: ReportDataT<ReportRecordingT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report shows all recordings with the same name that have
+         different artists (having different MBIDs) with the same name.
+         These are most likely cases where the {ac|artist credit} is
+         incorrect for at least one of the recordings.`,
+        {ac: '/doc/Artist_Credits'},
+      )}
+      entityType="recording"
+      extraInfo={l(
+        `Currently, this report only works
+        with recordings that have one artist.`,
+      )}
+      filtered={filtered}
+      generated={generated}
+      title={l(
+        `Recordings with the same name
+         by different artists with the same name`,
+      )}
+      totalEntries={pager.total_entries}
+    >
+      <PaginatedResults pager={pager}>
+        <table className="tbl">
+          <thead>
+            <tr>
+              <th>{l('Artist')}</th>
+              <th>{l('Recording')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item, index) => {
+              const recording = item.recording;
+              return (
+                <tr className={loopParity(index)} key={item.recording_id}>
+                  {recording ? (
+                    <>
+                      <td>
+                        <ArtistCreditLink
+                          artistCredit={recording.artistCredit}
+                        />
+                        <span className="comment">
+                          <bdi key="comment">
+                            {' ' + bracketedText(
+                              recording.artistCredit.names[0].artist.comment,
+                            )}
+                          </bdi>
+                        </span>
+                      </td>
+                      <td>
+                        <EntityLink entity={recording} />
+                      </td>
+                    </>
+                  ) : (
+                    <td colSpan="2">
+                      {l('This recording no longer exists.')}
                     </td>
-                    <td>
-                      <EntityLink entity={recording} />
-                    </td>
-                  </>
-                ) : (
-                  <td colSpan="2">
-                    {l('This recording no longer exists.')}
-                  </td>
-                )}
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </PaginatedResults>
-  </ReportLayout>
-);
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </PaginatedResults>
+    </ReportLayout>
+  );
+}
 
 export default RecordingsSameNameDifferentArtistsSameName;

--- a/root/report/RecordingsWithEarliestReleaseRelationships.js
+++ b/root/report/RecordingsWithEarliestReleaseRelationships.js
@@ -11,31 +11,33 @@ import RecordingList from './components/RecordingList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportRecordingT} from './types.js';
 
-const RecordingsWithEarliestReleaseRelationships = ({
+component RecordingsWithEarliestReleaseRelationships(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportRecordingT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows recordings that have the deprecated "earliest
-       release" relationship. They should be merged if they are truly
-       the same recording; if they're not, the relationship should be
-       removed. Please, do not merge recordings blindly just because
-       the lengths fit, and do not merge recordings with very different
-       times!`,
-    )}
-    entityType="recording"
-    filtered={filtered}
-    generated={generated}
-    title={l('Recordings with earliest release relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <RecordingList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportRecordingT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows recordings that have the deprecated "earliest
+         release" relationship. They should be merged if they are truly
+         the same recording; if they're not, the relationship should be
+         removed. Please, do not merge recordings blindly just because
+         the lengths fit, and do not merge recordings with very different
+         times!`,
+      )}
+      entityType="recording"
+      filtered={filtered}
+      generated={generated}
+      title={l('Recordings with earliest release relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <RecordingList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default RecordingsWithEarliestReleaseRelationships;

--- a/root/report/RecordingsWithFutureDates.js
+++ b/root/report/RecordingsWithFutureDates.js
@@ -18,14 +18,13 @@ import RecordingList from './components/RecordingList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportRecordingRelationshipT} from './types.js';
 
-const RecordingsWithFutureDates = ({
+component RecordingsWithFutureDates(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportRecordingRelationshipT>):
-React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportRecordingRelationshipT>) {
   const extraColumns = React.useMemo(
     () => {
       const beginDateColumn = defineTextColumn<ReportRecordingRelationshipT>({
@@ -68,6 +67,6 @@ React$Element<typeof ReportLayout> => {
       />
     </ReportLayout>
   );
-};
+}
 
 export default RecordingsWithFutureDates;

--- a/root/report/RecordingsWithVaryingTrackLengths.js
+++ b/root/report/RecordingsWithVaryingTrackLengths.js
@@ -11,27 +11,29 @@ import RecordingList from './components/RecordingList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportRecordingT} from './types.js';
 
-const RecordingsWithVaryingTrackLengths = ({
+component RecordingsWithVaryingTrackLengths(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportRecordingT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows recordings where the linked tracks
-       have times that vary by more than 30 seconds.`,
-    )}
-    entityType="recording"
-    filtered={filtered}
-    generated={generated}
-    title={l('Recordings with varying track times')}
-    totalEntries={pager.total_entries}
-  >
-    <RecordingList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportRecordingT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows recordings where the linked tracks
+        have times that vary by more than 30 seconds.`,
+      )}
+      entityType="recording"
+      filtered={filtered}
+      generated={generated}
+      title={l('Recordings with varying track times')}
+      totalEntries={pager.total_entries}
+    >
+      <RecordingList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default RecordingsWithVaryingTrackLengths;

--- a/root/report/RecordingsWithoutVaCredit.js
+++ b/root/report/RecordingsWithoutVaCredit.js
@@ -11,27 +11,30 @@ import RecordingList from './components/RecordingList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportRecordingT} from './types.js';
 
-const RecordingsWithoutVaCredit = ({
+component RecordingsWithoutVaCredit(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportRecordingT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows recordings linked to the Various Artists entity
-       without "Various Artists" as the credited name.`,
-    )}
-    entityType="recording"
-    filtered={filtered}
-    generated={generated}
-    title={l('Recordings not credited to "Various Artists" but linked to VA')}
-    totalEntries={pager.total_entries}
-  >
-    <RecordingList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportRecordingT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows recordings linked to the Various Artists entity
+         without "Various Artists" as the credited name.`,
+      )}
+      entityType="recording"
+      filtered={filtered}
+      generated={generated}
+      title={l(`Recordings not credited to "Various Artists"
+                but linked to VA`)}
+      totalEntries={pager.total_entries}
+    >
+      <RecordingList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default RecordingsWithoutVaCredit;

--- a/root/report/RecordingsWithoutVaLink.js
+++ b/root/report/RecordingsWithoutVaLink.js
@@ -11,27 +11,30 @@ import RecordingList from './components/RecordingList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportRecordingT} from './types.js';
 
-const RecordingsWithoutVaLink = ({
+component RecordingsWithoutVaLink(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportRecordingT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows recordings with "Various Artists" as the
-       credited name but not linked to the Various Artists entity.`,
-    )}
-    entityType="recording"
-    filtered={filtered}
-    generated={generated}
-    title={l('Recordings credited to "Various Artists" but not linked to VA')}
-    totalEntries={pager.total_entries}
-  >
-    <RecordingList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportRecordingT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows recordings with "Various Artists" as the
+         credited name but not linked to the Various Artists entity.`,
+      )}
+      entityType="recording"
+      filtered={filtered}
+      generated={generated}
+      title={l(`Recordings credited to "Various Artists"
+                but not linked to VA`)}
+      totalEntries={pager.total_entries}
+    >
+      <RecordingList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default RecordingsWithoutVaLink;

--- a/root/report/ReleaseGroupsWithoutVaCredit.js
+++ b/root/report/ReleaseGroupsWithoutVaCredit.js
@@ -11,29 +11,31 @@ import ReleaseGroupList from './components/ReleaseGroupList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseGroupT} from './types.js';
 
-const ReleaseGroupsWithoutVaCredit = ({
+component ReleaseGroupsWithoutVaCredit(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseGroupT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows release groups linked to the Various Artists
-       entity without "Various Artists" as the credited name.`,
-    )}
-    entityType="release_group"
-    filtered={filtered}
-    generated={generated}
-    title={l(
-      'Release groups not credited to "Various Artists" but linked to VA',
-    )}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseGroupList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseGroupT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows release groups linked to the Various Artists
+         entity without "Various Artists" as the credited name.`,
+      )}
+      entityType="release_group"
+      filtered={filtered}
+      generated={generated}
+      title={l(
+        'Release groups not credited to "Various Artists" but linked to VA',
+      )}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseGroupList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ReleaseGroupsWithoutVaCredit;

--- a/root/report/ReleaseGroupsWithoutVaLink.js
+++ b/root/report/ReleaseGroupsWithoutVaLink.js
@@ -11,29 +11,31 @@ import ReleaseGroupList from './components/ReleaseGroupList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseGroupT} from './types.js';
 
-const ReleaseGroupsWithoutVaLink = ({
+component ReleaseGroupsWithoutVaLink(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseGroupT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows release groups with "Various Artists" as the
-       credited name but not linked to the Various Artists entity.`,
-    )}
-    entityType="release_group"
-    filtered={filtered}
-    generated={generated}
-    title={l(
-      'Release groups credited to "Various Artists" but not linked to VA',
-    )}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseGroupList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseGroupT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows release groups with "Various Artists" as the
+         credited name but not linked to the Various Artists entity.`,
+      )}
+      entityType="release_group"
+      filtered={filtered}
+      generated={generated}
+      title={l(
+        'Release groups credited to "Various Artists" but not linked to VA',
+      )}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseGroupList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ReleaseGroupsWithoutVaLink;

--- a/root/report/ReleaseLabelSameArtist.js
+++ b/root/report/ReleaseLabelSameArtist.js
@@ -13,13 +13,13 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseLabelT} from './types.js';
 
-const ReleaseLabelSameArtist = ({
+component ReleaseLabelSameArtist(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseLabelT>): React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportReleaseLabelT>) {
   const labelColumn = {
     Cell: ({
       row: {original},
@@ -57,6 +57,6 @@ const ReleaseLabelSameArtist = ({
       />
     </ReportLayout>
   );
-};
+}
 
 export default ReleaseLabelSameArtist;

--- a/root/report/ReleaseRgDifferentName.js
+++ b/root/report/ReleaseRgDifferentName.js
@@ -15,14 +15,13 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseReleaseGroupT} from './types.js';
 
-const ReleaseRgDifferentName = ({
+component ReleaseRgDifferentName(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseReleaseGroupT>):
-React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportReleaseReleaseGroupT>) {
   const releaseGroupColumn = defineEntityColumn<ReportReleaseReleaseGroupT>({
     columnName: 'release_group',
     descriptive: false,
@@ -51,6 +50,6 @@ React$Element<typeof ReportLayout> => {
       />
     </ReportLayout>
   );
-};
+}
 
 export default ReleaseRgDifferentName;

--- a/root/report/ReleasedTooEarly.js
+++ b/root/report/ReleasedTooEarly.js
@@ -11,30 +11,32 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const ReleasedTooEarly = ({
+component ReleasedTooEarly(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases which have disc IDs even though they
-       were released too early to have disc IDs, where one of the medium
-       formats didn't exist at the time the release was released or
-       where a disc ID is attached to a medium whose format does not
-       have disc IDs.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases released too early')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases which have disc IDs even though they
+         were released too early to have disc IDs, where one of the medium
+         formats didn't exist at the time the release was released or
+         where a disc ID is attached to a medium whose format does not
+         have disc IDs.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases released too early')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ReleasedTooEarly;

--- a/root/report/ReleasesConflictingDiscIds.js
+++ b/root/report/ReleasesConflictingDiscIds.js
@@ -11,28 +11,31 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const ReleasesConflictingDiscIds = ({
+component ReleasesConflictingDiscIds(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases that have conflicting disc IDs on the
-       same medium with significant differences in duration. This usually
-       means a disc ID was applied to the wrong medium or the wrong release.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases with conflicting disc IDs')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} subPath="discids" />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases that have conflicting disc IDs on the
+         same medium with significant differences in duration. This usually
+         means a disc ID was applied to the wrong medium
+         or the wrong release.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases with conflicting disc IDs')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} subPath="discids" />
+    </ReportLayout>
+  );
+}
 
 export default ReleasesConflictingDiscIds;

--- a/root/report/ReleasesMissingDiscIds.js
+++ b/root/report/ReleasesMissingDiscIds.js
@@ -11,33 +11,35 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const ReleasesMissingDiscIds = ({
+component ReleasesMissingDiscIds(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases (official and promotional only) that
-       have at least one medium with a format that supports disc IDs,
-       but is missing one.`,
-    )}
-    entityType="release"
-    extraInfo={exp.l(
-      `For instructions on how to add one, see the
-       {add_discids|documentation page}.`,
-      {add_discids: '/doc/How_to_Add_Disc_IDs'},
-    )}
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases missing disc IDs')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases (official and promotional only) that
+         have at least one medium with a format that supports disc IDs,
+         but is missing one.`,
+      )}
+      entityType="release"
+      extraInfo={exp.l(
+        `For instructions on how to add one, see the
+         {add_discids|documentation page}.`,
+        {add_discids: '/doc/How_to_Add_Disc_IDs'},
+      )}
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases missing disc IDs')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ReleasesMissingDiscIds;

--- a/root/report/ReleasesSameBarcode.js
+++ b/root/report/ReleasesSameBarcode.js
@@ -26,13 +26,13 @@ type ReportRowT = {
   +row_number: number,
 };
 
-const ReleasesSameBarcode = ({
+component ReleasesSameBarcode(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportRowT>): React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportRowT>) {
   const barcodeColumn = defineTextColumn<ReportRowT>({
     cellProps: {className: 'barcode-cell'},
     columnName: 'barcode',
@@ -68,6 +68,6 @@ const ReleasesSameBarcode = ({
       />
     </ReportLayout>
   );
-};
+}
 
 export default ReleasesSameBarcode;

--- a/root/report/ReleasesToConvert.js
+++ b/root/report/ReleasesToConvert.js
@@ -11,29 +11,31 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const ReleasesToConvert = ({
+component ReleasesToConvert(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report aims to identify releases which need converting to
-       multiple artists (because the track artists are on the title
-       field, for example). Currently it does this by looking for
-       releases where every track contains "/" or "-".`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases which might need converting to "multiple artists"')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report aims to identify releases which need converting to
+         multiple artists (because the track artists are on the title
+         field, for example). Currently it does this by looking for
+         releases where every track contains "/" or "-".`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases which might need converting to "multiple artists"')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ReleasesToConvert;

--- a/root/report/ReleasesWithAmazonCoverArt.js
+++ b/root/report/ReleasesWithAmazonCoverArt.js
@@ -11,32 +11,34 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const ReleasesWithAmazonCoverArt = ({
+component ReleasesWithAmazonCoverArt(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases which have cover art on Amazon, but have
-       no front cover in the Cover Art Archive. The use of Amazon art has been
-       discontinued since the 16th of May 2022, so these releases have no
-       front cover anymore until one is added to the Cover Art Archive.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l(
-      `Releases that have Amazon cover art
-       but no Cover Art Archive front cover`,
-    )}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases which have cover art on Amazon, but have
+         no front cover in the Cover Art Archive. The use of Amazon art has
+         been discontinued since the 16th of May 2022, so these releases have
+         no front cover anymore until one is added to the Cover Art Archive.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l(
+        `Releases that have Amazon cover art
+         but no Cover Art Archive front cover`,
+      )}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ReleasesWithAmazonCoverArt;

--- a/root/report/ReleasesWithCaaNoTypes.js
+++ b/root/report/ReleasesWithCaaNoTypes.js
@@ -11,30 +11,31 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const ReleasesWithCaaNoTypes = ({
+component ReleasesWithCaaNoTypes(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases which have cover art in the Cover Art
-       Archive, but where none of it has any types set. This often means
-       a front cover was added, but not marked as such.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l(
-      'Releases in the Cover Art Archive where no cover art piece has types',
-    )}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases which have cover art in the Cover Art
+         Archive, but where none of it has any types set. This often means
+         a front cover was added, but not marked as such.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l(`Releases in the Cover Art Archive
+                where no cover art piece has types`)}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ReleasesWithCaaNoTypes;

--- a/root/report/ReleasesWithDownloadRelationships.js
+++ b/root/report/ReleasesWithDownloadRelationships.js
@@ -11,31 +11,33 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const ReleasesWithDownloadRelationships = ({
+component ReleasesWithDownloadRelationships(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases that have relationships
-       that only apply to digital media releases (download/streaming),
-       but have media whose format is not “Digital Media”.
-       Generally, these should be moved to the appropriate
-       digital media release. If one doesn’t exist yet,
-       feel free to add it.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Non-digital releases with digital relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases that have relationships
+         that only apply to digital media releases (download/streaming),
+         but have media whose format is not “Digital Media”.
+         Generally, these should be moved to the appropriate
+         digital media release. If one doesn’t exist yet,
+         feel free to add it.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Non-digital releases with digital relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ReleasesWithDownloadRelationships;

--- a/root/report/ReleasesWithEmptyMediums.js
+++ b/root/report/ReleasesWithEmptyMediums.js
@@ -11,28 +11,30 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const ReleasesWithEmptyMediums = ({
+component ReleasesWithEmptyMediums(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases with at least one medium
-       that is missing a tracklist. If you can find the tracklist,
-       please help complete the data!`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases with empty mediums')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases with at least one medium
+         that is missing a tracklist. If you can find the tracklist,
+         please help complete the data!`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases with empty mediums')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ReleasesWithEmptyMediums;

--- a/root/report/ReleasesWithMailOrderRelationships.js
+++ b/root/report/ReleasesWithMailOrderRelationships.js
@@ -11,30 +11,32 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const ReleasesWithMailOrderRelationships = ({
+component ReleasesWithMailOrderRelationships(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases that have mail order relationships
-       (which by definition only apply to physical media releases),
-       but only have media whose format is “Digital Media”.
-       Generally, these should be moved to the appropriate physical release.
-       If one doesn’t exist yet, feel free to add it.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Digital releases with mail order relationships')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases that have mail order relationships
+         (which by definition only apply to physical media releases),
+         but only have media whose format is “Digital Media”.
+         Generally, these should be moved to the appropriate physical release.
+         If one doesn’t exist yet, feel free to add it.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Digital releases with mail order relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ReleasesWithMailOrderRelationships;

--- a/root/report/ReleasesWithNoMediums.js
+++ b/root/report/ReleasesWithNoMediums.js
@@ -11,26 +11,28 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const ReleasesWithNoMediums = ({
+component ReleasesWithNoMediums(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      'This report shows releases without any mediums (no tracklist).',
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases with no mediums')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        'This report shows releases without any mediums (no tracklist).',
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases with no mediums')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ReleasesWithNoMediums;

--- a/root/report/ReleasesWithUnlikelyLanguageScript.js
+++ b/root/report/ReleasesWithUnlikelyLanguageScript.js
@@ -12,13 +12,13 @@ import ReportLayout from './components/ReportLayout.js';
 import useReleaseLanguageColumn from './hooks/useReleaseLanguageColumn.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const ReleasesWithUnlikelyLanguageScript = ({
+component ReleasesWithUnlikelyLanguageScript(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportReleaseT>) {
   const releaseLanguageColumn = useReleaseLanguageColumn<ReportReleaseT>();
 
   return (
@@ -41,6 +41,6 @@ const ReleasesWithUnlikelyLanguageScript = ({
       />
     </ReportLayout>
   );
-};
+}
 
 export default ReleasesWithUnlikelyLanguageScript;

--- a/root/report/ReleasesWithoutCaa.js
+++ b/root/report/ReleasesWithoutCaa.js
@@ -11,39 +11,41 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const ReleasesWithoutCaa = ({
+component ReleasesWithoutCaa(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={exp.l(
-      `This report shows releases that have no cover art in the Cover Art
-       Archive. Given that most releases have some form of cover art, the
-       vast majority of releases in this report should have artwork 
-       {caa_how_to|uploaded to the Cover Art Archive}.
-       Note that the cover art uploaded for a release must always exactly
-       match the actual art for that specific release (for example,
-       they should have the same barcode, format, etc.).
-       This report skips pseudo-releases, since they should generally
-       not have cover art.`,
-      {caa_how_to: '/doc/How_to_Add_Cover_Art'},
-    )}
-    entityType="release"
-    extraInfo={l(
-      `We strongly suggest restricting this report to entities
-       in your subscriptions only for a more manageable list of results.`,
-    )}
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases without any art in the Cover Art Archive')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report shows releases that have no cover art in the Cover Art
+         Archive. Given that most releases have some form of cover art, the
+         vast majority of releases in this report should have artwork 
+         {caa_how_to|uploaded to the Cover Art Archive}.
+         Note that the cover art uploaded for a release must always exactly
+         match the actual art for that specific release (for example,
+         they should have the same barcode, format, etc.).
+         This report skips pseudo-releases, since they should generally
+         not have cover art.`,
+        {caa_how_to: '/doc/How_to_Add_Cover_Art'},
+      )}
+      entityType="release"
+      extraInfo={l(
+        `We strongly suggest restricting this report to entities
+         in your subscriptions only for a more manageable list of results.`,
+      )}
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases without any art in the Cover Art Archive')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ReleasesWithoutCaa;

--- a/root/report/ReleasesWithoutVaCredit.js
+++ b/root/report/ReleasesWithoutVaCredit.js
@@ -11,27 +11,29 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const ReleasesWithoutVaCredit = ({
+component ReleasesWithoutVaCredit(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases linked to the Various Artists entity
-       without "Various Artists" as the credited name.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases not credited to "Various Artists" but linked to VA')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases linked to the Various Artists entity
+        without "Various Artists" as the credited name.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases not credited to "Various Artists" but linked to VA')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ReleasesWithoutVaCredit;

--- a/root/report/ReleasesWithoutVaLink.js
+++ b/root/report/ReleasesWithoutVaLink.js
@@ -11,27 +11,29 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const ReleasesWithoutVaLink = ({
+component ReleasesWithoutVaLink(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases with "Various Artists" as the credited
-       name but not linked to the Various Artists entity.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases credited to "Various Artists" but not linked to VA')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases with "Various Artists" as the credited
+         name but not linked to the Various Artists entity.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases credited to "Various Artists" but not linked to VA')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ReleasesWithoutVaLink;

--- a/root/report/ReportNotAvailable.js
+++ b/root/report/ReportNotAvailable.js
@@ -9,17 +9,19 @@
 
 import Layout from '../layout/index.js';
 
-const ReportNotAvailable = (): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Error')}>
-    <div id="content">
-      <h1>{l('Error')}</h1>
+component ReportNotAvailable() {
+  return (
+    <Layout fullWidth title={l('Error')}>
+      <div id="content">
+        <h1>{l('Error')}</h1>
 
-      <p>
-        {l(`We are sorry, but data for this report is not available
-            right now.`)}
-      </p>
-    </div>
-  </Layout>
-);
+        <p>
+          {l(`We are sorry, but data for this report is not available
+              right now.`)}
+        </p>
+      </div>
+    </Layout>
+  );
+}
 
 export default ReportNotAvailable;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -16,24 +16,17 @@ import {
   isRelationshipEditor,
 } from '../static/scripts/common/utility/privileges.js';
 
-type ReportsIndexEntryProps = {
-  +content: string,
-  +reportName: string,
-};
+component ReportsIndexEntry(content: string, reportName: string) {
+  return (
+    <li>
+      <a href={`/report/${reportName}`}>
+        {content}
+      </a>
+    </li>
+  );
+}
 
-const ReportsIndexEntry = ({
-  content,
-  reportName,
-}: ReportsIndexEntryProps): React$Element<'li'> => (
-  <li>
-    <a href={`/report/${reportName}`}>
-      {content}
-    </a>
-  </li>
-
-);
-
-const ReportsIndex = (): React$Element<typeof Layout> => {
+component ReportsIndex() {
   const $c = React.useContext(SanitizedCatalystContext);
   return (
     <Layout fullWidth title={l('Reports')}>
@@ -234,14 +227,14 @@ const ReportsIndex = (): React$Element<typeof Layout> => {
           <ReportsIndexEntry
             content={l(
               `Release groups not credited to "Various Artists"
-               but linked to VA`,
+              but linked to VA`,
             )}
             reportName="ReleaseGroupsWithoutVACredit"
           />
           <ReportsIndexEntry
             content={l(
               `Release groups credited to "Various Artists"
-               but not linked to VA`,
+              but not linked to VA`,
             )}
             reportName="ReleaseGroupsWithoutVALink"
           />
@@ -315,7 +308,7 @@ const ReportsIndex = (): React$Element<typeof Layout> => {
           <ReportsIndexEntry
             content={l(
               `Releases where some (but not all) mediums
-               have no format set`,
+              have no format set`,
             )}
             reportName="SomeFormatsUnset"
           />
@@ -336,28 +329,28 @@ const ReportsIndex = (): React$Element<typeof Layout> => {
           <ReportsIndexEntry
             content={l(
               `Translated/Transliterated Pseudo-Releases
-               marked as the original version`,
+              marked as the original version`,
             )}
             reportName="MislinkedPseudoReleases"
           />
           <ReportsIndexEntry
             content={l(
               `Translated/Transliterated Pseudo-Releases
-               not linked to an original version`,
+              not linked to an original version`,
             )}
             reportName="UnlinkedPseudoReleases"
           />
           <ReportsIndexEntry
             content={l(
               `Releases that have Amazon cover art
-               but no Cover Art Archive front cover`,
+              but no Cover Art Archive front cover`,
             )}
             reportName="ReleasesWithAmazonCoverArt"
           />
           <ReportsIndexEntry
             content={l(
               `Releases in the Cover Art Archive
-               where no cover art piece has types`,
+              where no cover art piece has types`,
             )}
             reportName="ReleasesWithCAANoTypes"
           />
@@ -509,14 +502,14 @@ const ReportsIndex = (): React$Element<typeof Layout> => {
           <ReportsIndexEntry
             content={l(
               `Recordings not credited to "Various Artists"
-               but linked to VA`,
+              but linked to VA`,
             )}
             reportName="RecordingsWithoutVACredit"
           />
           <ReportsIndexEntry
             content={l(
               `Recordings credited to "Various Artists"
-               but not linked to VA`,
+              but not linked to VA`,
             )}
             reportName="RecordingsWithoutVALink"
           />
@@ -646,6 +639,6 @@ const ReportsIndex = (): React$Element<typeof Layout> => {
       </div>
     </Layout>
   );
-};
+}
 
 export default ReportsIndex;

--- a/root/report/SeparateDiscs.js
+++ b/root/report/SeparateDiscs.js
@@ -11,32 +11,34 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const SeparateDiscs = ({
+component SeparateDiscs(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases which have
-       (disc n) or (bonus disc) in the title.`,
-    )}
-    entityType="release"
-    extraInfo={exp.l(
-      `For instructions on how to fix them, please see
-       the documentation about {howto|how to merge releases}.`,
-      {howto: '/doc/How_to_Merge_Releases'},
-    )}
-    filtered={filtered}
-    generated={generated}
-    title={l('Discs as separate releases')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases which have
+         (disc n) or (bonus disc) in the title.`,
+      )}
+      entityType="release"
+      extraInfo={exp.l(
+        `For instructions on how to fix them, please see
+         the documentation about {howto|how to merge releases}.`,
+        {howto: '/doc/How_to_Merge_Releases'},
+      )}
+      filtered={filtered}
+      generated={generated}
+      title={l('Discs as separate releases')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default SeparateDiscs;

--- a/root/report/SetInDifferentRg.js
+++ b/root/report/SetInDifferentRg.js
@@ -11,33 +11,35 @@ import ReleaseGroupList from './components/ReleaseGroupList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseGroupT} from './types.js';
 
-const SetInDifferentRg = ({
+component SetInDifferentRg(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseGroupT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={exp.l(
-      `This report shows release groups with releases that are linked to
-       releases in different release groups by part-of-set or
-       transliteration relationships. If a pair of release groups are
-       listed here, you should probably merge them. If the releases are
-       discs linked with "part of set" relationships, you might want to
-       merge them too into one multi-disc release
-       (see {how_to_merge_releases|How to Merge Releases}).`,
-      {how_to_merge_releases: '/doc/How_to_Merge_Releases'},
-    )}
-    entityType="release_group"
-    filtered={filtered}
-    generated={generated}
-    title={l('Release groups that might need to be merged')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseGroupList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseGroupT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report shows release groups with releases that are linked to
+         releases in different release groups by part-of-set or
+         transliteration relationships. If a pair of release groups are
+         listed here, you should probably merge them. If the releases are
+         discs linked with "part of set" relationships, you might want to
+         merge them too into one multi-disc release
+         (see {how_to_merge_releases|How to Merge Releases}).`,
+        {how_to_merge_releases: '/doc/How_to_Merge_Releases'},
+      )}
+      entityType="release_group"
+      filtered={filtered}
+      generated={generated}
+      title={l('Release groups that might need to be merged')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseGroupList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default SetInDifferentRg;

--- a/root/report/ShouldNotHaveDiscIds.js
+++ b/root/report/ShouldNotHaveDiscIds.js
@@ -11,29 +11,31 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const ShouldNotHaveDiscIds = ({
+component ShouldNotHaveDiscIds(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases that have at least one medium with a
-       format that does not support disc IDs, yet have disc IDs attached.
-       Usually this means the disc IDs ended up here because of a bug
-       and should be moved or removed.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases that have disc IDs, but shouldn’t')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} subPath="discids" />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases that have at least one medium with a
+         format that does not support disc IDs, yet have disc IDs attached.
+         Usually this means the disc IDs ended up here because of a bug
+         and should be moved or removed.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases that have disc IDs, but shouldn’t')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} subPath="discids" />
+    </ReportLayout>
+  );
+}
 
 export default ShouldNotHaveDiscIds;

--- a/root/report/ShowNotesButNotBroadcast.js
+++ b/root/report/ShowNotesButNotBroadcast.js
@@ -11,34 +11,36 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const ShowNotesButNotBroadcast = ({
+component ShowNotesButNotBroadcast(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={exp.l(
-      `This report shows releases that have a {doc|show notes relationship},
-       but are not in a release group of type Broadcast.
-       Show notes are meant for podcasts and similar shows, and should
-       not be used to link to some random notes about any sort of release,
-       yet the relationship often gets used in that way. If that is the case,
-       the relationship should be either switched to a better type or removed
-       if nothing is a good fit. If the release is indeed a podcast, the
-       release group type should be set to Broadcast.`,
-      {doc: '/relationship/2d24d075-9943-4c4d-a659-8ce52e6e6b57'},
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Non-broadcast releases with linked show notes')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report shows releases that have a {doc|show notes relationship},
+         but are not in a release group of type Broadcast.
+         Show notes are meant for podcasts and similar shows, and should
+         not be used to link to some random notes about any sort of release,
+         yet the relationship often gets used in that way. If that is the
+         case, the relationship should be either switched to a better type or
+         removed if nothing is a good fit. If the release is indeed a podcast,
+         the release group type should be set to Broadcast.`,
+        {doc: '/relationship/2d24d075-9943-4c4d-a659-8ce52e6e6b57'},
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Non-broadcast releases with linked show notes')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default ShowNotesButNotBroadcast;

--- a/root/report/SingleMediumReleasesWithMediumTitles.js
+++ b/root/report/SingleMediumReleasesWithMediumTitles.js
@@ -11,28 +11,30 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const SingleMediumReleasesWithMediumTitles = ({
+component SingleMediumReleasesWithMediumTitles(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases that have a single medium, where this
-       medium also has a specific name. Usually, this is not necessary
-       and is duplicate information which can be removed.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases with a single medium that has a name')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases that have a single medium, where this
+         medium also has a specific name. Usually, this is not necessary
+         and is duplicate information which can be removed.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases with a single medium that has a name')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default SingleMediumReleasesWithMediumTitles;

--- a/root/report/SomeFormatsUnset.js
+++ b/root/report/SomeFormatsUnset.js
@@ -11,29 +11,31 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const SomeFormatsUnset = ({
+component SomeFormatsUnset(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases where some of the medium formats are
-       set, but others are unset. In most cases, it should be easy to
-       find out which the correct formats are (don't just assume that
-       they're all CDs because one is though!).`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases with some formats unset')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases where some of the medium formats are
+         set, but others are unset. In most cases, it should be easy to
+         find out which the correct formats are (don't just assume that
+         they're all CDs because one is though!).`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases with some formats unset')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default SomeFormatsUnset;

--- a/root/report/SuperfluousDataTracks.js
+++ b/root/report/SuperfluousDataTracks.js
@@ -11,36 +11,38 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const SuperfluousDataTracks = ({
+component SuperfluousDataTracks(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={exp.l(
-      `This report lists releases without any disc IDs that probably
-       contain data tracks (like videos) at the end of a medium, but have
-       no tracks marked as data tracks. A data track should be marked as
-       such if it is the last track of the CD and contains audio or video.
-       Otherwise, it should just be removed. See the
-       {data_track_guidelines|data track guidelines}.`,
-      {
-        data_track_guidelines:
-          '/doc/Style/Unknown_and_untitled/' +
-          'Special_purpose_track_title#Data_tracks',
-      },
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases with superfluous data tracks')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report lists releases without any disc IDs that probably
+         contain data tracks (like videos) at the end of a medium, but have
+         no tracks marked as data tracks. A data track should be marked as
+         such if it is the last track of the CD and contains audio or video.
+         Otherwise, it should just be removed. See the
+         {data_track_guidelines|data track guidelines}.`,
+        {
+          data_track_guidelines:
+            '/doc/Style/Unknown_and_untitled/' +
+            'Special_purpose_track_title#Data_tracks',
+        },
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases with superfluous data tracks')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default SuperfluousDataTracks;

--- a/root/report/TracksNamedWithSequence.js
+++ b/root/report/TracksNamedWithSequence.js
@@ -11,30 +11,32 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const TracksNamedWithSequence = ({
+component TracksNamedWithSequence(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report aims to identify releases where track names include
-       their own track number, such as "1) Some Name" (instead of just
-       "Some Name"). Notice that sometimes this is justified and correct,
-       don't automatically assume it is a mistake! If you confirm it
-       is a mistake, please correct it.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases where track names start with their track number')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report aims to identify releases where track names include
+         their own track number, such as "1) Some Name" (instead of just
+         "Some Name"). Notice that sometimes this is justified and correct,
+         don't automatically assume it is a mistake! If you confirm it
+         is a mistake, please correct it.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases where track names start with their track number')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default TracksNamedWithSequence;

--- a/root/report/TracksWithSequenceIssues.js
+++ b/root/report/TracksWithSequenceIssues.js
@@ -11,28 +11,30 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const TracksWithSequenceIssues = ({
+component TracksWithSequenceIssues(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists all releases where the track numbers are not
-       continuous (for example, there is no "track 2"), or with duplicated
-       track numbers (for example, there are two "track 4"s).`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases with track number issues')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists all releases where the track numbers are not
+         continuous (for example, there is no "track 2"), or with duplicated
+         track numbers (for example, there are two "track 4"s).`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases with track number issues')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default TracksWithSequenceIssues;

--- a/root/report/TracksWithoutTimes.js
+++ b/root/report/TracksWithoutTimes.js
@@ -11,27 +11,29 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const TracksWithoutTimes = ({
+component TracksWithoutTimes(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report lists all releases where some or all tracks
-       have unknown track lengths.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Releases with unknown track times')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists all releases where some or all tracks
+         have unknown track lengths.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases with unknown track times')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default TracksWithoutTimes;

--- a/root/report/UnlinkedPseudoReleases.js
+++ b/root/report/UnlinkedPseudoReleases.js
@@ -11,29 +11,31 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-const UnlinkedPseudoReleases = ({
+component UnlinkedPseudoReleases(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportReleaseT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows releases with status Pseudo-Release that aren’t
-       linked via the translation/transliteration relationship to an
-       original version. This could be because the original version is
-       missing, or just because the release status is wrongly set.`,
-    )}
-    entityType="release"
-    filtered={filtered}
-    generated={generated}
-    title={l('Unlinked pseudo-releases')}
-    totalEntries={pager.total_entries}
-  >
-    <ReleaseList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases with status Pseudo-Release that aren’t
+         linked via the translation/transliteration relationship to an
+         original version. This could be because the original version is
+         missing, or just because the release status is wrongly set.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Unlinked pseudo-releases')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default UnlinkedPseudoReleases;

--- a/root/report/VideosInNonVideoMediums.js
+++ b/root/report/VideosInNonVideoMediums.js
@@ -11,37 +11,39 @@ import RecordingList from './components/RecordingList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportRecordingT} from './types.js';
 
-const VideosInNonVideoMediums = ({
+component VideosInNonVideoMediums(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportRecordingT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={l(
-      `This report shows recordings marked as video, but that appear in
-       at least one medium that does not support videos.`,
-    )}
-    entityType="recording"
-    extraInfo={exp.l(
-      `There are two main possibilities here: either the recording being
-       marked as a video is correct, but the format is not (a CD should be a
-       VCD, for example), or the recording is being used for both a video and 
-       and audio-only recording, in which case the two should be split since
-       video recordings should always be separate. If you split the
-       recordings, consider whether it makes sense to link them with a
-       {doc_link|music video relationship}.`,
-      {doc_link: '/relationship/ce3de655-7451-44d1-9224-87eb948c205d'},
-    )}
-    filtered={filtered}
-    generated={generated}
-    title={l('Video recordings in non-video mediums')}
-    totalEntries={pager.total_entries}
-  >
-    <RecordingList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportRecordingT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows recordings marked as video, but that appear in
+         at least one medium that does not support videos.`,
+      )}
+      entityType="recording"
+      extraInfo={exp.l(
+        `There are two main possibilities here: either the recording being
+         marked as a video is correct, but the format is not (a CD should be a
+         VCD, for example), or the recording is being used for both a video 
+         and audio-only recording, in which case the two should be split since
+         video recordings should always be separate. If you split the
+         recordings, consider whether it makes sense to link them with a
+         {doc_link|music video relationship}.`,
+        {doc_link: '/relationship/ce3de655-7451-44d1-9224-87eb948c205d'},
+      )}
+      filtered={filtered}
+      generated={generated}
+      title={l('Video recordings in non-video mediums')}
+      totalEntries={pager.total_entries}
+    >
+      <RecordingList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default VideosInNonVideoMediums;

--- a/root/report/WikidataLinksWithMultipleEntities.js
+++ b/root/report/WikidataLinksWithMultipleEntities.js
@@ -24,13 +24,13 @@ type ReportEntryT = {
   +url_id: number,
 };
 
-const WikidataLinksWithMultipleEntities = ({
+component WikidataLinksWithMultipleEntities(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportEntryT>): React$Element<typeof ReportLayout> => {
+}: ReportDataT<ReportEntryT>) {
   const $c = React.useContext(CatalystContext);
 
   return (
@@ -88,6 +88,6 @@ const WikidataLinksWithMultipleEntities = ({
       </PaginatedResults>
     </ReportLayout>
   );
-};
+}
 
 export default WikidataLinksWithMultipleEntities;

--- a/root/report/WorkSameTypeAsParent.js
+++ b/root/report/WorkSameTypeAsParent.js
@@ -11,32 +11,34 @@ import ReportLayout from './components/ReportLayout.js';
 import WorkList from './components/WorkList.js';
 import type {ReportDataT, ReportWorkT} from './types.js';
 
-const WorkSameTypeAsParent = ({
+component WorkSameTypeAsParent(...{
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportWorkT>): React$Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={exp.l(
-      `This report shows works with at least one parent work that has the same
-       work type as them (such as a work marked as a sonata which is part of
-       another sonata). In most cases, that means these works should have
-       a different type or (most likely) no type at all, as per
-       {work_style_doc|the work guidelines}. Sometimes the parent work
-       type might be the one that needs to be changed.`,
-      {work_style_doc: '/doc/Style/Work'},
-    )}
-    entityType="work"
-    filtered={filtered}
-    generated={generated}
-    title={l('Works with the same type as their parent')}
-    totalEntries={pager.total_entries}
-  >
-    <WorkList items={items} pager={pager} />
-  </ReportLayout>
-);
+}: ReportDataT<ReportWorkT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report shows works with at least one parent work that has the
+         same work type as them (such as a work marked as a sonata which is
+         part of another sonata). In most cases, that means these works should
+         have a different type or (most likely) no type at all, as per
+         {work_style_doc|the work guidelines}. Sometimes the parent work
+         type might be the one that needs to be changed.`,
+        {work_style_doc: '/doc/Style/Work'},
+      )}
+      entityType="work"
+      filtered={filtered}
+      generated={generated}
+      title={l('Works with the same type as their parent')}
+      totalEntries={pager.total_entries}
+    >
+      <WorkList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
 
 export default WorkSameTypeAsParent;

--- a/root/report/components/ArtistCreditList.js
+++ b/root/report/components/ArtistCreditList.js
@@ -13,44 +13,41 @@ import ArtistCreditUsageLink
 import loopParity from '../../utility/loopParity.js';
 import type {ReportArtistCreditT} from '../types.js';
 
-type Props = {
-  +items: $ReadOnlyArray<ReportArtistCreditT>,
-  +pager: PagerT,
-};
-
-const ArtistCreditList = ({
-  items,
-  pager,
-}: Props): React$Element<typeof PaginatedResults> => (
-  <PaginatedResults pager={pager}>
-    <table className="tbl">
-      <thead>
-        <tr>
-          <th>{l('Artist credit')}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {items.map((item, index) => (
-          <tr className={loopParity(index)} key={item.artist_credit_id}>
-            {item.artist_credit ? (
-              <>
-                <td>
-                  <ArtistCreditUsageLink
-                    artistCredit={item.artist_credit}
-                    showEditsPending
-                  />
-                </td>
-              </>
-            ) : (
-              <td>
-                {l('This artist credit no longer exists.')}
-              </td>
-            )}
+component ArtistCreditList(
+  items: $ReadOnlyArray<ReportArtistCreditT>,
+  pager: PagerT,
+) {
+  return (
+    <PaginatedResults pager={pager}>
+      <table className="tbl">
+        <thead>
+          <tr>
+            <th>{l('Artist credit')}</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
-  </PaginatedResults>
-);
+        </thead>
+        <tbody>
+          {items.map((item, index) => (
+            <tr className={loopParity(index)} key={item.artist_credit_id}>
+              {item.artist_credit ? (
+                <>
+                  <td>
+                    <ArtistCreditUsageLink
+                      artistCredit={item.artist_credit}
+                      showEditsPending
+                    />
+                  </td>
+                </>
+              ) : (
+                <td>
+                  {l('This artist credit no longer exists.')}
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </PaginatedResults>
+  );
+}
 
 export default ArtistCreditList;

--- a/root/report/components/ArtistList.js
+++ b/root/report/components/ArtistList.js
@@ -17,21 +17,13 @@ import {
   defineTextColumn,
 } from '../../utility/tableColumns.js';
 
-type Props<D: {+artist: ?ArtistT, ...}> = {
-  +columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +items: $ReadOnlyArray<D>,
-  +pager: PagerT,
-  +subPath?: string,
-};
-
-const ArtistList = <D: {+artist: ?ArtistT, ...}>({
-  columnsBefore,
-  columnsAfter,
-  items,
-  pager,
-  subPath,
-}: Props<D>): React$Element<typeof PaginatedResults> => {
+component ArtistList<D: {+artist: ?ArtistT, ...}>(
+  columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  items: $ReadOnlyArray<D>,
+  pager: PagerT,
+  subPath?: string,
+) {
   const existingArtistItems = items.reduce((
     result: Array<D>,
     item,
@@ -82,6 +74,6 @@ const ArtistList = <D: {+artist: ?ArtistT, ...}>({
       {table}
     </PaginatedResults>
   );
-};
+}
 
 export default ArtistList;

--- a/root/report/components/ArtistUrlList.js
+++ b/root/report/components/ArtistUrlList.js
@@ -14,15 +14,10 @@ import type {ReportArtistUrlT} from '../types.js';
 
 import RemovedUrlRow from './RemovedUrlRow.js';
 
-type Props = {
-  +items: $ReadOnlyArray<ReportArtistUrlT>,
-  +pager: PagerT,
-};
-
-const ArtistUrlList = ({
-  items,
-  pager,
-}: Props): React$Element<typeof PaginatedResults> => {
+component ArtistUrlList(
+  items: $ReadOnlyArray<ReportArtistUrlT>,
+  pager: PagerT,
+) {
   let lastGID: string = '';
   let currentGID: string = '';
 
@@ -82,6 +77,6 @@ const ArtistUrlList = ({
       </table>
     </PaginatedResults>
   );
-};
+}
 
 export default ArtistUrlList;

--- a/root/report/components/CDTocList.js
+++ b/root/report/components/CDTocList.js
@@ -19,15 +19,10 @@ import {
 } from '../../utility/tableColumns.js';
 import type {ReportCDTocT} from '../types.js';
 
-type Props = {
-  +items: $ReadOnlyArray<ReportCDTocT>,
-  +pager: PagerT,
-};
-
-const CDTocList = ({
-  items,
-  pager,
-}: Props): React$Element<typeof PaginatedResults> => {
+component CDTocList(
+  items: $ReadOnlyArray<ReportCDTocT>,
+  pager: PagerT,
+) {
   const existingCDTocItems = items.reduce((
     result: Array<ReportCDTocT>,
     item,
@@ -73,6 +68,6 @@ const CDTocList = ({
       {table}
     </PaginatedResults>
   );
-};
+}
 
 export default CDTocList;

--- a/root/report/components/CDTocReleaseList.js
+++ b/root/report/components/CDTocReleaseList.js
@@ -18,15 +18,10 @@ import {
 } from '../../utility/tableColumns.js';
 import type {ReportCDTocReleaseT} from '../types.js';
 
-type Props = {
-  +items: $ReadOnlyArray<ReportCDTocReleaseT>,
-  +pager: PagerT,
-};
-
-const CDTocReleaseList = ({
-  items,
-  pager,
-}: Props): React$Element<typeof PaginatedResults> => {
+component CDTocReleaseList(
+  items: $ReadOnlyArray<ReportCDTocReleaseT>,
+  pager: PagerT,
+) {
   const existingCDTocItems = items.reduce((
     result: Array<ReportCDTocReleaseT>,
     item,
@@ -75,6 +70,6 @@ const CDTocReleaseList = ({
       {table}
     </PaginatedResults>
   );
-};
+}
 
 export default CDTocReleaseList;

--- a/root/report/components/EditorList.js
+++ b/root/report/components/EditorList.js
@@ -19,15 +19,10 @@ import {
 } from '../../utility/tableColumns.js';
 import type {ReportEditorT} from '../types.js';
 
-type Props = {
-  +items: $ReadOnlyArray<ReportEditorT>,
-  +pager: PagerT,
-};
-
-const EditorList = ({
-  items,
-  pager,
-}: Props): React$Element<typeof PaginatedResults> => {
+component EditorList(
+  items: $ReadOnlyArray<ReportEditorT>,
+  pager: PagerT,
+) {
   const existingEditorItems = items.reduce((
     result: Array<ReportEditorT>,
     item,
@@ -105,6 +100,6 @@ const EditorList = ({
       {table}
     </PaginatedResults>
   );
-};
+}
 
 export default EditorList;

--- a/root/report/components/EventList.js
+++ b/root/report/components/EventList.js
@@ -21,19 +21,12 @@ import {
   defineTextColumn,
 } from '../../utility/tableColumns.js';
 
-type Props<D: {+event: ?EventT, ...}> = {
-  +columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +items: $ReadOnlyArray<D>,
-  +pager: PagerT,
-};
-
-const EventList = <D: {+event: ?EventT, ...}>({
-  columnsBefore,
-  columnsAfter,
-  items,
-  pager,
-}: Props<D>): React$Element<typeof PaginatedResults> => {
+component EventList<D: {+event: ?EventT, ...}>(
+  columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  items: $ReadOnlyArray<D>,
+  pager: PagerT,
+) {
   const existingEventItems = items.reduce((
     result: Array<D>,
     item,
@@ -102,6 +95,6 @@ const EventList = <D: {+event: ?EventT, ...}>({
       {manifest.js('common/components/ArtistRoles', {async: 'async'})}
     </PaginatedResults>
   );
-};
+}
 
 export default EventList;

--- a/root/report/components/InstrumentList.js
+++ b/root/report/components/InstrumentList.js
@@ -19,15 +19,10 @@ import {
 } from '../../utility/tableColumns.js';
 import type {ReportInstrumentT} from '../types.js';
 
-type Props = {
-  +items: $ReadOnlyArray<ReportInstrumentT>,
-  +pager: PagerT,
-};
-
-const InstrumentList = ({
-  items,
-  pager,
-}: Props): React$Element<typeof PaginatedResults> => {
+component InstrumentList(
+  items: $ReadOnlyArray<ReportInstrumentT>,
+  pager: PagerT,
+) {
   const $c = React.useContext(CatalystContext);
   const existingInstrumentItems = items.reduce((
     result: Array<ReportInstrumentT>,
@@ -88,6 +83,6 @@ const InstrumentList = ({
       {table}
     </PaginatedResults>
   );
-};
+}
 
 export default InstrumentList;

--- a/root/report/components/LabelList.js
+++ b/root/report/components/LabelList.js
@@ -16,19 +16,12 @@ import {
   defineEntityColumn,
 } from '../../utility/tableColumns.js';
 
-type Props<D: {+label: ?LabelT, ...}> = {
-  +columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +items: $ReadOnlyArray<D>,
-  +pager: PagerT,
-};
-
-const LabelList = <D: {+label: ?LabelT, ...}>({
-  columnsBefore,
-  columnsAfter,
-  items,
-  pager,
-}: Props<D>): React$Element<typeof PaginatedResults> => {
+component LabelList<D: {+label: ?LabelT, ...}>(
+  columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  items: $ReadOnlyArray<D>,
+  pager: PagerT,
+) {
   const existingLabelItems = items.reduce((
     result: Array<D>,
     item,
@@ -63,6 +56,6 @@ const LabelList = <D: {+label: ?LabelT, ...}>({
       {table}
     </PaginatedResults>
   );
-};
+}
 
 export default LabelList;

--- a/root/report/components/LabelUrlList.js
+++ b/root/report/components/LabelUrlList.js
@@ -14,15 +14,10 @@ import type {ReportLabelUrlT} from '../types.js';
 
 import RemovedUrlRow from './RemovedUrlRow.js';
 
-type Props = {
-  +items: $ReadOnlyArray<ReportLabelUrlT>,
-  +pager: PagerT,
-};
-
-const LabelUrlList = ({
-  items,
-  pager,
-}: Props): React$Element<typeof PaginatedResults> => {
+component LabelUrlList(
+  items: $ReadOnlyArray<ReportLabelUrlT>,
+  pager: PagerT,
+) {
   let lastGID: string = '';
   let currentGID: string = '';
 
@@ -83,6 +78,6 @@ const LabelUrlList = ({
       </table>
     </PaginatedResults>
   );
-};
+}
 
 export default LabelUrlList;

--- a/root/report/components/PlaceList.js
+++ b/root/report/components/PlaceList.js
@@ -16,19 +16,12 @@ import {
   defineEntityColumn,
 } from '../../utility/tableColumns.js';
 
-type Props<D: {+place: ?PlaceT, ...}> = {
-  +columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +items: $ReadOnlyArray<D>,
-  +pager: PagerT,
-};
-
-const PlaceList = <D: {+place: ?PlaceT, ...}>({
-  columnsBefore,
-  columnsAfter,
-  items,
-  pager,
-}: Props<D>): React$Element<typeof PaginatedResults> => {
+component PlaceList<D: {+place: ?PlaceT, ...}>(
+  columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  items: $ReadOnlyArray<D>,
+  pager: PagerT,
+) {
   const existingPlaceItems = items.reduce((
     result: Array<D>,
     item,
@@ -63,6 +56,6 @@ const PlaceList = <D: {+place: ?PlaceT, ...}>({
       {table}
     </PaginatedResults>
   );
-};
+}
 
 export default PlaceList;

--- a/root/report/components/RecordingList.js
+++ b/root/report/components/RecordingList.js
@@ -17,19 +17,12 @@ import {
   defineEntityColumn,
 } from '../../utility/tableColumns.js';
 
-type Props<D: {+recording: ?RecordingT, ...}> = {
-  +columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +items: $ReadOnlyArray<D>,
-  +pager: PagerT,
-};
-
-const RecordingList = <D: {+recording: ?RecordingT, ...}>({
-  columnsBefore,
-  columnsAfter,
-  items,
-  pager,
-}: Props<D>): React$Element<typeof PaginatedResults> => {
+component RecordingList<D: {+recording: ?RecordingT, ...}>(
+  columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  items: $ReadOnlyArray<D>,
+  pager: PagerT,
+) {
   const existingRecordingItems = items.reduce((
     result: Array<D>,
     item,
@@ -72,6 +65,6 @@ const RecordingList = <D: {+recording: ?RecordingT, ...}>({
       {table}
     </PaginatedResults>
   );
-};
+}
 
 export default RecordingList;

--- a/root/report/components/ReleaseGroupList.js
+++ b/root/report/components/ReleaseGroupList.js
@@ -18,19 +18,12 @@ import {
   defineTextColumn,
 } from '../../utility/tableColumns.js';
 
-type Props<D: {+release_group: ?ReleaseGroupT, ...}> = {
-  +columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +items: $ReadOnlyArray<D>,
-  +pager: PagerT,
-};
-
-const ReleaseGroupList = <D: {+release_group: ?ReleaseGroupT, ...}>({
-  columnsBefore,
-  columnsAfter,
-  items,
-  pager,
-}: Props<D>): React$Element<typeof PaginatedResults> => {
+component ReleaseGroupList<D: {+release_group: ?ReleaseGroupT, ...}>(
+  columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  items: $ReadOnlyArray<D>,
+  pager: PagerT,
+) {
   const existingReleaseGroupItems = items.reduce((
     result: Array<D>,
     item,
@@ -83,6 +76,6 @@ const ReleaseGroupList = <D: {+release_group: ?ReleaseGroupT, ...}>({
       {table}
     </PaginatedResults>
   );
-};
+}
 
 export default ReleaseGroupList;

--- a/root/report/components/ReleaseGroupUrlList.js
+++ b/root/report/components/ReleaseGroupUrlList.js
@@ -16,15 +16,10 @@ import type {ReportReleaseGroupUrlT} from '../types.js';
 
 import RemovedUrlRow from './RemovedUrlRow.js';
 
-type Props = {
-  +items: $ReadOnlyArray<ReportReleaseGroupUrlT>,
-  +pager: PagerT,
-};
-
-const ReleaseGroupUrlList = ({
-  items,
-  pager,
-}: Props): React$Element<typeof PaginatedResults> => {
+component ReleaseGroupUrlList(
+  items: $ReadOnlyArray<ReportReleaseGroupUrlT>,
+  pager: PagerT,
+) {
   let lastGID: string = '';
   let currentGID: string = '';
 
@@ -91,6 +86,6 @@ const ReleaseGroupUrlList = ({
       </table>
     </PaginatedResults>
   );
-};
+}
 
 export default ReleaseGroupUrlList;

--- a/root/report/components/ReleaseList.js
+++ b/root/report/components/ReleaseList.js
@@ -17,21 +17,13 @@ import {
   defineEntityColumn,
 } from '../../utility/tableColumns.js';
 
-type Props<D: {+release: ?ReleaseT, ...}> = {
-  +columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +items: $ReadOnlyArray<D>,
-  +pager: PagerT,
-  +subPath?: string,
-};
-
-const ReleaseList = <D: {+release: ?ReleaseT, ...}>({
-  columnsBefore,
-  columnsAfter,
-  items,
-  pager,
-  subPath,
-}: Props<D>): React$Element<typeof PaginatedResults> => {
+component ReleaseList<D: {+release: ?ReleaseT, ...}>(
+  columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  items: $ReadOnlyArray<D>,
+  pager: PagerT,
+  subPath?: string,
+) {
   const existingReleaseItems = items.reduce((
     result: Array<D>,
     item,
@@ -75,6 +67,6 @@ const ReleaseList = <D: {+release: ?ReleaseT, ...}>({
       {table}
     </PaginatedResults>
   );
-};
+}
 
 export default ReleaseList;

--- a/root/report/components/ReleaseUrlList.js
+++ b/root/report/components/ReleaseUrlList.js
@@ -16,15 +16,10 @@ import type {ReportReleaseUrlT} from '../types.js';
 
 import RemovedUrlRow from './RemovedUrlRow.js';
 
-type Props = {
-  +items: $ReadOnlyArray<ReportReleaseUrlT>,
-  +pager: PagerT,
-};
-
-const ReleaseUrlList = ({
-  items,
-  pager,
-}: Props): React$Element<typeof PaginatedResults> => {
+component ReleaseUrlList(
+  items: $ReadOnlyArray<ReportReleaseUrlT>,
+  pager: PagerT,
+) {
   let lastGID: string = '';
   let currentGID: string = '';
 
@@ -91,6 +86,6 @@ const ReleaseUrlList = ({
       </table>
     </PaginatedResults>
   );
-};
+}
 
 export default ReleaseUrlList;

--- a/root/report/components/RemovedUrlRow.js
+++ b/root/report/components/RemovedUrlRow.js
@@ -7,15 +7,14 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const RemovedUrlRow = ({
-  colSpan,
-  index,
-}: {colSpan: string, index: number}): React$Element<'tr'> => (
-  <tr className="even" key={index}>
-    <td colSpan={colSpan}>
-      {l('This URL no longer exists.')}
-    </td>
-  </tr>
-);
+component RemovedUrlRow(colSpan: string, index: number) {
+  return (
+    <tr className="even" key={index}>
+      <td colSpan={colSpan}>
+        {l('This URL no longer exists.')}
+      </td>
+    </tr>
+  );
+}
 
 export default RemovedUrlRow;

--- a/root/report/components/ReportLayout.js
+++ b/root/report/components/ReportLayout.js
@@ -35,31 +35,18 @@ const countTextPicker = {
   work: N_l('Total works found: {count}'),
 };
 
-type Props = {
-  +canBeFiltered: boolean,
-  +children: React$Node,
-  +countText?: string,
-  +description: Expand2ReactOutput,
-  +entityType: string,
-  +extraInfo?: Expand2ReactOutput,
-  +filtered: boolean,
-  +generated: string,
-  +title: string,
-  +totalEntries: number,
-};
-
-const ReportLayout = ({
-  canBeFiltered,
-  children,
-  countText,
-  description,
-  entityType,
-  extraInfo,
-  filtered,
-  generated,
-  title,
-  totalEntries,
-}: Props): React$Element<typeof Layout> => {
+component ReportLayout(
+  canBeFiltered: boolean,
+  children: React$Node,
+  countText?: string,
+  description: Expand2ReactOutput,
+  entityType: string,
+  extraInfo?: Expand2ReactOutput,
+  filtered: boolean,
+  generated: string,
+  title: string,
+  totalEntries: number,
+) {
   const $c = React.useContext(CatalystContext);
 
   return (
@@ -92,6 +79,6 @@ const ReportLayout = ({
       {children}
     </Layout>
   );
-};
+}
 
 export default ReportLayout;

--- a/root/report/components/SeriesList.js
+++ b/root/report/components/SeriesList.js
@@ -16,19 +16,12 @@ import {
   defineEntityColumn,
 } from '../../utility/tableColumns.js';
 
-type Props<D: {+series: ?SeriesT, ...}> = {
-  +columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +items: $ReadOnlyArray<D>,
-  +pager: PagerT,
-};
-
-const SeriesList = <D: {+series: ?SeriesT, ...}>({
-  columnsBefore,
-  columnsAfter,
-  items,
-  pager,
-}: Props<D>): React$Element<typeof PaginatedResults> => {
+component SeriesList<D: {+series: ?SeriesT, ...}>(
+  columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  items: $ReadOnlyArray<D>,
+  pager: PagerT,
+) {
   const existingSeriesItems = items.reduce((
     result: Array<D>,
     item,
@@ -63,6 +56,6 @@ const SeriesList = <D: {+series: ?SeriesT, ...}>({
       {table}
     </PaginatedResults>
   );
-};
+}
 
 export default SeriesList;

--- a/root/report/components/UrlList.js
+++ b/root/report/components/UrlList.js
@@ -14,19 +14,12 @@ import PaginatedResults from '../../components/PaginatedResults.js';
 import useTable from '../../hooks/useTable.js';
 import {defineLinkColumn} from '../../utility/tableColumns.js';
 
-type Props<D: {+url: ?UrlT, ...}> = {
-  +columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +items: $ReadOnlyArray<D>,
-  +pager: PagerT,
-};
-
-const UrlList = <D: {+url: ?UrlT, ...}>({
-  columnsBefore,
-  columnsAfter,
-  items,
-  pager,
-}: Props<D>): React$Element<typeof PaginatedResults> => {
+component UrlList<D: {+url: ?UrlT, ...}>(
+  columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  items: $ReadOnlyArray<D>,
+  pager: PagerT,
+) {
   const existingUrlItems = items.reduce((
     result: Array<D>,
     item,
@@ -69,6 +62,6 @@ const UrlList = <D: {+url: ?UrlT, ...}>({
       {table}
     </PaginatedResults>
   );
-};
+}
 
 export default UrlList;

--- a/root/report/components/WorkList.js
+++ b/root/report/components/WorkList.js
@@ -19,19 +19,12 @@ import {
   defineTextColumn,
 } from '../../utility/tableColumns.js';
 
-type Props<D: {+work: ?WorkT, ...}> = {
-  +columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
-  +items: $ReadOnlyArray<D>,
-  +pager: PagerT,
-};
-
-const WorkList = <D: {+work: ?WorkT, ...}>({
-  columnsBefore,
-  columnsAfter,
-  items,
-  pager,
-}: Props<D>): React$Element<typeof PaginatedResults> => {
+component WorkList<D: {+work: ?WorkT, ...}>(
+  columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  items: $ReadOnlyArray<D>,
+  pager: PagerT,
+) {
   const existingWorkItems = items.reduce((
     result: Array<D>,
     item,
@@ -85,6 +78,6 @@ const WorkList = <D: {+work: ?WorkT, ...}>({
       {manifest.js('common/components/ArtistRoles', {async: 'async'})}
     </PaginatedResults>
   );
-};
+}
 
 export default WorkList;


### PR DESCRIPTION
Flow now supports a specific [React Component Syntax](https://flow.org/en/docs/react/component-syntax/) which reduces the amount of types we need to define manually, and is supposed to be better for type checking as well. I'm converting our React components to this syntax bit by bit with this PR.

This changes all stuff in the `report` subfolder.

Note: To be reviewed without whitespace changes (since this adds explicit `return()` calls that require spacing things one more tab in many cases).

On top of https://github.com/metabrainz/musicbrainz-server/pull/3225