### PR TITLE
Amend pull request #3065: Upgrade Node.js to v20

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Full installation instructions are available in [INSTALL.md](INSTALL.md).
 General Prerequisites:
 
 * Ubuntu/Debian (or some other Unix-like operating system at your own risks)
-* Node (at least version 16)
+* Node (at least version 20)
 * Perl (at least version 5.30)
 * PostgreSQL (at least version 12)
 

--- a/root/static/scripts/common/utility/createFastObjectCloneFunction.js
+++ b/root/static/scripts/common/utility/createFastObjectCloneFunction.js
@@ -10,9 +10,9 @@
 /*
  * See ./createFastObjectCloneFunction.benchmark.js
  *
- * node v16.6.0:
- * spread x 30,049,382 ops/sec ±0.60% (92 runs sampled)
- * fastClone x 182,189,219 ops/sec ±0.04% (100 runs sampled)
+ * node v20.11.1:
+ * spread x 31,909,715 ops/sec ±0.95% (87 runs sampled)
+ * fastClone x 196,128,209 ops/sec ±1.08% (90 runs sampled)
  */
 
 export default function createFastObjectCloneFunction<T: {...}>(

--- a/webpack/server.config.mjs
+++ b/webpack/server.config.mjs
@@ -93,5 +93,5 @@ export default {
     ),
   ],
 
-  target: 'node16.0',
+  target: 'node20',
 };


### PR DESCRIPTION
# Problem 
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

The required version of Node.js has been bumped to 20 since MBS-13261 last November as announced in our [blog post](https://blog.metabrainz.org/2023/09/04/musicbrainz-website-mirror-will-require-node-js-20-starting-from-november-13-2023/), but the previously required version 16 has been forgotten in a couple of files.

These oversights are likely due to the fact that the version 18 has been used but not required in the meantime.

The recent upgrade of imports-loader version to 5.0.0 requires Node.js v20 as experienced in [MBVM-95](https://tickets.metabrainz.org/browse/MBVM-95).

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Complete the previous pull request #3065 as follows:

* Bump the required version of Node.js to 20 in the main `README.md` (it had been changed in the file `INSTALL.md` only).
* Bump the target version of Node.js to 20 in Webpack configuration for the server side.
* Rerun the benchmark of `createFastObjectClone` to make sure that it stays useful.

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

* [x] Restated the container and checked the file `/compile_resources.log`
* [x] Logged in locally and edited a release