### PR TITLE
Migrate React edit components to Flow component syntax

### DIFF
--- a/root/edit/CancelEdit.js
+++ b/root/edit/CancelEdit.js
@@ -13,15 +13,10 @@ import EnterEditNote
 
 import getEditDetailsElement from './utility/getEditDetailsElement.js';
 
-type Props = {
-  +edit: $ReadOnly<{...EditT, +id: number}>,
-  +form: ConfirmFormT,
-};
-
-const CancelEdit = ({
-  edit,
-  form,
-}: Props): React$Element<typeof Layout> => {
+component CancelEdit(
+  edit: $ReadOnly<{...EditT, +id: number}>,
+  form: ConfirmFormT,
+) {
   const detailsElement = getEditDetailsElement(edit);
 
   return (
@@ -59,6 +54,6 @@ const CancelEdit = ({
       </form>
     </Layout>
   );
-};
+}
 
 export default CancelEdit;

--- a/root/edit/CannotApproveEdit.js
+++ b/root/edit/CannotApproveEdit.js
@@ -11,11 +11,7 @@ import {EDIT_STATUS_DELETED} from '../constants.js';
 import Layout from '../layout/index.js';
 import EditLink from '../static/scripts/common/components/EditLink.js';
 
-type Props = {
-  +edit: GenericEditWithIdT,
-};
-
-const CannotApproveEdit = ({edit}: Props): React$Element<typeof Layout> => {
+component CannotApproveEdit(edit: GenericEditWithIdT) {
   const editDisplay = 'edit #' + edit.id;
   const editLink = <EditLink content={editDisplay} edit={edit} />;
   const editIsClosed = !edit.is_open;
@@ -42,6 +38,6 @@ const CannotApproveEdit = ({edit}: Props): React$Element<typeof Layout> => {
       <p>{reason}</p>
     </Layout>
   );
-};
+}
 
 export default CannotApproveEdit;

--- a/root/edit/CannotCancelEdit.js
+++ b/root/edit/CannotCancelEdit.js
@@ -10,11 +10,7 @@
 import Layout from '../layout/index.js';
 import EditLink from '../static/scripts/common/components/EditLink.js';
 
-type Props = {
-  +edit: GenericEditWithIdT,
-};
-
-const CannotCancelEdit = ({edit}: Props): React$Element<typeof Layout> => {
+component CannotCancelEdit(edit: GenericEditWithIdT) {
   const editDisplay = 'edit #' + edit.id;
   const editIsClosed = !edit.is_open;
   const editLink = <EditLink content={editDisplay} edit={edit} />;
@@ -34,6 +30,6 @@ const CannotCancelEdit = ({edit}: Props): React$Element<typeof Layout> => {
       </p>
     </Layout>
   );
-};
+}
 
 export default CannotCancelEdit;

--- a/root/edit/CannotVote.js
+++ b/root/edit/CannotVote.js
@@ -9,13 +9,15 @@
 
 import Layout from '../layout/index.js';
 
-const CannotVote = (): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Error voting on edits')}>
-    <h1>{l('Error voting on edits')}</h1>
-    <p>
-      {l('You’re not currently allowed to vote, please read the banner.')}
-    </p>
-  </Layout>
-);
+component CannotVote() {
+  return (
+    <Layout fullWidth title={l('Error voting on edits')}>
+      <h1>{l('Error voting on edits')}</h1>
+      <p>
+        {l('You’re not currently allowed to vote, please read the banner.')}
+      </p>
+    </Layout>
+  );
+}
 
 export default CannotVote;

--- a/root/edit/DeleteNote.js
+++ b/root/edit/DeleteNote.js
@@ -18,62 +18,58 @@ type DeleteNoteFormT = FormT<{
   +submit: FieldT<string>,
 }>;
 
-type Props = {
-  +edit: GenericEditWithIdT,
-  +editNote: EditNoteT,
-  +form: DeleteNoteFormT,
-};
-
-const DeleteNote = ({
-  edit,
-  editNote,
-  form,
-}: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Remove edit note')}>
-    <h1>{l('Remove edit note')}</h1>
-    <p>
-      {l('Are you sure you want to remove the following edit note?')}
-    </p>
-    <div className="edit-notes">
-      <EditNoteListEntry
-        edit={edit}
-        editNote={editNote}
-        showEditControls={false}
-      />
-    </div>
-    <form method="post">
+component DeleteNote(
+  edit: GenericEditWithIdT,
+  editNote: EditNoteT,
+  form: DeleteNoteFormT,
+) {
+  return (
+    <Layout fullWidth title={l('Remove edit note')}>
+      <h1>{l('Remove edit note')}</h1>
       <p>
-        {l(
-          `Providing a reason for the removal is recommended if you feel
-           it will make things clearer for other editors checking
-           the editing history in the future. Otherwise it can be omitted.`,
-        )}
+        {l('Are you sure you want to remove the following edit note?')}
       </p>
-      <FormRowText
-        field={form.field.reason}
-        label={addColonText(l('Reason'))}
-        size={50}
-        uncontrolled
-      />
-      <span className="buttons">
-        <button
-          name="edit-note-delete.submit"
-          type="submit"
-          value="1"
-        >
-          {l('Yes, I am sure')}
-        </button>
-        <button
-          className="negative"
-          name="edit-note-delete.cancel"
-          type="submit"
-          value="1"
-        >
-          {l('Cancel')}
-        </button>
-      </span>
-    </form>
-  </Layout>
-);
+      <div className="edit-notes">
+        <EditNoteListEntry
+          edit={edit}
+          editNote={editNote}
+          showEditControls={false}
+        />
+      </div>
+      <form method="post">
+        <p>
+          {l(
+            `Providing a reason for the removal is recommended if you feel
+             it will make things clearer for other editors checking
+             the editing history in the future. Otherwise it can be omitted.`,
+          )}
+        </p>
+        <FormRowText
+          field={form.field.reason}
+          label={addColonText(l('Reason'))}
+          size={50}
+          uncontrolled
+        />
+        <span className="buttons">
+          <button
+            name="edit-note-delete.submit"
+            type="submit"
+            value="1"
+          >
+            {l('Yes, I am sure')}
+          </button>
+          <button
+            className="negative"
+            name="edit-note-delete.cancel"
+            type="submit"
+            value="1"
+          >
+            {l('Cancel')}
+          </button>
+        </span>
+      </form>
+    </Layout>
+  );
+}
 
 export default DeleteNote;

--- a/root/edit/EditData.js
+++ b/root/edit/EditData.js
@@ -16,21 +16,17 @@ import {formatPluralEntityTypeName}
   from '../static/scripts/common/utility/formatEntityTypeName.js';
 import {getEditStatusName} from '../utility/edit.js';
 
-type Props = {
-  +edit: GenericEditWithIdT,
-  +rawData: string,
-  +relatedEntities: {
-    +[type: EditableEntityTypeT]: {
-      +[entityId: string]: EditableEntityT,
-    },
+type RelatedEntitiesT = {
+  +[type: EditableEntityTypeT]: {
+    +[entityId: string]: EditableEntityT,
   },
 };
 
-const EditData = ({
-  edit,
-  rawData,
-  relatedEntities,
-}: Props): React$Element<typeof Layout> => {
+component EditData(
+  edit: GenericEditWithIdT,
+  rawData: string,
+  relatedEntities: RelatedEntitiesT,
+) {
   const title = texp.l('Edit data for edit #{id}', {id: edit.id});
   const relatedEntityTypes = Object.keys(relatedEntities).sort();
 
@@ -99,6 +95,6 @@ const EditData = ({
       </p>
     </Layout>
   );
-};
+}
 
 export default EditData;

--- a/root/edit/EditIndex.js
+++ b/root/edit/EditIndex.js
@@ -30,15 +30,10 @@ import Vote from './components/Vote.js';
 import VoteTally from './components/VoteTally.js';
 import getEditDetailsElement from './utility/getEditDetailsElement.js';
 
-type Props = {
-  +edit: $ReadOnly<{...EditT, +id: number}>,
-  +fullWidth?: boolean,
-};
-
-const EditIndex = ({
-  edit,
-  fullWidth = false,
-}: Props): React$Element<typeof Layout> => {
+component EditIndex(
+  edit: $ReadOnly<{...EditT, +id: number}>,
+  fullWidth: boolean = false,
+) {
   const $c = React.useContext(CatalystContext);
   const canAddNote = Boolean($c.user && editorMayAddNote(edit, $c.user));
   const isOwnEdit = Boolean($c.user && $c.user.id === edit.editor_id);
@@ -181,6 +176,6 @@ const EditIndex = ({
       )}
     </Layout>
   );
-};
+}
 
 export default EditIndex;

--- a/root/edit/ModifyNote.js
+++ b/root/edit/ModifyNote.js
@@ -22,75 +22,71 @@ type ModifyEditNoteFormT = FormT<{
   +text: FieldT<string>,
 }>;
 
-type Props = {
-  +edit: GenericEditWithIdT,
-  +editNote: EditNoteT,
-  +form: ModifyEditNoteFormT,
-};
-
-const ModifyNote = ({
-  edit,
-  editNote,
-  form,
-}: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Modify edit note')}>
-    <h1>{l('Modify edit note')}</h1>
-    <p>
-      {l('You are modifying the following edit note:')}
-    </p>
-    <div className="edit-notes">
-      <EditNoteListEntry
-        edit={edit}
-        editNote={editNote}
-        showEditControls={false}
-      />
-    </div>
-    <form method="post">
-      <FormRowTextArea
-        cols={50}
-        field={form.field.text}
-        label={addColonText(l('New edit note'))}
-        rows={10}
-      />
-      <EditNoteHelp>
-        <p>
-          {l(
-            `Keep in mind modification of edit notes is mostly intended
-             to correct small mistakes. Editors won’t be notified
-             of your changes via email.`,
-          )}
-        </p>
-      </EditNoteHelp>
+component ModifyNote(
+  edit: GenericEditWithIdT,
+  editNote: EditNoteT,
+  form: ModifyEditNoteFormT,
+) {
+  return (
+    <Layout fullWidth title={l('Modify edit note')}>
+      <h1>{l('Modify edit note')}</h1>
       <p>
-        {l(`Providing a reason is optional but can make things more clear
-            for editors checking this edit in the future. Keep in mind
-            the reason will be displayed to other editors.`)}
+        {l('You are modifying the following edit note:')}
       </p>
-      <FormRowText
-        field={form.field.reason}
-        label={addColonText(l('Reason'))}
-        size={50}
-        uncontrolled
-      />
-      <span className="buttons">
-        <button
-          name="edit-note-modify.submit"
-          type="submit"
-          value="1"
-        >
-          {l('Submit')}
-        </button>
-        <button
-          className="negative"
-          name="edit-note-modify.cancel"
-          type="submit"
-          value="1"
-        >
-          {l('Cancel')}
-        </button>
-      </span>
-    </form>
-  </Layout>
-);
+      <div className="edit-notes">
+        <EditNoteListEntry
+          edit={edit}
+          editNote={editNote}
+          showEditControls={false}
+        />
+      </div>
+      <form method="post">
+        <FormRowTextArea
+          cols={50}
+          field={form.field.text}
+          label={addColonText(l('New edit note'))}
+          rows={10}
+        />
+        <EditNoteHelp>
+          <p>
+            {l(
+              `Keep in mind modification of edit notes is mostly intended
+               to correct small mistakes. Editors won’t be notified
+               of your changes via email.`,
+            )}
+          </p>
+        </EditNoteHelp>
+        <p>
+          {l(`Providing a reason is optional but can make things more clear
+              for editors checking this edit in the future. Keep in mind
+              the reason will be displayed to other editors.`)}
+        </p>
+        <FormRowText
+          field={form.field.reason}
+          label={addColonText(l('Reason'))}
+          size={50}
+          uncontrolled
+        />
+        <span className="buttons">
+          <button
+            name="edit-note-modify.submit"
+            type="submit"
+            value="1"
+          >
+            {l('Submit')}
+          </button>
+          <button
+            className="negative"
+            name="edit-note-modify.cancel"
+            type="submit"
+            value="1"
+          >
+            {l('Cancel')}
+          </button>
+        </span>
+      </form>
+    </Layout>
+  );
+}
 
 export default ModifyNote;

--- a/root/edit/NoteIsRequired.js
+++ b/root/edit/NoteIsRequired.js
@@ -10,11 +10,7 @@
 import Layout from '../layout/index.js';
 import EditLink from '../static/scripts/common/components/EditLink.js';
 
-type Props = {
-  +edit: GenericEditWithIdT,
-};
-
-const NoteIsRequired = ({edit}: Props): React$Element<typeof Layout> => {
+component NoteIsRequired(edit: GenericEditWithIdT) {
   const editDisplay = 'edit #' + edit.id;
   const editLink = <EditLink content={editDisplay} edit={edit} />;
   return (
@@ -29,6 +25,6 @@ const NoteIsRequired = ({edit}: Props): React$Element<typeof Layout> => {
       </p>
     </Layout>
   );
-};
+}
 
 export default NoteIsRequired;

--- a/root/edit/NotesReceived.js
+++ b/root/edit/NotesReceived.js
@@ -20,15 +20,7 @@ import getRequestCookie from '../utility/getRequestCookie.mjs';
 
 import EditNoteListEntry from './components/EditNoteListEntry.js';
 
-type Props = {
-  +editNotes: $ReadOnlyArray<EditNoteT>,
-  +pager: PagerT,
-};
-
-const NotesReceived = ({
-  editNotes,
-  pager,
-}: Props): React$Element<typeof Layout> => {
+component NotesReceived(editNotes: $ReadOnlyArray<EditNoteT>, pager: PagerT) {
   const $c = React.useContext(CatalystContext);
 
   return (
@@ -72,6 +64,6 @@ const NotesReceived = ({
       {manifest.js('edit/components/NewNotesAlertCheckbox', {async: 'async'})}
     </Layout>
   );
-};
+}
 
 export default NotesReceived;

--- a/root/edit/OpenEdits.js
+++ b/root/edit/OpenEdits.js
@@ -11,32 +11,27 @@ import Layout from '../layout/index.js';
 
 import EditList from './components/EditList.js';
 
-type Props = {
-  +editCountLimit: number,
-  +edits: $ReadOnlyArray<$ReadOnly<{...EditT, +id: number}>>,
-  +pager: PagerT,
-  +refineUrlArgs: {+[argument: string]: string},
-};
-
-const OpenEdits = ({
-  editCountLimit,
-  edits,
-  pager,
-  refineUrlArgs,
-}: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={lp('Open edits', 'noun')}>
-    <div id="content">
-      <h1>{lp('Open edits', 'noun')}</h1>
-      <EditList
-        editCountLimit={editCountLimit}
-        edits={edits}
-        guessSearch
-        page="open"
-        pager={pager}
-        refineUrlArgs={refineUrlArgs}
-      />
-    </div>
-  </Layout>
-);
+component OpenEdits(
+  editCountLimit: number,
+  edits: $ReadOnlyArray<$ReadOnly<{...EditT, +id: number}>>,
+  pager: PagerT,
+  refineUrlArgs: {+[argument: string]: string},
+) {
+  return (
+    <Layout fullWidth title={lp('Open edits', 'noun')}>
+      <div id="content">
+        <h1>{lp('Open edits', 'noun')}</h1>
+        <EditList
+          editCountLimit={editCountLimit}
+          edits={edits}
+          guessSearch
+          page="open"
+          pager={pager}
+          refineUrlArgs={refineUrlArgs}
+        />
+      </div>
+    </Layout>
+  );
+}
 
 export default OpenEdits;

--- a/root/edit/SubscribedEditorEdits.js
+++ b/root/edit/SubscribedEditorEdits.js
@@ -11,32 +11,27 @@ import Layout from '../layout/index.js';
 
 import EditList from './components/EditList.js';
 
-type Props = {
-  +editCountLimit: number,
-  +edits: $ReadOnlyArray<$ReadOnly<{...EditT, +id: number}>>,
-  +pager: PagerT,
-  +refineUrlArgs?: {+[argument: string]: string},
-};
-
-const SubscribedEditorEdits = ({
-  editCountLimit,
-  edits,
-  pager,
-  refineUrlArgs,
-}: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Edits by your subscribed editors')}>
-    <div id="content">
-      <h1>{l('Edits by your subscribed editors')}</h1>
-      <EditList
-        editCountLimit={editCountLimit}
-        edits={edits}
-        guessSearch
-        page="subscribed_editors"
-        pager={pager}
-        refineUrlArgs={refineUrlArgs}
-      />
-    </div>
-  </Layout>
-);
+component SubscribedEditorEdits(
+  editCountLimit: number,
+  edits: $ReadOnlyArray<$ReadOnly<{...EditT, +id: number}>>,
+  pager: PagerT,
+  refineUrlArgs?: {+[argument: string]: string},
+) {
+  return (
+    <Layout fullWidth title={l('Edits by your subscribed editors')}>
+      <div id="content">
+        <h1>{l('Edits by your subscribed editors')}</h1>
+        <EditList
+          editCountLimit={editCountLimit}
+          edits={edits}
+          guessSearch
+          page="subscribed_editors"
+          pager={pager}
+          refineUrlArgs={refineUrlArgs}
+        />
+      </div>
+    </Layout>
+  );
+}
 
 export default SubscribedEditorEdits;

--- a/root/edit/SubscribedEdits.js
+++ b/root/edit/SubscribedEdits.js
@@ -11,39 +11,34 @@ import Layout from '../layout/index.js';
 
 import EditList from './components/EditList.js';
 
-type Props = {
-  +editCountLimit: number,
-  +edits: $ReadOnlyArray<$ReadOnly<{...EditT, +id: number}>>,
-  +pager: PagerT,
-  +refineUrlArgs?: {+[argument: string]: string},
-};
+component SubscribedEdits(
+  editCountLimit: number,
+  edits: $ReadOnlyArray<$ReadOnly<{...EditT, +id: number}>>,
+  pager: PagerT,
+  refineUrlArgs?: {+[argument: string]: string},
+) {
+  return (
+    <Layout fullWidth title={l('Edits for your subscribed entities')}>
+      <div id="content">
+        <h1>{l('Edits for your subscribed entities')}</h1>
 
-const SubscribedEdits = ({
-  editCountLimit,
-  edits,
-  pager,
-  refineUrlArgs,
-}: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Edits for your subscribed entities')}>
-    <div id="content">
-      <h1>{l('Edits for your subscribed entities')}</h1>
+        <p>
+          {l(`This page lists edits linked to entities you are directly
+              subscribed to, as well as edits linked to entities which are
+              part of a collection you are subscribed to.`)}
+        </p>
 
-      <p>
-        {l(`This page lists edits linked to entities you are directly
-            subscribed to, as well as edits linked to entities which are
-            part of a collection you are subscribed to.`)}
-      </p>
-
-      <EditList
-        editCountLimit={editCountLimit}
-        edits={edits}
-        guessSearch
-        page="subscribed"
-        pager={pager}
-        refineUrlArgs={refineUrlArgs}
-      />
-    </div>
-  </Layout>
-);
+        <EditList
+          editCountLimit={editCountLimit}
+          edits={edits}
+          guessSearch
+          page="subscribed"
+          pager={pager}
+          refineUrlArgs={refineUrlArgs}
+        />
+      </div>
+    </Layout>
+  );
+}
 
 export default SubscribedEdits;

--- a/root/edit/components/EditArtwork.js
+++ b/root/edit/components/EditArtwork.js
@@ -11,17 +11,11 @@ import {Artwork} from '../../components/Artwork.js';
 import expand2html from '../../static/scripts/common/i18n/expand2html.js';
 import entityHref from '../../static/scripts/common/utility/entityHref.js';
 
-type Props = {
-  +artwork: ArtworkT,
-  +colSpan?: number,
-  +release: ReleaseT,
-};
-
-const EditArtwork = ({
-  artwork,
-  colSpan,
-  release,
-}: Props): React$Element<'tr'> => {
+component EditArtwork(
+  artwork: ArtworkT,
+  colSpan?: number,
+  release: ReleaseT,
+ ) {
   const historyMessage = release.gid ? (
     expand2html(
       l(`We are unable to display history for this cover
@@ -39,6 +33,6 @@ const EditArtwork = ({
       </td>
     </tr>
   );
-};
+}
 
 export default EditArtwork;

--- a/root/edit/components/EditHeader.js
+++ b/root/edit/components/EditHeader.js
@@ -32,17 +32,11 @@ import {returnToCurrentPage} from '../../utility/returnUri.js';
 import EditorTypeInfo from './EditorTypeInfo.js';
 import VoteTally from './VoteTally.js';
 
-type Props = {
-  +edit: GenericEditWithIdT,
-  +isSummary?: boolean,
-  +voter?: UnsanitizedEditorT,
-};
-
-const EditHeader = ({
-  edit,
-  isSummary = false,
-  voter,
-}: Props): React$Element<'div'> => {
+component EditHeader(
+  edit: GenericEditWithIdT,
+  isSummary: boolean = false,
+  voter?: UnsanitizedEditorT,
+) {
   const $c = React.useContext(CatalystContext);
   const user = $c.user;
   const mayApprove = editorMayApprove(edit, user);
@@ -194,6 +188,6 @@ const EditHeader = ({
       <SubHeader subHeading={subHeading} />
     </div>
   );
-};
+}
 
 export default EditHeader;

--- a/root/edit/components/EditList.js
+++ b/root/edit/components/EditList.js
@@ -18,31 +18,18 @@ import FormSubmit from '../../static/scripts/edit/components/FormSubmit.js';
 import ListEdit from '../components/ListEdit.js';
 import ListHeader from '../components/ListHeader.js';
 
-type Props = {
-  +editCountLimit: number,
-  +edits: $ReadOnlyArray<$ReadOnly<{...EditT, +id: number}>>,
-  +entity?: EditableEntityT | CollectionT,
-  +guessSearch?: boolean,
-  +isSearch?: boolean,
-  +page: string,
-  +pager: PagerT,
-  +refineUrlArgs?: {+[argument: string]: string},
-  +username?: string,
-  +voter?: UnsanitizedEditorT,
-};
-
-const EditList = ({
-  editCountLimit,
-  edits,
-  entity,
-  guessSearch = false,
-  isSearch = false,
-  page,
-  pager,
-  refineUrlArgs,
-  username,
-  voter,
-}: Props): React.MixedElement => {
+component EditList(
+  editCountLimit: number,
+  edits: $ReadOnlyArray<$ReadOnly<{...EditT, +id: number}>>,
+  entity?: EditableEntityT | CollectionT,
+  guessSearch: boolean = false,
+  isSearch: boolean = false,
+  page: string,
+  pager: PagerT,
+  refineUrlArgs?: {+[argument: string]: string},
+  username?: string,
+  voter?: UnsanitizedEditorT,
+) {
   const $c = React.useContext(SanitizedCatalystContext);
 
   /*
@@ -136,6 +123,6 @@ const EditList = ({
       ) : null}
     </>
   );
-};
+}
 
 export default EditList;

--- a/root/edit/components/EditNote.js
+++ b/root/edit/components/EditNote.js
@@ -26,14 +26,6 @@ import parseIsoDate from '../../utility/parseIsoDate.js';
 
 import EditorTypeInfo from './EditorTypeInfo.js';
 
-type PropsT = {
-  +edit: GenericEditWithIdT,
-  +editNote: EditNoteT,
-  +index: number,
-  +isOnEditPage?: boolean,
-  +showEditControls?: boolean,
-};
-
 function returnNoteAnchor(edit: GenericEditWithIdT, index: number) {
   return `note-${edit.id}-${index + 1}`;
 }
@@ -55,13 +47,13 @@ function returnVoteClass(vote: ?VoteT, isOwner: boolean) {
   return className;
 }
 
-const EditNote = ({
-  edit,
-  editNote,
-  index,
-  isOnEditPage = false,
-  showEditControls = true,
-}: PropsT): React$Element<'div'> => {
+component EditNote(
+  edit: GenericEditWithIdT,
+  editNote: EditNoteT,
+  index: number,
+  isOnEditPage: boolean = false,
+  showEditControls: boolean = true,
+) {
   const $c = React.useContext(CatalystContext);
   const user = $c.user;
   const allEditNotes = edit.edit_notes;
@@ -254,6 +246,6 @@ const EditNote = ({
       )}
     </div>
   );
-};
+}
 
 export default EditNote;

--- a/root/edit/components/EditNoteHelp.js
+++ b/root/edit/components/EditNoteHelp.js
@@ -7,28 +7,24 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type Props = {
-  +children?: React$Node,
-};
-
-const EditNoteHelp = ({
-  children,
-}: Props): React$Element<'div'> => (
-  <div className="edit-note-help">
-    <p>
-      {exp.l(
-        `Edit notes support
-        {doc_formatting|a limited set of wiki formatting options}.
-        Please do always keep the {doc_coc|Code of Conduct} in mind
-        when writing edit notes!`,
-        {
-          doc_coc: {href: '/doc/Code_of_Conduct', target: '_blank'},
-          doc_formatting: {href: '/doc/Edit_Note', target: '_blank'},
-        },
-      )}
-    </p>
-    {children}
-  </div>
-);
+component EditNoteHelp(children?: React$Node) {
+  return (
+    <div className="edit-note-help">
+      <p>
+        {exp.l(
+          `Edit notes support
+           {doc_formatting|a limited set of wiki formatting options}.
+           Please do always keep the {doc_coc|Code of Conduct} in mind
+           when writing edit notes!`,
+          {
+            doc_coc: {href: '/doc/Code_of_Conduct', target: '_blank'},
+            doc_formatting: {href: '/doc/Edit_Note', target: '_blank'},
+          },
+        )}
+      </p>
+      {children}
+    </div>
+  );
+}
 
 export default EditNoteHelp;

--- a/root/edit/components/EditNoteListEntry.js
+++ b/root/edit/components/EditNoteListEntry.js
@@ -12,17 +12,11 @@ import {getEditHeaderClass} from '../../utility/edit.js';
 
 import EditNote from './EditNote.js';
 
-type PropsT = {
-  +edit: GenericEditWithIdT,
-  +editNote: EditNoteT,
-  +showEditControls?: boolean,
-};
-
-const EditNoteListEntry = ({
-  edit,
-  editNote,
-  showEditControls,
-}: PropsT): React$Element<'div'> => {
+component EditNoteListEntry(
+  edit: GenericEditWithIdT,
+  editNote: EditNoteT,
+  showEditControls?: boolean,
+) {
   const editTitle = texp.l(
     'Edit #{id} - {name}',
     {id: edit.id, name: l(edit.edit_name)},
@@ -43,6 +37,6 @@ const EditNoteListEntry = ({
       />
     </div>
   );
-};
+}
 
 export default EditNoteListEntry;

--- a/root/edit/components/EditNotes.js
+++ b/root/edit/components/EditNotes.js
@@ -18,21 +18,13 @@ import {
 import EditNote from './EditNote.js';
 import EditNoteHelp from './EditNoteHelp.js';
 
-type Props = {
-  +edit: GenericEditWithIdT,
-  +hide?: boolean,
-  +index?: number,
-  +isOnEditPage?: boolean,
-  +verbose?: boolean,
-};
-
-const EditNotes = ({
-  edit,
-  hide = false,
-  index = 0,
-  isOnEditPage,
-  verbose = true,
-}: Props): React$Element<'div'> => {
+component EditNotes(
+  edit: GenericEditWithIdT,
+  hide: boolean = false,
+  index: number = 0,
+  isOnEditPage?: boolean,
+  verbose: boolean = true,
+) {
   const $c = React.useContext(CatalystContext);
   const user = $c.user;
   const mayAddNote = editorMayAddNote(edit, user);
@@ -84,6 +76,6 @@ const EditNotes = ({
       )}
     </div>
   );
-};
+}
 
 export default EditNotes;

--- a/root/edit/components/EditSidebar.js
+++ b/root/edit/components/EditSidebar.js
@@ -23,13 +23,7 @@ import {
 } from '../../utility/edit.js';
 import formatUserDate from '../../utility/formatUserDate.js';
 
-type Props = {
-  +edit: GenericEditWithIdT,
-};
-
-const EditSidebar = ({
-  edit,
-}: Props): React$Element<'div'> => {
+component EditSidebar(edit: GenericEditWithIdT) {
   const $c = React.useContext(SanitizedCatalystContext);
   return (
     <div id="sidebar">
@@ -100,6 +94,6 @@ const EditSidebar = ({
       </ul>
     </div>
   );
-};
+}
 
 export default EditSidebar;

--- a/root/edit/components/EditSummary.js
+++ b/root/edit/components/EditSummary.js
@@ -25,15 +25,10 @@ import returnUri from '../../utility/returnUri.js';
 
 import Vote from './Vote.js';
 
-type Props = {
-  +edit: GenericEditWithIdT,
-  +index: number,
-};
-
-const EditSummary = ({
-  edit,
-  index,
-}: Props): React.MixedElement => {
+component EditSummary(
+  edit: GenericEditWithIdT,
+  index: number,
+) {
   const $c = React.useContext(CatalystContext);
   const user = $c.user;
   const mayAddNote = editorMayAddNote(edit, user);
@@ -99,6 +94,6 @@ const EditSummary = ({
         </div>) : null}
     </>
   );
-};
+}
 
 export default EditSummary;

--- a/root/edit/components/EditorTypeInfo.js
+++ b/root/edit/components/EditorTypeInfo.js
@@ -10,38 +10,34 @@
 import bracketed from '../../static/scripts/common/utility/bracketed.js';
 import {isBot} from '../../static/scripts/common/utility/privileges.js';
 
-type Props = {
-  +editor: EditorT | null,
-};
-
-const EditorTypeInfo = ({
-  editor,
-}: Props): React.MixedElement | null => (
-  editor == null ? null : (
-    <>
-      {editor.is_limited ? (
-        <span className="editor-class">
-          {bracketed(
-            <span
-              className="tooltip"
-              title={l('This user is new to MusicBrainz.')}
-            >
-              {l('beginner')}
-            </span>,
-          )}
-        </span>
-      ) : null}
-      {isBot(editor) ? (
-        <span className="editor-class">
-          {bracketed(
-            <span className="tooltip" title={l('This user is automated.')}>
-              {l('bot')}
-            </span>,
-          )}
-        </span>
-      ) : null}
-    </>
-  )
-);
+component EditorTypeInfo(editor: EditorT | null) {
+  return (
+    editor == null ? null : (
+      <>
+        {editor.is_limited ? (
+          <span className="editor-class">
+            {bracketed(
+              <span
+                className="tooltip"
+                title={l('This user is new to MusicBrainz.')}
+              >
+                {l('beginner')}
+              </span>,
+            )}
+          </span>
+        ) : null}
+        {isBot(editor) ? (
+          <span className="editor-class">
+            {bracketed(
+              <span className="tooltip" title={l('This user is automated.')}>
+                {l('bot')}
+              </span>,
+            )}
+          </span>
+        ) : null}
+      </>
+    )
+  );
+}
 
 export default EditorTypeInfo;

--- a/root/edit/components/HistoricReleaseList.js
+++ b/root/edit/components/HistoricReleaseList.js
@@ -12,45 +12,39 @@ import DescriptiveLink
 import {DeletedLink}
   from '../../static/scripts/common/components/EntityLink.js';
 
-type HistoricReleaseListContentProps = {
-  +releases: $ReadOnlyArray<ReleaseT | null>,
-};
+export component HistoricReleaseListContent(
+  releases: $ReadOnlyArray<ReleaseT | null>,
+) {
+  return (
+    <ul>
+      {releases.length ? (
+        releases.map((release, index) => (
+          <li key={index}>
+            {release?.id
+              ? <DescriptiveLink entity={release} />
+              : <DeletedLink allowNew={false} name={release?.name ?? null} />}
+          </li>
+        ))
+      ) : (
+        <DeletedLink allowNew={false} name={null} />
+      )}
+    </ul>
+  );
+}
 
-type HistoricReleaseListProps = {
-  +colSpan?: string,
-  +label?: string,
-  +releases: $ReadOnlyArray<ReleaseT | null>,
-};
-
-export const HistoricReleaseListContent = ({
-  releases,
-}: HistoricReleaseListContentProps): React$Element<'ul'> => (
-  <ul>
-    {releases.length ? (
-      releases.map((release, index) => (
-        <li key={index}>
-          {release?.id
-            ? <DescriptiveLink entity={release} />
-            : <DeletedLink allowNew={false} name={release?.name ?? null} />}
-        </li>
-      ))
-    ) : (
-      <DeletedLink allowNew={false} name={null} />
-    )}
-  </ul>
-);
-
-const HistoricReleaseList = ({
-  colSpan,
-  label,
-  releases,
-}: HistoricReleaseListProps): React$Element<'tr'> => (
-  <tr>
-    <th>{nonEmpty(label) ? label : addColonText(l('Releases'))}</th>
-    <td colSpan={colSpan}>
-      <HistoricReleaseListContent releases={releases} />
-    </td>
-  </tr>
-);
+component HistoricReleaseList(
+  colSpan?: string,
+  label?: string,
+  ...contentProps: React.PropsOf<HistoricReleaseListContent>
+) {
+  return (
+    <tr>
+      <th>{nonEmpty(label) ? label : addColonText(l('Releases'))}</th>
+      <td colSpan={colSpan}>
+        <HistoricReleaseListContent {...contentProps} />
+      </td>
+    </tr>
+  );
+}
 
 export default HistoricReleaseList;

--- a/root/edit/components/IntentionallyRawIcon.js
+++ b/root/edit/components/IntentionallyRawIcon.js
@@ -10,13 +10,14 @@
 import InformationIcon
   from '../../static/scripts/edit/components/InformationIcon.js';
 
-const IntentionallyRawIcon =
-  (): React$Element<typeof InformationIcon> => (
+component IntentionallyRawIcon() {
+  return (
     <InformationIcon
       className="align-top"
       title={l(`This field is intentionally left as it was originally
                 entered (untranslated, unformatted).`)}
     />
   );
+}
 
 export default IntentionallyRawIcon;

--- a/root/edit/components/ListEdit.js
+++ b/root/edit/components/ListEdit.js
@@ -16,17 +16,11 @@ import EditNotes from '../components/EditNotes.js';
 import EditSummary from '../components/EditSummary.js';
 import getEditDetailsElement from '../utility/getEditDetailsElement.js';
 
-type Props = {
-  +edit: $ReadOnly<{...EditT, +id: number}>,
-  +index: number,
-  +voter?: UnsanitizedEditorT,
-};
-
-const ListEdit = ({
-  edit,
-  index,
-  voter,
-}: Props): React$Element<'div'> => {
+component ListEdit(
+  edit: $ReadOnly<{...EditT, +id: number}>,
+  index: number,
+  voter?: UnsanitizedEditorT,
+) {
   const $c = React.useContext(SanitizedCatalystContext);
   const editStatusClass = getEditStatusClass(edit);
   const detailsElement = getEditDetailsElement(edit);
@@ -59,6 +53,6 @@ const ListEdit = ({
       ) : null}
     </div>
   );
-};
+}
 
 export default ListEdit;

--- a/root/edit/components/ListHeader.js
+++ b/root/edit/components/ListHeader.js
@@ -14,21 +14,13 @@ import {CatalystContext} from '../../context.mjs';
 import DBDefs from '../../static/scripts/common/DBDefs.mjs';
 import uriWith from '../../utility/uriWith.js';
 
-type Props = {
-  +entity?: EditableEntityT | CollectionT,
-  +isSearch?: boolean,
-  +page: string,
-  +refineUrlArgs?: {+[argument: string]: string},
-  +username?: string,
-};
-
-const QuickLinks = ({
-  entity,
-  isSearch = false,
-  page,
-  refineUrlArgs,
-  username,
-}: Props): React.MixedElement => {
+component QuickLinks(
+  entity?: EditableEntityT | CollectionT,
+  isSearch: boolean = false,
+  page: string,
+  refineUrlArgs?: {+[argument: string]: string},
+  username?: string,
+) {
   const $c = React.useContext(CatalystContext);
   const isSecureConnection = $c.req.secure;
   const protocol = isSecureConnection ? 'https://' : 'http://';
@@ -182,47 +174,37 @@ const QuickLinks = ({
       return accum;
     }, [],
   ));
-};
+}
 
-const ListHeader = ({
-  entity,
-  isSearch,
-  page,
-  refineUrlArgs,
-  username,
-}: Props): React$Element<'table'> => (
-  <table className="search-help">
-    <tr>
-      <th>
-        {l('Quick links:')}
-      </th>
-      <td>
-        <QuickLinks
-          entity={entity}
-          isSearch={isSearch}
-          page={page}
-          refineUrlArgs={refineUrlArgs}
-          username={username}
-        />
-      </td>
-    </tr>
-    <tr>
-      <th>
-        {l('Help:')}
-      </th>
-      <td>
-        <a href="/doc/Introduction_to_Voting">
-          {l('Introduction to voting')}
-        </a>
-        {' | '}
-        <a href="/doc/Introduction_to_Editing">
-          {l('Introduction to editing')}
-        </a>
-        {' | '}
-        <a href="/doc/Style">{l('Style guidelines')}</a>
-      </td>
-    </tr>
-  </table>
-);
+component ListHeader(...props: React.PropsOf<QuickLinks>) {
+  return (
+    <table className="search-help">
+      <tr>
+        <th>
+          {l('Quick links:')}
+        </th>
+        <td>
+          <QuickLinks {...props} />
+        </td>
+      </tr>
+      <tr>
+        <th>
+          {l('Help:')}
+        </th>
+        <td>
+          <a href="/doc/Introduction_to_Voting">
+            {l('Introduction to voting')}
+          </a>
+          {' | '}
+          <a href="/doc/Introduction_to_Editing">
+            {l('Introduction to editing')}
+          </a>
+          {' | '}
+          <a href="/doc/Style">{l('Style guidelines')}</a>
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default ListHeader;

--- a/root/edit/components/TrackDurationChanges.js
+++ b/root/edit/components/TrackDurationChanges.js
@@ -12,19 +12,12 @@ import formatTrackLength
 import DiffSide from '../../static/scripts/edit/components/edit/DiffSide.js';
 import {DELETE, INSERT} from '../../static/scripts/edit/utility/editDiff.js';
 
-type Props = {
-  +newLabel?: string,
-  +newLengths: $ReadOnlyArray<number | null>,
-  +oldLabel?: string,
-  +oldLengths: $ReadOnlyArray<number | null>,
-};
-
-const TrackDurationChanges = ({
-  newLabel,
-  newLengths,
-  oldLabel,
-  oldLengths,
-}: Props): React.MixedElement => {
+component TrackDurationChanges(
+  newLabel?: string,
+  newLengths: $ReadOnlyArray<number | null>,
+  oldLabel?: string,
+  oldLengths: $ReadOnlyArray<number | null>,
+) {
   const lengthsSize = oldLengths.length;
   const lengthComparisonTables = [];
   for (let i = 0; i < lengthsSize; i++) {
@@ -68,6 +61,6 @@ const TrackDurationChanges = ({
       {lengthComparisonTables}
     </>
   );
-};
+}
 
 export default TrackDurationChanges;

--- a/root/edit/components/Vote.js
+++ b/root/edit/components/Vote.js
@@ -23,27 +23,19 @@ import {
   getLatestVoteForEditor,
 } from '../../utility/edit.js';
 
-type VoteCheckboxProps = {
-  +edit: GenericEditWithIdT,
-  +label: string,
-  +name: string,
-  +user: UnsanitizedEditorT,
-  +value: number,
-};
-
-const VoteCheckbox = ({
-  edit,
-  user,
-  label,
-  name,
-  ...props
-}: VoteCheckboxProps) => {
+component VoteCheckbox(
+  edit: GenericEditWithIdT,
+  label: string,
+  name: string,
+  user: UnsanitizedEditorT,
+  value: number,
+) {
   const latestVote = user
     ? getLatestVoteForEditor(edit, user)
     : null;
   const checked =
-    (latestVote && latestVote.vote === props.value) ||
-    (!latestVote && props.value === EDIT_VOTE_NONE);
+    (latestVote && latestVote.vote === value) ||
+    (!latestVote && value === EDIT_VOTE_NONE);
   return (
     <label htmlFor={`id-${name}-${label}`}>
       <input
@@ -51,24 +43,18 @@ const VoteCheckbox = ({
         id={`id-${name}-${label}`}
         name={name}
         type="radio"
-        {...props}
+        value={value}
       />
       {label}
     </label>
   );
-};
+}
 
-type VoteProps = {
-  +edit: GenericEditWithIdT,
-  +index?: number,
-  +summary?: boolean,
-};
-
-const Vote = ({
-  edit,
-  index = 0,
-  summary = false,
-}: VoteProps): React$Element<'div'> | null => {
+component Vote(
+  edit: GenericEditWithIdT,
+  index: number = 0,
+  summary: boolean = false,
+) {
   const $c = React.useContext(CatalystContext);
   const user = $c.user;
   if (DBDefs.DB_READ_ONLY || !user || !editorMayVoteOnEdit(edit, user)) {
@@ -112,6 +98,6 @@ const Vote = ({
       {summary ? null : <FormSubmit label={l('Submit vote and note')} />}
     </div>
   );
-};
+}
 
 export default Vote;

--- a/root/edit/components/VoteTally.js
+++ b/root/edit/components/VoteTally.js
@@ -24,9 +24,7 @@ function countVotes(
   );
 }
 
-const VoteTally = ({edit}: {
-  edit: GenericEditWithIdT,
-}): Expand2ReactOutput => {
+component VoteTally(edit: GenericEditWithIdT) {
   if (edit.auto_edit) {
     return <strong>{l('automatically applied')}</strong>;
   }
@@ -43,6 +41,6 @@ const VoteTally = ({edit}: {
       },
     )
   );
-};
+}
 
 export default VoteTally;

--- a/root/edit/details/AddAnnotation.js
+++ b/root/edit/details/AddAnnotation.js
@@ -13,11 +13,7 @@ import formatEntityTypeName
   from '../../static/scripts/common/utility/formatEntityTypeName.js';
 import Diff from '../../static/scripts/edit/components/edit/Diff.js';
 
-type Props = {
-  +edit: AddAnnotationEditT,
-};
-
-const AddAnnotation = ({edit}: Props): React$Element<'table'> => {
+component AddAnnotation(edit: AddAnnotationEditT) {
   const display = edit.display_data;
   const entityType = display.entity_type;
   const oldAnnotation = display.old_annotation;
@@ -76,6 +72,6 @@ const AddAnnotation = ({edit}: Props): React$Element<'table'> => {
       ) : null}
     </table>
   );
-};
+}
 
 export default AddAnnotation;

--- a/root/edit/details/AddArea.js
+++ b/root/edit/details/AddArea.js
@@ -15,11 +15,7 @@ import formatDate from '../../static/scripts/common/utility/formatDate.js';
 import isDateEmpty from '../../static/scripts/common/utility/isDateEmpty.js';
 import yesNo from '../../static/scripts/common/utility/yesNo.js';
 
-type Props = {
-  +edit: AddAreaEditT,
-};
-
-const AddArea = ({edit}: Props): React$MixedElement => {
+component AddArea(edit: AddAreaEditT) {
   const display = edit.display_data;
   const areaType = display.type;
 
@@ -105,6 +101,6 @@ const AddArea = ({edit}: Props): React$MixedElement => {
       </table>
     </>
   );
-};
+}
 
 export default AddArea;

--- a/root/edit/details/AddArtist.js
+++ b/root/edit/details/AddArtist.js
@@ -21,11 +21,7 @@ import isDateEmpty from '../../static/scripts/common/utility/isDateEmpty.js';
 import yesNo from '../../static/scripts/common/utility/yesNo.js';
 import formatIsni from '../../utility/formatIsni.js';
 
-type Props = {
-  +edit: AddArtistEditT,
-};
-
-const AddArtist = ({edit}: Props): React$MixedElement => {
+component AddArtist(edit: AddArtistEditT) {
   const display = edit.display_data;
   const area = display.area;
   const beginArea = display.begin_area;
@@ -150,6 +146,6 @@ const AddArtist = ({edit}: Props): React$MixedElement => {
       </table>
     </>
   );
-};
+}
 
 export default AddArtist;

--- a/root/edit/details/AddCoverArt.js
+++ b/root/edit/details/AddCoverArt.js
@@ -13,11 +13,7 @@ import {commaOnlyListText}
   from '../../static/scripts/common/i18n/commaOnlyList.js';
 import EditArtwork from '../components/EditArtwork.js';
 
-type Props = {
-  +edit: AddCoverArtEditT,
-};
-
-const AddCoverArt = ({edit}: Props): React$Element<'table'> => {
+component AddCoverArt(edit: AddCoverArtEditT) {
   const display = edit.display_data;
 
   return (
@@ -59,6 +55,6 @@ const AddCoverArt = ({edit}: Props): React$Element<'table'> => {
       <EditArtwork artwork={display.artwork} release={display.release} />
     </table>
   );
-};
+}
 
 export default AddCoverArt;

--- a/root/edit/details/AddDiscId.js
+++ b/root/edit/details/AddDiscId.js
@@ -11,12 +11,7 @@ import CDTocLink from '../../static/scripts/common/components/CDTocLink.js';
 import MediumLink
   from '../../static/scripts/common/components/MediumLink.js';
 
-type Props = {
-  +allowNew?: boolean,
-  +edit: AddDiscIdEditT,
-};
-
-const AddDiscId = ({allowNew, edit}: Props): React$Element<'table'> => {
+component AddDiscId(allowNew?: boolean, edit: AddDiscIdEditT) {
   const medium = edit.display_data.medium;
   const cdToc = edit.display_data.medium_cdtoc.cdtoc;
 
@@ -38,6 +33,6 @@ const AddDiscId = ({allowNew, edit}: Props): React$Element<'table'> => {
       </tr>
     </table>
   );
-};
+}
 
 export default AddDiscId;

--- a/root/edit/details/AddEvent.js
+++ b/root/edit/details/AddEvent.js
@@ -12,11 +12,7 @@ import formatDate from '../../static/scripts/common/utility/formatDate.js';
 import isDateEmpty from '../../static/scripts/common/utility/isDateEmpty.js';
 import yesNo from '../../static/scripts/common/utility/yesNo.js';
 
-type Props = {
-  +edit: AddEventEditT,
-};
-
-const AddEvent = ({edit}: Props): React$MixedElement => {
+component AddEvent(edit: AddEventEditT) {
   const display = edit.display_data;
   const eventType = display.type;
 
@@ -88,6 +84,6 @@ const AddEvent = ({edit}: Props): React$MixedElement => {
       </table>
     </>
   );
-};
+}
 
 export default AddEvent;

--- a/root/edit/details/AddGenre.js
+++ b/root/edit/details/AddGenre.js
@@ -10,11 +10,7 @@
 import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink.js';
 
-type Props = {
-  +edit: AddGenreEditT,
-};
-
-const AddGenre = ({edit}: Props): React$MixedElement => {
+component AddGenre(edit: AddGenreEditT) {
   const display = edit.display_data;
 
   return (
@@ -45,6 +41,6 @@ const AddGenre = ({edit}: Props): React$MixedElement => {
       </table>
     </>
   );
-};
+}
 
 export default AddGenre;

--- a/root/edit/details/AddInstrument.js
+++ b/root/edit/details/AddInstrument.js
@@ -12,12 +12,7 @@ import EntityLink
 import expand2react from '../../static/scripts/common/i18n/expand2react.js';
 import IntentionallyRawIcon from '../components/IntentionallyRawIcon.js';
 
-type Props = {
-  +allowNew?: boolean,
-  +edit: AddInstrumentEditT,
-};
-
-const AddInstrument = ({allowNew, edit}: Props): React$MixedElement => {
+component AddInstrument(allowNew?: boolean, edit: AddInstrumentEditT) {
   const display = edit.display_data;
   const description = display.description;
   const instrumentType = display.type;
@@ -73,6 +68,6 @@ const AddInstrument = ({allowNew, edit}: Props): React$MixedElement => {
       </table>
     </>
   );
-};
+}
 
 export default AddInstrument;

--- a/root/edit/details/AddIsrcs.js
+++ b/root/edit/details/AddIsrcs.js
@@ -12,11 +12,7 @@ import CodeLink
 import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink.js';
 
-type Props = {
-  +edit: AddIsrcsEditT,
-};
-
-const AddIsrcs = ({edit}: Props): React$Element<'table'> => {
+component AddIsrcs(edit: AddIsrcsEditT) {
   const additions = edit.display_data.additions;
   const clientVersion = edit.display_data.client_version;
 
@@ -51,6 +47,6 @@ const AddIsrcs = ({edit}: Props): React$Element<'table'> => {
       </tr>
     </table>
   );
-};
+}
 
 export default AddIsrcs;

--- a/root/edit/details/AddIswcs.js
+++ b/root/edit/details/AddIswcs.js
@@ -12,11 +12,7 @@ import CodeLink
 import EntityLink
   from '../../static/scripts/common/components/EntityLink.js';
 
-type Props = {
-  +edit: AddIswcsEditT,
-};
-
-const AddIswcs = ({edit}: Props): React$Element<'table'> => {
+component AddIswcs(edit: AddIswcsEditT) {
   const additions = edit.display_data.additions;
 
   return (
@@ -41,6 +37,6 @@ const AddIswcs = ({edit}: Props): React$Element<'table'> => {
       </tr>
     </table>
   );
-};
+}
 
 export default AddIswcs;

--- a/root/edit/details/AddLabel.js
+++ b/root/edit/details/AddLabel.js
@@ -15,12 +15,7 @@ import isDateEmpty from '../../static/scripts/common/utility/isDateEmpty.js';
 import yesNo from '../../static/scripts/common/utility/yesNo.js';
 import formatIsni from '../../utility/formatIsni.js';
 
-type Props = {
-  +allowNew?: boolean,
-  +edit: AddLabelEditT,
-};
-
-const AddLabel = ({allowNew, edit}: Props): React$MixedElement => {
+component AddLabel(allowNew?: boolean, edit: AddLabelEditT) {
   const display = edit.display_data;
   const type = display.type;
   return (
@@ -117,6 +112,6 @@ const AddLabel = ({allowNew, edit}: Props): React$MixedElement => {
       </table>
     </>
   );
-};
+}
 
 export default AddLabel;

--- a/root/edit/details/AddMedium.js
+++ b/root/edit/details/AddMedium.js
@@ -17,44 +17,27 @@ import {artistCreditsAreEqual}
   from '../../static/scripts/common/immutable-entities.js';
 import loopParity from '../../utility/loopParity.js';
 
-type CondensedTrackACsRowProps = {
-  +artistCredit: ArtistCreditT,
-  +endNumber?: string,
-  +rowCounter: number,
-  +startNumber: string,
-};
+component CondensedTrackACsRow(
+  artistCredit: ArtistCreditT,
+  endNumber?: string,
+  rowCounter: number,
+  startNumber: string,
+) {
+  return (
+    <tr className={loopParity(rowCounter)}>
+      <td className="pos t">
+        {nonEmpty(endNumber) && endNumber !== startNumber
+          ? startNumber + '-' + endNumber
+          : startNumber}
+      </td>
+      <td>
+        <ExpandedArtistCredit artistCredit={artistCredit} />
+      </td>
+    </tr>
+  );
+}
 
-type CondensedTrackACsProps = {
-  +tracks?: $ReadOnlyArray<TrackT>,
-};
-
-type Props = {
-  +allowNew?: boolean,
-  +edit: AddMediumEditT,
-};
-
-const CondensedTrackACsRow = ({
-  artistCredit,
-  endNumber,
-  rowCounter,
-  startNumber,
-}: CondensedTrackACsRowProps): React$Element<'tr'> => (
-  <tr className={loopParity(rowCounter)}>
-    <td className="pos t">
-      {nonEmpty(endNumber) && endNumber !== startNumber
-        ? startNumber + '-' + endNumber
-        : startNumber}
-    </td>
-    <td>
-      <ExpandedArtistCredit artistCredit={artistCredit} />
-    </td>
-  </tr>
-);
-
-const CondensedTrackACs = ({
-  tracks,
-}: CondensedTrackACsProps):
-  Array<React$Element<typeof CondensedTrackACsRow>> => {
+component CondensedTrackACs(tracks?: $ReadOnlyArray<TrackT>) {
   if (!tracks) {
     return [];
   }
@@ -100,9 +83,9 @@ const CondensedTrackACs = ({
     }
   });
   return rows;
-};
+}
 
-const AddMedium = ({allowNew, edit}: Props): React$MixedElement => {
+component AddMedium(allowNew?: boolean, edit: AddMediumEditT) {
   const display = edit.display_data;
   const format = display.format;
 
@@ -177,6 +160,6 @@ const AddMedium = ({allowNew, edit}: Props): React$MixedElement => {
       ) : null}
     </table>
   );
-};
+}
 
 export default AddMedium;

--- a/root/edit/details/AddPlace.js
+++ b/root/edit/details/AddPlace.js
@@ -14,11 +14,7 @@ import isDateEmpty from '../../static/scripts/common/utility/isDateEmpty.js';
 import yesNo from '../../static/scripts/common/utility/yesNo.js';
 import {formatCoordinates} from '../../utility/coordinates.js';
 
-type Props = {
-  +edit: AddPlaceEditT,
-};
-
-const AddPlace = ({edit}: Props): React$MixedElement => {
+component AddPlace(edit: AddPlaceEditT) {
   const display = edit.display_data;
   const type = display.type;
   const place = display.place;
@@ -88,6 +84,6 @@ const AddPlace = ({edit}: Props): React$MixedElement => {
       </table>
     </>
   );
-};
+}
 
 export default AddPlace;

--- a/root/edit/details/AddRelationship.js
+++ b/root/edit/details/AddRelationship.js
@@ -10,11 +10,7 @@
 import Relationship
   from '../../static/scripts/common/components/Relationship.js';
 
-type Props = {
-  +edit: AddRelationshipEditT,
-};
-
-const AddRelationship = ({edit}: Props): React$MixedElement => {
+component AddRelationship(edit: AddRelationshipEditT) {
   const relationship = edit.display_data.relationship;
   return (
     <table className="details add-relationship">
@@ -45,6 +41,6 @@ const AddRelationship = ({edit}: Props): React$MixedElement => {
       ) : null}
     </table>
   );
-};
+}
 
 export default AddRelationship;

--- a/root/edit/details/AddRelationshipAttribute.js
+++ b/root/edit/details/AddRelationshipAttribute.js
@@ -13,11 +13,7 @@ import yesNo from '../../static/scripts/common/utility/yesNo.js';
 import IntentionallyRawIcon
   from '../components/IntentionallyRawIcon.js';
 
-type Props = {
-  +edit: AddRelationshipAttributeEditT,
-};
-
-const AddRelationshipAttribute = ({edit}: Props): React$Element<'table'> => {
+component AddRelationshipAttribute(edit: AddRelationshipAttributeEditT) {
   const display = edit.display_data;
   const description = display.description;
   const parent = display.parent;
@@ -66,6 +62,6 @@ const AddRelationshipAttribute = ({edit}: Props): React$Element<'table'> => {
       </tr>
     </table>
   );
-};
+}
 
 export default AddRelationshipAttribute;

--- a/root/edit/details/AddRelationshipType.js
+++ b/root/edit/details/AddRelationshipType.js
@@ -15,13 +15,7 @@ import OrderableDirection
 import {ENTITY_NAMES} from '../../static/scripts/common/constants.js';
 import IntentionallyRawIcon from '../components/IntentionallyRawIcon.js';
 
-type Props = {
-  +edit: AddRelationshipTypeEditT,
-};
-
-const AddRelationshipType = ({
-  edit,
-}: Props): React.MixedElement => {
+component AddRelationshipType(edit: AddRelationshipTypeEditT) {
   const display = edit.display_data;
   const entity0Type = ENTITY_NAMES[display.entity0_type]();
   const entity1Type = ENTITY_NAMES[display.entity1_type]();
@@ -196,6 +190,6 @@ const AddRelationshipType = ({
       </table>
     </>
   );
-};
+}
 
 export default AddRelationshipType;

--- a/root/edit/details/AddRelease.js
+++ b/root/edit/details/AddRelease.js
@@ -17,12 +17,7 @@ import ReleaseEvents
 import formatBarcode
   from '../../static/scripts/common/utility/formatBarcode.js';
 
-type Props = {
-  +allowNew?: boolean,
-  +edit: AddReleaseEditT,
-};
-
-const AddRelease = ({allowNew, edit}: Props): React$MixedElement => {
+component AddRelease(allowNew?: boolean, edit: AddReleaseEditT) {
   const display = edit.display_data;
   const language = display.language;
   const packaging = display.packaging;
@@ -133,6 +128,6 @@ const AddRelease = ({allowNew, edit}: Props): React$MixedElement => {
       </table>
     </>
   );
-};
+}
 
 export default AddRelease;

--- a/root/edit/details/AddReleaseGroup.js
+++ b/root/edit/details/AddReleaseGroup.js
@@ -12,12 +12,7 @@ import DescriptiveLink from
 import ExpandedArtistCredit from
   '../../static/scripts/common/components/ExpandedArtistCredit.js';
 
-type Props = {
-  +allowNew?: boolean,
-  +edit: AddReleaseGroupEditT,
-};
-
-const AddReleaseGroup = ({allowNew, edit}: Props): React$MixedElement => {
+component AddReleaseGroup(allowNew?: boolean, edit: AddReleaseGroupEditT) {
   const display = edit.display_data;
   const type = display.type;
   const secondaryType = display.secondary_types;
@@ -85,6 +80,6 @@ const AddReleaseGroup = ({allowNew, edit}: Props): React$MixedElement => {
       </table>
     </>
   );
-};
+}
 
 export default AddReleaseGroup;

--- a/root/edit/details/AddReleaseLabel.js
+++ b/root/edit/details/AddReleaseLabel.js
@@ -12,11 +12,7 @@ import DescriptiveLink
 import EntityLink
   from '../../static/scripts/common/components/EntityLink.js';
 
-type Props = {
-  +edit: AddReleaseLabelEditT,
-};
-
-const AddReleaseLabel = ({edit}: Props): React$Element<'table'> => {
+component AddReleaseLabel(edit: AddReleaseLabelEditT) {
   const display = edit.display_data;
 
   return (
@@ -45,6 +41,6 @@ const AddReleaseLabel = ({edit}: Props): React$Element<'table'> => {
       </tr>
     </table>
   );
-};
+}
 
 export default AddReleaseLabel;

--- a/root/edit/details/AddRemoveAlias.js
+++ b/root/edit/details/AddRemoveAlias.js
@@ -19,11 +19,7 @@ import isDateEmpty from '../../static/scripts/common/utility/isDateEmpty.js';
 import isolateText from '../../static/scripts/common/utility/isolateText.js';
 import yesNo from '../../static/scripts/common/utility/yesNo.js';
 
-type Props = {
-  edit: AddRemoveAliasEditT,
-};
-
-const AddRemoveAlias = ({edit}: Props): React$Element<'table'> => {
+component AddRemoveAlias(edit: AddRemoveAliasEditT) {
   const display = edit.display_data;
   const entityType = display.entity_type;
   const entity = display[entityType];
@@ -108,6 +104,6 @@ const AddRemoveAlias = ({edit}: Props): React$Element<'table'> => {
       </tbody>
     </table>
   );
-};
+}
 
 export default AddRemoveAlias;

--- a/root/edit/details/AddSeries.js
+++ b/root/edit/details/AddSeries.js
@@ -9,11 +9,7 @@
 
 import EntityLink from '../../static/scripts/common/components/EntityLink.js';
 
-type Props = {
-  +edit: AddSeriesEditT,
-};
-
-const AddSeries = ({edit}: Props): React$MixedElement => {
+component AddSeries(edit: AddSeriesEditT) {
   const type = edit.display_data.type;
   const orderingType = edit.display_data.ordering_type;
 
@@ -59,6 +55,6 @@ const AddSeries = ({edit}: Props): React$MixedElement => {
       </table>
     </>
   );
-};
+}
 
 export default AddSeries;

--- a/root/edit/details/AddStandaloneRecording.js
+++ b/root/edit/details/AddStandaloneRecording.js
@@ -14,15 +14,10 @@ import formatTrackLength from
   '../../static/scripts/common/utility/formatTrackLength.js';
 import yesNo from '../../static/scripts/common/utility/yesNo.js';
 
-type Props = {
-  +allowNew?: boolean,
-  +edit: AddStandaloneRecordingEditT,
-};
-
-const AddStandaloneRecording = ({
-  allowNew,
-  edit,
-}: Props): React$MixedElement => {
+component AddStandaloneRecording(
+  allowNew?: boolean,
+  edit: AddStandaloneRecordingEditT,
+) {
   const display = edit.display_data;
   return (
     <>
@@ -68,6 +63,6 @@ const AddStandaloneRecording = ({
       </table>
     </>
   );
-};
+}
 
 export default AddStandaloneRecording;

--- a/root/edit/details/AddWork.js
+++ b/root/edit/details/AddWork.js
@@ -13,11 +13,7 @@ import {commaOnlyListText} from
 import localizeLanguageName
   from '../../static/scripts/common/i18n/localizeLanguageName.js';
 
-type Props = {
-  +edit: AddWorkEditT,
-};
-
-const AddWork = ({edit}: Props): React$MixedElement => {
+component AddWork(edit: AddWorkEditT) {
   const display = edit.display_data;
   const attributes = display.attributes ?? {};
   const type = display.type;
@@ -100,6 +96,6 @@ const AddWork = ({edit}: Props): React$MixedElement => {
       </table>
     </>
   );
-};
+}
 
 export default AddWork;

--- a/root/edit/details/ChangeReleaseQuality.js
+++ b/root/edit/details/ChangeReleaseQuality.js
@@ -11,11 +11,7 @@ import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink.js';
 import {QUALITY_NAMES} from '../../static/scripts/common/constants.js';
 
-type Props = {
-  +edit: ChangeReleaseQualityEditT,
-};
-
-const ChangeReleaseQuality = ({edit}: Props): React$Element<'table'> => {
+component ChangeReleaseQuality(edit: ChangeReleaseQualityEditT) {
   const oldQuality = QUALITY_NAMES.get(edit.display_data.quality.old);
   const newQuality = QUALITY_NAMES.get(edit.display_data.quality.new);
   return (
@@ -33,6 +29,6 @@ const ChangeReleaseQuality = ({edit}: Props): React$Element<'table'> => {
       </tr>
     </table>
   );
-};
+}
 
 export default ChangeReleaseQuality;

--- a/root/edit/details/ChangeWikiDoc.js
+++ b/root/edit/details/ChangeWikiDoc.js
@@ -9,13 +9,7 @@
 
 import DBDefs from '../../static/scripts/common/DBDefs.mjs';
 
-type Props = {
-  +edit: ChangeWikiDocEditT,
-};
-
-const ChangeWikiDoc = ({
-  edit,
-}: Props): React$Element<'table'> => {
+component ChangeWikiDoc(edit: ChangeWikiDocEditT) {
   const display = edit.display_data;
   const page = display.page;
   const oldVersion = display.old_version;
@@ -82,6 +76,6 @@ const ChangeWikiDoc = ({
       ) : null}
     </table>
   );
-};
+}
 
 export default ChangeWikiDoc;

--- a/root/edit/details/EditAlias.js
+++ b/root/edit/details/EditAlias.js
@@ -23,11 +23,7 @@ import FullChangeDiff
   from '../../static/scripts/edit/components/edit/FullChangeDiff.js';
 import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 
-type Props = {
-  +edit: EditAliasEditT,
-};
-
-const EditAlias = ({edit}: Props): React$Element<'table'> => {
+component EditAlias(edit: EditAliasEditT) {
   const display = edit.display_data;
   const entityType = display.entity_type;
   const entity = display[entityType];
@@ -133,6 +129,6 @@ const EditAlias = ({edit}: Props): React$Element<'table'> => {
       </tbody>
     </table>
   );
-};
+}
 
 export default EditAlias;

--- a/root/edit/details/EditArea.js
+++ b/root/edit/details/EditArea.js
@@ -18,11 +18,7 @@ import FullChangeDiff
   from '../../static/scripts/edit/components/edit/FullChangeDiff.js';
 import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 
-type Props = {
-  +edit: EditAreaEditT,
-};
-
-const EditArea = ({edit}: Props): React$MixedElement => {
+component EditArea(edit: EditAreaEditT) {
   const display = edit.display_data;
   const beginDate = display.begin_date;
   const comment = display.comment;
@@ -125,6 +121,6 @@ const EditArea = ({edit}: Props): React$MixedElement => {
       </table>
     </>
   );
-};
+}
 
 export default EditArea;

--- a/root/edit/details/EditArtist.js
+++ b/root/edit/details/EditArtist.js
@@ -25,11 +25,7 @@ import FullChangeDiff
   from '../../static/scripts/edit/components/edit/FullChangeDiff.js';
 import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 
-type Props = {
-  +edit: EditArtistEditT,
-};
-
-const EditArtist = ({edit}: Props): React$MixedElement => {
+component EditArtist(edit: EditArtistEditT) {
   const display = edit.display_data;
   const area = display.area;
   const beginDate = display.begin_date;
@@ -177,6 +173,6 @@ const EditArtist = ({edit}: Props): React$MixedElement => {
       </table>
     </>
   );
-};
+}
 
 export default EditArtist;

--- a/root/edit/details/EditArtistCredit.js
+++ b/root/edit/details/EditArtistCredit.js
@@ -12,11 +12,7 @@ import ArtistCreditUsageLink
 import ExpandedArtistCredit from
   '../../static/scripts/common/components/ExpandedArtistCredit.js';
 
-type Props = {
-  +edit: EditArtistCreditEditT,
-};
-
-const EditArtistCredit = ({edit}: Props): React$Element<'table'> => {
+component EditArtistCredit(edit: EditArtistCreditEditT) {
   const display = edit.display_data;
 
   return (
@@ -47,6 +43,6 @@ const EditArtistCredit = ({edit}: Props): React$Element<'table'> => {
       </tbody>
     </table>
   );
-};
+}
 
 export default EditArtistCredit;

--- a/root/edit/details/EditBarcodes.js
+++ b/root/edit/details/EditBarcodes.js
@@ -13,11 +13,7 @@ import formatBarcode
   from '../../static/scripts/common/utility/formatBarcode.js';
 import Diff from '../../static/scripts/edit/components/edit/Diff.js';
 
-type Props = {
-  +edit: EditBarcodesEditT,
-};
-
-const EditBarcodes = ({edit}: Props): React$Element<'table'> => {
+component EditBarcodes(edit: EditBarcodesEditT) {
   const display = edit.display_data;
 
   return (
@@ -57,6 +53,6 @@ const EditBarcodes = ({edit}: Props): React$Element<'table'> => {
       })}
     </table>
   );
-};
+}
 
 export default EditBarcodes;

--- a/root/edit/details/EditCoverArt.js
+++ b/root/edit/details/EditCoverArt.js
@@ -15,10 +15,6 @@ import Diff from '../../static/scripts/edit/components/edit/Diff.js';
 import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 import EditArtwork from '../components/EditArtwork.js';
 
-type Props = {
-  +edit: EditCoverArtEditT,
-};
-
 function displayCoverArtTypes(types: $ReadOnlyArray<CoverArtTypeT>) {
   if (types?.length) {
     return commaOnlyListText(types.map(
@@ -28,7 +24,7 @@ function displayCoverArtTypes(types: $ReadOnlyArray<CoverArtTypeT>) {
   return '';
 }
 
-const EditCoverArt = ({edit}: Props): React$Element<'table'> => {
+component EditCoverArt(edit: EditCoverArtEditT) {
   const display = edit.display_data;
   const comment = display.comment;
   const types = display.types;
@@ -77,6 +73,6 @@ const EditCoverArt = ({edit}: Props): React$Element<'table'> => {
       />
     </table>
   );
-};
+}
 
 export default EditCoverArt;

--- a/root/edit/details/EditEvent.js
+++ b/root/edit/details/EditEvent.js
@@ -15,11 +15,7 @@ import FullChangeDiff from
   '../../static/scripts/edit/components/edit/FullChangeDiff.js';
 import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 
-type Props = {
-  +edit: EditEventEditT,
-};
-
-const EditEvent = ({edit}: Props): React$Element<'table'> => {
+component EditEvent(edit: EditEventEditT) {
   const display = edit.display_data;
   const name = display.name;
   const comment = display.comment;
@@ -99,6 +95,6 @@ const EditEvent = ({edit}: Props): React$Element<'table'> => {
       ) : null}
     </table>
   );
-};
+}
 
 export default EditEvent;

--- a/root/edit/details/EditGenre.js
+++ b/root/edit/details/EditGenre.js
@@ -11,11 +11,7 @@ import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink.js';
 import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 
-type Props = {
-  +edit: EditGenreEditT,
-};
-
-const EditGenre = ({edit}: Props): React$MixedElement => {
+component EditGenre(edit: EditGenreEditT) {
   const display = edit.display_data;
   const comment = display.comment;
   const name = display.name;
@@ -50,6 +46,6 @@ const EditGenre = ({edit}: Props): React$MixedElement => {
       </table>
     </>
   );
-};
+}
 
 export default EditGenre;

--- a/root/edit/details/EditInstrument.js
+++ b/root/edit/details/EditInstrument.js
@@ -14,11 +14,7 @@ import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 import IntentionallyRawIcon
   from '../components/IntentionallyRawIcon.js';
 
-type Props = {
-  +edit: EditInstrumentEditT,
-};
-
-const EditInstrument = ({edit}: Props): React$Element<'table'> => {
+component EditInstrument(edit: EditInstrumentEditT) {
   const display = edit.display_data;
   const name = display.name;
   const comment = display.comment;
@@ -75,6 +71,6 @@ const EditInstrument = ({edit}: Props): React$Element<'table'> => {
       ) : null}
     </table>
   );
-};
+}
 
 export default EditInstrument;

--- a/root/edit/details/EditLabel.js
+++ b/root/edit/details/EditLabel.js
@@ -19,11 +19,7 @@ import FullChangeDiff from
   '../../static/scripts/edit/components/edit/FullChangeDiff.js';
 import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 
-type Props = {
-  +edit: EditLabelEditT,
-};
-
-const EditLabel = ({edit}: Props): React$Element<'table'> => {
+component EditLabel(edit: EditLabelEditT) {
   const display = edit.display_data;
   const name = display.name;
   const sortName = display.sort_name;
@@ -146,6 +142,6 @@ const EditLabel = ({edit}: Props): React$Element<'table'> => {
       </tbody>
     </table>
   );
-};
+}
 
 export default EditLabel;

--- a/root/edit/details/EditMedium.js
+++ b/root/edit/details/EditMedium.js
@@ -36,59 +36,18 @@ import diffArtistCredits
 import {DELETE, INSERT} from '../../static/scripts/edit/utility/editDiff.js';
 import loopParity from '../../utility/loopParity.js';
 
-type TracklistChangesAddProps = {
-  +change: TracklistChangesAddT,
-  +changedMbids: boolean,
-};
+component ChangedMbidIcon() {
+  return (
+    <InformationIcon
+      title={l("This track's MBID will change when this edit is applied.")}
+    />
+  );
+}
 
-type TracklistChangesChangeProps = {
-  +change: TracklistChangesChangeT,
-  +changedMbids: boolean,
-  +index: number,
-};
-
-type TracklistChangesRemoveProps = {
-  +change: TracklistChangesRemoveT,
-  +changedMbids: boolean,
-};
-
-type TracklistChangesTableProps = {
-  +changedMbids: boolean,
-  +changes: $ReadOnlyArray<
-    | TracklistChangesAddT
-    | TracklistChangesChangeT
-    | TracklistChangesRemoveT>,
-};
-
-type CondensedTrackACsDiffRowProps = {
-  +endNumber?: string,
-  +newArtistCredit: ArtistCreditT,
-  +oldArtistCredit?: ArtistCreditT,
-  +rowCounter: number,
-  +startNumber: string,
-};
-
-type CondensedTrackACsDiffProps = {
-  +artistCreditChanges: $ReadOnlyArray<
-    | TracklistChangesAddT
-    | TracklistChangesChangeT>,
-};
-
-type Props = {
-  +allowNew?: boolean,
-  +edit: EditMediumEditT,
-};
-
-const ChangedMbidIcon = () => (
-  <InformationIcon
-    title={l("This track's MBID will change when this edit is applied.")}
-  />
-);
-
-const TracklistChangesAdd = ({
-  change,
-  changedMbids,
-}: TracklistChangesAddProps): React$Element<'tr'> => {
+component TracklistChangesAdd(
+  change: TracklistChangesAddT,
+  changedMbids: boolean,
+) {
   const track = change.new_track;
   return (
     <tr className="diff-addition edit-medium-track">
@@ -129,13 +88,13 @@ const TracklistChangesAdd = ({
       ) : null}
     </tr>
   );
-};
+}
 
-const TracklistChangesChange = ({
-  changedMbids,
-  change,
-  index,
-}: TracklistChangesChangeProps): React$Element<'tr'> => {
+component TracklistChangesChange(
+  change: TracklistChangesChangeT,
+  changedMbids: boolean,
+  index: number,
+) {
   const oldTrack = change.old_track;
   const newTrack = change.new_track;
   const artistCreditDiff = diffArtistCredits(
@@ -258,12 +217,12 @@ const TracklistChangesChange = ({
       ) : null}
     </tr>
   );
-};
+}
 
-const TracklistChangesRemove = ({
-  change,
-  changedMbids,
-}: TracklistChangesRemoveProps): React$Element<'tr'> => {
+component TracklistChangesRemove(
+  change: TracklistChangesRemoveT,
+  changedMbids: boolean,
+) {
   const track = change.old_track;
   return (
     <tr className="diff-removal edit-medium-track">
@@ -297,95 +256,103 @@ const TracklistChangesRemove = ({
       <td colSpan={changedMbids ? '5' : '4'} />
     </tr>
   );
-};
+}
 
-const TracklistChangesTable = ({
-  changedMbids,
-  changes,
-}: TracklistChangesTableProps): React$Element<'table'> => (
-  <table className="tbl">
-    <thead>
-      <tr>
-        <th colSpan="4">{l('Old tracklist')}</th>
-        <th colSpan="4">{l('New tracklist')}</th>
-        {changedMbids ? <th /> : null}
-      </tr>
-      <tr>
-        <th>{l('#')}</th>
-        <th>{l('Title')}</th>
-        <th>{l('Artist')}</th>
-        <th>{l('Length')}</th>
-        <th>{l('#')}</th>
-        <th>{l('Title')}</th>
-        <th>{l('Artist')}</th>
-        <th>{l('Length')}</th>
-        {changedMbids ? <th /> : null}
-      </tr>
-    </thead>
-    <tbody>
-      {changes.map((change, index) => {
-        if (change.change_type === 'c' || change.change_type === 'u') {
-          return (
-            <TracklistChangesChange
-              change={change}
-              changedMbids={changedMbids}
-              index={index}
-              key={index}
-            />
-          );
-        } else if (change.change_type === '+') {
-          return (
-            <TracklistChangesAdd
-              change={change}
-              changedMbids={changedMbids}
-              key={index}
-            />
-          );
-        } else if (change.change_type === '-') {
-          return (
-            <TracklistChangesRemove
-              change={change}
-              changedMbids={changedMbids}
-              key={index}
-            />
-          );
-        }
-        return null;
-      })}
-    </tbody>
-  </table>
-);
+component TracklistChangesTable (
+  changedMbids: boolean,
+  changes: $ReadOnlyArray<
+    | TracklistChangesAddT
+    | TracklistChangesChangeT
+    | TracklistChangesRemoveT>,
+) {
+  return (
+    <table className="tbl">
+      <thead>
+        <tr>
+          <th colSpan="4">{l('Old tracklist')}</th>
+          <th colSpan="4">{l('New tracklist')}</th>
+          {changedMbids ? <th /> : null}
+        </tr>
+        <tr>
+          <th>{l('#')}</th>
+          <th>{l('Title')}</th>
+          <th>{l('Artist')}</th>
+          <th>{l('Length')}</th>
+          <th>{l('#')}</th>
+          <th>{l('Title')}</th>
+          <th>{l('Artist')}</th>
+          <th>{l('Length')}</th>
+          {changedMbids ? <th /> : null}
+        </tr>
+      </thead>
+      <tbody>
+        {changes.map((change, index) => {
+          if (change.change_type === 'c' || change.change_type === 'u') {
+            return (
+              <TracklistChangesChange
+                change={change}
+                changedMbids={changedMbids}
+                index={index}
+                key={index}
+              />
+            );
+          } else if (change.change_type === '+') {
+            return (
+              <TracklistChangesAdd
+                change={change}
+                changedMbids={changedMbids}
+                key={index}
+              />
+            );
+          } else if (change.change_type === '-') {
+            return (
+              <TracklistChangesRemove
+                change={change}
+                changedMbids={changedMbids}
+                key={index}
+              />
+            );
+          }
+          return null;
+        })}
+      </tbody>
+    </table>
+  );
+}
 
-const CondensedTrackACsDiffRow = ({
-  endNumber,
-  newArtistCredit,
-  oldArtistCredit,
-  rowCounter,
-  startNumber,
-}: CondensedTrackACsDiffRowProps): React$Element<'tr'> => (
-  <tr className={loopParity(rowCounter)}>
-    <td className="pos t">
-      {nonEmpty(endNumber) && endNumber !== startNumber
-        ? startNumber + '-' + endNumber
-        : startNumber}
-    </td>
-    <td>
-      {oldArtistCredit ? (
-        <ExpandedArtistCredit artistCredit={oldArtistCredit} />
-      ) : null}
-    </td>
-    <td>
-      {newArtistCredit ? (
-        <ExpandedArtistCredit artistCredit={newArtistCredit} />
-      ) : null}
-    </td>
-  </tr>
-);
+component CondensedTrackACsDiffRow(
+  endNumber?: string,
+  newArtistCredit: ArtistCreditT,
+  oldArtistCredit?: ArtistCreditT,
+  rowCounter: number,
+  startNumber: string,
+) {
+  return (
+    <tr className={loopParity(rowCounter)}>
+      <td className="pos t">
+        {nonEmpty(endNumber) && endNumber !== startNumber
+          ? startNumber + '-' + endNumber
+          : startNumber}
+      </td>
+      <td>
+        {oldArtistCredit ? (
+          <ExpandedArtistCredit artistCredit={oldArtistCredit} />
+        ) : null}
+      </td>
+      <td>
+        {newArtistCredit ? (
+          <ExpandedArtistCredit artistCredit={newArtistCredit} />
+        ) : null}
+      </td>
+    </tr>
+  );
+}
 
-const CondensedTrackACsDiff = ({
-  artistCreditChanges,
-}: CondensedTrackACsDiffProps):
-  Array<React$Element<typeof CondensedTrackACsDiffRow>> => {
+component CondensedTrackACsDiff(
+  artistCreditChanges: $ReadOnlyArray<
+    | TracklistChangesAddT
+    | TracklistChangesChangeT>,
+) {
   let thisOldCredit;
   let thisNewCredit;
   let thisPosition = 0;
@@ -440,9 +407,9 @@ const CondensedTrackACsDiff = ({
     }
   });
   return rows;
-};
+}
 
-const EditMedium = ({edit}: Props): React$MixedElement => {
+component EditMedium(edit: EditMediumEditT) {
   const display = edit.display_data;
   const artistCreditChanges = display.artist_credit_changes;
   const changedDataTracks = display.data_track_changes;
@@ -588,6 +555,6 @@ const EditMedium = ({edit}: Props): React$MixedElement => {
       ) : null}
     </table>
   );
-};
+}
 
 export default EditMedium;

--- a/root/edit/details/EditPlace.js
+++ b/root/edit/details/EditPlace.js
@@ -17,11 +17,7 @@ import FullChangeDiff from
 import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 import {formatCoordinates} from '../../utility/coordinates.js';
 
-type Props = {
-  +edit: EditPlaceEditT,
-};
-
-const EditPlace = ({edit}: Props): React$Element<'table'> => {
+component EditPlace(edit: EditPlaceEditT) {
   const display = edit.display_data;
   const address = display.address;
   const area = display.area;
@@ -114,6 +110,6 @@ const EditPlace = ({edit}: Props): React$Element<'table'> => {
       </tbody>
     </table>
   );
-};
+}
 
 export default EditPlace;

--- a/root/edit/details/EditRecording.js
+++ b/root/edit/details/EditRecording.js
@@ -19,11 +19,7 @@ import FullChangeDiff from
   '../../static/scripts/edit/components/edit/FullChangeDiff.js';
 import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 
-type Props = {
-  +edit: EditRecordingEditT,
-};
-
-const EditRecording = ({edit}: Props): React$Element<'table'> => {
+component EditRecording(edit: EditRecordingEditT) {
   const display = edit.display_data;
   const name = display.name;
   const comment = display.comment;
@@ -97,6 +93,6 @@ const EditRecording = ({edit}: Props): React$Element<'table'> => {
       </tbody>
     </table>
   );
-};
+}
 
 export default EditRecording;

--- a/root/edit/details/EditRelationship.js
+++ b/root/edit/details/EditRelationship.js
@@ -10,27 +10,24 @@
 import RelationshipDiff
   from '../../static/scripts/edit/components/edit/RelationshipDiff.js';
 
-type Props = {
-  +edit: EditRelationshipEditT,
-};
-
-const EditRelationship = ({edit}: Props): React$MixedElement => (
-  <table className="details edit-relationship">
-    <RelationshipDiff
-      newRelationship={edit.display_data.new}
-      oldRelationship={edit.display_data.old}
-    />
-    {edit.display_data.unknown_attributes ? (
-      <tr>
-        <th />
-        <td>
-          {l(`This relationship edit also included changes
-              to relationship attributes which no longer exist.`)}
-        </td>
-      </tr>
-    ) : null}
-  </table>
-);
-
+component EditRelationship(edit: EditRelationshipEditT) {
+  return (
+    <table className="details edit-relationship">
+      <RelationshipDiff
+        newRelationship={edit.display_data.new}
+        oldRelationship={edit.display_data.old}
+      />
+      {edit.display_data.unknown_attributes ? (
+        <tr>
+          <th />
+          <td>
+            {l(`This relationship edit also included changes
+                to relationship attributes which no longer exist.`)}
+          </td>
+        </tr>
+      ) : null}
+    </table>
+  );
+}
 
 export default EditRelationship;

--- a/root/edit/details/EditRelationshipAttribute.js
+++ b/root/edit/details/EditRelationshipAttribute.js
@@ -17,11 +17,7 @@ import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 import IntentionallyRawIcon
   from '../components/IntentionallyRawIcon.js';
 
-type Props = {
-  +edit: EditRelationshipAttributeEditT,
-};
-
-const EditRelationshipAttribute = ({edit}: Props): React$Element<'table'> => {
+component EditRelationshipAttribute(edit: EditRelationshipAttributeEditT) {
   const display = edit.display_data;
   const childOrder = display.child_order;
   const oldDescription = display.description.old ?? '';
@@ -113,6 +109,6 @@ const EditRelationshipAttribute = ({edit}: Props): React$Element<'table'> => {
       ) : null}
     </table>
   );
-};
+}
 
 export default EditRelationshipAttribute;

--- a/root/edit/details/EditRelationshipType.js
+++ b/root/edit/details/EditRelationshipType.js
@@ -28,10 +28,6 @@ import FullChangeDiff from
 import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 import IntentionallyRawIcon from '../components/IntentionallyRawIcon.js';
 
-type Props = {
-  +edit: EditRelationshipTypeEditT,
-};
-
 function formatLongLinkPhrase(longLinkPhrase: string): string {
   let formattedPhrase = longLinkPhrase;
   if (longLinkPhrase && !longLinkPhrase.match('{entity0}')) {
@@ -88,9 +84,7 @@ function formatExample(
   );
 }
 
-const EditRelationshipType = ({
-  edit,
-}: Props): React.MixedElement => {
+component EditRelationshipType(edit: EditRelationshipTypeEditT) {
   const display = edit.display_data;
   const name = display.name;
   const oldDescription = display.description?.old ?? '';
@@ -350,6 +344,6 @@ const EditRelationshipType = ({
       </table>
     </>
   );
-};
+}
 
 export default EditRelationshipType;

--- a/root/edit/details/EditRelease.js
+++ b/root/edit/details/EditRelease.js
@@ -22,11 +22,7 @@ import ReleaseEventsDiff
   from '../../static/scripts/edit/components/edit/ReleaseEventsDiff.js';
 import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 
-type Props = {
-  +edit: EditReleaseEditT,
-};
-
-const EditRelease = ({edit}: Props): React$MixedElement => {
+component EditRelease(edit: EditReleaseEditT) {
   const display = edit.display_data;
   const name = display.name;
   const artistCredit = display.artist_credit;
@@ -167,6 +163,6 @@ const EditRelease = ({edit}: Props): React$MixedElement => {
       ) : null}
     </table>
   );
-};
+}
 
 export default EditRelease;

--- a/root/edit/details/EditReleaseGroup.js
+++ b/root/edit/details/EditReleaseGroup.js
@@ -16,11 +16,7 @@ import FullChangeDiff from
   '../../static/scripts/edit/components/edit/FullChangeDiff.js';
 import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 
-type Props = {
-  +edit: EditReleaseGroupEditT,
-};
-
-const EditReleaseGroup = ({edit}: Props): React$Element<'table'> => {
+component EditReleaseGroup(edit: EditReleaseGroupEditT) {
   const display = edit.display_data;
   const name = display.name;
   const comment = display.comment;
@@ -99,6 +95,6 @@ const EditReleaseGroup = ({edit}: Props): React$Element<'table'> => {
       ) : null}
     </table>
   );
-};
+}
 
 export default EditReleaseGroup;

--- a/root/edit/details/EditReleaseLabel.js
+++ b/root/edit/details/EditReleaseLabel.js
@@ -18,11 +18,7 @@ import formatBarcode
 import formatDate from '../../static/scripts/common/utility/formatDate.js';
 import Diff from '../../static/scripts/edit/components/edit/Diff.js';
 
-type Props = {
-  +edit: EditReleaseLabelEditT,
-};
-
-const EditReleaseLabel = ({edit}: Props): React$Element<'table'> => {
+component EditReleaseLabel(edit: EditReleaseLabelEditT) {
   const display = edit.display_data;
   const barcode = display.barcode;
   const catNo = display.catalog_number;
@@ -134,6 +130,6 @@ const EditReleaseLabel = ({edit}: Props): React$Element<'table'> => {
       ) : null}
     </table>
   );
-};
+}
 
 export default EditReleaseLabel;

--- a/root/edit/details/EditSeries.js
+++ b/root/edit/details/EditSeries.js
@@ -12,11 +12,7 @@ import FullChangeDiff from
   '../../static/scripts/edit/components/edit/FullChangeDiff.js';
 import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 
-type Props = {
-  +edit: EditSeriesEditT,
-};
-
-const EditSeries = ({edit}: Props): React$Element<'table'> => {
+component EditSeries(edit: EditSeriesEditT) {
   const display = edit.display_data;
   const name = display.name;
   const series = display.series;
@@ -79,6 +75,6 @@ const EditSeries = ({edit}: Props): React$Element<'table'> => {
       </tbody>
     </table>
   );
-};
+}
 
 export default EditSeries;

--- a/root/edit/details/EditUrl.js
+++ b/root/edit/details/EditUrl.js
@@ -15,11 +15,7 @@ import DiffSide from '../../static/scripts/edit/components/edit/DiffSide.js';
 import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 import {DELETE, INSERT} from '../../static/scripts/edit/utility/editDiff.js';
 
-type Props = {
-  +edit: EditUrlEditT,
-};
-
-const EditUrl = ({edit}: Props): React.MixedElement => {
+component EditUrl(edit: EditUrlEditT) {
   const display = edit.display_data;
   const description = display.description;
   const uri = display.uri;
@@ -87,6 +83,6 @@ const EditUrl = ({edit}: Props): React.MixedElement => {
       ) : null}
     </>
   );
-};
+}
 
 export default EditUrl;

--- a/root/edit/details/EditWork.js
+++ b/root/edit/details/EditWork.js
@@ -20,14 +20,10 @@ import FullChangeDiff
 import WordDiff from '../../static/scripts/edit/components/edit/WordDiff.js';
 import {DELETE, INSERT} from '../../static/scripts/edit/utility/editDiff.js';
 
-type Props = {
-  +edit: EditWorkEditT,
-};
-
 const localizeLanguage =
   (language: LanguageT) => localizeLanguageName(language, true);
 
-const EditWork = ({edit}: Props): React$Element<'table'> => {
+component EditWork(edit: EditWorkEditT) {
   const display = edit.display_data;
   const comment = display.comment;
   const iswc = display.iswc;
@@ -136,6 +132,6 @@ const EditWork = ({edit}: Props): React$Element<'table'> => {
       }) : null}
     </table>
   );
-};
+}
 
 export default EditWork;

--- a/root/edit/details/MergeAreas.js
+++ b/root/edit/details/MergeAreas.js
@@ -9,25 +9,23 @@
 
 import AreaList from '../../components/list/AreaList.js';
 
-type Props = {
-  +edit: MergeAreasEditT,
-};
-
-const MergeAreas = ({edit}: Props): React$Element<'table'> => (
-  <table className="details merge-areas">
-    <tr>
-      <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
-      <td>
-        <AreaList areas={edit.display_data.old} />
-      </td>
-    </tr>
-    <tr>
-      <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
-      <td>
-        <AreaList areas={[edit.display_data.new]} />
-      </td>
-    </tr>
-  </table>
-);
+component MergeAreas(edit: MergeAreasEditT) {
+  return (
+    <table className="details merge-areas">
+      <tr>
+        <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
+        <td>
+          <AreaList areas={edit.display_data.old} />
+        </td>
+      </tr>
+      <tr>
+        <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
+        <td>
+          <AreaList areas={[edit.display_data.new]} />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default MergeAreas;

--- a/root/edit/details/MergeArtists.js
+++ b/root/edit/details/MergeArtists.js
@@ -10,29 +10,27 @@
 import ArtistList from '../../components/list/ArtistList.js';
 import yesNo from '../../static/scripts/common/utility/yesNo.js';
 
-type Props = {
-  +edit: MergeArtistsEditT,
-};
-
-const MergeArtists = ({edit}: Props): React$Element<'table'> => (
-  <table className="details merge-artists">
-    <tr>
-      <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
-      <td>
-        <ArtistList artists={edit.display_data.old} showBeginEnd />
-      </td>
-    </tr>
-    <tr>
-      <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
-      <td>
-        <ArtistList artists={[edit.display_data.new]} showBeginEnd />
-      </td>
-    </tr>
-    <tr className="rename-artist-credits">
-      <th>{l('Rename artist and relationship credits')}</th>
-      <td>{yesNo(edit.display_data.rename)}</td>
-    </tr>
-  </table>
-);
+component MergeArtists(edit: MergeArtistsEditT) {
+  return (
+    <table className="details merge-artists">
+      <tr>
+        <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
+        <td>
+          <ArtistList artists={edit.display_data.old} showBeginEnd />
+        </td>
+      </tr>
+      <tr>
+        <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
+        <td>
+          <ArtistList artists={[edit.display_data.new]} showBeginEnd />
+        </td>
+      </tr>
+      <tr className="rename-artist-credits">
+        <th>{l('Rename artist and relationship credits')}</th>
+        <td>{yesNo(edit.display_data.rename)}</td>
+      </tr>
+    </table>
+  );
+}
 
 export default MergeArtists;

--- a/root/edit/details/MergeEvents.js
+++ b/root/edit/details/MergeEvents.js
@@ -9,35 +9,33 @@
 
 import EventList from '../../components/list/EventList.js';
 
-type Props = {
-  +edit: MergeEventsEditT,
-};
-
-const MergeEvents = ({edit}: Props): React$Element<'table'> => (
-  <table className="details merge-events">
-    <tr>
-      <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
-      <td>
-        <EventList
-          events={edit.display_data.old}
-          showArtists
-          showLocation
-          showType
-        />
-      </td>
-    </tr>
-    <tr>
-      <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
-      <td>
-        <EventList
-          events={[edit.display_data.new]}
-          showArtists
-          showLocation
-          showType
-        />
-      </td>
-    </tr>
-  </table>
-);
+component MergeEvents(edit: MergeEventsEditT) {
+  return (
+    <table className="details merge-events">
+      <tr>
+        <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
+        <td>
+          <EventList
+            events={edit.display_data.old}
+            showArtists
+            showLocation
+            showType
+          />
+        </td>
+      </tr>
+      <tr>
+        <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
+        <td>
+          <EventList
+            events={[edit.display_data.new]}
+            showArtists
+            showLocation
+            showType
+          />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default MergeEvents;

--- a/root/edit/details/MergeInstruments.js
+++ b/root/edit/details/MergeInstruments.js
@@ -9,25 +9,23 @@
 
 import InstrumentList from '../../components/list/InstrumentList.js';
 
-type Props = {
-  +edit: MergeInstrumentsEditT,
-};
-
-const MergeInstruments = ({edit}: Props): React$Element<'table'> => (
-  <table className="details merge-instruments">
-    <tr>
-      <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
-      <td>
-        <InstrumentList instruments={edit.display_data.old} />
-      </td>
-    </tr>
-    <tr>
-      <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
-      <td>
-        <InstrumentList instruments={[edit.display_data.new]} />
-      </td>
-    </tr>
-  </table>
-);
+component MergeInstruments(edit: MergeInstrumentsEditT) {
+  return (
+    <table className="details merge-instruments">
+      <tr>
+        <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
+        <td>
+          <InstrumentList instruments={edit.display_data.old} />
+        </td>
+      </tr>
+      <tr>
+        <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
+        <td>
+          <InstrumentList instruments={[edit.display_data.new]} />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default MergeInstruments;

--- a/root/edit/details/MergeLabels.js
+++ b/root/edit/details/MergeLabels.js
@@ -9,25 +9,23 @@
 
 import LabelList from '../../components/list/LabelList.js';
 
-type Props = {
-  +edit: MergeLabelsEditT,
-};
-
-const MergeLabels = ({edit}: Props): React$Element<'table'> => (
-  <table className="details merge-labels">
-    <tr>
-      <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
-      <td>
-        <LabelList labels={edit.display_data.old} />
-      </td>
-    </tr>
-    <tr>
-      <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
-      <td>
-        <LabelList labels={[edit.display_data.new]} />
-      </td>
-    </tr>
-  </table>
-);
+component MergeLabels(edit: MergeLabelsEditT) {
+  return (
+    <table className="details merge-labels">
+      <tr>
+        <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
+        <td>
+          <LabelList labels={edit.display_data.old} />
+        </td>
+      </tr>
+      <tr>
+        <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
+        <td>
+          <LabelList labels={[edit.display_data.new]} />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default MergeLabels;

--- a/root/edit/details/MergePlaces.js
+++ b/root/edit/details/MergePlaces.js
@@ -9,25 +9,23 @@
 
 import PlaceList from '../../components/list/PlaceList.js';
 
-type Props = {
-  +edit: MergePlacesEditT,
-};
-
-const MergePlaces = ({edit}: Props): React$Element<'table'> => (
-  <table className="details merge-place">
-    <tr>
-      <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
-      <td>
-        <PlaceList places={edit.display_data.old} />
-      </td>
-    </tr>
-    <tr>
-      <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
-      <td>
-        <PlaceList places={[edit.display_data.new]} />
-      </td>
-    </tr>
-  </table>
-);
+component MergePlaces(edit: MergePlacesEditT) {
+  return (
+    <table className="details merge-place">
+      <tr>
+        <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
+        <td>
+          <PlaceList places={edit.display_data.old} />
+        </td>
+      </tr>
+      <tr>
+        <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
+        <td>
+          <PlaceList places={[edit.display_data.new]} />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default MergePlaces;

--- a/root/edit/details/MergeRecordings.js
+++ b/root/edit/details/MergeRecordings.js
@@ -9,33 +9,31 @@
 
 import RecordingList from '../../components/list/RecordingList.js';
 
-type Props = {
-  +edit: MergeRecordingsEditT,
-};
-
-const MergeRecordings = ({edit}: Props): React$Element<'table'> => (
-  <table className="details merge-recordings">
-    <tr>
-      <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
-      <td>
-        <RecordingList
-          lengthClass={edit.display_data.large_spread ? 'warn-lengths' : ''}
-          recordings={edit.display_data.old}
-          showExpandedArtistCredits
-        />
-      </td>
-    </tr>
-    <tr>
-      <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
-      <td>
-        <RecordingList
-          lengthClass={edit.display_data.large_spread ? 'warn-lengths' : ''}
-          recordings={[edit.display_data.new]}
-          showExpandedArtistCredits
-        />
-      </td>
-    </tr>
-  </table>
-);
+component MergeRecordings(edit: MergeRecordingsEditT) {
+  return (
+    <table className="details merge-recordings">
+      <tr>
+        <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
+        <td>
+          <RecordingList
+            lengthClass={edit.display_data.large_spread ? 'warn-lengths' : ''}
+            recordings={edit.display_data.old}
+            showExpandedArtistCredits
+          />
+        </td>
+      </tr>
+      <tr>
+        <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
+        <td>
+          <RecordingList
+            lengthClass={edit.display_data.large_spread ? 'warn-lengths' : ''}
+            recordings={[edit.display_data.new]}
+            showExpandedArtistCredits
+          />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default MergeRecordings;

--- a/root/edit/details/MergeReleaseGroups.js
+++ b/root/edit/details/MergeReleaseGroups.js
@@ -10,25 +10,23 @@
 import {ReleaseGroupListTable}
   from '../../components/list/ReleaseGroupList.js';
 
-type Props = {
-  +edit: MergeReleaseGroupsEditT,
-};
-
-const MergeReleaseGroups = ({edit}: Props): React$Element<'table'> => (
-  <table className="details merge-release-groups">
-    <tr>
-      <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
-      <td>
-        <ReleaseGroupListTable releaseGroups={edit.display_data.old} />
-      </td>
-    </tr>
-    <tr>
-      <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
-      <td>
-        <ReleaseGroupListTable releaseGroups={[edit.display_data.new]} />
-      </td>
-    </tr>
-  </table>
-);
+component MergeReleaseGroups(edit: MergeReleaseGroupsEditT) {
+  return (
+    <table className="details merge-release-groups">
+      <tr>
+        <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
+        <td>
+          <ReleaseGroupListTable releaseGroups={edit.display_data.old} />
+        </td>
+      </tr>
+      <tr>
+        <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
+        <td>
+          <ReleaseGroupListTable releaseGroups={[edit.display_data.new]} />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default MergeReleaseGroups;

--- a/root/edit/details/MergeReleases.js
+++ b/root/edit/details/MergeReleases.js
@@ -27,10 +27,6 @@ import formatTrackLength from
   '../../static/scripts/common/utility/formatTrackLength.js';
 import loopParity from '../../utility/loopParity.js';
 
-type Props = {
-  +edit: MergeReleasesEditT,
-};
-
 const strategyDescriptions = {
   append: N_l('Append mediums to target release'),
   merge: N_l('Merge mediums and recordings'),
@@ -218,9 +214,7 @@ function getHtmlVars(
   return htmlArgs;
 }
 
-const MergeReleases = ({
-  edit,
-}: Props): React.MixedElement => {
+component MergeReleases(edit: MergeReleasesEditT) {
   const display = edit.display_data;
   const emptyReleases = display.empty_releases;
   const changes = display.changes;
@@ -363,6 +357,6 @@ const MergeReleases = ({
       </table>
     </>
   );
-};
+}
 
 export default MergeReleases;

--- a/root/edit/details/MergeSeries.js
+++ b/root/edit/details/MergeSeries.js
@@ -9,25 +9,23 @@
 
 import SeriesList from '../../components/list/SeriesList.js';
 
-type Props = {
-  +edit: MergeSeriesEditT,
-};
-
-const MergeSeries = ({edit}: Props): React$Element<'table'> => (
-  <table className="details merge-series">
-    <tr>
-      <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
-      <td>
-        <SeriesList series={edit.display_data.old} />
-      </td>
-    </tr>
-    <tr>
-      <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
-      <td>
-        <SeriesList series={[edit.display_data.new]} />
-      </td>
-    </tr>
-  </table>
-);
+component MergeSeries(edit: MergeSeriesEditT) {
+  return (
+    <table className="details merge-series">
+      <tr>
+        <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
+        <td>
+          <SeriesList series={edit.display_data.old} />
+        </td>
+      </tr>
+      <tr>
+        <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
+        <td>
+          <SeriesList series={[edit.display_data.new]} />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default MergeSeries;

--- a/root/edit/details/MergeWorks.js
+++ b/root/edit/details/MergeWorks.js
@@ -9,25 +9,23 @@
 
 import WorkList from '../../components/list/WorkList.js';
 
-type Props = {
-  +edit: MergeWorksEditT,
-};
-
-const MergeWorks = ({edit}: Props): React$Element<'table'> => (
-  <table className="details merge-works">
-    <tr>
-      <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
-      <td>
-        <WorkList works={edit.display_data.old} />
-      </td>
-    </tr>
-    <tr>
-      <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
-      <td>
-        <WorkList works={[edit.display_data.new]} />
-      </td>
-    </tr>
-  </table>
-);
+component MergeWorks(edit: MergeWorksEditT) {
+  return (
+    <table className="details merge-works">
+      <tr>
+        <th>{addColonText(lp('Merge', 'verb, header, paired with Into'))}</th>
+        <td>
+          <WorkList works={edit.display_data.old} />
+        </td>
+      </tr>
+      <tr>
+        <th>{addColonText(lp('Into', 'header, paired with Merge'))}</th>
+        <td>
+          <WorkList works={[edit.display_data.new]} />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default MergeWorks;

--- a/root/edit/details/MoveDiscId.js
+++ b/root/edit/details/MoveDiscId.js
@@ -11,11 +11,7 @@ import CDTocLink from '../../static/scripts/common/components/CDTocLink.js';
 import MediumLink
   from '../../static/scripts/common/components/MediumLink.js';
 
-type Props = {
-  +edit: MoveDiscIdEditT,
-};
-
-const MoveDiscId = ({edit}: Props): React$Element<'table'> => {
+component MoveDiscId(edit: MoveDiscIdEditT) {
   const oldMedium = edit.display_data.old_medium;
   const newMedium = edit.display_data.new_medium;
   const cdToc = edit.display_data.medium_cdtoc.cdtoc;
@@ -38,6 +34,6 @@ const MoveDiscId = ({edit}: Props): React$Element<'table'> => {
       </tr>
     </table>
   );
-};
+}
 
 export default MoveDiscId;

--- a/root/edit/details/RemoveCoverArt.js
+++ b/root/edit/details/RemoveCoverArt.js
@@ -13,11 +13,7 @@ import {commaOnlyListText}
   from '../../static/scripts/common/i18n/commaOnlyList.js';
 import EditArtwork from '../components/EditArtwork.js';
 
-type Props = {
-  +edit: RemoveCoverArtEditT,
-};
-
-const RemoveCoverArt = ({edit}: Props): React$Element<'table'> => {
+component RemoveCoverArt(edit: RemoveCoverArtEditT) {
   const display = edit.display_data;
 
   return (
@@ -61,6 +57,6 @@ const RemoveCoverArt = ({edit}: Props): React$Element<'table'> => {
       <EditArtwork artwork={display.artwork} release={display.release} />
     </table>
   );
-};
+}
 
 export default RemoveCoverArt;

--- a/root/edit/details/RemoveDiscId.js
+++ b/root/edit/details/RemoveDiscId.js
@@ -11,11 +11,7 @@ import CDTocLink from '../../static/scripts/common/components/CDTocLink.js';
 import MediumLink
   from '../../static/scripts/common/components/MediumLink.js';
 
-type Props = {
-  +edit: RemoveDiscIdEditT,
-};
-
-const RemoveDiscId = ({edit}: Props): React$Element<'table'> => {
+component RemoveDiscId(edit: RemoveDiscIdEditT) {
   const medium = edit.display_data.medium;
   const cdToc = edit.display_data.cdtoc;
 
@@ -35,6 +31,6 @@ const RemoveDiscId = ({edit}: Props): React$Element<'table'> => {
       </tr>
     </table>
   );
-};
+}
 
 export default RemoveDiscId;

--- a/root/edit/details/RemoveEntity.js
+++ b/root/edit/details/RemoveEntity.js
@@ -11,11 +11,7 @@ import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink.js';
 import {ENTITY_NAMES} from '../../static/scripts/common/constants.js';
 
-type Props = {
-  +edit: RemoveEntityEditT,
-};
-
-const RemoveEntity = ({edit}: Props): React$Element<'table'> => {
+component RemoveEntity(edit: RemoveEntityEditT) {
   const display = edit.display_data;
 
   return (
@@ -26,6 +22,6 @@ const RemoveEntity = ({edit}: Props): React$Element<'table'> => {
       </tr>
     </table>
   );
-};
+}
 
 export default RemoveEntity;

--- a/root/edit/details/RemoveIsrc.js
+++ b/root/edit/details/RemoveIsrc.js
@@ -13,11 +13,7 @@ import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink.js';
 import linkedEntities from '../../static/scripts/common/linkedEntities.mjs';
 
-type Props = {
-  +edit: RemoveIsrcEditT,
-};
-
-const RemoveIsrc = ({edit}: Props): React$Element<'table'> => {
+component RemoveIsrc(edit: RemoveIsrcEditT) {
   const isrc = edit.display_data.isrc;
   const recording = linkedEntities.recording[isrc.recording_id];
 
@@ -33,6 +29,6 @@ const RemoveIsrc = ({edit}: Props): React$Element<'table'> => {
       </tr>
     </table>
   );
-};
+}
 
 export default RemoveIsrc;

--- a/root/edit/details/RemoveIswc.js
+++ b/root/edit/details/RemoveIswc.js
@@ -13,11 +13,7 @@ import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink.js';
 import linkedEntities from '../../static/scripts/common/linkedEntities.mjs';
 
-type Props = {
-  +edit: RemoveIswcEditT,
-};
-
-const RemoveIswc = ({edit}: Props): React$Element<'table'> => {
+component RemoveIswc(edit: RemoveIswcEditT) {
   const iswc = edit.display_data.iswc;
   const work = linkedEntities.work[iswc.work_id];
 
@@ -33,6 +29,6 @@ const RemoveIswc = ({edit}: Props): React$Element<'table'> => {
       </tr>
     </table>
   );
-};
+}
 
 export default RemoveIswc;

--- a/root/edit/details/RemoveMedium.js
+++ b/root/edit/details/RemoveMedium.js
@@ -18,20 +18,13 @@ import {
 } from '../../static/scripts/common/immutable-entities.js';
 import {arraysEqual} from '../../static/scripts/common/utility/arrays.js';
 
-type Props = {
-  +allowNew?: boolean,
-  +edit: RemoveMediumEditT,
-};
-
 const areTracksEqual = (a: TrackT, b: TrackT) => (
   a.name === b.name &&
   artistCreditsAreEqual(a.artistCredit, b.artistCredit) &&
   a.length === b.length
 );
 
-const RemoveMedium = ({
-  edit,
-}: Props): React.MixedElement => {
+component RemoveMedium(edit: RemoveMediumEditT) {
   const display = edit.display_data;
   const originalTracklist = display.tracks ?? [];
   const currentTracklist = display.medium.tracks ?? [];
@@ -112,6 +105,6 @@ const RemoveMedium = ({
       </table>
     </>
   );
-};
+}
 
 export default RemoveMedium;

--- a/root/edit/details/RemoveRelationship.js
+++ b/root/edit/details/RemoveRelationship.js
@@ -10,17 +10,17 @@
 import Relationship
   from '../../static/scripts/common/components/Relationship.js';
 
-type Props = {
-  +edit: RemoveRelationshipEditT,
-};
-
-const RemoveRelationship = ({edit}: Props): React$MixedElement => (
-  <table className="details remove-relationship">
-    <tr>
-      <th>{addColonText(l('Relationship'))}</th>
-      <td><Relationship relationship={edit.display_data.relationship} /></td>
-    </tr>
-  </table>
-);
+component RemoveRelationship(edit: RemoveRelationshipEditT) {
+  return (
+    <table className="details remove-relationship">
+      <tr>
+        <th>{addColonText(l('Relationship'))}</th>
+        <td>
+          <Relationship relationship={edit.display_data.relationship} />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default RemoveRelationship;

--- a/root/edit/details/RemoveRelationshipAttribute.js
+++ b/root/edit/details/RemoveRelationshipAttribute.js
@@ -9,13 +9,9 @@
 
 import IntentionallyRawIcon from '../components/IntentionallyRawIcon.js';
 
-type Props = {
-  +edit: RemoveRelationshipAttributeEditT,
-};
-
-const RemoveRelationshipAttribute = ({
-  edit,
-}: Props): React$Element<'table'> => {
+component RemoveRelationshipAttribute(
+  edit: RemoveRelationshipAttributeEditT,
+) {
   const display = edit.display_data;
 
   const rawIconSection = (
@@ -49,6 +45,6 @@ const RemoveRelationshipAttribute = ({
       </tr>
     </table>
   );
-};
+}
 
 export default RemoveRelationshipAttribute;

--- a/root/edit/details/RemoveRelationshipType.js
+++ b/root/edit/details/RemoveRelationshipType.js
@@ -10,11 +10,7 @@
 import {ENTITY_NAMES} from '../../static/scripts/common/constants.js';
 import IntentionallyRawIcon from '../components/IntentionallyRawIcon.js';
 
-type Props = {
-  +edit: RemoveRelationshipTypeEditT,
-};
-
-const RemoveRelationshipType = ({edit}: Props): React$Element<'table'> => {
+component RemoveRelationshipType(edit: RemoveRelationshipTypeEditT) {
   const display = edit.display_data;
   const entity0Type = ENTITY_NAMES[display.entity0_type]();
   const entity1Type = ENTITY_NAMES[display.entity1_type]();
@@ -132,6 +128,6 @@ const RemoveRelationshipType = ({edit}: Props): React$Element<'table'> => {
       ) : null}
     </table>
   );
-};
+}
 
 export default RemoveRelationshipType;

--- a/root/edit/details/RemoveReleaseLabel.js
+++ b/root/edit/details/RemoveReleaseLabel.js
@@ -12,11 +12,7 @@ import DescriptiveLink
 import EntityLink
   from '../../static/scripts/common/components/EntityLink.js';
 
-type Props = {
-  +edit: RemoveReleaseLabelEditT,
-};
-
-const RemoveReleaseLabel = ({edit}: Props): React$Element<'table'> => {
+component RemoveReleaseLabel(edit: RemoveReleaseLabelEditT) {
   const display = edit.display_data;
 
   return (
@@ -41,6 +37,6 @@ const RemoveReleaseLabel = ({edit}: Props): React$Element<'table'> => {
       </tr>
     </table>
   );
-};
+}
 
 export default RemoveReleaseLabel;

--- a/root/edit/details/ReorderCoverArt.js
+++ b/root/edit/details/ReorderCoverArt.js
@@ -13,11 +13,7 @@ import DescriptiveLink
 import expand2html from '../../static/scripts/common/i18n/expand2html.js';
 import entityHref from '../../static/scripts/common/utility/entityHref.js';
 
-type Props = {
-  +edit: ReorderCoverArtEditT,
-};
-
-const ReorderCoverArt = ({edit}: Props): React$Element<'table'> => {
+component ReorderCoverArt(edit: ReorderCoverArtEditT) {
   const display = edit.display_data;
   const oldArt = display.old;
   const newArt = display.new;
@@ -65,6 +61,6 @@ const ReorderCoverArt = ({edit}: Props): React$Element<'table'> => {
       </tr>
     </table>
   );
-};
+}
 
 export default ReorderCoverArt;

--- a/root/edit/details/ReorderMediums.js
+++ b/root/edit/details/ReorderMediums.js
@@ -10,11 +10,7 @@
 import DescriptiveLink from
   '../../static/scripts/common/components/DescriptiveLink.js';
 
-type Props = {
-  +edit: ReorderMediumsEditT,
-};
-
-const ReorderMediums = ({edit}: Props): React$Element<'table'> => {
+component ReorderMediums(edit: ReorderMediumsEditT) {
   const display = edit.display_data;
   let isFirstMediumChange = true;
 
@@ -68,6 +64,6 @@ const ReorderMediums = ({edit}: Props): React$Element<'table'> => {
       })}
     </table>
   );
-};
+}
 
 export default ReorderMediums;

--- a/root/edit/details/ReorderRelationships.js
+++ b/root/edit/details/ReorderRelationships.js
@@ -10,27 +10,25 @@
 import Relationship
   from '../../static/scripts/common/components/Relationship.js';
 
-type Props = {
-  +edit: ReorderRelationshipsEditT,
-};
-
-const ReorderRelationships = ({edit}: Props): React$MixedElement => (
-  <table className="details reorder-relationships">
-    <tr>
-      <th className="align-left wide">{l('Relationship')}</th>
-      <th className="narrow">{l('Old order')}</th>
-      <th className="narrow">{l('New order')}</th>
-    </tr>
-    {edit.display_data.relationships.map((reorder, index) => (
-      <tr key={index}>
-        <td className="wide">
-          <Relationship relationship={reorder.relationship} />
-        </td>
-        <td className="align-right narrow old">{reorder.old_order}</td>
-        <td className="align-right narrow new">{reorder.new_order}</td>
+component ReorderRelationships(edit: ReorderRelationshipsEditT) {
+  return (
+    <table className="details reorder-relationships">
+      <tr>
+        <th className="align-left wide">{l('Relationship')}</th>
+        <th className="narrow">{l('Old order')}</th>
+        <th className="narrow">{l('New order')}</th>
       </tr>
-    ))}
-  </table>
-);
+      {edit.display_data.relationships.map((reorder, index) => (
+        <tr key={index}>
+          <td className="wide">
+            <Relationship relationship={reorder.relationship} />
+          </td>
+          <td className="align-right narrow old">{reorder.old_order}</td>
+          <td className="align-right narrow new">{reorder.new_order}</td>
+        </tr>
+      ))}
+    </table>
+  );
+}
 
 export default ReorderRelationships;

--- a/root/edit/details/SetCoverArt.js
+++ b/root/edit/details/SetCoverArt.js
@@ -15,11 +15,7 @@ import ReleaseEvents
   from '../../static/scripts/common/components/ReleaseEvents.js';
 import commaList from '../../static/scripts/common/i18n/commaList.js';
 
-type Props = {
-  +edit: SetCoverArtEditT,
-};
-
-const SetCoverArt = ({edit}: Props): React$Element<'table'> => {
+component SetCoverArt(edit: SetCoverArtEditT) {
   const display = edit.display_data;
   const oldArt = display.artwork.old;
   const newArt = display.artwork.new;
@@ -88,6 +84,6 @@ const SetCoverArt = ({edit}: Props): React$Element<'table'> => {
       {manifest.js('common/components/ReleaseEvents', {async: 'async'})}
     </table>
   );
-};
+}
 
 export default SetCoverArt;

--- a/root/edit/details/SetTrackLengths.js
+++ b/root/edit/details/SetTrackLengths.js
@@ -17,11 +17,7 @@ import {HistoricReleaseListContent}
   from '../components/HistoricReleaseList.js';
 import TrackDurationChanges from '../components/TrackDurationChanges.js';
 
-type Props = {
-  +edit: SetTrackLengthsEditT,
-};
-
-const SetTrackLengths = ({edit}: Props): React$Element<'table'> => {
+component SetTrackLengths(edit: SetTrackLengthsEditT) {
   const display = edit.display_data;
   const medium = display.medium;
   const cdtoc = display.cdtoc;
@@ -79,6 +75,6 @@ const SetTrackLengths = ({edit}: Props): React$Element<'table'> => {
       ) : null}
     </table>
   );
-};
+}
 
 export default SetTrackLengths;

--- a/root/edit/details/historic/AddDiscId.js
+++ b/root/edit/details/historic/AddDiscId.js
@@ -12,24 +12,22 @@ import CDTocLink
 import HistoricReleaseList
   from '../../components/HistoricReleaseList.js';
 
-type Props = {
-  +edit: AddDiscIdHistoricEditT,
-};
-
-const AddDiscId = ({edit}: Props): React$Element<'table'> => (
-  <table className="details add-discid">
-    <HistoricReleaseList releases={edit.display_data.releases} />
-    <tr>
-      <th>{l('CD TOC:')}</th>
-      <td>{edit.display_data.full_toc}</td>
-    </tr>
-    <tr>
-      <th>{addColonText(l('Disc ID'))}</th>
-      <td>
-        <CDTocLink cdToc={edit.display_data.cdtoc} />
-      </td>
-    </tr>
-  </table>
-);
+component AddDiscId(edit: AddDiscIdHistoricEditT) {
+  return (
+    <table className="details add-discid">
+      <HistoricReleaseList releases={edit.display_data.releases} />
+      <tr>
+        <th>{l('CD TOC:')}</th>
+        <td>{edit.display_data.full_toc}</td>
+      </tr>
+      <tr>
+        <th>{addColonText(l('Disc ID'))}</th>
+        <td>
+          <CDTocLink cdToc={edit.display_data.cdtoc} />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default AddDiscId;

--- a/root/edit/details/historic/AddRelationship.js
+++ b/root/edit/details/historic/AddRelationship.js
@@ -10,25 +10,23 @@
 import {HistoricRelationship}
   from '../../../static/scripts/common/components/Relationship.js';
 
-type Props = {
-  +edit: AddRelationshipHistoricEditT,
-};
-
-const AddRelationship = ({edit}: Props): React$Element<'table'> => (
-  <table className="details add-relationship-historic">
-    <tr>
-      <th rowSpan="2">{addColonText(l('Relationships'))}</th>
-      <td>
-        <ul>
-          {edit.display_data.relationships.map(relationship => (
-            <li key={relationship.id}>
-              <HistoricRelationship relationship={relationship} />
-            </li>
-          ))}
-        </ul>
-      </td>
-    </tr>
-  </table>
-);
+component AddRelationship(edit: AddRelationshipHistoricEditT) {
+  return (
+    <table className="details add-relationship-historic">
+      <tr>
+        <th rowSpan="2">{addColonText(l('Relationships'))}</th>
+        <td>
+          <ul>
+            {edit.display_data.relationships.map(relationship => (
+              <li key={relationship.id}>
+                <HistoricRelationship relationship={relationship} />
+              </li>
+            ))}
+          </ul>
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default AddRelationship;

--- a/root/edit/details/historic/AddRelease.js
+++ b/root/edit/details/historic/AddRelease.js
@@ -16,11 +16,7 @@ import formatTrackLength
 import HistoricReleaseList
   from '../../components/HistoricReleaseList.js';
 
-type Props = {
-  +edit: AddReleaseHistoricEditT,
-};
-
-const AddRelease = ({edit}: Props): React$Element<'table'> => {
+component AddRelease(edit: AddReleaseHistoricEditT) {
   const display = edit.display_data;
   const artist = display.artist;
   const type = display.type;
@@ -155,6 +151,6 @@ const AddRelease = ({edit}: Props): React$Element<'table'> => {
       </tr>
     </table>
   );
-};
+}
 
 export default AddRelease;

--- a/root/edit/details/historic/AddReleaseAnnotation.js
+++ b/root/edit/details/historic/AddReleaseAnnotation.js
@@ -9,11 +9,7 @@
 
 import HistoricReleaseList from '../../components/HistoricReleaseList.js';
 
-type Props = {
-  +edit: AddReleaseAnnotationHistoricEditT,
-};
-
-const AddReleaseAnnotation = ({edit}: Props): React$Element<'table'> => {
+component AddReleaseAnnotation(edit: AddReleaseAnnotationHistoricEditT) {
   const display = edit.display_data;
 
   return (
@@ -48,6 +44,6 @@ const AddReleaseAnnotation = ({edit}: Props): React$Element<'table'> => {
       ) : null}
     </table>
   );
-};
+}
 
 export default AddReleaseAnnotation;

--- a/root/edit/details/historic/AddTrackKV.js
+++ b/root/edit/details/historic/AddTrackKV.js
@@ -14,11 +14,7 @@ import formatTrackLength
 import HistoricReleaseList
   from '../../components/HistoricReleaseList.js';
 
-type Props = {
-  +edit: AddTrackKVHistoricEditT,
-};
-
-const AddTrackKV = ({edit}: Props): React$Element<'table'> => {
+component AddTrackKV(edit: AddTrackKVHistoricEditT) {
   const display = edit.display_data;
   const artist = display.artist;
 
@@ -56,6 +52,6 @@ const AddTrackKV = ({edit}: Props): React$Element<'table'> => {
       </tr>
     </table>
   );
-};
+}
 
 export default AddTrackKV;

--- a/root/edit/details/historic/AddTrackOld.js
+++ b/root/edit/details/historic/AddTrackOld.js
@@ -10,31 +10,29 @@
 import HistoricReleaseList
   from '../../components/HistoricReleaseList.js';
 
-type Props = {
-  +edit: AddTrackOldHistoricEditT,
-};
+component AddTrackOld(edit: AddTrackOldHistoricEditT) {
+  return (
+    <table className="details add-track">
+      <HistoricReleaseList releases={edit.display_data.releases} />
 
-const AddTrackOld = ({edit}: Props): React$Element<'table'> => (
-  <table className="details add-track">
-    <HistoricReleaseList releases={edit.display_data.releases} />
-
-    <tr>
-      <th>{addColonText(l('Name'))}</th>
-      <td>{edit.display_data.name}</td>
-    </tr>
-
-    {nonEmpty(edit.display_data.artist_name) ? (
       <tr>
-        <th>{l('Artist name:')}</th>
-        <td>{edit.display_data.artist_name}</td>
+        <th>{addColonText(l('Name'))}</th>
+        <td>{edit.display_data.name}</td>
       </tr>
-    ) : null}
 
-    <tr>
-      <th>{addColonText(l('Track number'))}</th>
-      <td>{edit.display_data.position}</td>
-    </tr>
-  </table>
-);
+      {nonEmpty(edit.display_data.artist_name) ? (
+        <tr>
+          <th>{l('Artist name:')}</th>
+          <td>{edit.display_data.artist_name}</td>
+        </tr>
+      ) : null}
+
+      <tr>
+        <th>{addColonText(l('Track number'))}</th>
+        <td>{edit.display_data.position}</td>
+      </tr>
+    </table>
+  );
+}
 
 export default AddTrackOld;

--- a/root/edit/details/historic/ChangeArtistQuality.js
+++ b/root/edit/details/historic/ChangeArtistQuality.js
@@ -11,11 +11,7 @@ import DescriptiveLink
   from '../../../static/scripts/common/components/DescriptiveLink.js';
 import {QUALITY_NAMES} from '../../../static/scripts/common/constants.js';
 
-type Props = {
-  +edit: ChangeArtistQualityHistoricEditT,
-};
-
-const ChangeArtistQuality = ({edit}: Props): React$Element<'table'> => {
+component ChangeArtistQuality(edit: ChangeArtistQualityHistoricEditT) {
   const oldQuality = QUALITY_NAMES.get(edit.display_data.quality.old);
   const newQuality = QUALITY_NAMES.get(edit.display_data.quality.new);
   return (
@@ -33,6 +29,6 @@ const ChangeArtistQuality = ({edit}: Props): React$Element<'table'> => {
       </tr>
     </table>
   );
-};
+}
 
 export default ChangeArtistQuality;

--- a/root/edit/details/historic/ChangeReleaseArtist.js
+++ b/root/edit/details/historic/ChangeReleaseArtist.js
@@ -11,26 +11,24 @@ import DescriptiveLink
   from '../../../static/scripts/common/components/DescriptiveLink.js';
 import HistoricReleaseList from '../../components/HistoricReleaseList.js';
 
-type Props = {
-  +edit: ChangeReleaseArtistHistoricEditT,
-};
-
-const ChangeReleaseArtist = ({edit}: Props): React$Element<'table'> => (
-  <table className="details change-release-artist">
-    <HistoricReleaseList
-      colSpan="2"
-      releases={edit.display_data.releases}
-    />
-    <tr>
-      <th>{addColonText(l('Artist'))}</th>
-      <td className="old">
-        <DescriptiveLink entity={edit.display_data.artist.old} />
-      </td>
-      <td className="new">
-        <DescriptiveLink entity={edit.display_data.artist.new} />
-      </td>
-    </tr>
-  </table>
-);
+component ChangeReleaseArtist(edit: ChangeReleaseArtistHistoricEditT) {
+  return (
+    <table className="details change-release-artist">
+      <HistoricReleaseList
+        colSpan="2"
+        releases={edit.display_data.releases}
+      />
+      <tr>
+        <th>{addColonText(l('Artist'))}</th>
+        <td className="old">
+          <DescriptiveLink entity={edit.display_data.artist.old} />
+        </td>
+        <td className="new">
+          <DescriptiveLink entity={edit.display_data.artist.new} />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default ChangeReleaseArtist;

--- a/root/edit/details/historic/ChangeReleaseGroup.js
+++ b/root/edit/details/historic/ChangeReleaseGroup.js
@@ -11,26 +11,24 @@ import DescriptiveLink
   from '../../../static/scripts/common/components/DescriptiveLink.js';
 import HistoricReleaseList from '../../components/HistoricReleaseList.js';
 
-type Props = {
-  +edit: ChangeReleaseGroupHistoricEditT,
-};
-
-const ChangeReleaseGroup = ({edit}: Props): React$Element<'table'> => (
-  <table className="details change-release-group">
-    <HistoricReleaseList
-      colSpan="2"
-      releases={edit.display_data.releases}
-    />
-    <tr>
-      <th>{addColonText(l('Release group'))}</th>
-      <td className="old">
-        <DescriptiveLink entity={edit.display_data.release_group.old} />
-      </td>
-      <td className="new">
-        <DescriptiveLink entity={edit.display_data.release_group.new} />
-      </td>
-    </tr>
-  </table>
-);
+component ChangeReleaseGroup(edit: ChangeReleaseGroupHistoricEditT) {
+  return (
+    <table className="details change-release-group">
+      <HistoricReleaseList
+        colSpan="2"
+        releases={edit.display_data.releases}
+      />
+      <tr>
+        <th>{addColonText(l('Release group'))}</th>
+        <td className="old">
+          <DescriptiveLink entity={edit.display_data.release_group.old} />
+        </td>
+        <td className="new">
+          <DescriptiveLink entity={edit.display_data.release_group.new} />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default ChangeReleaseGroup;

--- a/root/edit/details/historic/ChangeReleaseQuality.js
+++ b/root/edit/details/historic/ChangeReleaseQuality.js
@@ -13,38 +13,36 @@ import DescriptiveLink
   from '../../../static/scripts/common/components/DescriptiveLink.js';
 import {QUALITY_NAMES} from '../../../static/scripts/common/constants.js';
 
-type Props = {
-  +edit: ChangeReleaseQualityHistoricEditT,
-};
-
-const ChangeReleaseQuality = ({edit}: Props): React$Element<'table'> => (
-  <table className="details change-release-quality">
-    {edit.display_data.changes.map((change, index) => {
-      const oldQuality = QUALITY_NAMES.get(change.quality.old);
-      const newQuality = QUALITY_NAMES.get(change.quality.new);
-      return (
-        <React.Fragment key={index}>
-          <tr>
-            <th>{addColonText(l('Releases'))}</th>
-            <td colSpan="2">
-              <ul>
-                {change.releases.map(release => (
-                  <li key={release.id}>
-                    <DescriptiveLink entity={release} />
-                  </li>
-                ))}
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <th>{addColonText(l('Data quality'))}</th>
-            <td className="old">{oldQuality ? oldQuality() : ''}</td>
-            <td className="new">{newQuality ? newQuality() : ''}</td>
-          </tr>
-        </React.Fragment>
-      );
-    })}
-  </table>
-);
+component ChangeReleaseQuality(edit: ChangeReleaseQualityHistoricEditT) {
+  return (
+    <table className="details change-release-quality">
+      {edit.display_data.changes.map((change, index) => {
+        const oldQuality = QUALITY_NAMES.get(change.quality.old);
+        const newQuality = QUALITY_NAMES.get(change.quality.new);
+        return (
+          <React.Fragment key={index}>
+            <tr>
+              <th>{addColonText(l('Releases'))}</th>
+              <td colSpan="2">
+                <ul>
+                  {change.releases.map(release => (
+                    <li key={release.id}>
+                      <DescriptiveLink entity={release} />
+                    </li>
+                  ))}
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th>{addColonText(l('Data quality'))}</th>
+              <td className="old">{oldQuality ? oldQuality() : ''}</td>
+              <td className="new">{newQuality ? newQuality() : ''}</td>
+            </tr>
+          </React.Fragment>
+        );
+      })}
+    </table>
+  );
+}
 
 export default ChangeReleaseQuality;

--- a/root/edit/details/historic/EditRelationship.js
+++ b/root/edit/details/historic/EditRelationship.js
@@ -23,13 +23,7 @@ import {
 import {interpolateText}
   from '../../../static/scripts/edit/utility/linkPhrase.js';
 
-type Props = {
-  +edit: EditRelationshipHistoricEditT,
-};
-
-const EditRelationship = ({
-  edit,
-}: Props): React.MixedElement => {
+component EditRelationship(edit: EditRelationshipHistoricEditT) {
   const oldRels = edit.display_data.relationship.old;
   const newRels = edit.display_data.relationship.new;
   const isDataBroken = oldRels.length !== newRels.length;
@@ -193,6 +187,6 @@ const EditRelationship = ({
       </table>
     </>
   );
-};
+}
 
 export default EditRelationship;

--- a/root/edit/details/historic/EditReleaseAttributes.js
+++ b/root/edit/details/historic/EditReleaseAttributes.js
@@ -10,10 +10,6 @@
 import {HistoricReleaseListContent}
   from '../../components/HistoricReleaseList.js';
 
-type Props = {
-  +edit: EditReleaseAttributesHistoricEditT,
-};
-
 function getTypeName(
   type: ReleaseGroupTypeT | ReleaseGroupHistoricTypeT | null,
 ) {
@@ -28,50 +24,52 @@ function getTypeName(
   ) : '?';
 }
 
-const EditReleaseAttributes = ({edit}: Props): React$Element<'table'> => (
-  <table className="details edit-release">
-    <tr>
-      <th>{addColonText(lp('Old', 'release type and status'))}</th>
-      <td>
-        <table>
-          {edit.display_data.changes.map((change, index) => (
-            <tr key={index}>
-              <td className="old">
-                {texp.l(
-                  'Type: {type}, status: {status}',
-                  {
-                    status: change.status
-                      ? lp_attributes(change.status.name, 'release_status')
-                      : '?',
-                    type: getTypeName(change.type),
-                  },
-                )}
-              </td>
-              <td>
-                <HistoricReleaseListContent releases={change.releases} />
-              </td>
-            </tr>
-          ))}
-        </table>
-      </td>
-    </tr>
+component EditReleaseAttributes(edit: EditReleaseAttributesHistoricEditT) {
+  return (
+    <table className="details edit-release">
+      <tr>
+        <th>{addColonText(lp('Old', 'release type and status'))}</th>
+        <td>
+          <table>
+            {edit.display_data.changes.map((change, index) => (
+              <tr key={index}>
+                <td className="old">
+                  {texp.l(
+                    'Type: {type}, status: {status}',
+                    {
+                      status: change.status
+                        ? lp_attributes(change.status.name, 'release_status')
+                        : '?',
+                      type: getTypeName(change.type),
+                    },
+                  )}
+                </td>
+                <td>
+                  <HistoricReleaseListContent releases={change.releases} />
+                </td>
+              </tr>
+            ))}
+          </table>
+        </td>
+      </tr>
 
-    <tr>
-      <th>{l('New type:')}</th>
-      <td className="new" colSpan="2">
-        {getTypeName(edit.display_data.type)}
-      </td>
-    </tr>
+      <tr>
+        <th>{l('New type:')}</th>
+        <td className="new" colSpan="2">
+          {getTypeName(edit.display_data.type)}
+        </td>
+      </tr>
 
-    <tr>
-      <th>{l('New status:')}</th>
-      <td className="new" colSpan="2">
-        {edit.display_data.status
-          ? lp_attributes(edit.display_data.status.name, 'release_status')
-          : '?'}
-      </td>
-    </tr>
-  </table>
-);
+      <tr>
+        <th>{l('New status:')}</th>
+        <td className="new" colSpan="2">
+          {edit.display_data.status
+            ? lp_attributes(edit.display_data.status.name, 'release_status')
+            : '?'}
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default EditReleaseAttributes;

--- a/root/edit/details/historic/EditReleaseEvents.js
+++ b/root/edit/details/historic/EditReleaseEvents.js
@@ -11,10 +11,6 @@ import EntityLink, {DeletedLink}
   from '../../../static/scripts/common/components/EntityLink.js';
 import formatDate from '../../../static/scripts/common/utility/formatDate.js';
 
-type Props = {
-  +edit: EditReleaseEventsHistoricEditT,
-};
-
 function buildEventComp(
   event: OldReleaseEventCompT,
   key: string,
@@ -101,66 +97,70 @@ function buildEvent(
   );
 }
 
-const EditReleaseEvents = ({edit}: Props): React$Element<'table'> => (
-  <table className="tbl edit-release-events">
-    <thead>
-      <tr>
-        <th>{l('Release')}</th>
-        <th>{l('Date')}</th>
-        <th>{l('Country')}</th>
-        <th>{l('Label')}</th>
-        <th>{l('Catalog number')}</th>
-        <th>{l('Barcode')}</th>
-        <th>{l('Format')}</th>
-      </tr>
-    </thead>
-    {edit.display_data.additions.length ? (
-      <>
-        <thead>
-          <tr>
-            <th colSpan="7">{lp('Added', 'list of added release events')}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {edit.display_data.additions.map(
-            (event, index) => buildEvent(event, 'additions' + index),
-          )}
-        </tbody>
-      </>
-    ) : null}
-    {edit.display_data.removals.length ? (
-      <>
-        <thead>
-          <tr>
-            <th colSpan="7">
-              {lp('Removed', 'list of removed release events')}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {edit.display_data.removals.map(
-            (event, index) => buildEvent(event, 'removals' + index),
-          )}
-        </tbody>
-      </>
-    ) : null}
-    {edit.display_data.edits.length ? (
-      <>
-        <thead>
-          <tr>
-            <th colSpan="7">
-              {lp('Edited', 'list of edited release events')}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {edit.display_data.edits.map(
-            (event, index) => buildEventComp(event, 'edits' + index),
-          )}
-        </tbody>
-      </>
-    ) : null}
-  </table>
-);
+component EditReleaseEvents(edit: EditReleaseEventsHistoricEditT) {
+  return (
+    <table className="tbl edit-release-events">
+      <thead>
+        <tr>
+          <th>{l('Release')}</th>
+          <th>{l('Date')}</th>
+          <th>{l('Country')}</th>
+          <th>{l('Label')}</th>
+          <th>{l('Catalog number')}</th>
+          <th>{l('Barcode')}</th>
+          <th>{l('Format')}</th>
+        </tr>
+      </thead>
+      {edit.display_data.additions.length ? (
+        <>
+          <thead>
+            <tr>
+              <th colSpan="7">
+                {lp('Added', 'list of added release events')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {edit.display_data.additions.map(
+              (event, index) => buildEvent(event, 'additions' + index),
+            )}
+          </tbody>
+        </>
+      ) : null}
+      {edit.display_data.removals.length ? (
+        <>
+          <thead>
+            <tr>
+              <th colSpan="7">
+                {lp('Removed', 'list of removed release events')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {edit.display_data.removals.map(
+              (event, index) => buildEvent(event, 'removals' + index),
+            )}
+          </tbody>
+        </>
+      ) : null}
+      {edit.display_data.edits.length ? (
+        <>
+          <thead>
+            <tr>
+              <th colSpan="7">
+                {lp('Edited', 'list of edited release events')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {edit.display_data.edits.map(
+              (event, index) => buildEventComp(event, 'edits' + index),
+            )}
+          </tbody>
+        </>
+      ) : null}
+    </table>
+  );
+}
 
 export default EditReleaseEvents;

--- a/root/edit/details/historic/EditReleaseLanguage.js
+++ b/root/edit/details/historic/EditReleaseLanguage.js
@@ -10,58 +10,56 @@
 import {HistoricReleaseListContent}
   from '../../components/HistoricReleaseList.js';
 
-type Props = {
-  +edit: EditReleaseLanguageHistoricEditT,
-};
+component EditReleaseLanguage(edit: EditReleaseLanguageHistoricEditT) {
+  return (
+    <table className="details edit-release">
+      <tr>
+        <th>{addColonText(lp('Old', 'release language'))}</th>
+        <td>
+          <table>
+            {edit.display_data.old.map((change, index) => (
+              <tr key={index}>
+                <td className="old">
+                  {texp.l(
+                    'Language: {language}, script: {script}',
+                    {
+                      language: change.language
+                        ? l_languages(change.language.name)
+                        : '?',
+                      script: change.script
+                        ? l_scripts(change.script.name)
+                        : '?',
+                    },
+                  )}
+                </td>
+                <td>
+                  <HistoricReleaseListContent releases={change.releases} />
+                </td>
+              </tr>
+            ))}
+          </table>
+        </td>
+      </tr>
 
-const EditReleaseLanguage = ({edit}: Props): React$Element<'table'> => (
-  <table className="details edit-release">
-    <tr>
-      <th>{addColonText(lp('Old', 'release language'))}</th>
-      <td>
-        <table>
-          {edit.display_data.old.map((change, index) => (
-            <tr key={index}>
-              <td className="old">
-                {texp.l(
-                  'Language: {language}, script: {script}',
-                  {
-                    language: change.language
-                      ? l_languages(change.language.name)
-                      : '?',
-                    script: change.script
-                      ? l_scripts(change.script.name)
-                      : '?',
-                  },
-                )}
-              </td>
-              <td>
-                <HistoricReleaseListContent releases={change.releases} />
-              </td>
-            </tr>
-          ))}
-        </table>
-      </td>
-    </tr>
+      <tr>
+        <th>{l('New language:')}</th>
+        <td className="new">
+          {edit.display_data.language
+            ? l_languages(edit.display_data.language.name)
+            : '?'}
+        </td>
+      </tr>
 
-    <tr>
-      <th>{l('New language:')}</th>
-      <td className="new">
-        {edit.display_data.language
-          ? l_languages(edit.display_data.language.name)
-          : '?'}
-      </td>
-    </tr>
-
-    <tr>
-      <th>{l('New script:')}</th>
-      <td className="new">
-        {edit.display_data.script
-          ? l_scripts(edit.display_data.script.name)
-          : '?'}
-      </td>
-    </tr>
-  </table>
-);
+      <tr>
+        <th>{l('New script:')}</th>
+        <td className="new">
+          {edit.display_data.script
+            ? l_scripts(edit.display_data.script.name)
+            : '?'}
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default EditReleaseLanguage;

--- a/root/edit/details/historic/EditReleaseName.js
+++ b/root/edit/details/historic/EditReleaseName.js
@@ -11,19 +11,20 @@ import WordDiff
   from '../../../static/scripts/edit/components/edit/WordDiff.js';
 import HistoricReleaseList from '../../components/HistoricReleaseList.js';
 
-type Props = {
-  +edit: EditReleaseNameHistoricEditT,
-};
-
-const EditReleaseName = ({edit}: Props): React$Element<'table'> => (
-  <table className="details edit-release">
-    <HistoricReleaseList colSpan="2" releases={edit.display_data.releases} />
-    <WordDiff
-      label={addColonText(l('Name'))}
-      newText={edit.display_data.name.new}
-      oldText={edit.display_data.name.old}
-    />
-  </table>
-);
+component EditReleaseName(edit: EditReleaseNameHistoricEditT) {
+  return (
+    <table className="details edit-release">
+      <HistoricReleaseList
+        colSpan="2"
+        releases={edit.display_data.releases}
+      />
+      <WordDiff
+        label={addColonText(l('Name'))}
+        newText={edit.display_data.name.new}
+        oldText={edit.display_data.name.old}
+      />
+    </table>
+  );
+}
 
 export default EditReleaseName;

--- a/root/edit/details/historic/EditTrack.js
+++ b/root/edit/details/historic/EditTrack.js
@@ -12,11 +12,7 @@ import DescriptiveLink
 import WordDiff
   from '../../../static/scripts/edit/components/edit/WordDiff.js';
 
-type Props = {
-  +edit: EditTrackHistoricEditT,
-};
-
-const EditTrack = ({edit}: Props): React$Element<'table'> => {
+component EditTrack(edit: EditTrackHistoricEditT) {
   const display = edit.display_data;
   const artist = display.artist;
   const position = display.position;
@@ -51,6 +47,6 @@ const EditTrack = ({edit}: Props): React$Element<'table'> => {
       ) : null}
     </table>
   );
-};
+}
 
 export default EditTrack;

--- a/root/edit/details/historic/MergeReleases.js
+++ b/root/edit/details/historic/MergeReleases.js
@@ -11,57 +11,55 @@ import DescriptiveLink
   from '../../../static/scripts/common/components/DescriptiveLink.js';
 import yesNo from '../../../static/scripts/common/utility/yesNo.js';
 
-type Props = {
-  +edit: MergeReleasesHistoricEditT,
-};
-
-const MergeReleases = ({edit}: Props): React$MixedElement => (
-  <>
-    <table className="details merge-releases">
-      <tr>
-        <th>{l('Old releases:')}</th>
-        <td>
-          <ul>
-            {edit.display_data.releases.old.map((release, index) => (
-              <li key={'old-' + index}>
-                <DescriptiveLink entity={release} />
-              </li>
-            ))}
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <th>{l('New releases:')}</th>
-        <td>
-          <ul>
-            {edit.display_data.releases.new.map((release, index) => (
-              <li key={'new-' + index}>
-                <DescriptiveLink entity={release} />
-              </li>
-            ))}
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <th>{l('Merge attributes:')}</th>
-        <td>{yesNo(edit.display_data.merge_attributes)}</td>
-      </tr>
-      <tr>
-        <th>{l('Merge language & script:')}</th>
-        <td>{yesNo(edit.display_data.merge_language)}</td>
-      </tr>
-      {edit.historic_type === 25 ? (
+component MergeReleases(edit: MergeReleasesHistoricEditT) {
+  return (
+    <>
+      <table className="details merge-releases">
         <tr>
-          <th>{addColonText(l('Note'))}</th>
+          <th>{l('Old releases:')}</th>
           <td>
-            {l(`This edit was a "Merge Releases (Various Artists)"
-                edit which additionally set the release artist
-                to Various Artists.`)}
+            <ul>
+              {edit.display_data.releases.old.map((release, index) => (
+                <li key={'old-' + index}>
+                  <DescriptiveLink entity={release} />
+                </li>
+              ))}
+            </ul>
           </td>
         </tr>
-      ) : null}
-    </table>
-  </>
-);
+        <tr>
+          <th>{l('New releases:')}</th>
+          <td>
+            <ul>
+              {edit.display_data.releases.new.map((release, index) => (
+                <li key={'new-' + index}>
+                  <DescriptiveLink entity={release} />
+                </li>
+              ))}
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th>{l('Merge attributes:')}</th>
+          <td>{yesNo(edit.display_data.merge_attributes)}</td>
+        </tr>
+        <tr>
+          <th>{l('Merge language & script:')}</th>
+          <td>{yesNo(edit.display_data.merge_language)}</td>
+        </tr>
+        {edit.historic_type === 25 ? (
+          <tr>
+            <th>{addColonText(l('Note'))}</th>
+            <td>
+              {l(`This edit was a "Merge Releases (Various Artists)"
+                  edit which additionally set the release artist
+                  to Various Artists.`)}
+            </td>
+          </tr>
+        ) : null}
+      </table>
+    </>
+  );
+}
 
 export default MergeReleases;

--- a/root/edit/details/historic/MoveDiscId.js
+++ b/root/edit/details/historic/MoveDiscId.js
@@ -11,27 +11,25 @@ import CDTocLink
   from '../../../static/scripts/common/components/CDTocLink.js';
 import HistoricReleaseList from '../../components/HistoricReleaseList.js';
 
-type Props = {
-  +edit: MoveDiscIdHistoricEditT,
-};
-
-const MoveDiscId = ({edit}: Props): React$Element<'table'> => (
-  <table className="details move-discid">
-    <tr>
-      <th>{addColonText(l('Disc ID'))}</th>
-      <td>
-        <CDTocLink cdToc={edit.display_data.cdtoc} />
-      </td>
-    </tr>
-    <HistoricReleaseList
-      label={l('From:')}
-      releases={edit.display_data.old_releases}
-    />
-    <HistoricReleaseList
-      label={l('To:')}
-      releases={edit.display_data.new_releases}
-    />
-  </table>
-);
+component MoveDiscId(edit: MoveDiscIdHistoricEditT) {
+  return (
+    <table className="details move-discid">
+      <tr>
+        <th>{addColonText(l('Disc ID'))}</th>
+        <td>
+          <CDTocLink cdToc={edit.display_data.cdtoc} />
+        </td>
+      </tr>
+      <HistoricReleaseList
+        label={l('From:')}
+        releases={edit.display_data.old_releases}
+      />
+      <HistoricReleaseList
+        label={l('To:')}
+        releases={edit.display_data.new_releases}
+      />
+    </table>
+  );
+}
 
 export default MoveDiscId;

--- a/root/edit/details/historic/MoveRelease.js
+++ b/root/edit/details/historic/MoveRelease.js
@@ -12,30 +12,28 @@ import DescriptiveLink
 import yesNo from '../../../static/scripts/common/utility/yesNo.js';
 import HistoricReleaseList from '../../components/HistoricReleaseList.js';
 
-type Props = {
-  +edit: MoveReleaseHistoricEditT,
-};
-
-const MoveRelease = ({edit}: Props): React$Element<'table'> => (
-  <table className="details edit-release">
-    <HistoricReleaseList
-      colSpan="2"
-      releases={edit.display_data.releases}
-    />
-    <tr>
-      <th>{l('Change track artists:')}</th>
-      <td colSpan="2">{yesNo(edit.display_data.move_tracks)}</td>
-    </tr>
-    <tr>
-      <th>{addColonText(l('Artist'))}</th>
-      <td className="old">
-        <DescriptiveLink entity={edit.display_data.artist.old} />
-      </td>
-      <td className="new">
-        <DescriptiveLink entity={edit.display_data.artist.new} />
-      </td>
-    </tr>
-  </table>
-);
+component MoveRelease(edit: MoveReleaseHistoricEditT) {
+  return (
+    <table className="details edit-release">
+      <HistoricReleaseList
+        colSpan="2"
+        releases={edit.display_data.releases}
+      />
+      <tr>
+        <th>{l('Change track artists:')}</th>
+        <td colSpan="2">{yesNo(edit.display_data.move_tracks)}</td>
+      </tr>
+      <tr>
+        <th>{addColonText(l('Artist'))}</th>
+        <td className="old">
+          <DescriptiveLink entity={edit.display_data.artist.old} />
+        </td>
+        <td className="new">
+          <DescriptiveLink entity={edit.display_data.artist.new} />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default MoveRelease;

--- a/root/edit/details/historic/MoveReleaseToReleaseGroup.js
+++ b/root/edit/details/historic/MoveReleaseToReleaseGroup.js
@@ -10,30 +10,28 @@
 import DescriptiveLink
   from '../../../static/scripts/common/components/DescriptiveLink.js';
 
-type Props = {
-  +edit: MoveReleaseToReleaseGroupHistoricEditT,
-};
-
-const MoveReleaseToReleaseGroup = ({
-  edit,
-}: Props): React$Element<'table'> => (
-  <table className="details edit-release">
-    <tr>
-      <th>{addColonText(l('Release'))}</th>
-      <td colSpan="2">
-        <DescriptiveLink entity={edit.display_data.release} />
-      </td>
-    </tr>
-    <tr>
-      <th>{addColonText(l('Release group'))}</th>
-      <td className="old">
-        <DescriptiveLink entity={edit.display_data.release_group.old} />
-      </td>
-      <td className="new">
-        <DescriptiveLink entity={edit.display_data.release_group.new} />
-      </td>
-    </tr>
-  </table>
-);
+component MoveReleaseToReleaseGroup(
+  edit: MoveReleaseToReleaseGroupHistoricEditT,
+) {
+  return (
+    <table className="details edit-release">
+      <tr>
+        <th>{addColonText(l('Release'))}</th>
+        <td colSpan="2">
+          <DescriptiveLink entity={edit.display_data.release} />
+        </td>
+      </tr>
+      <tr>
+        <th>{addColonText(l('Release group'))}</th>
+        <td className="old">
+          <DescriptiveLink entity={edit.display_data.release_group.old} />
+        </td>
+        <td className="new">
+          <DescriptiveLink entity={edit.display_data.release_group.new} />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default MoveReleaseToReleaseGroup;

--- a/root/edit/details/historic/RemoveDiscId.js
+++ b/root/edit/details/historic/RemoveDiscId.js
@@ -12,20 +12,18 @@ import CDTocLink
 import HistoricReleaseList
   from '../../components/HistoricReleaseList.js';
 
-type Props = {
-  +edit: RemoveDiscIdHistoricEditT,
-};
-
-const RemoveDiscId = ({edit}: Props): React$Element<'table'> => (
-  <table className="details remove-discid">
-    <HistoricReleaseList releases={edit.display_data.releases} />
-    <tr>
-      <th>{addColonText(l('Disc ID'))}</th>
-      <td>
-        <CDTocLink cdToc={edit.display_data.cdtoc} />
-      </td>
-    </tr>
-  </table>
-);
+component RemoveDiscId(edit: RemoveDiscIdHistoricEditT) {
+  return (
+    <table className="details remove-discid">
+      <HistoricReleaseList releases={edit.display_data.releases} />
+      <tr>
+        <th>{addColonText(l('Disc ID'))}</th>
+        <td>
+          <CDTocLink cdToc={edit.display_data.cdtoc} />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default RemoveDiscId;

--- a/root/edit/details/historic/RemoveLabelAlias.js
+++ b/root/edit/details/historic/RemoveLabelAlias.js
@@ -7,17 +7,15 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type Props = {
-  +edit: RemoveLabelAliasHistoricEditT,
-};
-
-const RemoveLabelAlias = ({edit}: Props): React$Element<'table'> => (
-  <table className="details remove-label-alias">
-    <tr>
-      <th>{addColonText(l('Alias'))}</th>
-      <td>{edit.display_data.alias}</td>
-    </tr>
-  </table>
-);
+component RemoveLabelAlias(edit: RemoveLabelAliasHistoricEditT) {
+  return (
+    <table className="details remove-label-alias">
+      <tr>
+        <th>{addColonText(l('Alias'))}</th>
+        <td>{edit.display_data.alias}</td>
+      </tr>
+    </table>
+  );
+}
 
 export default RemoveLabelAlias;

--- a/root/edit/details/historic/RemoveRelationship.js
+++ b/root/edit/details/historic/RemoveRelationship.js
@@ -10,33 +10,31 @@
 import {HistoricRelationship}
   from '../../../static/scripts/common/components/Relationship.js';
 
-type Props = {
-  +edit: RemoveRelationshipHistoricEditT,
-};
-
-const RemoveRelationship = ({edit}: Props): React$Element<'table'> => (
-  <table className="details remove-relationship-historic">
-    <tr>
-      {edit.display_data.relationships.length ? (
-        <>
-          <th>{addColonText(l('Relationships'))}</th>
+component RemoveRelationship(edit: RemoveRelationshipHistoricEditT) {
+  return (
+    <table className="details remove-relationship-historic">
+      <tr>
+        {edit.display_data.relationships.length ? (
+          <>
+            <th>{addColonText(l('Relationships'))}</th>
+            <td>
+              <ul>
+                {edit.display_data.relationships.map(relationship => (
+                  <li key={relationship.id}>
+                    <HistoricRelationship relationship={relationship} />
+                  </li>
+                ))}
+              </ul>
+            </td>
+          </>
+        ) : (
           <td>
-            <ul>
-              {edit.display_data.relationships.map(relationship => (
-                <li key={relationship.id}>
-                  <HistoricRelationship relationship={relationship} />
-                </li>
-              ))}
-            </ul>
+            {l('An error occurred while loading this edit.')}
           </td>
-        </>
-      ) : (
-        <td>
-          {l('An error occurred while loading this edit.')}
-        </td>
-      )}
-    </tr>
-  </table>
-);
+        )}
+      </tr>
+    </table>
+  );
+}
 
 export default RemoveRelationship;

--- a/root/edit/details/historic/RemoveRelease.js
+++ b/root/edit/details/historic/RemoveRelease.js
@@ -12,11 +12,7 @@ import ArtistCreditLink
 import HistoricReleaseList
   from '../../components/HistoricReleaseList.js';
 
-type Props = {
-  +edit: RemoveReleaseHistoricEditT,
-};
-
-const RemoveRelease = ({edit}: Props): React$Element<'table'> => {
+component RemoveRelease(edit: RemoveReleaseHistoricEditT) {
   const artistCredit = edit.display_data.artist_credit;
   return (
     <table className="details remove-release">
@@ -31,6 +27,6 @@ const RemoveRelease = ({edit}: Props): React$Element<'table'> => {
       ) : null}
     </table>
   );
-};
+}
 
 export default RemoveRelease;

--- a/root/edit/details/historic/RemoveReleases.js
+++ b/root/edit/details/historic/RemoveReleases.js
@@ -10,25 +10,23 @@
 import DescriptiveLink
   from '../../../static/scripts/common/components/DescriptiveLink.js';
 
-type Props = {
-  +edit: RemoveReleasesHistoricEditT,
-};
-
-const RemoveReleases = ({edit}: Props): React$Element<'table'> => (
-  <table className="details remove-releases">
-    <tr>
-      <th>{addColonText(l('Releases'))}</th>
-      <td colSpan="2">
-        <ul>
-          {edit.display_data.releases.map((release, index) => (
-            <li key={index}>
-              <DescriptiveLink entity={release} />
-            </li>
-          ))}
-        </ul>
-      </td>
-    </tr>
-  </table>
-);
+component RemoveReleases(edit: RemoveReleasesHistoricEditT) {
+  return (
+    <table className="details remove-releases">
+      <tr>
+        <th>{addColonText(l('Releases'))}</th>
+        <td colSpan="2">
+          <ul>
+            {edit.display_data.releases.map((release, index) => (
+              <li key={index}>
+                <DescriptiveLink entity={release} />
+              </li>
+            ))}
+          </ul>
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default RemoveReleases;

--- a/root/edit/details/historic/RemoveTrack.js
+++ b/root/edit/details/historic/RemoveTrack.js
@@ -12,23 +12,21 @@ import DescriptiveLink
 import HistoricReleaseList
   from '../../components/HistoricReleaseList.js';
 
-type Props = {
-  +edit: RemoveTrackHistoricEditT,
-};
-
-const RemoveTrack = ({edit}: Props): React$Element<'table'> => (
-  <table className="details remove-track">
-    <HistoricReleaseList releases={edit.display_data.releases} />
-    <tr>
-      <th>{addColonText(l('Track'))}</th>
-      <td>
-        <DescriptiveLink
-          content={edit.display_data.name}
-          entity={edit.display_data.recording}
-        />
-      </td>
-    </tr>
-  </table>
-);
+component RemoveTrack(edit: RemoveTrackHistoricEditT) {
+  return (
+    <table className="details remove-track">
+      <HistoricReleaseList releases={edit.display_data.releases} />
+      <tr>
+        <th>{addColonText(l('Track'))}</th>
+        <td>
+          <DescriptiveLink
+            content={edit.display_data.name}
+            entity={edit.display_data.recording}
+          />
+        </td>
+      </tr>
+    </table>
+  );
+}
 
 export default RemoveTrack;


### PR DESCRIPTION
Flow now supports a specific [React Component Syntax](https://flow.org/en/docs/react/component-syntax/) which reduces the amount of types we need to define manually, and is supposed to be better for type checking as well. I'm converting our React components to this syntax bit by bit with this PR.

This changes all stuff in the `edit` subfolder.

Note: To be reviewed without whitespace changes (since this adds explicit `return()` calls that require spacing things one more tab in many cases).

On top of https://github.com/metabrainz/musicbrainz-server/pull/3226