### PR TITLE
Migrate React layout components to Flow component syntax

### DIFF
--- a/root/layout/components/BottomMenu.js
+++ b/root/layout/components/BottomMenu.js
@@ -45,13 +45,7 @@ function languageName(
   return text;
 }
 
-type LanguageLinkPropsT = {
-  language: ServerLanguageT,
-};
-
-const LanguageLink = ({
-  language,
-}: LanguageLinkPropsT) => {
+component LanguageLink(language: ServerLanguageT) {
   const $c = React.useContext(SanitizedCatalystContext);
   return (
     <a
@@ -63,17 +57,12 @@ const LanguageLink = ({
       {languageName(language, false)}
     </a>
   );
-};
+}
 
-type LanguageMenuProps = {
-  +currentBCP47Language: string,
-  +serverLanguages: $ReadOnlyArray<ServerLanguageT>,
-};
-
-const LanguageMenu = ({
-  currentBCP47Language,
-  serverLanguages,
-}: LanguageMenuProps) => {
+component LanguageMenu(
+  currentBCP47Language: string,
+  serverLanguages: $ReadOnlyArray<ServerLanguageT>,
+) {
   const $c = React.useContext(SanitizedCatalystContext);
   return (
     <li className="language-selector" tabIndex="-1">
@@ -107,232 +96,242 @@ const LanguageMenu = ({
       </ul>
     </li>
   );
-};
+}
 
-const AboutMenu = () => (
-  <li className="about" tabIndex="-1">
-    <span className="menu-header">
-      {l('About us')}
-      {'\xA0\u25BE'}
-    </span>
-    <ul>
-      <li>
-        <a href="/doc/About">{l('About MusicBrainz')}</a>
-      </li>
-      <li>
-        <a href="https://metabrainz.org/sponsors">{l('Sponsors')}</a>
-      </li>
-      <li>
-        <a href="https://metabrainz.org/team">{l('Team')}</a>
-      </li>
-      <li>
-        <a href="https://www.redbubble.com/people/metabrainz/shop">{l('Shop')}</a>
-      </li>
-      <li>
-        <a href="https://metabrainz.org/contact">{l('Contact us')}</a>
-      </li>
-      <li className="separator">
-        <a href="/doc/About/Data_License">{l('Data licenses')}</a>
-      </li>
-      <li>
-        <a href="https://metabrainz.org/social-contract">{l('Social contract')}</a>
-      </li>
-      <li>
-        <a href="/doc/Code_of_Conduct">{l('Code of Conduct')}</a>
-      </li>
-      <li>
-        <a href="https://metabrainz.org/privacy">{l('Privacy policy')}</a>
-      </li>
-      <li>
-        <a href="https://metabrainz.org/gdpr">{l('GDPR compliance')}</a>
-      </li>
-      <li>
-        <a href="/doc/Data_Removal_Policy">{l('Data removal policy')}</a>
-      </li>
-      <li className="separator">
-        <a href="/elections">{l('Auto-editor elections')}</a>
-      </li>
-      <li>
-        <a href="/privileged">{l('Privileged user accounts')}</a>
-      </li>
-      <li>
-        <a href="/statistics">{l('Statistics')}</a>
-      </li>
-      <li>
-        <a href="/statistics/timeline">{l('Timeline graph')}</a>
-      </li>
-      <li>
-        <a href="/history">{l('MusicBrainz history')}</a>
-      </li>
-    </ul>
-  </li>
-);
+component AboutMenu() {
+  return (
+    <li className="about" tabIndex="-1">
+      <span className="menu-header">
+        {l('About us')}
+        {'\xA0\u25BE'}
+      </span>
+      <ul>
+        <li>
+          <a href="/doc/About">{l('About MusicBrainz')}</a>
+        </li>
+        <li>
+          <a href="https://metabrainz.org/sponsors">{l('Sponsors')}</a>
+        </li>
+        <li>
+          <a href="https://metabrainz.org/team">{l('Team')}</a>
+        </li>
+        <li>
+          <a href="https://www.redbubble.com/people/metabrainz/shop">{l('Shop')}</a>
+        </li>
+        <li>
+          <a href="https://metabrainz.org/contact">{l('Contact us')}</a>
+        </li>
+        <li className="separator">
+          <a href="/doc/About/Data_License">{l('Data licenses')}</a>
+        </li>
+        <li>
+          <a href="https://metabrainz.org/social-contract">{l('Social contract')}</a>
+        </li>
+        <li>
+          <a href="/doc/Code_of_Conduct">{l('Code of Conduct')}</a>
+        </li>
+        <li>
+          <a href="https://metabrainz.org/privacy">{l('Privacy policy')}</a>
+        </li>
+        <li>
+          <a href="https://metabrainz.org/gdpr">{l('GDPR compliance')}</a>
+        </li>
+        <li>
+          <a href="/doc/Data_Removal_Policy">{l('Data removal policy')}</a>
+        </li>
+        <li className="separator">
+          <a href="/elections">{l('Auto-editor elections')}</a>
+        </li>
+        <li>
+          <a href="/privileged">{l('Privileged user accounts')}</a>
+        </li>
+        <li>
+          <a href="/statistics">{l('Statistics')}</a>
+        </li>
+        <li>
+          <a href="/statistics/timeline">{l('Timeline graph')}</a>
+        </li>
+        <li>
+          <a href="/history">{l('MusicBrainz history')}</a>
+        </li>
+      </ul>
+    </li>
+  );
+}
 
-const ProductsMenu = () => (
-  <li className="products" tabIndex="-1">
-    <span className="menu-header">
-      {l('Products')}
-      {'\xA0\u25BE'}
-    </span>
-    <ul>
-      <li>
-        <a href="//picard.musicbrainz.org">{l('MusicBrainz Picard')}</a>
-      </li>
-      <li>
-        <a href="/doc/AudioRanger">{l('AudioRanger')}</a>
-      </li>
-      <li>
-        <a href="/doc/Mp3tag">{l('Mp3tag')}</a>
-      </li>
-      <li>
-        <a href="/doc/Yate_Music_Tagger">{l('Yate Music Tagger')}</a>
-      </li>
-      <li className="separator">
-        <a href="/doc/MusicBrainz_for_Android">
-          {l('MusicBrainz for Android')}
-        </a>
-      </li>
-      <li className="separator">
-        <a href="/doc/MusicBrainz_Server">{l('MusicBrainz Server')}</a>
-      </li>
-      <li>
-        <a href="/doc/MusicBrainz_Database">{l('MusicBrainz Database')}</a>
-      </li>
-      <li className="separator">
-        <a href="/doc/Developer_Resources">{l('Developer resources')}</a>
-      </li>
-      <li>
-        <a href="/doc/MusicBrainz_API">{l('MusicBrainz API')}</a>
-      </li>
-      <li>
-        <a href="/doc/Live_Data_Feed">{l('Live Data Feed')}</a>
-      </li>
-    </ul>
-  </li>
-);
+component ProductsMenu() {
+  return (
+    <li className="products" tabIndex="-1">
+      <span className="menu-header">
+        {l('Products')}
+        {'\xA0\u25BE'}
+      </span>
+      <ul>
+        <li>
+          <a href="//picard.musicbrainz.org">{l('MusicBrainz Picard')}</a>
+        </li>
+        <li>
+          <a href="/doc/AudioRanger">{l('AudioRanger')}</a>
+        </li>
+        <li>
+          <a href="/doc/Mp3tag">{l('Mp3tag')}</a>
+        </li>
+        <li>
+          <a href="/doc/Yate_Music_Tagger">{l('Yate Music Tagger')}</a>
+        </li>
+        <li className="separator">
+          <a href="/doc/MusicBrainz_for_Android">
+            {l('MusicBrainz for Android')}
+          </a>
+        </li>
+        <li className="separator">
+          <a href="/doc/MusicBrainz_Server">{l('MusicBrainz Server')}</a>
+        </li>
+        <li>
+          <a href="/doc/MusicBrainz_Database">{l('MusicBrainz Database')}</a>
+        </li>
+        <li className="separator">
+          <a href="/doc/Developer_Resources">{l('Developer resources')}</a>
+        </li>
+        <li>
+          <a href="/doc/MusicBrainz_API">{l('MusicBrainz API')}</a>
+        </li>
+        <li>
+          <a href="/doc/Live_Data_Feed">{l('Live Data Feed')}</a>
+        </li>
+      </ul>
+    </li>
+  );
+}
 
-const SearchMenu = () => (
-  <li className="search" tabIndex="-1">
-    <span className="menu-header">
-      {l('Search')}
-      {'\xA0\u25BE'}
-    </span>
-    <ul>
-      <li>
-        <a href="/search">{l('Advanced search')}</a>
-      </li>
-      <li>
-        <a href="/search/edits">{l('Edit search')}</a>
-      </li>
-      <li>
-        <a href="/tags">{lp('Tag cloud', 'folksonomy')}</a>
-      </li>
-      <li>
-        <a href="/cdstub/browse">{l('Top CD stubs')}</a>
-      </li>
-    </ul>
-  </li>
-);
+component SearchMenu() {
+  return (
+    <li className="search" tabIndex="-1">
+      <span className="menu-header">
+        {l('Search')}
+        {'\xA0\u25BE'}
+      </span>
+      <ul>
+        <li>
+          <a href="/search">{l('Advanced search')}</a>
+        </li>
+        <li>
+          <a href="/search/edits">{l('Edit search')}</a>
+        </li>
+        <li>
+          <a href="/tags">{lp('Tag cloud', 'folksonomy')}</a>
+        </li>
+        <li>
+          <a href="/cdstub/browse">{l('Top CD stubs')}</a>
+        </li>
+      </ul>
+    </li>
+  );
+}
 
-const EditingMenu = () => (
-  <li className="editing" tabIndex="-1">
-    <span className="menu-header">
-      {l('Editing')}
-      {'\xA0\u25BE'}
-    </span>
-    <ul>
-      <li>
-        <a href="/artist/create">{lp('Add artist', 'interactive')}</a>
-      </li>
-      <li>
-        <a href="/label/create">{lp('Add label', 'interactive')}</a>
-      </li>
-      <li>
-        <a href="/release-group/create">
-          {lp('Add release group', 'interactive')}
-        </a>
-      </li>
-      <li>
-        <a href="/release/add">{lp('Add release', 'interactive')}</a>
-      </li>
-      <li>
-        <a href={'/release/add?artist=' + encodeURIComponent(VARTIST_GID)}>
-          {lp('Add Various Artists release', 'interactive')}
-        </a>
-      </li>
-      <li>
-        <a href="/recording/create">
-          {lp('Add standalone recording', 'interactive')}
-        </a>
-      </li>
-      <li>
-        <a href="/work/create">{lp('Add work', 'interactive')}</a>
-      </li>
-      <li>
-        <a href="/place/create">{lp('Add place', 'interactive')}</a>
-      </li>
-      <li>
-        <a href="/series/create">
-          {lp('Add series', 'singular, interactive')}
-        </a>
-      </li>
-      <li>
-        <a href="/event/create">{lp('Add event', 'interactive')}</a>
-      </li>
-      <li className="separator">
-        <a href="/vote">{l('Vote on edits')}</a>
-      </li>
-      <li>
-        <a href="/reports">{l('Reports')}</a>
-      </li>
-    </ul>
-  </li>
-);
+component EditingMenu() {
+  return (
+    <li className="editing" tabIndex="-1">
+      <span className="menu-header">
+        {l('Editing')}
+        {'\xA0\u25BE'}
+      </span>
+      <ul>
+        <li>
+          <a href="/artist/create">{lp('Add artist', 'interactive')}</a>
+        </li>
+        <li>
+          <a href="/label/create">{lp('Add label', 'interactive')}</a>
+        </li>
+        <li>
+          <a href="/release-group/create">
+            {lp('Add release group', 'interactive')}
+          </a>
+        </li>
+        <li>
+          <a href="/release/add">{lp('Add release', 'interactive')}</a>
+        </li>
+        <li>
+          <a href={'/release/add?artist=' + encodeURIComponent(VARTIST_GID)}>
+            {lp('Add Various Artists release', 'interactive')}
+          </a>
+        </li>
+        <li>
+          <a href="/recording/create">
+            {lp('Add standalone recording', 'interactive')}
+          </a>
+        </li>
+        <li>
+          <a href="/work/create">{lp('Add work', 'interactive')}</a>
+        </li>
+        <li>
+          <a href="/place/create">{lp('Add place', 'interactive')}</a>
+        </li>
+        <li>
+          <a href="/series/create">
+            {lp('Add series', 'singular, interactive')}
+          </a>
+        </li>
+        <li>
+          <a href="/event/create">{lp('Add event', 'interactive')}</a>
+        </li>
+        <li className="separator">
+          <a href="/vote">{l('Vote on edits')}</a>
+        </li>
+        <li>
+          <a href="/reports">{l('Reports')}</a>
+        </li>
+      </ul>
+    </li>
+  );
+}
 
-const DocumentationMenu = () => (
-  <li className="documentation" tabIndex="-1">
-    <span className="menu-header">
-      {l('Documentation')}
-      {'\xA0\u25BE'}
-    </span>
-    <ul>
-      <li>
-        <a href="/doc/Beginners_Guide">{l('Beginners guide')}</a>
-      </li>
-      <li>
-        <a href="/doc/Style">{l('Style guidelines')}</a>
-      </li>
-      <li>
-        <a href="/doc/How_To">{l('How tos')}</a>
-      </li>
-      <li>
-        <a href="/doc/Frequently_Asked_Questions">{l('FAQs')}</a>
-      </li>
-      <li>
-        <a href="/doc/MusicBrainz_Documentation">
-          {l('Documentation index')}
-        </a>
-      </li>
-      <li className="separator">
-        <a href="/doc/Edit_Types">{lp('Edit types', 'noun')}</a>
-      </li>
-      <li>
-        <a href="/relationships">{l('Relationship types')}</a>
-      </li>
-      <li>
-        <a href="/instruments">{l('Instrument list')}</a>
-      </li>
-      <li>
-        <a href="/genres">{l('Genre list')}</a>
-      </li>
-      <li className="separator">
-        <a href="/doc/Development">{l('Development')}</a>
-      </li>
-    </ul>
-  </li>
-);
+component DocumentationMenu() {
+  return (
+    <li className="documentation" tabIndex="-1">
+      <span className="menu-header">
+        {l('Documentation')}
+        {'\xA0\u25BE'}
+      </span>
+      <ul>
+        <li>
+          <a href="/doc/Beginners_Guide">{l('Beginners guide')}</a>
+        </li>
+        <li>
+          <a href="/doc/Style">{l('Style guidelines')}</a>
+        </li>
+        <li>
+          <a href="/doc/How_To">{l('How tos')}</a>
+        </li>
+        <li>
+          <a href="/doc/Frequently_Asked_Questions">{l('FAQs')}</a>
+        </li>
+        <li>
+          <a href="/doc/MusicBrainz_Documentation">
+            {l('Documentation index')}
+          </a>
+        </li>
+        <li className="separator">
+          <a href="/doc/Edit_Types">{lp('Edit types', 'noun')}</a>
+        </li>
+        <li>
+          <a href="/relationships">{l('Relationship types')}</a>
+        </li>
+        <li>
+          <a href="/instruments">{l('Instrument list')}</a>
+        </li>
+        <li>
+          <a href="/genres">{l('Genre list')}</a>
+        </li>
+        <li className="separator">
+          <a href="/doc/Development">{l('Development')}</a>
+        </li>
+      </ul>
+    </li>
+  );
+}
 
-const BottomMenu = (): React$Element<'div'> => {
+component BottomMenu() {
   const $c = React.useContext(SanitizedCatalystContext);
   const serverLanguages = $c.stash.server_languages;
   return (
@@ -352,6 +351,6 @@ const BottomMenu = (): React$Element<'div'> => {
       </ul>
     </div>
   );
-};
+}
 
 export default BottomMenu;

--- a/root/layout/components/ExternalLinks.js
+++ b/root/layout/components/ExternalLinks.js
@@ -30,21 +30,13 @@ function faviconClass(urlEntity: UrlT) {
   return (matchingClass || 'no') + '-favicon';
 }
 
-type ExternalLinkProps = {
-  +className?: string,
-  +editsPending: boolean,
-  +entityCredit: string,
-  +text?: string,
-  +url: UrlT,
-};
-
-const ExternalLink = ({
-  className,
-  editsPending,
-  entityCredit,
-  text,
-  url,
-}: ExternalLinkProps) => {
+component ExternalLink(
+  className?: string,
+  editsPending: boolean,
+  entityCredit: string,
+  text?: string,
+  url: UrlT,
+) {
   let element: Expand2ReactOutput = (
     <a href={url.href_url}>
       {nonEmpty(text) ? text : url.sidebar_name}
@@ -71,19 +63,13 @@ const ExternalLink = ({
       {element}
     </li>
   );
-};
+}
 
-type Props = {
+component ExternalLinks(
   empty: boolean,
   entity: RelatableEntityT,
   heading?: string,
-};
-
-const ExternalLinks = ({
-  entity,
-  empty,
-  heading,
-}: Props): React$MixedElement | null => {
+) {
   const relationships = entity.relationships;
   if (!relationships) {
     return null;
@@ -183,6 +169,6 @@ const ExternalLinks = ({
       </ul>
     </>
   );
-};
+}
 
 export default ExternalLinks;

--- a/root/layout/components/FaviconLinks.js
+++ b/root/layout/components/FaviconLinks.js
@@ -7,79 +7,81 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const FaviconLinks = (): React.MixedElement => (
-  <>
-    <link
-      href="/static/images/favicons/apple-touch-icon-57x57.png"
-      rel="apple-touch-icon"
-      sizes="57x57"
-    />
-    <link
-      href="/static/images/favicons/apple-touch-icon-60x60.png"
-      rel="apple-touch-icon"
-      sizes="60x60"
-    />
-    <link
-      href="/static/images/favicons/apple-touch-icon-72x72.png"
-      rel="apple-touch-icon"
-      sizes="72x72"
-    />
-    <link
-      href="/static/images/favicons/apple-touch-icon-76x76.png"
-      rel="apple-touch-icon"
-      sizes="76x76"
-    />
-    <link
-      href="/static/images/favicons/apple-touch-icon-114x114.png"
-      rel="apple-touch-icon"
-      sizes="114x114"
-    />
-    <link
-      href="/static/images/favicons/apple-touch-icon-120x120.png"
-      rel="apple-touch-icon"
-      sizes="120x120"
-    />
-    <link
-      href="/static/images/favicons/apple-touch-icon-144x144.png"
-      rel="apple-touch-icon"
-      sizes="144x144"
-    />
-    <link
-      href="/static/images/favicons/apple-touch-icon-152x152.png"
-      rel="apple-touch-icon"
-      sizes="152x152"
-    />
-    <link
-      href="/static/images/favicons/apple-touch-icon-180x180.png"
-      rel="apple-touch-icon"
-      sizes="180x180"
-    />
-    <link
-      href="/static/images/favicons/favicon-32x32.png"
-      rel="icon"
-      sizes="32x32"
-      type="image/png"
-    />
-    <link
-      href="/static/images/favicons/favicon-16x16.png"
-      rel="icon"
-      sizes="16x16"
-      type="image/png"
-    />
-    <link href="/static/images/favicons/site.webmanifest" rel="manifest" />
-    <link
-      color="#bb4890"
-      href="/static/images/favicons/safari-pinned-tab.svg"
-      rel="mask-icon"
-    />
-    <link href="/favicon.ico" rel="shortcut icon" />
-    <meta content="#f1f1f1" name="msapplication-TileColor" />
-    <meta
-      content="/static/images/favicons/mstile-144x144.png"
-      name="msapplication-TileImage"
-    />
-    <meta content="#ffffff" name="theme-color" />
-  </>
-);
+component FaviconLinks() {
+  return (
+    <>
+      <link
+        href="/static/images/favicons/apple-touch-icon-57x57.png"
+        rel="apple-touch-icon"
+        sizes="57x57"
+      />
+      <link
+        href="/static/images/favicons/apple-touch-icon-60x60.png"
+        rel="apple-touch-icon"
+        sizes="60x60"
+      />
+      <link
+        href="/static/images/favicons/apple-touch-icon-72x72.png"
+        rel="apple-touch-icon"
+        sizes="72x72"
+      />
+      <link
+        href="/static/images/favicons/apple-touch-icon-76x76.png"
+        rel="apple-touch-icon"
+        sizes="76x76"
+      />
+      <link
+        href="/static/images/favicons/apple-touch-icon-114x114.png"
+        rel="apple-touch-icon"
+        sizes="114x114"
+      />
+      <link
+        href="/static/images/favicons/apple-touch-icon-120x120.png"
+        rel="apple-touch-icon"
+        sizes="120x120"
+      />
+      <link
+        href="/static/images/favicons/apple-touch-icon-144x144.png"
+        rel="apple-touch-icon"
+        sizes="144x144"
+      />
+      <link
+        href="/static/images/favicons/apple-touch-icon-152x152.png"
+        rel="apple-touch-icon"
+        sizes="152x152"
+      />
+      <link
+        href="/static/images/favicons/apple-touch-icon-180x180.png"
+        rel="apple-touch-icon"
+        sizes="180x180"
+      />
+      <link
+        href="/static/images/favicons/favicon-32x32.png"
+        rel="icon"
+        sizes="32x32"
+        type="image/png"
+      />
+      <link
+        href="/static/images/favicons/favicon-16x16.png"
+        rel="icon"
+        sizes="16x16"
+        type="image/png"
+      />
+      <link href="/static/images/favicons/site.webmanifest" rel="manifest" />
+      <link
+        color="#bb4890"
+        href="/static/images/favicons/safari-pinned-tab.svg"
+        rel="mask-icon"
+      />
+      <link href="/favicon.ico" rel="shortcut icon" />
+      <meta content="#f1f1f1" name="msapplication-TileColor" />
+      <meta
+        content="/static/images/favicons/mstile-144x144.png"
+        name="msapplication-TileImage"
+      />
+      <meta content="#ffffff" name="theme-color" />
+    </>
+  );
+}
 
 export default FaviconLinks;

--- a/root/layout/components/Footer.js
+++ b/root/layout/components/Footer.js
@@ -17,7 +17,7 @@ import {bracketedText}
 import formatUserDate from '../../utility/formatUserDate.js';
 import {returnToCurrentPage} from '../../utility/returnUri.js';
 
-const Footer = (): React$Element<'div'> => {
+component Footer() {
   const $c = React.useContext(CatalystContext);
   const stash = $c.stash;
   return (
@@ -92,6 +92,6 @@ const Footer = (): React$Element<'div'> => {
       </p>
     </div>
   );
-};
+}
 
 export default Footer;

--- a/root/layout/components/Head.js
+++ b/root/layout/components/Head.js
@@ -21,13 +21,6 @@ import FaviconLinks from './FaviconLinks.js';
 import globalsScript from './globalsScript.mjs';
 import MetaDescription from './MetaDescription.js';
 
-export type HeadProps = {
-  +isHomepage?: boolean,
-  +noIcons?: boolean,
-  +pager?: PagerT,
-  +title?: string,
-};
-
 const canonRegexp = new RegExp('^(https?:)?//' + DBDefs.WEB_SERVER);
 function canonicalize(url: string) {
   return DBDefs.CANONICAL_SERVER
@@ -64,12 +57,12 @@ const CanonicalLink = ({requestUri}: {+requestUri: string}) => {
   return null;
 };
 
-const Head = ({
-  isHomepage = false,
-  noIcons = false,
-  pager,
-  title,
-}: HeadProps): React$Element<'head'> => {
+component Head(
+  isHomepage: boolean = false,
+  noIcons: boolean = false,
+  pager?: PagerT,
+  title?: string,
+) {
   const $c = React.useContext(CatalystContext);
 
   return (
@@ -162,6 +155,6 @@ const Head = ({
       ) : null}
     </head>
   );
-};
+}
 
 export default Head;

--- a/root/layout/components/Header.js
+++ b/root/layout/components/Header.js
@@ -11,16 +11,18 @@ import BottomMenu from './BottomMenu.js';
 import HeaderLogo from './HeaderLogo.js';
 import TopMenu from './TopMenu.js';
 
-const Header = (): React$Element<'div'> => (
-  <div className="header">
-    <a className="logo" href="/" title="MusicBrainz">
-      <HeaderLogo />
-    </a>
-    <div className="right">
-      <TopMenu />
-      <BottomMenu />
+component Header() {
+  return (
+    <div className="header">
+      <a className="logo" href="/" title="MusicBrainz">
+        <HeaderLogo />
+      </a>
+      <div className="right">
+        <TopMenu />
+        <BottomMenu />
+      </div>
     </div>
-  </div>
-);
+  );
+}
 
 export default Header;

--- a/root/layout/components/HeaderLogo.js
+++ b/root/layout/components/HeaderLogo.js
@@ -10,12 +10,14 @@
 import headerLogoSvgUrl
   from '../../static/images/layout/header-logo.svg';
 
-const HeaderLogo = (): React$Element<'img'> => (
-  <img
-    alt="MusicBrainz"
-    className="logo"
-    src={headerLogoSvgUrl}
-  />
-);
+component HeaderLogo() {
+  return (
+    <img
+      alt="MusicBrainz"
+      className="logo"
+      src={headerLogoSvgUrl}
+    />
+  );
+}
 
 export default HeaderLogo;

--- a/root/layout/components/MergeHelper.js
+++ b/root/layout/components/MergeHelper.js
@@ -14,11 +14,7 @@ import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink.js';
 import {returnToCurrentPage} from '../../utility/returnUri.js';
 
-type Props = {
-  +merger: MergeQueueT,
-};
-
-const MergeHelper = ({merger}: Props): React$Element<'div'> => {
+component MergeHelper(merger: MergeQueueT) {
   const $c = React.useContext(CatalystContext);
 
   return (
@@ -86,6 +82,6 @@ const MergeHelper = ({merger}: Props): React$Element<'div'> => {
       </form>
     </div>
   );
-};
+}
 
 export default MergeHelper;

--- a/root/layout/components/MetaDescription.js
+++ b/root/layout/components/MetaDescription.js
@@ -184,11 +184,7 @@ function workDescription(work: WorkT) {
   return desc;
 }
 
-type Props = {
-  +entity: ?RelatableEntityT,
-};
-
-const MetaDescription = ({entity}: Props): React$Element<'meta'> | null => {
+component MetaDescription(entity: ?RelatableEntityT) {
   if (!entity) {
     return null;
   }
@@ -220,6 +216,6 @@ const MetaDescription = ({entity}: Props): React$Element<'meta'> | null => {
     return <meta content={desc.join(', ')} name="description" />;
   }
   return null;
-};
+}
 
 export default MetaDescription;

--- a/root/layout/components/Search.js
+++ b/root/layout/components/Search.js
@@ -66,48 +66,52 @@ function compareTypeOptionEntries(
   );
 }
 
-const SearchOptions = () => (
-  <select id="headerid-type" name="type">
-    {TYPE_OPTION_GROUPS.map((group) => (
-      Object.entries(group)
-        .sort(compareTypeOptionEntries)
-        .map(([key, option]) => {
-          const text = localizedTypeOption(option);
-          if (!text) {
-            return null;
-          }
-          return (
-            <option key={key} value={key}>
-              {text}
-            </option>
-          );
-        })
-      ))}
-  </select>
-);
+component SearchOptions() {
+  return (
+    <select id="headerid-type" name="type">
+      {TYPE_OPTION_GROUPS.map((group) => (
+        Object.entries(group)
+          .sort(compareTypeOptionEntries)
+          .map(([key, option]) => {
+            const text = localizedTypeOption(option);
+            if (!text) {
+              return null;
+            }
+            return (
+              <option key={key} value={key}>
+                {text}
+              </option>
+            );
+          })
+        ))}
+    </select>
+  );
+}
 
-const Search = (): React$Element<'form'> => (
-  <form action="/search" method="get">
-    <input
-      id="headerid-query"
-      name="query"
-      placeholder={l('Search')}
-      required
-      type="text"
-    />
-    {' '}
-    <SearchOptions />
-    {' '}
-    <input
-      id="headerid-method"
-      name="method"
-      type="hidden"
-      value="indexed"
-    />
-    <button type="submit">
-      <SearchIcon />
-    </button>
-  </form>
-);
+component Search() {
+  return (
+    <form action="/search" method="get">
+      <input
+        id="headerid-query"
+        name="query"
+        placeholder={l('Search')}
+        required
+        type="text"
+      />
+      {' '}
+      <SearchOptions />
+      {' '}
+      <input
+        id="headerid-method"
+        name="method"
+        type="hidden"
+        value="indexed"
+      />
+      <button type="submit">
+        <SearchIcon />
+      </button>
+    </form>
+  );
+}
 
 export default Search;

--- a/root/layout/components/TopMenu.js
+++ b/root/layout/components/TopMenu.js
@@ -27,15 +27,7 @@ function userLink(userName: string, path: string) {
   return `/user/${encodeURIComponent(userName)}${path}`;
 }
 
-type UserProp = {+user: UnsanitizedEditorT};
-
-type AccountMenuPropsT = {
-  +user: UnsanitizedEditorT,
-};
-
-const AccountMenu = ({
-  user,
-}: AccountMenuPropsT) => {
+component AccountMenu(user: UnsanitizedEditorT) {
   const $c = React.useContext(CatalystContext);
   return (
     <li className="account" tabIndex="-1">
@@ -71,9 +63,9 @@ const AccountMenu = ({
       </ul>
     </li>
   );
-};
+}
 
-const DataMenu = ({user}: UserProp) => {
+component DataMenu(user: UnsanitizedEditorT) {
   const userName = user.name;
 
   return (
@@ -116,79 +108,83 @@ const DataMenu = ({user}: UserProp) => {
       </ul>
     </li>
   );
-};
+}
 
-const AdminMenu = ({user}: UserProp) => (
-  <li className="admin" tabIndex="-1">
-    <span className="menu-header">
-      {l('Admin')}
-      {'\xA0\u25BE'}
-    </span>
-    <ul>
-      {isLocationEditor(user) ? (
-        <li>
-          <a href="/area/create">{l_admin('Add area')}</a>
-        </li>
-      ) : null}
+component AdminMenu(user: UnsanitizedEditorT) {
+  return (
+    <li className="admin" tabIndex="-1">
+      <span className="menu-header">
+        {l('Admin')}
+        {'\xA0\u25BE'}
+      </span>
+      <ul>
+        {isLocationEditor(user) ? (
+          <li>
+            <a href="/area/create">{l_admin('Add area')}</a>
+          </li>
+        ) : null}
 
-      {isRelationshipEditor(user) ? (
-        <>
-          <li>
-            <a href="/instrument/create">
-              {l_admin('Add instrument')}
-            </a>
-          </li>
-          <li>
-            <a href="/genre/create">{l_admin('Add genre')}</a>
-          </li>
-          <li>
-            <a href="/relationships">{l_admin('Edit relationship types')}</a>
-          </li>
-        </>
-      ) : null}
+        {isRelationshipEditor(user) ? (
+          <>
+            <li>
+              <a href="/instrument/create">
+                {l_admin('Add instrument')}
+              </a>
+            </li>
+            <li>
+              <a href="/genre/create">{l_admin('Add genre')}</a>
+            </li>
+            <li>
+              <a href="/relationships">
+                {l_admin('Edit relationship types')}
+              </a>
+            </li>
+          </>
+        ) : null}
 
-      {isWikiTranscluder(user) ? (
-        <li>
-          <a href="/admin/wikidoc">{l_admin('Transclude WikiDocs')}</a>
-        </li>
-      ) : null}
+        {isWikiTranscluder(user) ? (
+          <li>
+            <a href="/admin/wikidoc">{l_admin('Transclude WikiDocs')}</a>
+          </li>
+        ) : null}
 
-      {isBannerEditor(user) ? (
-        <li>
-          <a href="/admin/banner/edit">{l_admin('Edit banner message')}</a>
-        </li>
-      ) : null}
+        {isBannerEditor(user) ? (
+          <li>
+            <a href="/admin/banner/edit">{l_admin('Edit banner message')}</a>
+          </li>
+        ) : null}
 
-      {isAccountAdmin(user) ? (
-        <>
-          <li>
-            <a href="/admin/attributes">{l_admin('Edit attributes')}</a>
-          </li>
-          <li>
-            <a href="/admin/statistics-events">
-              {l_admin('Edit statistics events')}
-            </a>
-          </li>
-          <li>
-            <a href="/admin/email-search">{l_admin('Email search')}</a>
-          </li>
-          <li>
-            <a href="/admin/privilege-search">
-              {l_admin('Privilege search')}
-            </a>
-          </li>
-          <li>
-            <a href="/admin/locked-usernames/search">
-              {l_admin('Locked username search')}
-            </a>
-          </li>
-        </>
-      ) : null}
-    </ul>
-  </li>
-);
+        {isAccountAdmin(user) ? (
+          <>
+            <li>
+              <a href="/admin/attributes">{l_admin('Edit attributes')}</a>
+            </li>
+            <li>
+              <a href="/admin/statistics-events">
+                {l_admin('Edit statistics events')}
+              </a>
+            </li>
+            <li>
+              <a href="/admin/email-search">{l_admin('Email search')}</a>
+            </li>
+            <li>
+              <a href="/admin/privilege-search">
+                {l_admin('Privilege search')}
+              </a>
+            </li>
+            <li>
+              <a href="/admin/locked-usernames/search">
+                {l_admin('Locked username search')}
+              </a>
+            </li>
+          </>
+        ) : null}
+      </ul>
+    </li>
+  );
+}
 
-const UserMenu = () => {
+component UserMenu() {
   const $c = React.useContext(CatalystContext);
   return (
     <ul className="menu" tabIndex="-1">
@@ -212,17 +208,19 @@ const UserMenu = () => {
       )}
     </ul>
   );
-};
+}
 
-const TopMenu = (): React$Element<'div'> => (
-  <div className="top">
-    <div className="links-container">
-      <UserMenu />
+component TopMenu() {
+  return (
+    <div className="top">
+      <div className="links-container">
+        <UserMenu />
+      </div>
+      <div className="search-container">
+        <Search />
+      </div>
     </div>
-    <div className="search-container">
-      <Search />
-    </div>
-  </div>
-);
+  );
+}
 
 export default TopMenu;

--- a/root/layout/components/sidebar/AnnotationLinks.js
+++ b/root/layout/components/sidebar/AnnotationLinks.js
@@ -13,13 +13,7 @@ import {CatalystContext} from '../../../context.mjs';
 import entityHref from '../../../static/scripts/common/utility/entityHref.js';
 import returnUri from '../../../utility/returnUri.js';
 
-type Props = {
-  +entity: AnnotatedEntityT,
-};
-
-const AnnotationLinks = ({
-  entity,
-}: Props): React.MixedElement => {
+component AnnotationLinks(entity: AnnotatedEntityT) {
   const $c = React.useContext(CatalystContext);
   const numberOfRevisions = $c.stash.number_of_revisions ?? 0;
 
@@ -47,6 +41,6 @@ const AnnotationLinks = ({
       ) : null}
     </>
   );
-};
+}
 
 export default AnnotationLinks;

--- a/root/layout/components/sidebar/AreaSidebar.js
+++ b/root/layout/components/sidebar/AreaSidebar.js
@@ -30,11 +30,7 @@ import {SidebarProperties, SidebarProperty} from './SidebarProperties.js';
 import SidebarTags from './SidebarTags.js';
 import SidebarType from './SidebarType.js';
 
-type Props = {
-  +area: AreaT,
-};
-
-const AreaSidebar = ({area}: Props): React$Element<'div'> => {
+component AreaSidebar(area: AreaT) {
   const $c = React.useContext(CatalystContext);
   const areaAge = age.age(area);
 
@@ -120,6 +116,6 @@ const AreaSidebar = ({area}: Props): React$Element<'div'> => {
       <LastUpdated entity={area} />
     </div>
   );
-};
+}
 
 export default AreaSidebar;

--- a/root/layout/components/sidebar/ArtistSidebar.js
+++ b/root/layout/components/sidebar/ArtistSidebar.js
@@ -44,11 +44,7 @@ import SidebarTags from './SidebarTags.js';
 import SidebarType from './SidebarType.js';
 import SubscriptionLinks from './SubscriptionLinks.js';
 
-type Props = {
-  +artist: ArtistT,
-};
-
-const ArtistSidebar = ({artist}: Props): React$Element<'div'> => {
+component ArtistSidebar(artist: ArtistT) {
   const $c = React.useContext(CatalystContext);
   const artistAge = age.age(artist);
   const gid = encodeURIComponent(artist.gid);
@@ -198,6 +194,6 @@ const ArtistSidebar = ({artist}: Props): React$Element<'div'> => {
       <LastUpdated entity={artist} />
     </div>
   );
-};
+}
 
 export default ArtistSidebar;

--- a/root/layout/components/sidebar/CDStubSidebar.js
+++ b/root/layout/components/sidebar/CDStubSidebar.js
@@ -18,11 +18,7 @@ import {
 
 import {SidebarProperties, SidebarProperty} from './SidebarProperties.js';
 
-type Props = {
-  +cdstub: CDStubT,
-};
-
-const CDStubSidebar = ({cdstub}: Props): React$Element<'div'> => {
+component CDStubSidebar(cdstub: CDStubT) {
   const artistField =
     escapeLuceneValue(cdstub.artist || l('Various Artists'));
   const releaseField = escapeLuceneValue(cdstub.title);
@@ -100,6 +96,6 @@ const CDStubSidebar = ({cdstub}: Props): React$Element<'div'> => {
       </ul>
     </div>
   );
-};
+}
 
 export default CDStubSidebar;

--- a/root/layout/components/sidebar/CollectionLinks.js
+++ b/root/layout/components/sidebar/CollectionLinks.js
@@ -15,10 +15,6 @@ import EntityLink
 
 import CollectionList from './CollectionList.js';
 
-type Props = {
-  +entity: CollectableEntityT,
-};
-
 const noCollectionsStrings = {
   area: N_l('You have no area collections!'),
   artist: N_l('You have no artist collections!'),
@@ -34,9 +30,7 @@ const noCollectionsStrings = {
   work: N_l('You have no work collections!'),
 };
 
-const CollectionLinks = ({
-  entity,
-}: Props): React$Element<typeof CollectionList> | null => {
+component CollectionLinks(entity: CollectableEntityT) {
   const $c = React.useContext(CatalystContext);
   const numberOfCollections = $c.stash.number_of_collections || 0;
   const userExists = Boolean($c.user);
@@ -67,6 +61,6 @@ const CollectionLinks = ({
       usersLinkHeader={l('Other collections')}
     />
   );
-};
+}
 
 export default CollectionLinks;

--- a/root/layout/components/sidebar/CollectionList.js
+++ b/root/layout/components/sidebar/CollectionList.js
@@ -37,150 +37,126 @@ function hasEntity(
   return !!(containment && containment[collection.id]);
 }
 
-type CollectionAddRemoveProps = {
-  +collections?: $ReadOnlyArray<CollectionT>,
-  +entity: CollectableEntityT,
-  +noneText?: string,
-};
+component CollectionAddRemove(
+  collections?: $ReadOnlyArray<CollectionT>,
+  entity: CollectableEntityT,
+  noneText?: string,
+) {
+  return (
+    collections?.length ? (
+      collections.map(collection => (
+        <li key={collection.id}>
+          <CatalystContext.Consumer>
+            {$c => (
+              hasEntity($c, collection) ? (
+                <a href={collectionUrl($c, collection, entity, 'remove')}>
+                  {texp.l(
+                    'Remove from {collection}', {collection: collection.name},
+                  )}
+                </a>
+              ) : (
+                <a href={collectionUrl($c, collection, entity, 'add')}>
+                  {texp.l('Add to {collection}',
+                          {collection: collection.name})}
+                </a>
+              )
+            )}
+          </CatalystContext.Consumer>
+        </li>
+      ))
+    ) : <li>{noneText}</li>
+  );
+}
 
-type CollaborativeCollectionListProps = {
-  +collections?: $ReadOnlyArray<CollectionT>,
-  +entity: CollectableEntityT,
-};
-
-type OwnCollectionListProps = {
-  +addText: string,
-  +collections?: $ReadOnlyArray<CollectionT>,
-  +entity: CollectableEntityT,
-  +noneText: string,
-};
-
-type CollectionListProps = {
-  +addCollectionText: string,
-  +collaborativeCollections?: $ReadOnlyArray<CollectionT>,
-  +collaborativeCollectionsHeader: string,
-  +entity: CollectableEntityT,
-  +header: string,
-  +ownCollections?: $ReadOnlyArray<CollectionT>,
-  +ownCollectionsHeader: string,
-  +ownCollectionsNoneText: string,
-  +sectionClass: string,
-  +userExists: boolean,
-  +usersLink: React$Element<EntityLink>,
-  +usersLinkHeader: string,
-};
-
-const CollectionAddRemove = ({
-  collections,
-  entity,
-  noneText,
-}: CollectionAddRemoveProps) => (
-  collections?.length ? (
-    collections.map(collection => (
-      <li key={collection.id}>
-        <CatalystContext.Consumer>
-          {$c => (
-            hasEntity($c, collection) ? (
-              <a href={collectionUrl($c, collection, entity, 'remove')}>
-                {texp.l(
-                  'Remove from {collection}', {collection: collection.name},
-                )}
-              </a>
-            ) : (
-              <a href={collectionUrl($c, collection, entity, 'add')}>
-                {texp.l('Add to {collection}', {collection: collection.name})}
-              </a>
-            )
-          )}
-        </CatalystContext.Consumer>
-      </li>
-    ))
-  ) : <li>{noneText}</li>
-);
-
-const CollaborativeCollectionList = ({
-  collections,
-  entity,
-}: CollaborativeCollectionListProps) => (
-  <ul className="links">
-    <CollectionAddRemove
-      collections={collections}
-      entity={entity}
-    />
-    <li className="separator" role="separator" />
-  </ul>
-);
-
-const OwnCollectionList = ({
-  addText,
-  collections,
-  entity,
-  noneText,
-}: OwnCollectionListProps) => (
-  <ul className="links">
-    <CollectionAddRemove
-      collections={collections}
-      entity={entity}
-      noneText={noneText}
-    />
-    <li>
-      <a href={'/collection/create' + entityArg(entity)}>
-        {addText}
-      </a>
-    </li>
-    <li className="separator" role="separator" />
-  </ul>
-);
-
-const CollectionList = ({
-  addCollectionText,
-  collaborativeCollections,
-  collaborativeCollectionsHeader,
-  entity,
-  header,
-  ownCollections,
-  ownCollectionsHeader,
-  ownCollectionsNoneText,
-  sectionClass,
-  userExists,
-  usersLink,
-  usersLinkHeader,
-}: CollectionListProps): React$MixedElement => (
-  <>
-    <h2 className={sectionClass}>
-      {header}
-    </h2>
-    {userExists ? (
-      <>
-        <h3>
-          {ownCollectionsHeader}
-        </h3>
-        <OwnCollectionList
-          addText={addCollectionText}
-          collections={ownCollections}
-          entity={entity}
-          noneText={ownCollectionsNoneText}
-        />
-        {collaborativeCollections?.length ? (
-          <>
-            <h3>
-              {collaborativeCollectionsHeader}
-            </h3>
-            <CollaborativeCollectionList
-              collections={collaborativeCollections}
-              entity={entity}
-            />
-          </>
-        ) : null}
-        <h3>
-          {usersLinkHeader}
-        </h3>
-      </>
-    ) : null}
+component CollaborativeCollectionList(
+  collections?: $ReadOnlyArray<CollectionT>,
+  entity: CollectableEntityT,
+) {
+  return (
     <ul className="links">
-      <li>{usersLink}</li>
+      <CollectionAddRemove
+        collections={collections}
+        entity={entity}
+      />
+      <li className="separator" role="separator" />
     </ul>
-  </>
-);
+  );
+}
+
+component OwnCollectionList(
+  addText: string,
+  collections?: $ReadOnlyArray<CollectionT>,
+  entity: CollectableEntityT,
+  noneText: string,
+) {
+  return (
+    <ul className="links">
+      <CollectionAddRemove
+        collections={collections}
+        entity={entity}
+        noneText={noneText}
+      />
+      <li>
+        <a href={'/collection/create' + entityArg(entity)}>
+          {addText}
+        </a>
+      </li>
+      <li className="separator" role="separator" />
+    </ul>
+  );
+}
+
+component CollectionList(
+  addCollectionText: string,
+  collaborativeCollections?: $ReadOnlyArray<CollectionT>,
+  collaborativeCollectionsHeader: string,
+  entity: CollectableEntityT,
+  header: string,
+  ownCollections?: $ReadOnlyArray<CollectionT>,
+  ownCollectionsHeader: string,
+  ownCollectionsNoneText: string,
+  sectionClass: string,
+  userExists: boolean,
+  usersLink: React$Element<EntityLink>,
+  usersLinkHeader: string,
+) {
+  return (
+    <>
+      <h2 className={sectionClass}>
+        {header}
+      </h2>
+      {userExists ? (
+        <>
+          <h3>
+            {ownCollectionsHeader}
+          </h3>
+          <OwnCollectionList
+            addText={addCollectionText}
+            collections={ownCollections}
+            entity={entity}
+            noneText={ownCollectionsNoneText}
+          />
+          {collaborativeCollections?.length ? (
+            <>
+              <h3>
+                {collaborativeCollectionsHeader}
+              </h3>
+              <CollaborativeCollectionList
+                collections={collaborativeCollections}
+                entity={entity}
+              />
+            </>
+          ) : null}
+          <h3>
+            {usersLinkHeader}
+          </h3>
+        </>
+      ) : null}
+      <ul className="links">
+        <li>{usersLink}</li>
+      </ul>
+    </>
+  );
+}
 
 export default CollectionList;

--- a/root/layout/components/sidebar/CollectionSidebar.js
+++ b/root/layout/components/sidebar/CollectionSidebar.js
@@ -21,15 +21,10 @@ import MergeLink from './MergeLink.js';
 import PlayOnListenBrainzButton from './PlayOnListenBrainzButton.js';
 import {SidebarProperties, SidebarProperty} from './SidebarProperties.js';
 
-type Props = {
-  +collection: CollectionT,
-  +recordingMbids?: $ReadOnlyArray<string> | null,
-};
-
-const CollectionSidebar = ({
-  collection,
-  recordingMbids,
-}: Props): React$Element<'div'> => {
+component CollectionSidebar(
+  collection: CollectionT,
+  recordingMbids?: $ReadOnlyArray<string> | null,
+) {
   const $c = React.useContext(CatalystContext);
   const typeName = collection.typeName;
   const owner = collection.editor;
@@ -132,6 +127,6 @@ const CollectionSidebar = ({
       ) : null}
     </div>
   );
-};
+}
 
 export default CollectionSidebar;

--- a/root/layout/components/sidebar/EditLinks.js
+++ b/root/layout/components/sidebar/EditLinks.js
@@ -14,17 +14,11 @@ import {CatalystContext} from '../../../context.mjs';
 import EntityLink
   from '../../../static/scripts/common/components/EntityLink.js';
 
-type Props = {
-  +children?: React$Node,
-  +entity: EditableEntityT,
-  +requiresPrivileges?: boolean,
-};
-
-const EditLinks = ({
-  children,
-  entity,
-  requiresPrivileges = false,
-}: Props): React.MixedElement => {
+component EditLinks(
+  children?: React$Node,
+  entity: EditableEntityT,
+  requiresPrivileges: boolean = false,
+) {
   const $c = React.useContext(CatalystContext);
   return (
     <>
@@ -55,6 +49,6 @@ const EditLinks = ({
       </ul>
     </>
   );
-};
+}
 
 export default EditLinks;

--- a/root/layout/components/sidebar/EventSidebar.js
+++ b/root/layout/components/sidebar/EventSidebar.js
@@ -31,11 +31,7 @@ import SidebarRating from './SidebarRating.js';
 import SidebarTags from './SidebarTags.js';
 import SidebarType from './SidebarType.js';
 
-type Props = {
-  +event: EventT,
-};
-
-const EventSidebar = ({event}: Props): React$Element<'div'> => {
+component EventSidebar(event: EventT) {
   const $c = React.useContext(CatalystContext);
   const hasBegin = !isDateEmpty(event.begin_date);
   const hasEnd = !isDateEmpty(event.end_date);
@@ -109,6 +105,6 @@ const EventSidebar = ({event}: Props): React$Element<'div'> => {
       <LastUpdated entity={event} />
     </div>
   );
-};
+}
 
 export default EventSidebar;

--- a/root/layout/components/sidebar/GenreSidebar.js
+++ b/root/layout/components/sidebar/GenreSidebar.js
@@ -20,11 +20,7 @@ import EditLinks from './EditLinks.js';
 import LastUpdated from './LastUpdated.js';
 import RemoveLink from './RemoveLink.js';
 
-type Props = {
-  +genre: GenreT,
-};
-
-const GenreSidebar = ({genre}: Props): React$Element<'div'> => {
+component GenreSidebar(genre: GenreT) {
   const $c = React.useContext(CatalystContext);
 
   return (
@@ -46,6 +42,6 @@ const GenreSidebar = ({genre}: Props): React$Element<'div'> => {
       <LastUpdated entity={genre} />
     </div>
   );
-};
+}
 
 export default GenreSidebar;

--- a/root/layout/components/sidebar/InstrumentSidebar.js
+++ b/root/layout/components/sidebar/InstrumentSidebar.js
@@ -29,11 +29,7 @@ import {SidebarProperties} from './SidebarProperties.js';
 import SidebarTags from './SidebarTags.js';
 import SidebarType from './SidebarType.js';
 
-type Props = {
-  +instrument: InstrumentT,
-};
-
-const InstrumentSidebar = ({instrument}: Props): React$Element<'div'> => {
+component InstrumentSidebar(instrument: InstrumentT) {
   const $c = React.useContext(CatalystContext);
 
   return (
@@ -82,6 +78,6 @@ const InstrumentSidebar = ({instrument}: Props): React$Element<'div'> => {
       <LastUpdated entity={instrument} />
     </div>
   );
-};
+}
 
 export default InstrumentSidebar;

--- a/root/layout/components/sidebar/LabelSidebar.js
+++ b/root/layout/components/sidebar/LabelSidebar.js
@@ -36,11 +36,7 @@ import SidebarTags from './SidebarTags.js';
 import SidebarType from './SidebarType.js';
 import SubscriptionLinks from './SubscriptionLinks.js';
 
-type Props = {
-  +label: LabelT,
-};
-
-const LabelSidebar = ({label}: Props): React$Element<'div'> => {
+component LabelSidebar(label: LabelT) {
   const $c = React.useContext(CatalystContext);
   const labelAge = age.age(label);
   const gid = encodeURIComponent(label.gid);
@@ -126,6 +122,6 @@ const LabelSidebar = ({label}: Props): React$Element<'div'> => {
       <LastUpdated entity={label} />
     </div>
   );
-};
+}
 
 export default LabelSidebar;

--- a/root/layout/components/sidebar/LastUpdated.js
+++ b/root/layout/components/sidebar/LastUpdated.js
@@ -10,11 +10,7 @@
 import {CatalystContext} from '../../../context.mjs';
 import formatUserDate from '../../../utility/formatUserDate.js';
 
-type Props = {
-  +entity: $ReadOnly<{...LastUpdateRoleT, ...}>,
-};
-
-const LastUpdated = ({entity}: Props): React$Element<'p'> => {
+component LastUpdated(entity: $ReadOnly<{...LastUpdateRoleT, ...}>) {
   const lastUpdated = entity.last_updated;
   return (
     <p className="lastupdate">
@@ -29,6 +25,6 @@ const LastUpdated = ({entity}: Props): React$Element<'p'> => {
       )}
     </p>
   );
-};
+}
 
 export default LastUpdated;

--- a/root/layout/components/sidebar/MergeLink.js
+++ b/root/layout/components/sidebar/MergeLink.js
@@ -12,10 +12,6 @@ import * as React from 'react';
 import {CatalystContext} from '../../../context.mjs';
 import {returnToCurrentPage} from '../../../utility/returnUri.js';
 
-type Props = {
-  +entity: MergeableEntityT,
-};
-
 const mergeUrl = (
   $c: CatalystContextT,
   entity: MergeableEntityT,
@@ -26,7 +22,7 @@ const mergeUrl = (
     returnToCurrentPage($c);
 };
 
-const MergeLink = ({entity}: Props): React$Element<'li'> => {
+component MergeLink(entity: MergeableEntityT) {
   const $c = React.useContext(CatalystContext);
   return (
     <li>
@@ -35,6 +31,6 @@ const MergeLink = ({entity}: Props): React$Element<'li'> => {
       </a>
     </li>
   );
-};
+}
 
 export default MergeLink;

--- a/root/layout/components/sidebar/PlaceSidebar.js
+++ b/root/layout/components/sidebar/PlaceSidebar.js
@@ -33,11 +33,7 @@ import SidebarRating from './SidebarRating.js';
 import SidebarTags from './SidebarTags.js';
 import SidebarType from './SidebarType.js';
 
-type Props = {
-  +place: PlaceT,
-};
-
-const PlaceSidebar = ({place}: Props): React$Element<'div'> => {
+component PlaceSidebar(place: PlaceT) {
   const $c = React.useContext(CatalystContext);
   const placeAge = age.age(place);
   const gid = encodeURIComponent(place.gid);
@@ -138,6 +134,6 @@ const PlaceSidebar = ({place}: Props): React$Element<'div'> => {
       <LastUpdated entity={place} />
     </div>
   );
-};
+}
 
 export default PlaceSidebar;

--- a/root/layout/components/sidebar/PlayOnListenBrainzButton.js
+++ b/root/layout/components/sidebar/PlayOnListenBrainzButton.js
@@ -10,11 +10,6 @@
 import listenBrainzIconUrl
   from '../../../static/images/icons/listenbrainz.png';
 
-type Props = {
-  +entityType: 'release' | 'recording',
-  +mbids: string | $ReadOnlyArray<string>,
-};
-
 function getListenBrainzLink(
   entityType: 'release' | 'recording',
   mbids: string | $ReadOnlyArray<string>,
@@ -38,10 +33,10 @@ function getListenBrainzLink(
   return null;
 }
 
-const PlayOnListenBrainzButton = ({
-  entityType,
-  mbids,
-}: Props): React$Element<'a'> | null => {
+component PlayOnListenBrainzButton(
+  entityType: 'release' | 'recording',
+  mbids: string | $ReadOnlyArray<string>,
+) {
   const link = getListenBrainzLink(entityType, mbids);
 
   if (link == null) {
@@ -64,6 +59,6 @@ const PlayOnListenBrainzButton = ({
       {l('Play on ListenBrainz')}
     </a>
   );
-};
+}
 
 export default PlayOnListenBrainzButton;

--- a/root/layout/components/sidebar/RecordingSidebar.js
+++ b/root/layout/components/sidebar/RecordingSidebar.js
@@ -27,11 +27,7 @@ import {SidebarProperties, SidebarProperty} from './SidebarProperties.js';
 import SidebarRating from './SidebarRating.js';
 import SidebarTags from './SidebarTags.js';
 
-type Props = {
-  +recording: RecordingWithArtistCreditT,
-};
-
-const RecordingSidebar = ({recording}: Props): React$Element<'div'> => {
+component RecordingSidebar(recording: RecordingWithArtistCreditT) {
   const firstReleaseYear = recording.first_release_date?.year;
 
   return (
@@ -103,6 +99,6 @@ const RecordingSidebar = ({recording}: Props): React$Element<'div'> => {
       <LastUpdated entity={recording} />
     </div>
   );
-};
+}
 
 export default RecordingSidebar;

--- a/root/layout/components/sidebar/ReleaseGroupSidebar.js
+++ b/root/layout/components/sidebar/ReleaseGroupSidebar.js
@@ -25,15 +25,10 @@ import {SidebarProperties, SidebarProperty} from './SidebarProperties.js';
 import SidebarRating from './SidebarRating.js';
 import SidebarTags from './SidebarTags.js';
 
-type Props = {
-  +firstReleaseGid?: string | null,
-  +releaseGroup: ReleaseGroupT,
-};
-
-const ReleaseGroupSidebar = ({
-  firstReleaseGid,
-  releaseGroup,
-}: Props): React$Element<'div'> => {
+component ReleaseGroupSidebar(
+  firstReleaseGid?: string | null,
+  releaseGroup: ReleaseGroupT,
+) {
   const gid = encodeURIComponent(releaseGroup.gid);
   const typeName = releaseGroupType(releaseGroup);
 
@@ -103,6 +98,6 @@ const ReleaseGroupSidebar = ({
       <LastUpdated entity={releaseGroup} />
     </div>
   );
-};
+}
 
 export default ReleaseGroupSidebar;

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -47,11 +47,7 @@ import {SidebarProperties, SidebarProperty} from './SidebarProperties.js';
 import SidebarRating from './SidebarRating.js';
 import SidebarTags from './SidebarTags.js';
 
-type Props = {
-  +release: ReleaseT,
-};
-
-const ReleaseSidebar = ({release}: Props): React$Element<'div'> | null => {
+component ReleaseSidebar(release: ReleaseT) {
   const $c = React.useContext(CatalystContext);
 
   const releaseGroup = release.releaseGroup;
@@ -309,6 +305,6 @@ const ReleaseSidebar = ({release}: Props): React$Element<'div'> | null => {
       <LastUpdated entity={release} />
     </div>
   );
-};
+}
 
 export default ReleaseSidebar;

--- a/root/layout/components/sidebar/RemoveLink.js
+++ b/root/layout/components/sidebar/RemoveLink.js
@@ -12,17 +12,9 @@ import * as React from 'react';
 import {CatalystContext} from '../../../context.mjs';
 import entityHref from '../../../static/scripts/common/utility/entityHref.js';
 
-type Props = {
-  +entity:
-    | AreaT
-    | GenreT
-    | InstrumentT
-    | LabelT
-    | RecordingT
-    | ReleaseT,
-};
-
-const RemoveLink = ({entity}: Props): React$Element<'li'> | null => {
+component RemoveLink(
+  entity: AreaT | GenreT | InstrumentT | LabelT | RecordingT | ReleaseT,
+) {
   const $c = React.useContext(CatalystContext);
   if (!$c.stash.can_delete /*:: === true */) {
     return null;
@@ -35,6 +27,6 @@ const RemoveLink = ({entity}: Props): React$Element<'li'> | null => {
       </a>
     </li>
   );
-};
+}
 
 export default RemoveLink;

--- a/root/layout/components/sidebar/SeriesSidebar.js
+++ b/root/layout/components/sidebar/SeriesSidebar.js
@@ -27,11 +27,7 @@ import SidebarTags from './SidebarTags.js';
 import SidebarType from './SidebarType.js';
 import SubscriptionLinks from './SubscriptionLinks.js';
 
-type Props = {
-  +series: SeriesT,
-};
-
-const SeriesSidebar = ({series}: Props): React$Element<'div'> => {
+component SeriesSidebar(series: SeriesT) {
   const $c = React.useContext(CatalystContext);
 
   return (
@@ -80,6 +76,6 @@ const SeriesSidebar = ({series}: Props): React$Element<'div'> => {
       <LastUpdated entity={series} />
     </div>
   );
-};
+}
 
 export default SeriesSidebar;

--- a/root/layout/components/sidebar/SidebarBeginDate.js
+++ b/root/layout/components/sidebar/SidebarBeginDate.js
@@ -16,27 +16,23 @@ import {displayAgeAgo} from '../../../utility/age.js';
 
 import {SidebarProperty} from './SidebarProperties.js';
 
-type Props = {
-  +age?: [number, number, number] | null,
-  +entity: $ReadOnly<{...DatePeriodRoleT, ...}>,
-  +label: string,
-};
-
-const SidebarBeginDate = ({
-  age,
-  entity,
-  label,
-}: Props): React$MixedElement | null => (
-  isDateEmpty(entity.begin_date) ? (
-    null
-  ) : (
-    <SidebarProperty className="begin-date" label={label}>
-      {formatDate(entity.begin_date)}
-      {(age && isDateEmpty(entity.end_date))
-        ? ' ' + bracketedText(displayAgeAgo(age))
-        : null}
-    </SidebarProperty>
-  )
-);
+component SidebarBeginDate(
+  age?: [number, number, number] | null,
+  entity: $ReadOnly<{...DatePeriodRoleT, ...}>,
+  label: string,
+) {
+  return (
+    isDateEmpty(entity.begin_date) ? (
+      null
+    ) : (
+      <SidebarProperty className="begin-date" label={label}>
+        {formatDate(entity.begin_date)}
+        {(age && isDateEmpty(entity.end_date))
+          ? ' ' + bracketedText(displayAgeAgo(age))
+          : null}
+      </SidebarProperty>
+    )
+  );
+}
 
 export default SidebarBeginDate;

--- a/root/layout/components/sidebar/SidebarDataQuality.js
+++ b/root/layout/components/sidebar/SidebarDataQuality.js
@@ -11,11 +11,7 @@ import {QUALITY_NAMES} from '../../../static/scripts/common/constants.js';
 
 import {SidebarProperty} from './SidebarProperties.js';
 
-type Props = {
-  +quality: QualityT,
-};
-
-const SidebarDataQuality = ({quality}: Props): React$MixedElement | null => {
+component SidebarDataQuality(quality: QualityT) {
   const name = QUALITY_NAMES.get(quality);
   let qualityClass;
   switch (quality) {
@@ -39,6 +35,6 @@ const SidebarDataQuality = ({quality}: Props): React$MixedElement | null => {
       {name()}
     </SidebarProperty>
   ) : null;
-};
+}
 
 export default SidebarDataQuality;

--- a/root/layout/components/sidebar/SidebarEndDate.js
+++ b/root/layout/components/sidebar/SidebarEndDate.js
@@ -16,41 +16,32 @@ import {displayAge} from '../../../utility/age.js';
 
 import {SidebarProperty} from './SidebarProperties.js';
 
-type Props = {
-  +age?: [number, number, number] | null,
-  +entity:
-    | AreaT
-    | ArtistT
-    | EventT
-    | LabelT
-    | PlaceT,
-  +label: string,
-};
-
-const SidebarEndDate = ({
-  age,
-  entity,
-  label,
-}: Props): React$MixedElement | null => (
-  isDateEmpty(entity.end_date) ? (
-    entity.ended ? (
+component SidebarEndDate(
+  age?: [number, number, number] | null,
+  entity: AreaT | ArtistT | EventT | LabelT | PlaceT,
+  label: string,
+) {
+  return (
+    isDateEmpty(entity.end_date) ? (
+      entity.ended ? (
+        <SidebarProperty className="end-date" label={label}>
+          {lp('[unknown]', 'date')}
+        </SidebarProperty>
+      ) : null
+    ) : (
       <SidebarProperty className="end-date" label={label}>
-        {lp('[unknown]', 'date')}
+        {formatDate(entity.end_date)}
+        {age ? (
+          ' ' + bracketedText(
+            displayAge(
+              age,
+              entity.entityType === 'artist' && entity.typeID === 1,
+            ),
+          )
+        ) : null}
       </SidebarProperty>
-    ) : null
-  ) : (
-    <SidebarProperty className="end-date" label={label}>
-      {formatDate(entity.end_date)}
-      {age ? (
-        ' ' + bracketedText(
-          displayAge(
-            age,
-            entity.entityType === 'artist' && entity.typeID === 1,
-          ),
-        )
-      ) : null}
-    </SidebarProperty>
-  )
-);
+    )
+  );
+}
 
 export default SidebarEndDate;

--- a/root/layout/components/sidebar/SidebarIpis.js
+++ b/root/layout/components/sidebar/SidebarIpis.js
@@ -19,13 +19,10 @@ const buildSidebarIpi = (ipi: IpiCodeT) => (
   </SidebarProperty>
 );
 
-type Props = {
-  +entity: $ReadOnly<{...IpiCodesRoleT, ...}>,
-};
-
-const SidebarIpis = ({entity}: Props):
-  React.ChildrenArray<React$Element<typeof SidebarProperty>> => (
-  entity.ipi_codes.map(buildSidebarIpi)
-);
+component SidebarIpis(entity: $ReadOnly<{...IpiCodesRoleT, ...}>) {
+  return (
+    entity.ipi_codes.map(buildSidebarIpi)
+  );
+}
 
 export default SidebarIpis;

--- a/root/layout/components/sidebar/SidebarIsnis.js
+++ b/root/layout/components/sidebar/SidebarIsnis.js
@@ -25,13 +25,10 @@ const buildSidebarIsni = (isni: IsniCodeT) => (
   </SidebarProperty>
 );
 
-type Props = {
-  +entity: $ReadOnly<{...IsniCodesRoleT, ...}>,
-};
-
-const SidebarIsnis = ({entity}: Props):
-  React.ChildrenArray<React$Element<typeof SidebarProperty>> => (
-  entity.isni_codes.map(buildSidebarIsni)
-);
+component SidebarIsnis(entity: $ReadOnly<{...IsniCodesRoleT, ...}>) {
+  return (
+    entity.isni_codes.map(buildSidebarIsni)
+  );
+}
 
 export default SidebarIsnis;

--- a/root/layout/components/sidebar/SidebarLicenses.js
+++ b/root/layout/components/sidebar/SidebarLicenses.js
@@ -95,7 +95,7 @@ function licenseClass(url: UrlT): string {
   return '';
 }
 
-const LicenseDisplay = ({url}: {+url: UrlT}) => {
+component LicenseDisplay(url: UrlT) {
   const className = licenseClass(url);
   return (
     <li className={className}>
@@ -104,18 +104,14 @@ const LicenseDisplay = ({url}: {+url: UrlT}) => {
       </a>
     </li>
   );
-};
+}
 
 const cmpLinkPhrase = (
   a: [string, React$MixedElement],
   b: [string, React$MixedElement],
 ) => compare(a[0], b[0]);
 
-type Props = {
-  +entity: RelatableEntityT,
-};
-
-const SidebarLicenses = ({entity}: Props): React$MixedElement | null => {
+component SidebarLicenses(entity: RelatableEntityT) {
   const relationships = entity.relationships;
 
   if (!relationships) {
@@ -144,6 +140,6 @@ const SidebarLicenses = ({entity}: Props): React$MixedElement | null => {
       </ul>
     </>
   ) : null;
-};
+}
 
 export default SidebarLicenses;

--- a/root/layout/components/sidebar/SidebarProperties.js
+++ b/root/layout/components/sidebar/SidebarProperties.js
@@ -7,34 +7,22 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type SidebarPropertyProps = {
-  +children: React$Node,
-  +className: string,
-  +label: string,
-};
+export component SidebarProperty(
+  children: React$Node,
+  className: string,
+  label: string,
+) {
+  return (
+    <>
+      <dt>{label}</dt>
+      <dd className={className}>
+        {children}
+      </dd>
+    </>
+  );
+}
 
-export const SidebarProperty = ({
-  children,
-  className,
-  label,
-}: SidebarPropertyProps): React.MixedElement => (
-  <>
-    <dt>{label}</dt>
-    <dd className={className}>
-      {children}
-    </dd>
-  </>
-);
-
-type SidebarPropertiesProps = {
-  +children: React$Node,
-  +className?: string,
-};
-
-export const SidebarProperties = ({
-  className,
-  children,
-}: SidebarPropertiesProps): React$Element<'dl'> => {
+export component SidebarProperties(children: React$Node, className?: string) {
   let _className = 'properties';
   if (nonEmpty(className)) {
     _className += ' ' + className;
@@ -44,4 +32,4 @@ export const SidebarProperties = ({
       {children}
     </dl>
   );
-};
+}

--- a/root/layout/components/sidebar/SidebarRating.js
+++ b/root/layout/components/sidebar/SidebarRating.js
@@ -12,33 +12,27 @@ import EntityLink
 import RatingStars
   from '../../../static/scripts/common/components/RatingStars.js';
 
-type Props = {
-  +entity: RatableT,
-  +heading?: string,
-};
-
-const SidebarRating = ({
-  entity,
-  heading,
-}: Props): React.MixedElement => (
-  <>
-    <h2 className="rating">{nonEmpty(heading) ? heading : l('Rating')}</h2>
-    <p>
-      <RatingStars entity={entity} />
-      {/* $FlowIgnore[sketchy-null-number] */}
-      {entity.rating_count ? (
-        <>
-          {' ('}
-          <EntityLink
-            content={l('see all ratings')}
-            entity={entity}
-            subPath="ratings"
-          />
-          {')'}
-        </>
-      ) : null}
-    </p>
-  </>
-);
+component SidebarRating(entity: RatableT, heading?: string) {
+  return (
+    <>
+      <h2 className="rating">{nonEmpty(heading) ? heading : l('Rating')}</h2>
+      <p>
+        <RatingStars entity={entity} />
+        {/* $FlowIgnore[sketchy-null-number] */}
+        {entity.rating_count ? (
+          <>
+            {' ('}
+            <EntityLink
+              content={l('see all ratings')}
+              entity={entity}
+              subPath="ratings"
+            />
+            {')'}
+          </>
+        ) : null}
+      </p>
+    </>
+  );
+}
 
 export default SidebarRating;

--- a/root/layout/components/sidebar/SidebarTags.js
+++ b/root/layout/components/sidebar/SidebarTags.js
@@ -18,20 +18,10 @@ import TagLink from '../../../static/scripts/common/components/TagLink.js';
 import commaOnlyList
   from '../../../static/scripts/common/i18n/commaOnlyList.js';
 
-type TagListProps = {
-  +entity: TaggableEntityT,
-  +isGenreList?: boolean,
-  +tags: ?$ReadOnlyArray<AggregatedTagT>,
-};
-
-type SidebarTagsProps = {
-  +entity: TaggableEntityT,
-};
-
-const TagList = ({
-  isGenreList = false,
-  tags,
-}: TagListProps) => {
+component TagList(
+  isGenreList: boolean = false,
+  tags: ?$ReadOnlyArray<AggregatedTagT>,
+) {
   const upvotedTags = tags ? tags.filter(tag => tag.count > 0) : null;
   const links = upvotedTags ? upvotedTags.reduce((
     accum: Array<React$Element<typeof TagLink>>,
@@ -53,11 +43,9 @@ const TagList = ({
       : lp('(none)', 'folksonomy tag');
   }
   return commaOnlyList(links);
-};
+}
 
-const SidebarTags = ({
-  entity,
-}: SidebarTagsProps): React.MixedElement | null => {
+component SidebarTags(entity: TaggableEntityT) {
   const $c = React.useContext(CatalystContext);
   const aggregatedTags = $c.stash.top_tags;
   const more = Boolean($c.stash.more_tags);
@@ -82,21 +70,14 @@ const SidebarTags = ({
               <h3>{l('Genres')}</h3>
               <div className="genre-list">
                 <p>
-                  <TagList
-                    entity={entity}
-                    isGenreList
-                    tags={aggregatedTags}
-                  />
+                  <TagList isGenreList tags={aggregatedTags} />
                 </p>
               </div>
 
               <h3>{lp('Other tags', 'folksonomy')}</h3>
               <div id="sidebar-tag-list">
                 <p>
-                  <TagList
-                    entity={entity}
-                    tags={aggregatedTags}
-                  />
+                  <TagList tags={aggregatedTags} />
                 </p>
               </div>
 
@@ -112,6 +93,6 @@ const SidebarTags = ({
       </>
     )
   );
-};
+}
 
 export default SidebarTags;

--- a/root/layout/components/sidebar/SidebarType.js
+++ b/root/layout/components/sidebar/SidebarType.js
@@ -12,23 +12,20 @@ import linkedEntities
 
 import {SidebarProperty} from './SidebarProperties.js';
 
-type Props = {
-  +entity: $ReadOnly<{...TypeRoleT<empty>, ...}>,
-  +typeType: string,
-};
-
-const SidebarType = ({
-  entity,
-  typeType,
-}: Props): React$MixedElement | null => (
-  entity.typeID == null ? null : (
-    <SidebarProperty className="type" label={addColonText(l('Type'))}>
-      {lp_attributes(
-        linkedEntities[typeType][entity.typeID].name,
-        typeType,
-      )}
-    </SidebarProperty>
-  )
-);
+component SidebarType(
+  entity: $ReadOnly<{...TypeRoleT<empty>, ...}>,
+  typeType: string,
+) {
+  return (
+    entity.typeID == null ? null : (
+      <SidebarProperty className="type" label={addColonText(l('Type'))}>
+        {lp_attributes(
+          linkedEntities[typeType][entity.typeID].name,
+          typeType,
+        )}
+      </SidebarProperty>
+    )
+  );
+}
 
 export default SidebarType;

--- a/root/layout/components/sidebar/SubscriptionLinks.js
+++ b/root/layout/components/sidebar/SubscriptionLinks.js
@@ -14,13 +14,7 @@ import EntityLink
   from '../../../static/scripts/common/components/EntityLink.js';
 import {returnToCurrentPage} from '../../../utility/returnUri.js';
 
-type Props = {
-  +entity: SubscribableEntityWithSidebarT,
-};
-
-const SubscriptionLinks = ({
-  entity,
-}: Props): React.MixedElement => {
+component SubscriptionLinks(entity: SubscribableEntityWithSidebarT) {
   const $c = React.useContext(CatalystContext);
   const entityType = entity.entityType;
   const id = encodeURIComponent(String(entity.id));
@@ -63,6 +57,6 @@ const SubscriptionLinks = ({
       </ul>
     </>
   );
-};
+}
 
 export default SubscriptionLinks;

--- a/root/layout/components/sidebar/UrlSidebar.js
+++ b/root/layout/components/sidebar/UrlSidebar.js
@@ -10,11 +10,7 @@
 import EditLinks from './EditLinks.js';
 import LastUpdated from './LastUpdated.js';
 
-type Props = {
-  +url: UrlT,
-};
-
-const UrlSidebar = ({url}: Props): React$Element<'div'> => {
+component UrlSidebar(url: UrlT) {
   return (
     <div id="sidebar">
       <EditLinks entity={url} />
@@ -22,6 +18,6 @@ const UrlSidebar = ({url}: Props): React$Element<'div'> => {
       <LastUpdated entity={url} />
     </div>
   );
-};
+}
 
 export default UrlSidebar;

--- a/root/layout/components/sidebar/WorkSidebar.js
+++ b/root/layout/components/sidebar/WorkSidebar.js
@@ -33,11 +33,7 @@ import SidebarRating from './SidebarRating.js';
 import SidebarTags from './SidebarTags.js';
 import SidebarType from './SidebarType.js';
 
-type Props = {
-  +work: WorkT,
-};
-
-const WorkSidebar = ({work}: Props): React$Element<'div'> => {
+component WorkSidebar(work: WorkT) {
   const $c = React.useContext(CatalystContext);
   const {attributes, iswcs, languages, typeID} = work;
   const showInfo = Boolean(
@@ -125,6 +121,6 @@ const WorkSidebar = ({work}: Props): React$Element<'div'> => {
       <LastUpdated entity={work} />
     </div>
   );
-};
+}
 
 export default WorkSidebar;

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -22,25 +22,29 @@ import {formatUserDateObject} from '../utility/formatUserDate.js';
 import getRequestCookie from '../utility/getRequestCookie.mjs';
 
 import Footer from './components/Footer.js';
-import Head, {type HeadProps} from './components/Head.js';
+import Head from './components/Head.js';
 import Header from './components/Header.js';
 import MergeHelper from './components/MergeHelper.js';
 
-const DismissBannerButton = ({bannerName}: {+bannerName: string}) => (
-  <button
-    className="dismiss-banner remove-item icon"
-    data-banner-name={bannerName}
-    type="button"
-  />
-);
+component DismissBannerButton(bannerName: string) {
+  return (
+    <button
+      className="dismiss-banner remove-item icon"
+      data-banner-name={bannerName}
+      type="button"
+    />
+  );
+}
 
-const BirthdayCakes = () => (
-  <span aria-label={l('Birthday cakes')} role="img">
-    {String.fromCodePoint(0x1F382)}
-    {String.fromCodePoint(0x1F382)}
-    {String.fromCodePoint(0x1F382)}
-  </span>
-);
+component BirthdayCakes() {
+  return (
+    <span aria-label={l('Birthday cakes')} role="img">
+      {String.fromCodePoint(0x1F382)}
+      {String.fromCodePoint(0x1F382)}
+      {String.fromCodePoint(0x1F382)}
+    </span>
+  );
+}
 
 function showBirthdayBanner($c: CatalystContextT) {
   const birthDate = $c.user ? $c.user.birth_date : null;
@@ -55,7 +59,7 @@ function showBirthdayBanner($c: CatalystContextT) {
          !getRequestCookie($c.req, 'birthday_message_dismissed_mtime');
 }
 
-const AnniversaryBanner = () => {
+component AnniversaryBanner() {
   const $c = React.useContext(CatalystContext);
   const registrationDate = $c.user ? $c.user.registration_date : null;
   if (registrationDate == null) {
@@ -100,9 +104,9 @@ const AnniversaryBanner = () => {
   }
 
   return null;
-};
+}
 
-const ServerDetailsBanner = ({url}: {url: string}) => {
+component ServerDetailsBanner(url: string) {
   const returnUrl = new URL(url);
   returnUrl.port = ''; // won't unset it itself when setting host
   returnUrl.host = nonEmpty(DBDefs.BETA_REDIRECT_HOSTNAME)
@@ -156,22 +160,13 @@ const ServerDetailsBanner = ({url}: {url: string}) => {
   }
 
   return null;
-};
+}
 
-export type Props = $ReadOnly<{
-  ...HeadProps,
+component Layout(
   children: React$Node,
-  fullWidth?: boolean,
-}>;
-
-const Layout = ({
-  children,
-  fullWidth = false,
-  isHomepage = false,
-  noIcons,
-  pager,
-  title,
-}: Props): React$Element<'html'> => {
+  fullWidth: boolean = false,
+  ...headProps: React.PropsOf<Head>
+) {
   const $c = React.useContext(CatalystContext);
 
   const showAlert = nonEmpty($c.stash.alert) &&
@@ -188,12 +183,7 @@ const Layout = ({
 
   return (
     <html lang={$c.stash.current_language_html}>
-      <Head
-        isHomepage={isHomepage}
-        noIcons={noIcons}
-        pager={pager}
-        title={title}
-      />
+      <Head {...headProps} />
 
       <body>
         <Header />
@@ -314,7 +304,7 @@ const Layout = ({
 
         <div
           className={(fullWidth ? 'fullwidth ' : '') +
-            (isHomepage ? 'homepage' : '')}
+            (headProps.isHomepage /*:: === true */ ? 'homepage' : '')}
           id="page"
         >
           {children}
@@ -328,6 +318,6 @@ const Layout = ({
       </body>
     </html>
   );
-};
+}
 
 export default Layout;


### PR DESCRIPTION
Flow now supports a specific [React Component Syntax](https://flow.org/en/docs/react/component-syntax/) which reduces the amount of types we need to define manually, and is supposed to be better for type checking as well. I'm converting our React components to this syntax bit by bit with this PR.

This changes all stuff in the `layout` subfolder.

Note: To be reviewed without whitespace changes (since this adds explicit `return()` calls that require spacing things one more tab in many cases).

On top of https://github.com/metabrainz/musicbrainz-server/pull/3228