### PR TITLE
Migrate React static components to Flow component syntax

### DIFF
--- a/root/static/scripts/account/components/RegisterForm.js
+++ b/root/static/scripts/account/components/RegisterForm.js
@@ -23,11 +23,6 @@ export type RegisterFormT = FormT<{
   +username: FieldT<string>,
 }>;
 
-type PropsT = {
-  +captcha?: string,
-  +form: RegisterFormT,
-};
-
 function isPossibleEmail(string: string | null) {
   if (string == null) {
     return false;
@@ -35,10 +30,7 @@ function isPossibleEmail(string: string | null) {
   return /\w+@\w+\.\w+/.test(string);
 }
 
-export const RegisterForm = ({
-  captcha,
-  form,
-}: PropsT): React$Element<'form'> => {
+component RegisterForm(captcha?: string, form: RegisterFormT) {
   const [nameField, updateNameField] = React.useState(form.field.username);
 
   function handleUsernameChange(
@@ -125,9 +117,9 @@ export const RegisterForm = ({
       </FormRow>
     </form>
   );
-};
+}
 
-export default (hydrate<PropsT>(
+export default (hydrate<React.PropsOf<RegisterForm>>(
   'div.register-form',
   RegisterForm,
-): React.AbstractComponent<PropsT, void>);
+): React.AbstractComponent<React.PropsOf<RegisterForm>, void>);

--- a/root/static/scripts/common/components/AcoustIdCell.js
+++ b/root/static/scripts/common/components/AcoustIdCell.js
@@ -9,10 +9,6 @@
 
 import * as React from 'react';
 
-type PropsT = {
-  +recordingMbid: string,
-};
-
 type AcoustIdTrackT = {
   +disabled?: boolean,
   +id: string,
@@ -87,9 +83,7 @@ function loadAcoustIdData(
   }, REQUEST_BATCH_TIMEOUT);
 }
 
-const AcoustIdCell = ({
-  recordingMbid,
-}: PropsT): React.MixedElement => {
+component AcoustIdCell(recordingMbid: string) {
   const [acoustIdTracks, setAcoustIdTracks] = React.useState<
     $ReadOnlyArray<AcoustIdTrackT> | null,
   >(null);
@@ -136,11 +130,11 @@ const AcoustIdCell = ({
       )}
     </>
   );
-};
+}
 
 export default (
-  hydrate<PropsT>(
+  hydrate<React.PropsOf<AcoustIdCell>>(
     'div.acoustids',
     AcoustIdCell,
-  ): React$AbstractComponent<PropsT, void>
+  ): React$AbstractComponent<React.PropsOf<AcoustIdCell>>
 );

--- a/root/static/scripts/common/components/Annotation.js
+++ b/root/static/scripts/common/components/Annotation.js
@@ -21,26 +21,14 @@ type MinimalAnnotatedEntityT = {
   +latest_annotation?: AnnotationT,
 };
 
-type Props = {
-  +annotation: ?AnnotationT,
-  +collapse?: boolean,
-  +entity: $ReadOnly<{
-    ...MinimalAnnotatedEntityT,
-    ...
-  }>,
-  +numberOfRevisions: number,
-  +showChangeLog?: boolean,
-  +showEmpty?: boolean,
-};
-
-const Annotation = ({
-  annotation,
-  collapse = false,
-  entity,
-  numberOfRevisions,
-  showChangeLog = false,
-  showEmpty = false,
-}: Props) => {
+component Annotation(
+  annotation: ?AnnotationT,
+  collapse: boolean = false,
+  entity: $ReadOnly<{...MinimalAnnotatedEntityT, ...}>,
+  numberOfRevisions: number,
+  showChangeLog: boolean = false,
+  showEmpty: boolean = false,
+) {
   const annotationIsEmpty = empty(annotation?.text);
   if (!annotation || (annotationIsEmpty && !showEmpty)) {
     return null;
@@ -120,13 +108,13 @@ const Annotation = ({
       </SanitizedCatalystContext.Consumer>
     </>
   );
-};
+}
 
-export default (hydrate<Props>(
+export default (hydrate<React.PropsOf<Annotation>>(
   'div.annotation',
   Annotation,
   function (props) {
-    const newProps: {...Props} = {...props};
+    const newProps: {...React.PropsOf<Annotation>} = {...props};
     const entity = props.entity;
     const annotation = props.annotation;
 
@@ -153,4 +141,4 @@ export default (hydrate<Props>(
     newProps.entity = newEntity;
     return newProps;
   },
-): React$AbstractComponent<Props, void>);
+): React$AbstractComponent<React.PropsOf<Annotation>>);

--- a/root/static/scripts/common/components/AreaContainmentLink.js
+++ b/root/static/scripts/common/components/AreaContainmentLink.js
@@ -16,14 +16,12 @@ const makeLink = (
   key: number,
 ) => <EntityLink entity={area} key={key} />;
 
-type Props = {
-  +area: AreaT,
-};
-
-const AreaContainmentLink = ({area}: Props): Expand2ReactOutput | null => (
-  area.containment
-    ? commaOnlyList(area.containment.map(makeLink))
-    : null
-);
+component AreaContainmentLink(area: AreaT) {
+  return (
+    area.containment
+      ? commaOnlyList(area.containment.map(makeLink))
+      : null
+  );
+}
 
 export default AreaContainmentLink;

--- a/root/static/scripts/common/components/AreaWithContainmentLink.js
+++ b/root/static/scripts/common/components/AreaWithContainmentLink.js
@@ -11,27 +11,21 @@ import commaOnlyList from '../../common/i18n/commaOnlyList.js';
 
 import EntityLink from './EntityLink.js';
 
-type Props = {
-  +allowNew?: boolean,
-  +area: AreaT,
-  +className?: string,
-  +content?: Expand2ReactOutput,
-  +deletedCaption?: string,
-  +disableLink?: boolean,
-  +showDisambiguation?: boolean,
-  +showEditsPending?: boolean,
-  +showIcon?: boolean,
-  +subPath?: string,
-  +target?: '_blank',
-};
-
-const AreaWithContainmentLink = ({
-  area,
-  showDisambiguation = true,
-  showEditsPending = true,
-  showIcon = false,
-  ...props
-}: Props): Expand2ReactOutput => {
+component AreaWithContainmentLink(
+  area: AreaT,
+  showDisambiguation: boolean = true,
+  showEditsPending: boolean = true,
+  showIcon: boolean = false,
+  ...topLevelProps: {
+    allowNew?: boolean,
+    className?: string,
+    content?: Expand2ReactOutput,
+    deletedCaption?: string,
+    disableLink?: boolean,
+    subPath?: string,
+    target?: '_blank',
+  }
+) {
   const sharedProps = {
     showDisambiguation,
     showEditsPending,
@@ -42,7 +36,7 @@ const AreaWithContainmentLink = ({
     <EntityLink
       entity={area}
       key={0}
-      {...props}
+      {...topLevelProps}
       {...sharedProps}
     />
   );
@@ -56,6 +50,6 @@ const AreaWithContainmentLink = ({
       />
     ))),
   ) : areaLink;
-};
+}
 
 export default AreaWithContainmentLink;

--- a/root/static/scripts/common/components/ArtistCreditLink.js
+++ b/root/static/scripts/common/components/ArtistCreditLink.js
@@ -12,22 +12,7 @@ import Tooltip from '../../edit/components/Tooltip.js';
 
 import EntityLink, {DeletedLink} from './EntityLink.js';
 
-type Props = {
-  +artistCredit: ArtistCreditT,
-  +showDeleted?: boolean,
-  +showDisambiguation?: boolean,
-  +showEditsPending?: boolean,
-  +showIcon?: boolean,
-  +target?: '_blank',
-};
-
-type MpIconProps = {
-  +artistCredit: ArtistCreditT,
-};
-
-export const MpIcon = (hydrate<MpIconProps>('span.ac-mp', (
-  {artistCredit}: MpIconProps,
-): React$MixedElement => {
+component _MpIcon(artistCredit: ArtistCreditT) {
   let editSearch =
     '/search/edits?auto_edit_filter=&order=desc&negation=0' +
     '&combinator=and&conditions.0.field=type&conditions.0.operator=%3D' +
@@ -58,16 +43,21 @@ export const MpIcon = (hydrate<MpIconProps>('span.ac-mp', (
       }
     />
   );
-}): React$AbstractComponent<MpIconProps, void>);
+}
 
-const ArtistCreditLink = ({
-  artistCredit,
-  showDeleted = true,
-  showDisambiguation = false,
-  showEditsPending = true,
-  showIcon = false,
-  ...props
-}: Props): React$Node => {
+export const MpIcon = (hydrate<React.PropsOf<_MpIcon>>(
+  'span.ac-mp',
+  _MpIcon,
+): React$AbstractComponent<React.PropsOf<_MpIcon>>);
+
+component ArtistCreditLink(
+  artistCredit: ArtistCreditT,
+  showDeleted: boolean = true,
+  showDisambiguation: boolean = false,
+  showEditsPending: boolean = true,
+  showIcon: boolean = false,
+  target?: '_blank',
+) {
   const names = artistCredit.names;
   const parts: Array<React$Node> = [];
   for (let i = 0; i < names.length; i++) {
@@ -83,7 +73,7 @@ const ArtistCreditLink = ({
           showDisambiguation={showDisambiguation}
           showEditsPending={showEditsPending && !artistCredit.editsPending}
           showIcon={showIcon}
-          target={props.target}
+          target={target}
         />,
       );
     } else {
@@ -106,6 +96,6 @@ const ArtistCreditLink = ({
     );
   }
   return parts;
-};
+}
 
 export default ArtistCreditLink;

--- a/root/static/scripts/common/components/ArtistCreditUsageLink.js
+++ b/root/static/scripts/common/components/ArtistCreditUsageLink.js
@@ -11,21 +11,13 @@ import {reduceArtistCredit} from '../immutable-entities.js';
 
 import {MpIcon} from './ArtistCreditLink.js';
 
-type Props = {
-  +artistCredit: ArtistCreditT,
-  +content?: string,
-  +showEditsPending?: boolean,
-  +subPath?: string,
-  +target?: '_blank',
-};
-
-const ArtistCreditUsageLink = ({
-  artistCredit,
-  content,
-  showEditsPending = false,
-  subPath,
-  ...props
-}: Props): React$Element<'a' | 'span'> | null => {
+component ArtistCreditUsageLink(
+  artistCredit: ArtistCreditT,
+  content?: string,
+  showEditsPending: boolean = false,
+  subPath?: string,
+  target?: '_blank'
+) {
   const id = artistCredit.id;
   if (id == null) {
     return null;
@@ -36,7 +28,7 @@ const ArtistCreditUsageLink = ({
   }
 
   const artistCreditLink = (
-    <a href={href} {...props}>
+    <a href={href} target={target}>
       {nonEmpty(content) ? content : reduceArtistCredit(artistCredit)}
     </a>
   );
@@ -49,6 +41,6 @@ const ArtistCreditUsageLink = ({
       </span>
     ) : artistCreditLink
   );
-};
+}
 
 export default ArtistCreditUsageLink;

--- a/root/static/scripts/common/components/ArtistListEntry.js
+++ b/root/static/scripts/common/components/ArtistListEntry.js
@@ -22,45 +22,18 @@ import DescriptiveLink from './DescriptiveLink.js';
 import MergeCheckboxElement from './MergeCheckboxElement.js';
 import RatingStars from './RatingStars.js';
 
-type ArtistListRowProps = {
-  ...InstrumentCreditsAndRelTypesRoleT,
-  +artist: ArtistT,
-  +artistList?: $ReadOnlyArray<ArtistT>,
-  +checkboxes?: string,
-  +index: number,
-  +mergeForm?: MergeFormT,
-  +showBeginEnd?: boolean,
-  +showInstrumentCreditsAndRelTypes?: boolean,
-  +showRatings?: boolean,
-  +showSortName?: boolean,
-};
-
-type ArtistListEntryProps = {
-  ...InstrumentCreditsAndRelTypesRoleT,
-  +artist: ArtistT,
-  +artistList?: $ReadOnlyArray<ArtistT>,
-  +checkboxes?: string,
-  +index: number,
-  +mergeForm?: MergeFormT,
-  +score?: number,
-  +showBeginEnd?: boolean,
-  +showInstrumentCreditsAndRelTypes?: boolean,
-  +showRatings?: boolean,
-  +showSortName?: boolean,
-};
-
-const ArtistListRow = ({
-  artist,
-  artistList,
-  checkboxes,
-  index,
-  instrumentCreditsAndRelTypes,
-  mergeForm,
-  showBeginEnd = false,
-  showInstrumentCreditsAndRelTypes = false,
-  showRatings = false,
-  showSortName = false,
-}: ArtistListRowProps) => {
+component ArtistListRow(
+  artist: ArtistT,
+  artistList?: $ReadOnlyArray<ArtistT>,
+  checkboxes?: string,
+  index: number,
+  instrumentCreditsAndRelTypes?: InstrumentCreditsAndRelTypesT,
+  mergeForm?: MergeFormT,
+  showBeginEnd: boolean = false,
+  showInstrumentCreditsAndRelTypes: boolean = false,
+  showRatings: boolean = false,
+  showSortName: boolean = false,
+) {
   const $c = React.useContext(CatalystContext);
 
   return (
@@ -137,35 +110,17 @@ const ArtistListRow = ({
       ) : null}
     </>
   );
-};
+}
 
-const ArtistListEntry = ({
-  artist,
-  artistList,
-  checkboxes,
-  index,
-  instrumentCreditsAndRelTypes,
-  mergeForm,
-  score,
-  showBeginEnd,
-  showInstrumentCreditsAndRelTypes,
-  showRatings,
-  showSortName,
-}: ArtistListEntryProps): React$Element<'tr'> => (
-  <tr className={loopParity(index)} data-score={score ?? null}>
-    <ArtistListRow
-      artist={artist}
-      artistList={artistList}
-      checkboxes={checkboxes}
-      index={index}
-      instrumentCreditsAndRelTypes={instrumentCreditsAndRelTypes}
-      mergeForm={mergeForm}
-      showBeginEnd={showBeginEnd}
-      showInstrumentCreditsAndRelTypes={showInstrumentCreditsAndRelTypes}
-      showRatings={showRatings}
-      showSortName={showSortName}
-    />
-  </tr>
-);
+component ArtistListEntry(
+  score?: number,
+  ...rowProps: React.PropsOf<ArtistListRow>
+) {
+  return (
+    <tr className={loopParity(rowProps.index)} data-score={score ?? null}>
+      <ArtistListRow {...rowProps} />
+    </tr>
+  );
+}
 
 export default ArtistListEntry;

--- a/root/static/scripts/common/components/ArtistRoles.js
+++ b/root/static/scripts/common/components/ArtistRoles.js
@@ -19,10 +19,6 @@ type RelationT = {
   +roles: $ReadOnlyArray<string>,
 };
 
-type ArtistRolesProps = {
-  +relations: $ReadOnlyArray<RelationT>,
-};
-
 const buildArtistRoleRow = (relation: RelationT) => {
   return (
     <li key={relation.entity.id + '-' + relation.credit}>
@@ -39,22 +35,22 @@ const buildArtistRoleRow = (relation: RelationT) => {
   );
 };
 
-const ArtistRoles = ({
-  relations,
-}: ArtistRolesProps): React$MixedElement => (
-  <CollapsibleList
-    ariaLabel={l('Artist roles')}
-    buildRow={buildArtistRoleRow}
-    className="artist-roles"
-    rows={relations}
-    showAllTitle={l('Show all artists')}
-    showLessTitle={l('Show less artists')}
-    toShowAfter={0}
-    toShowBefore={4}
-  />
-);
+component ArtistRoles(relations: $ReadOnlyArray<RelationT>) {
+  return (
+    <CollapsibleList
+      ariaLabel={l('Artist roles')}
+      buildRow={buildArtistRoleRow}
+      className="artist-roles"
+      rows={relations}
+      showAllTitle={l('Show all artists')}
+      showLessTitle={l('Show less artists')}
+      toShowAfter={0}
+      toShowBefore={4}
+    />
+  );
+}
 
-export default (hydrate<ArtistRolesProps>(
+export default (hydrate<React.PropsOf<ArtistRoles>>(
   'div.artist-roles-container',
   ArtistRoles,
-): React$AbstractComponent<ArtistRolesProps, void>);
+): React$AbstractComponent<React.PropsOf<ArtistRoles>>);

--- a/root/static/scripts/common/components/AttributeList.js
+++ b/root/static/scripts/common/components/AttributeList.js
@@ -50,30 +50,27 @@ const buildAttributeSidebarRow = (attribute: WorkAttributeT) => (
   </SidebarProperty>
 );
 
-type AttributeListProps = {|
-  +attributes: ?$ReadOnlyArray<WorkAttributeT>,
-  +isSidebar?: boolean,
-|};
+component AttributeList(
+  attributes: ?$ReadOnlyArray<WorkAttributeT>,
+  isSidebar: boolean = false,
+) {
+  return (
+    <CollapsibleList
+      ContainerElement={isSidebar ? 'dl' : 'ul'}
+      InnerElement={isSidebar ? 'p' : 'li'}
+      ariaLabel={l('Work attributes')}
+      buildRow={isSidebar ? buildAttributeSidebarRow : buildAttributeListRow}
+      className={isSidebar ? 'properties work-attributes' : 'work-attributes'}
+      rows={attributes}
+      showAllTitle={l('Show all attributes')}
+      showLessTitle={l('Show less attributes')}
+      toShowAfter={1}
+      toShowBefore={2}
+    />
+  );
+}
 
-const AttributeList = ({
-  attributes,
-  isSidebar = false,
-}: AttributeListProps) => (
-  <CollapsibleList
-    ContainerElement={isSidebar ? 'dl' : 'ul'}
-    InnerElement={isSidebar ? 'p' : 'li'}
-    ariaLabel={l('Work attributes')}
-    buildRow={isSidebar ? buildAttributeSidebarRow : buildAttributeListRow}
-    className={isSidebar ? 'properties work-attributes' : 'work-attributes'}
-    rows={attributes}
-    showAllTitle={l('Show all attributes')}
-    showLessTitle={l('Show less attributes')}
-    toShowAfter={1}
-    toShowBefore={2}
-  />
-);
-
-export default (hydrate<AttributeListProps>(
+export default (hydrate<React.PropsOf<AttributeList>>(
   'div.entity-attributes-container',
   AttributeList,
-): React$AbstractComponent<AttributeListProps, void>);
+): React$AbstractComponent<React.PropsOf<AttributeList>>);

--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -230,7 +230,7 @@ export function createInitialState<T: EntityItemT>(
   return state;
 }
 
-type AutocompleteItemPropsT<T: EntityItemT> = {
+component _AutocompleteItem<T: EntityItemT>(
   autocompleteId: string,
   dispatch: (ActionT<T>) => void,
   formatOptions?: ?FormatOptionsT,
@@ -239,18 +239,7 @@ type AutocompleteItemPropsT<T: EntityItemT> = {
   isSelected: boolean,
   item: ItemT<T>,
   selectItem: (ItemT<T>) => boolean,
-};
-
-const AutocompleteItem = React.memo(<T: EntityItemT>({
-  autocompleteId,
-  dispatch,
-  formatOptions,
-  index,
-  isHighlighted,
-  isSelected,
-  item,
-  selectItem,
-}: AutocompleteItemPropsT<T>): React$MixedElement => {
+) {
   const itemId = `${autocompleteId}-item-${item.id}`;
   const isDisabled = !!item.disabled;
   const isSeparator = !!item.separator;
@@ -309,11 +298,11 @@ const AutocompleteItem = React.memo(<T: EntityItemT>({
       {formatItem<T>(item, formatOptions)}
     </li>
   );
-});
+}
 
-const Autocomplete2 = (React.memo(<T: EntityItemT>(
-  props: PropsT<T>,
-): React$Element<'div'> => {
+const AutocompleteItem = React.memo(_AutocompleteItem);
+
+component _Autocomplete2<T: EntityItemT>(...props: PropsT<T>) {
   const {dispatch, state} = props;
 
   const {
@@ -875,8 +864,11 @@ const Autocomplete2 = (React.memo(<T: EntityItemT>(
       ) : null}
     </div>
   );
+}
+
 // $FlowIgnore[unclear-type]
-}): React$AbstractComponent<PropsT<any>, void>);
+const Autocomplete2: React$AbstractComponent<PropsT<any>, mixed> =
+  React.memo(_Autocomplete2);
 
 export default Autocomplete2;
 

--- a/root/static/scripts/common/components/ButtonPopover.js
+++ b/root/static/scripts/common/components/ButtonPopover.js
@@ -27,39 +27,25 @@ import {unwrapNl} from '../i18n.js';
 
 import ErrorBoundary from './ErrorBoundary.js';
 
-type PropsT = {
-  +buildChildren: (
+component ButtonPopover(
+  buildChildren: (
     close: () => void,
     initialFocusRef: {current: HTMLElement | null},
   ) => React$Node,
-  +buttonContent: React$Node,
-  +buttonProps?: {
+  buttonContent: React$Node,
+  buttonProps?: {
     className?: string,
     id?: string,
     title?: string | (() => string),
   } | null,
-  +className?: string,
-  +closeOnOutsideClick?: boolean,
-  +id: string,
-  +isDisabled?: boolean,
-  +isOpen: boolean,
-  +toggle: (boolean) => void,
-  +wrapButton?: (React$MixedElement) => React$MixedElement,
-};
-
-const ButtonPopover = (props: PropsT): React$MixedElement => {
-  const {
-    buildChildren,
-    buttonContent,
-    buttonProps = null,
-    className,
-    closeOnOutsideClick = true,
-    isDisabled = false,
-    isOpen,
-    toggle,
-    wrapButton,
-    ...dialogProps
-  } = props;
+  className?: string,
+  closeOnOutsideClick: boolean = true,
+  isDisabled: boolean = false,
+  isOpen: boolean,
+  toggle: (boolean) => void,
+  wrapButton?: (React$MixedElement) => React$MixedElement,
+  ...dialogProps: {id: string}
+) {
   const buttonId = buttonProps?.id;
   const buttonTitle = buttonProps?.title;
 
@@ -142,6 +128,7 @@ const ButtonPopover = (props: PropsT): React$MixedElement => {
           style={floatingStyles}
         >
           <ErrorBoundary>
+            {/* $FlowIgnore[react-rule-unsafe-ref] */}
             {buildChildren(close, initialFocusRef)}
           </ErrorBoundary>
           <FloatingArrow
@@ -173,6 +160,6 @@ const ButtonPopover = (props: PropsT): React$MixedElement => {
       {popoverElement}
     </>
   );
-};
+}
 
 export default ButtonPopover;

--- a/root/static/scripts/common/components/CDStubLink.js
+++ b/root/static/scripts/common/components/CDStubLink.js
@@ -9,22 +9,14 @@
 
 import entityHref from '../utility/entityHref.js';
 
-type Props = {
-  +cdstub: CDStubT,
-  +content: string,
-  +subPath?: string,
-};
-
-const CDStubLink = ({
-  cdstub,
-  content,
-  subPath,
-}: Props): React$Element<'a'> => (
-  <a href={entityHref(cdstub, subPath)}>
-    <bdi>
-      {content}
-    </bdi>
-  </a>
-);
+component CDStubLink(cdstub: CDStubT, content: string, subPath?: string) {
+  return (
+    <a href={entityHref(cdstub, subPath)}>
+      <bdi>
+        {content}
+      </bdi>
+    </a>
+  );
+}
 
 export default CDStubLink;

--- a/root/static/scripts/common/components/CDTocLink.js
+++ b/root/static/scripts/common/components/CDTocLink.js
@@ -9,25 +9,19 @@
 
 import entityHref from '../utility/entityHref.js';
 
-type Props = {
-  +anchorPath?: string,
-  +cdToc: {
-    +discid: string,
-    +entityType: 'cdtoc',
-    ...
-  },
-  +content?: string,
-  +subPath?: string,
-};
-
-const CDTocLink = (
-  {cdToc, content, subPath, anchorPath}: Props,
-): React$Element<'a'> => (
-  <a href={entityHref(cdToc, subPath, anchorPath)}>
-    <bdi>
-      {nonEmpty(content) ? content : cdToc.discid}
-    </bdi>
-  </a>
-);
+component CDTocLink(
+  anchorPath?: string,
+  cdToc: {+discid: string, +entityType: 'cdtoc', ...},
+  content?: string,
+  subPath?: string,
+) {
+  return (
+    <a href={entityHref(cdToc, subPath, anchorPath)}>
+      <bdi>
+        {nonEmpty(content) ? content : cdToc.discid}
+      </bdi>
+    </a>
+  );
+}
 
 export default CDTocLink;

--- a/root/static/scripts/common/components/Cardinality.js
+++ b/root/static/scripts/common/components/Cardinality.js
@@ -9,11 +9,7 @@
 
 import {bracketedText} from '../utility/bracketed.js';
 
-type Props = {
-  +cardinality: number,
-};
-
-const Cardinality = ({cardinality}: Props): React$MixedElement => {
+component Cardinality(cardinality: number) {
   let cardinalityName;
   switch (cardinality) {
     case 0:
@@ -34,6 +30,6 @@ const Cardinality = ({cardinality}: Props): React$MixedElement => {
       {bracketedText(cardinality.toString())}
     </>
   );
-};
+}
 
 export default Cardinality;

--- a/root/static/scripts/common/components/CodeLink.js
+++ b/root/static/scripts/common/components/CodeLink.js
@@ -9,11 +9,7 @@
 
 import entityHref from '../utility/entityHref.js';
 
-type Props = {
-  +code: IsrcT | IswcT,
-};
-
-const CodeLink = ({code}: Props): React$MixedElement=> {
+component CodeLink(code: IsrcT | IswcT) {
   let link: React$MixedElement = (
     <a href={entityHref(code)}>
       <bdi>
@@ -26,6 +22,6 @@ const CodeLink = ({code}: Props): React$MixedElement=> {
     link = <span className="mp">{link}</span>;
   }
   return link;
-};
+}
 
 export default CodeLink;

--- a/root/static/scripts/common/components/CollapsibleList.js
+++ b/root/static/scripts/common/components/CollapsibleList.js
@@ -17,34 +17,20 @@ export type BuildRowPropsT = {
   abbreviated?: boolean,
 };
 
-type Props<T> = {
-  +ariaLabel: string,
-  +buildRow:
+component CollapsibleList<T>(
+  ariaLabel: string,
+  buildRow:
     (T, ?BuildRowPropsT) => React$Element<'li' | typeof SidebarProperty>,
-  +buildRowProps?: BuildRowPropsT,
-  +className: string,
-  +ContainerElement?: 'dl' | 'ul',
-  +InnerElement?: 'p' | 'li' | 'div',
-  +rows: ?$ReadOnlyArray<T>,
-  +showAllTitle: string,
-  +showLessTitle: string,
-  +toShowAfter: number,
-  +toShowBefore: number,
-};
-
-const CollapsibleList = <T>({
-  ariaLabel,
-  buildRow,
-  buildRowProps,
-  className,
-  ContainerElement = 'ul',
-  InnerElement = 'li',
-  rows,
-  showAllTitle,
-  showLessTitle,
-  toShowAfter,
-  toShowBefore,
-}: Props<T>): React$MixedElement | null => {
+  buildRowProps?: BuildRowPropsT,
+  className: string,
+  ContainerElement?: 'dl' | 'ul' = 'ul',
+  InnerElement?: 'p' | 'li' | 'div' = 'li',
+  rows: ?$ReadOnlyArray<T>,
+  showAllTitle: string,
+  showLessTitle: string,
+  toShowAfter: number,
+  toShowBefore: number,
+) {
   const [expanded, setExpanded] = React.useState<boolean>(false);
 
   const expand = (event: SyntheticMouseEvent<HTMLAnchorElement>) => {
@@ -114,6 +100,6 @@ const CollapsibleList = <T>({
       )
     ) : null
   );
-};
+}
 
 export default CollapsibleList;

--- a/root/static/scripts/common/components/CountryAbbr.js
+++ b/root/static/scripts/common/components/CountryAbbr.js
@@ -10,17 +10,11 @@
 import entityHref from '../utility/entityHref.js';
 import primaryAreaCode from '../utility/primaryAreaCode.js';
 
-type Props = {
-  +className?: string,
-  +country: AreaT,
-  +withLink?: boolean,
-};
-
-const CountryAbbr = ({
-  className,
-  country,
-  withLink = false,
-}: Props): React$Element<'span'> | null => {
+component CountryAbbr(
+  className?: string,
+  country: AreaT,
+  withLink: boolean = false,
+) {
   const primaryCode = primaryAreaCode(country);
   if (empty(primaryCode)) {
     return null;
@@ -45,6 +39,6 @@ const CountryAbbr = ({
       {content}
     </span>
   );
-};
+}
 
 export default CountryAbbr;

--- a/root/static/scripts/common/components/CritiqueBrainzReview.js
+++ b/root/static/scripts/common/components/CritiqueBrainzReview.js
@@ -16,11 +16,6 @@ import bracketed from '../utility/bracketed.js';
 
 import Collapsible from './Collapsible.js';
 
-type Props = {
-  +review: CritiqueBrainzReviewT,
-  +title: string,
-};
-
 const authorHref = (author: CritiqueBrainzUserT) => (
   DBDefs.CRITIQUEBRAINZ_SERVER + '/user/' + author.id
 );
@@ -29,35 +24,37 @@ const reviewHref = (review: CritiqueBrainzReviewT) => (
   DBDefs.CRITIQUEBRAINZ_SERVER + '/review/' + review.id
 );
 
-const CritiqueBrainzReview = ({review, title}: Props) => (
-  <>
-    <h3>{title}</h3>
-    <p className="review-metadata">
-      <SanitizedCatalystContext.Consumer>
-        {$c => exp.l('{review_link|Review} by {author} on {date}', {
-          author: (
-            <a href={authorHref(review.author)} key="author">
-              {review.author.name}
-            </a>
-          ),
-          date: formatUserDate($c, review.created, {dateOnly: true}),
-          review_link: {href: reviewHref(review), key: 'review_link'},
-        })}
-      </SanitizedCatalystContext.Consumer>
-      {review.rating == null ? null : (
-        <>
-          {' '}
-          {bracketed(
-            <StaticRatingStars rating={review.rating} />,
-          )}
-        </>
-      )}
-    </p>
-    <Collapsible className="review" html={review.body} />
-  </>
-);
+component CritiqueBrainzReview(review: CritiqueBrainzReviewT, title: string) {
+  return (
+    <>
+      <h3>{title}</h3>
+      <p className="review-metadata">
+        <SanitizedCatalystContext.Consumer>
+          {$c => exp.l('{review_link|Review} by {author} on {date}', {
+            author: (
+              <a href={authorHref(review.author)} key="author">
+                {review.author.name}
+              </a>
+            ),
+            date: formatUserDate($c, review.created, {dateOnly: true}),
+            review_link: {href: reviewHref(review), key: 'review_link'},
+          })}
+        </SanitizedCatalystContext.Consumer>
+        {review.rating == null ? null : (
+          <>
+            {' '}
+            {bracketed(
+              <StaticRatingStars rating={review.rating} />,
+            )}
+          </>
+        )}
+      </p>
+      <Collapsible className="review" html={review.body} />
+    </>
+  );
+}
 
-export default (hydrate<Props, Props>(
+export default (hydrate<React.PropsOf<CritiqueBrainzReview>>(
   'div.critiquebrainz-review',
   CritiqueBrainzReview,
-): React$AbstractComponent<Props, void>);
+): React$AbstractComponent<React.PropsOf<CritiqueBrainzReview>>);

--- a/root/static/scripts/common/components/DataTrackIcon.js
+++ b/root/static/scripts/common/components/DataTrackIcon.js
@@ -7,11 +7,13 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const DataTrackIcon = (): React$Element<'div'> => (
-  <div
-    className="data-track icon img"
-    title={l('This track is a data track.')}
-  />
-);
+component DataTrackIcon() {
+  return (
+    <div
+      className="data-track icon img"
+      title={l('This track is a data track.')}
+    />
+  );
+}
 
 export default DataTrackIcon;

--- a/root/static/scripts/common/components/DescriptiveLink.js
+++ b/root/static/scripts/common/components/DescriptiveLink.js
@@ -15,37 +15,21 @@ import AreaWithContainmentLink from './AreaWithContainmentLink.js';
 import ArtistCreditLink from './ArtistCreditLink.js';
 import EntityLink from './EntityLink.js';
 
-type DescriptiveLinkProps = {
-  +allowNew?: boolean,
-  +className?: string,
-  +content?: Expand2ReactOutput,
-  +customArtistCredit?: ArtistCreditT,
-  +deletedCaption?: string,
-  +disableLink?: boolean,
-  +entity: CollectionT | RelatableEntityT | TrackT | ReleaseEditorTrackT,
-  +showDeletedArtists?: boolean,
-  +showDisambiguation?: boolean,
-  +showEditsPending?: boolean,
-  +showIcon?: boolean,
-  +subPath?: string,
-  +target?: '_blank',
-};
-
-const DescriptiveLink = ({
-  allowNew,
-  className,
-  content,
-  customArtistCredit,
-  deletedCaption,
-  disableLink = false,
-  entity,
-  showDeletedArtists = true,
-  showDisambiguation = true,
-  showEditsPending = true,
-  showIcon = false,
-  subPath,
-  target,
-}: DescriptiveLinkProps): Expand2ReactOutput | React$Node => {
+component DescriptiveLink(
+  allowNew?: boolean,
+  className?: string,
+  content?: Expand2ReactOutput,
+  customArtistCredit?: ArtistCreditT,
+  deletedCaption?: string,
+  disableLink: boolean = false,
+  entity: CollectionT | RelatableEntityT | TrackT | ReleaseEditorTrackT,
+  showDeletedArtists: boolean = true,
+  showDisambiguation: boolean = true,
+  showEditsPending: boolean = true,
+  showIcon: boolean = false,
+  subPath?: string,
+  target?: '_blank',
+) {
   const sharedProps = {
     showDisambiguation,
     showEditsPending,
@@ -99,6 +83,6 @@ const DescriptiveLink = ({
   }
 
   return link;
-};
+}
 
 export default DescriptiveLink;

--- a/root/static/scripts/common/components/EditLink.js
+++ b/root/static/scripts/common/components/EditLink.js
@@ -9,22 +9,18 @@
 
 import {editHref} from '../utility/entityHref.js';
 
-type Props = {
-  +content: string,
-  +edit: GenericEditWithIdT,
-  +subPath?: string,
-};
-
-const EditLink = ({
-  edit,
-  content,
-  subPath,
-}: Props): React$Element<'a'> => (
-  <a href={editHref(edit, subPath)}>
-    <bdi>
-      {content}
-    </bdi>
-  </a>
-);
+component EditLink(
+  content: string,
+  edit: GenericEditWithIdT,
+  subPath?: string,
+) {
+  return (
+    <a href={editHref(edit, subPath)}>
+      <bdi>
+        {content}
+      </bdi>
+    </a>
+  );
+}
 
 export default EditLink;

--- a/root/static/scripts/common/components/EditorLink.js
+++ b/root/static/scripts/common/components/EditorLink.js
@@ -11,7 +11,7 @@ import defaultAvatarUrl from '../../../images/entity/editor.svg';
 import entityHref from '../utility/entityHref.js';
 import isolateText from '../utility/isolateText.js';
 
-const MissingEditorLink = (): React$Element<'span'> => {
+component MissingEditorLink() {
   return (
     <span
       className="deleted tooltip"
@@ -23,21 +23,14 @@ const MissingEditorLink = (): React$Element<'span'> => {
       {isolateText(l('[missing editor]'))}
     </span>
   );
-};
+}
 
-type Props = {
-  +avatarSize?: number,
-  +content?: string,
-  +editor: ?$ReadOnly<{...EditorT, ...}>,
-  +subPath?: string,
-};
-
-const EditorLink = ({
-  editor,
-  content: passedContent,
-  avatarSize = 15,
-  subPath,
-}: Props): React$Element<typeof MissingEditorLink | 'a'> => {
+component EditorLink(
+  avatarSize?: number = 15,
+  content as passedContent?: string,
+  editor: ?$ReadOnly<{...EditorT, ...}>,
+  subPath?: string,
+) {
   if (!editor) {
     return <MissingEditorLink />;
   }
@@ -65,6 +58,6 @@ const EditorLink = ({
       {isolateText(content)}
     </a>
   );
-};
+}
 
 export default EditorLink;

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -21,19 +21,12 @@ import entityHref from '../utility/entityHref.js';
 import formatDatePeriod from '../utility/formatDatePeriod.js';
 import isolateText from '../utility/isolateText.js';
 
-type DeletedLinkProps = {
-  +allowNew: boolean,
-  +className?: string,
-  +deletedCaption?: string,
-  +name: ?Expand2ReactOutput,
-};
-
-export const DeletedLink = ({
-  allowNew,
-  className,
-  deletedCaption,
-  name,
-}: DeletedLinkProps): React$Element<'span'> => {
+export component DeletedLink(
+  allowNew: boolean,
+  className?: string,
+  deletedCaption?: string,
+  name: ?Expand2ReactOutput,
+) {
   const caption = nonEmpty(deletedCaption) ? deletedCaption : (allowNew
     ? l('This entity will be added by this edit.')
     : l('This entity has been removed, and cannot be displayed correctly.'));
@@ -52,7 +45,7 @@ export const DeletedLink = ({
         : lp('[removed]', 'generic entity'))}
     </span>
   );
-};
+}
 
 const iconClassPicker = {
   area: 'arealink',
@@ -74,11 +67,11 @@ const iconClassPicker = {
   work: 'worklink',
 };
 
-const Comment = ({
-  alias,
-  className,
-  comment,
-}: {+alias?: string, +className: string, +comment: string}) => {
+component Comment(
+  alias?: string,
+  className: string,
+  comment: string,
+) {
   const aliasElement = nonEmpty(alias)
     ? <i title={l('Primary alias')}>{alias}</i>
     : null;
@@ -98,12 +91,9 @@ const Comment = ({
       </span>
     </>
   );
-};
+}
 
-const EventDisambiguation = ({
-  event,
-  showDate,
-}: {+event: EventT, +showDate: boolean}) => {
+component EventDisambiguation(event: EventT, showDate: boolean) {
   const dates = formatDatePeriod(event);
   if ((!dates || !showDate) && !event.cancelled) {
     return null;
@@ -116,9 +106,9 @@ const EventDisambiguation = ({
         : null}
     </>
   );
-};
+}
 
-const AreaDisambiguation = ({area}: {+area: AreaT}) => {
+component AreaDisambiguation(area: AreaT) {
   if (!area.ended) {
     return null;
   }
@@ -139,77 +129,58 @@ const AreaDisambiguation = ({area}: {+area: AreaT}) => {
   }
 
   return <Comment className="historical" comment={comment} />;
-};
+}
 
 const disabledLinkText = N_l(`This link has been temporarily disabled because
                               it has been reported as potentially harmful.`);
 
-const NoInfoURL = ({allowNew, url}: {+allowNew: boolean, +url: string}) => (
-  <>
-    {isGreyedOut(url) ? (
-      <span
-        className="deleted"
-        title={disabledLinkText()}
-      >
-        {isolateText(url)}
-      </span>
-    ) : <a className="wrap-anywhere" href={url}>{url}</a>}
-    {' '}
-    <DeletedLink
-      allowNew={allowNew}
-      name={bracketedText(l('info'), {type: '[]'})}
-    />
-  </>
-);
+component NoInfoURL(allowNew: boolean, url: string) {
+  return (
+    <>
+      {isGreyedOut(url) ? (
+        <span
+          className="deleted"
+          title={disabledLinkText()}
+        >
+          {isolateText(url)}
+        </span>
+      ) : <a className="wrap-anywhere" href={url}>{url}</a>}
+      {' '}
+      <DeletedLink
+        allowNew={allowNew}
+        name={bracketedText(l('info'), {type: '[]'})}
+      />
+    </>
+  );
+}
 
-/* eslint-disable sort-keys, ft-flow/sort-keys */
-type EntityLinkProps = {
-  +allowNew?: boolean,
-  +content?: ?Expand2ReactOutput,
-  +deletedCaption?: string,
-  +disableLink?: boolean,
-  +entity:
+component EntityLink(
+  allowNew: boolean = false,
+  content as passedContent?: ?Expand2ReactOutput,
+  deletedCaption?: string,
+  disableLink: boolean = false,
+  entity:
     | RelatableEntityT
     | CollectionT
     | LinkTypeT
     | TrackT
     | ReleaseEditorTrackT,
-  +hover?: string,
-  +nameVariation?: boolean,
-  +showCaaPresence?: boolean,
-  +showDeleted?: boolean,
-  +showDisambiguation?: boolean | 'hover',
-  +showEditsPending?: boolean,
-  +showEventDate?: boolean,
-  +showIcon?: boolean,
-  +subPath?: string,
-
-  // ...anchorProps
-  className?: string,
-  href?: string,
-  title?: string,
-  +target?: '_blank',
-};
-/* eslint-enable sort-keys, ft-flow/sort-keys */
-
-const EntityLink = ({
-  allowNew = false,
-  content: passedContent,
-  deletedCaption,
-  disableLink = false,
-  entity,
-  hover: passedHover,
-  nameVariation: passedNameVariation,
-  showCaaPresence = false,
-  showDeleted = true,
-  showDisambiguation: passedShowDisambiguation,
-  showEditsPending = true,
-  showEventDate = true,
-  showIcon: passedShowIcon = false,
-  subPath,
-  ...anchorProps
-}: EntityLinkProps):
-$ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
+  hover as passedHover?: string,
+  nameVariation as passedNameVariation?: boolean,
+  showCaaPresence: boolean = false,
+  showDeleted: boolean = true,
+  showDisambiguation as passedShowDisambiguation?: boolean | 'hover',
+  showEditsPending: boolean = true,
+  showEventDate: boolean = true,
+  showIcon as passedShowIcon?: boolean = false,
+  subPath?: string,
+  ...passedAnchorProps: {
+    className?: string,
+    href?: string,
+    +target?: '_blank',
+    title?: string,
+  }
+) {
   const hasCustomContent = nonEmpty(passedContent);
   // $FlowIgnore[sketchy-null-mixed]
   const hasEditsPending = entity.editsPending || false;
@@ -222,6 +193,7 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
   let nameVariation = passedNameVariation;
   let showDisambiguation = passedShowDisambiguation;
   let showIcon = passedShowIcon;
+  const anchorProps = {...passedAnchorProps};
 
   if (nameVariation === undefined &&
     nonEmpty(content) && typeof content !== 'string'
@@ -497,6 +469,6 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
   }
 
   return React.createElement(React.Fragment, null, ...parts);
-};
+}
 
 export default EntityLink;

--- a/root/static/scripts/common/components/EventLocations.js
+++ b/root/static/scripts/common/components/EventLocations.js
@@ -9,23 +9,21 @@
 
 import DescriptiveLink from './DescriptiveLink.js';
 
-type Props = {
-  +event: EventT,
-};
-
-const EventLocations = ({event}: Props): React$Element<'ul'> => (
-  <ul>
-    {event.places.map(place => (
-      <li key={place.entity.id}>
-        <DescriptiveLink content={place.credit} entity={place.entity} />
-      </li>
-    ))}
-    {event.areas.map(area => (
-      <li key={area.entity.id}>
-        <DescriptiveLink content={area.credit} entity={area.entity} />
-      </li>
-    ))}
-  </ul>
-);
+component EventLocations(event: EventT) {
+  return (
+    <ul>
+      {event.places.map(place => (
+        <li key={place.entity.id}>
+          <DescriptiveLink content={place.credit} entity={place.entity} />
+        </li>
+      ))}
+      {event.areas.map(area => (
+        <li key={area.entity.id}>
+          <DescriptiveLink content={area.credit} entity={area.entity} />
+        </li>
+      ))}
+    </ul>
+  );
+}
 
 export default EventLocations;

--- a/root/static/scripts/common/components/ExpandedArtistCredit.js
+++ b/root/static/scripts/common/components/ExpandedArtistCredit.js
@@ -11,13 +11,7 @@ import commaOnlyList from '../i18n/commaOnlyList.js';
 import ArtistCreditLink from './ArtistCreditLink.js';
 import DescriptiveLink from './DescriptiveLink.js';
 
-type Props = {
-  +artistCredit: ArtistCreditT,
-};
-
-export const ExpandedArtistCreditList = ({
-  artistCredit,
-}: Props): React$Element<'span'> | null => {
+export component ExpandedArtistCreditList(artistCredit: ArtistCreditT) {
   if (!artistCredit) {
     return null;
   }
@@ -47,14 +41,16 @@ export const ExpandedArtistCreditList = ({
   }
 
   return null;
-};
+}
 
-const ExpandedArtistCredit = ({artistCredit}: Props): React$MixedElement => (
-  <>
-    <ArtistCreditLink artistCredit={artistCredit} />
-    <br />
-    <ExpandedArtistCreditList artistCredit={artistCredit} />
-  </>
-);
+component ExpandedArtistCredit(artistCredit: ArtistCreditT) {
+  return (
+    <>
+      <ArtistCreditLink artistCredit={artistCredit} />
+      <br />
+      <ExpandedArtistCreditList artistCredit={artistCredit} />
+    </>
+  );
+}
 
 export default ExpandedArtistCredit;

--- a/root/static/scripts/common/components/Filter.js
+++ b/root/static/scripts/common/components/Filter.js
@@ -14,12 +14,7 @@ import setCookie from '../utility/setCookie.js';
 
 import FilterForm, {type FilterFormT} from './FilterForm.js';
 
-type Props = {
-  +ajaxFormUrl: string,
-  +initialFilterForm: ?FilterFormT,
-};
-
-const Filter = ({ajaxFormUrl, initialFilterForm}: Props) => {
+component Filter(ajaxFormUrl: string, initialFilterForm: ?FilterFormT) {
   const [filterForm, setFilterForm] = React.useState<?FilterFormT>(
     initialFilterForm,
   );
@@ -70,9 +65,9 @@ const Filter = ({ajaxFormUrl, initialFilterForm}: Props) => {
       ) : null}
     </>
   );
-};
+}
 
 export default (
-  hydrate<Props>('div.filter', Filter):
-  React$AbstractComponent<Props, void>
+  hydrate<React.PropsOf<Filter>>('div.filter', Filter):
+  React$AbstractComponent<React.PropsOf<Filter>>
 );

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -94,10 +94,6 @@ export type FilterFormT =
   | ReleaseGroupFilterT
   | WorkFilterT;
 
-type Props = {
-  +form: FilterFormT,
-};
-
 function getSubmitText(type: string) {
   switch (type) {
     case 'event':
@@ -160,247 +156,249 @@ const TypeField = ({field, options}: FieldProps): React$Element<'tr'> => (
   </tr>
 );
 
-const FilterForm = ({form}: Props): React$Element<'div'> => (
-  <div id="filter">
-    <form method="get">
-      <table>
-        <tbody>
-          <tr>
-            <td>{addColonText(l('Name'))}</td>
-            <td>
-              <input
-                defaultValue={form.field.name.value}
-                name={form.field.name.html_name}
-                size="47"
-                type="text"
-              />
-            </td>
-          </tr>
+component FilterForm(form: FilterFormT) {
+  return (
+    <div id="filter">
+      <form method="get">
+        <table>
+          <tbody>
+            <tr>
+              <td>{addColonText(l('Name'))}</td>
+              <td>
+                <input
+                  defaultValue={form.field.name.value}
+                  name={form.field.name.html_name}
+                  size="47"
+                  type="text"
+                />
+              </td>
+            </tr>
 
-          {form.entity_type === 'event' ? (
-            <>
-              <TypeField
-                field={form.field.type_id}
-                options={form.options_type_id}
-              />
-              <tr>
-                <td>
-                  {addColonText(l('Setlist contains'))}
-                </td>
-                <td>
-                  <input
-                    defaultValue={form.field.setlist.value ?? ''}
-                    name={form.field.setlist.html_name}
-                    size="47"
-                    type="text"
-                  />
-                  <FieldErrors field={form.field.setlist} />
-                </td>
-              </tr>
-            </>
-          ) : null}
+            {form.entity_type === 'event' ? (
+              <>
+                <TypeField
+                  field={form.field.type_id}
+                  options={form.options_type_id}
+                />
+                <tr>
+                  <td>
+                    {addColonText(l('Setlist contains'))}
+                  </td>
+                  <td>
+                    <input
+                      defaultValue={form.field.setlist.value ?? ''}
+                      name={form.field.setlist.html_name}
+                      size="47"
+                      type="text"
+                    />
+                    <FieldErrors field={form.field.setlist} />
+                  </td>
+                </tr>
+              </>
+            ) : null}
 
-          {form.entity_type === 'recording' ? (
-            <>
-              <ArtistCreditField
-                field={form.field.artist_credit_id}
-                options={form.options_artist_credit_id}
-              />
-              <tr>
-                <td>
-                  {addColonText(l('Video'))}
-                </td>
-                <td>
-                  <SelectField
-                    field={form.field.video}
-                    options={{
-                      grouped: false,
-                      options: form.options_video,
-                    }}
-                    style={{maxWidth: '40em'}}
-                    uncontrolled
-                  />
-                </td>
-              </tr>
-              <tr>
-                <td
-                  title={l(`Hide recordings that only appear
-                            on bootleg releases`)}
-                >
-                  {addColonText(l('Hide bootleg-only'))}
-                </td>
-                <td>
-                  <input
-                    defaultChecked={form.field.hide_bootlegs.value}
-                    id={'id-' + String(form.field.hide_bootlegs.html_name)}
-                    name={form.field.hide_bootlegs.html_name}
-                    type="checkbox"
+            {form.entity_type === 'recording' ? (
+              <>
+                <ArtistCreditField
+                  field={form.field.artist_credit_id}
+                  options={form.options_artist_credit_id}
+                />
+                <tr>
+                  <td>
+                    {addColonText(l('Video'))}
+                  </td>
+                  <td>
+                    <SelectField
+                      field={form.field.video}
+                      options={{
+                        grouped: false,
+                        options: form.options_video,
+                      }}
+                      style={{maxWidth: '40em'}}
+                      uncontrolled
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td
+                    title={l(`Hide recordings that only appear
+                              on bootleg releases`)}
+                  >
+                    {addColonText(l('Hide bootleg-only'))}
+                  </td>
+                  <td>
+                    <input
+                      defaultChecked={form.field.hide_bootlegs.value}
+                      id={'id-' + String(form.field.hide_bootlegs.html_name)}
+                      name={form.field.hide_bootlegs.html_name}
+                      type="checkbox"
+                      value="1"
+                    />
+                  </td>
+                </tr>
+              </>
+            ) : null}
+
+            {form.entity_type === 'release' ? (
+              <>
+                <ArtistCreditField
+                  field={form.field.artist_credit_id}
+                  options={form.options_artist_credit_id}
+                />
+                <tr>
+                  <td>
+                    {addColonText(l('Label'))}
+                  </td>
+                  <td>
+                    <SelectField
+                      field={form.field.label_id}
+                      options={{
+                        grouped: false,
+                        options: form.options_label_id,
+                      }}
+                      style={{maxWidth: '40em'}}
+                      uncontrolled
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    {addColonText(l('Country'))}
+                  </td>
+                  <td>
+                    <SelectField
+                      field={form.field.country_id}
+                      options={{
+                        grouped: false,
+                        options: form.options_country_id,
+                      }}
+                      style={{maxWidth: '40em'}}
+                      uncontrolled
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    {addColonText(lp('Status', 'release'))}
+                  </td>
+                  <td>
+                    <SelectField
+                      field={form.field.status_id}
+                      options={{
+                        grouped: false,
+                        options: form.options_status_id,
+                      }}
+                      style={{maxWidth: '40em'}}
+                      uncontrolled
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    {addColonText(l('Date'))}
+                  </td>
+                  <td>
+                    <input
+                      defaultValue={form.field.date.value ?? ''}
+                      name={form.field.date.html_name}
+                      size="47"
+                      type="text"
+                    />
+                    <FieldErrors field={form.field.date} />
+                  </td>
+                </tr>
+              </>
+            ) : null}
+
+            {form.entity_type === 'release_group' ? (
+              <>
+                <TypeField
+                  field={form.field.type_id}
+                  options={form.options_type_id}
+                />
+                <ArtistCreditField
+                  field={form.field.artist_credit_id}
+                  options={form.options_artist_credit_id}
+                />
+                <tr>
+                  <td>
+                    {addColonText(l('Secondary type'))}
+                  </td>
+                  <td>
+                    <SelectField
+                      field={form.field.secondary_type_id}
+                      options={{
+                        grouped: false,
+                        options: form.options_secondary_type_id,
+                      }}
+                      style={{maxWidth: '40em'}}
+                      uncontrolled
+                    />
+                  </td>
+                </tr>
+              </>
+            ) : null}
+
+            {form.entity_type === 'work' ? (
+              <>
+                <TypeField
+                  field={form.field.type_id}
+                  options={form.options_type_id}
+                />
+                <tr>
+                  <td>
+                    {addColonText(l('Role'))}
+                  </td>
+                  <td>
+                    <SelectField
+                      field={form.field.role_type}
+                      options={{
+                        grouped: false,
+                        options: form.options_role_type,
+                      }}
+                      style={{maxWidth: '40em'}}
+                      uncontrolled
+                    />
+                  </td>
+                </tr>
+              </>
+            ) : null}
+
+            <tr>
+              <td>{addColonText(l('Disambiguation'))}</td>
+              <td>
+                <input
+                  defaultValue={form.field.disambiguation.value}
+                  name={form.field.disambiguation.html_name}
+                  size="47"
+                  type="text"
+                />
+              </td>
+            </tr>
+
+            <tr>
+              <td />
+              <td>
+                <span className="buttons">
+                  <button className="submit positive" type="submit">
+                    {getSubmitText(form.entity_type)}
+                  </button>
+                  <button
+                    className="submit negative"
+                    name="filter.cancel"
+                    type="submit"
                     value="1"
-                  />
-                </td>
-              </tr>
-            </>
-          ) : null}
-
-          {form.entity_type === 'release' ? (
-            <>
-              <ArtistCreditField
-                field={form.field.artist_credit_id}
-                options={form.options_artist_credit_id}
-              />
-              <tr>
-                <td>
-                  {addColonText(l('Label'))}
-                </td>
-                <td>
-                  <SelectField
-                    field={form.field.label_id}
-                    options={{
-                      grouped: false,
-                      options: form.options_label_id,
-                    }}
-                    style={{maxWidth: '40em'}}
-                    uncontrolled
-                  />
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  {addColonText(l('Country'))}
-                </td>
-                <td>
-                  <SelectField
-                    field={form.field.country_id}
-                    options={{
-                      grouped: false,
-                      options: form.options_country_id,
-                    }}
-                    style={{maxWidth: '40em'}}
-                    uncontrolled
-                  />
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  {addColonText(lp('Status', 'release'))}
-                </td>
-                <td>
-                  <SelectField
-                    field={form.field.status_id}
-                    options={{
-                      grouped: false,
-                      options: form.options_status_id,
-                    }}
-                    style={{maxWidth: '40em'}}
-                    uncontrolled
-                  />
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  {addColonText(l('Date'))}
-                </td>
-                <td>
-                  <input
-                    defaultValue={form.field.date.value ?? ''}
-                    name={form.field.date.html_name}
-                    size="47"
-                    type="text"
-                  />
-                  <FieldErrors field={form.field.date} />
-                </td>
-              </tr>
-            </>
-          ) : null}
-
-          {form.entity_type === 'release_group' ? (
-            <>
-              <TypeField
-                field={form.field.type_id}
-                options={form.options_type_id}
-              />
-              <ArtistCreditField
-                field={form.field.artist_credit_id}
-                options={form.options_artist_credit_id}
-              />
-              <tr>
-                <td>
-                  {addColonText(l('Secondary type'))}
-                </td>
-                <td>
-                  <SelectField
-                    field={form.field.secondary_type_id}
-                    options={{
-                      grouped: false,
-                      options: form.options_secondary_type_id,
-                    }}
-                    style={{maxWidth: '40em'}}
-                    uncontrolled
-                  />
-                </td>
-              </tr>
-            </>
-          ) : null}
-
-          {form.entity_type === 'work' ? (
-            <>
-              <TypeField
-                field={form.field.type_id}
-                options={form.options_type_id}
-              />
-              <tr>
-                <td>
-                  {addColonText(l('Role'))}
-                </td>
-                <td>
-                  <SelectField
-                    field={form.field.role_type}
-                    options={{
-                      grouped: false,
-                      options: form.options_role_type,
-                    }}
-                    style={{maxWidth: '40em'}}
-                    uncontrolled
-                  />
-                </td>
-              </tr>
-            </>
-          ) : null}
-
-          <tr>
-            <td>{addColonText(l('Disambiguation'))}</td>
-            <td>
-              <input
-                defaultValue={form.field.disambiguation.value}
-                name={form.field.disambiguation.html_name}
-                size="47"
-                type="text"
-              />
-            </td>
-          </tr>
-
-          <tr>
-            <td />
-            <td>
-              <span className="buttons">
-                <button className="submit positive" type="submit">
-                  {getSubmitText(form.entity_type)}
-                </button>
-                <button
-                  className="submit negative"
-                  name="filter.cancel"
-                  type="submit"
-                  value="1"
-                >
-                  {l('Cancel')}
-                </button>
-              </span>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </form>
-  </div>
-);
+                  >
+                    {l('Cancel')}
+                  </button>
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </form>
+    </div>
+  );
+}
 
 export default FilterForm;

--- a/root/static/scripts/common/components/FingerprintTable.js
+++ b/root/static/scripts/common/components/FingerprintTable.js
@@ -33,7 +33,7 @@ function orderTracks(a: AcoustIdTrackT, b: AcoustIdTrackT) {
   return compareStrings(a.id, b.id);
 }
 
-const FingerprintTable = ({recording}: {recording: RecordingT}) => {
+component FingerprintTable(recording: RecordingT) {
   const [tracks, setTracks] =
     React.useState<$ReadOnlyArray<AcoustIdTrackT>>([]);
   const [isLoaded, setIsLoaded] = React.useState(false);
@@ -113,9 +113,9 @@ const FingerprintTable = ({recording}: {recording: RecordingT}) => {
       <p>{l('This recording does not have any associated AcoustIDs')}</p>
     ) : <p className="loading-message">{l('Loading...')}</p>
   );
-};
+}
 
-export default (hydrate<{recording: RecordingT}>(
+export default (hydrate<React.PropsOf<FingerprintTable>>(
   'div.acoustid-fingerprints',
   FingerprintTable,
-): React$AbstractComponent<{recording: RecordingT}, void>);
+): React$AbstractComponent<React.PropsOf<FingerprintTable>>);

--- a/root/static/scripts/common/components/InstrumentListEntry.js
+++ b/root/static/scripts/common/components/InstrumentListEntry.js
@@ -15,22 +15,7 @@ import expand2react from '../i18n/expand2react.js';
 
 import DescriptiveLink from './DescriptiveLink.js';
 
-type InstrumentListRowProps = {
-  +checkboxes?: string,
-  +instrument: InstrumentT,
-};
-
-type InstrumentListEntryProps = {
-  +checkboxes?: string,
-  +index: number,
-  +instrument: InstrumentT,
-  +score?: number,
-};
-
-const InstrumentListRow = ({
-  checkboxes,
-  instrument,
-}: InstrumentListRowProps) => {
+component InstrumentListRow(checkboxes?: string, instrument: InstrumentT) {
   const $c = React.useContext(SanitizedCatalystContext);
   return (
     <>
@@ -58,20 +43,18 @@ const InstrumentListRow = ({
       </td>
     </>
   );
-};
+}
 
-const InstrumentListEntry = ({
-  checkboxes,
-  index,
-  instrument,
-  score,
-}: InstrumentListEntryProps): React$Element<'tr'> => (
-  <tr className={loopParity(index)} data-score={score ?? null}>
-    <InstrumentListRow
-      checkboxes={checkboxes}
-      instrument={instrument}
-    />
-  </tr>
-);
+component InstrumentListEntry(
+  index: number,
+  score?: number,
+  ...rowProps: React.PropsOf<InstrumentListRow>
+) {
+  return (
+    <tr className={loopParity(index)} data-score={score ?? null}>
+      <InstrumentListRow {...rowProps} />
+    </tr>
+  );
+}
 
 export default InstrumentListEntry;

--- a/root/static/scripts/common/components/IrombookImage.js
+++ b/root/static/scripts/common/components/IrombookImage.js
@@ -7,15 +7,11 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type Props = {
-  +entity: InstrumentT,
-};
-
 function isIrombookImage(url: UrlT): boolean {
   return /https:\/\/static\.metabrainz\.org\/irombook\//.test(url.href_url);
 }
 
-const IrombookImage = ({entity}: Props): React$Element<'div'> | null => {
+component IrombookImage(entity: InstrumentT) {
   const relationships = entity.relationships;
 
   if (!relationships) {
@@ -43,6 +39,6 @@ const IrombookImage = ({entity}: Props): React$Element<'div'> | null => {
       </span>
     </div>
   ) : null;
-};
+}
 
 export default IrombookImage;

--- a/root/static/scripts/common/components/IsrcList.js
+++ b/root/static/scripts/common/components/IsrcList.js
@@ -29,30 +29,27 @@ const buildIsrcSidebarRow = (isrc: IsrcT) => (
   </SidebarProperty>
 );
 
-type IsrcListProps = {|
-  +isrcs: ?$ReadOnlyArray<IsrcT>,
-  +isSidebar?: boolean,
-|};
+component IsrcList(
+  isrcs: ?$ReadOnlyArray<IsrcT>,
+  isSidebar: boolean = false,
+) {
+  return (
+    <CollapsibleList
+      ContainerElement={isSidebar ? 'dl' : 'ul'}
+      InnerElement={isSidebar ? 'div' : 'li'}
+      ariaLabel={l('ISRCs')}
+      buildRow={isSidebar ? buildIsrcSidebarRow : buildIsrcListRow}
+      className={isSidebar ? 'properties isrcs' : 'isrcs'}
+      rows={isrcs}
+      showAllTitle={l('Show all ISRCs')}
+      showLessTitle={l('Show less ISRCs')}
+      toShowAfter={1}
+      toShowBefore={2}
+    />
+  );
+}
 
-const IsrcList = ({
-  isrcs,
-  isSidebar = false,
-}: IsrcListProps) => (
-  <CollapsibleList
-    ContainerElement={isSidebar ? 'dl' : 'ul'}
-    InnerElement={isSidebar ? 'div' : 'li'}
-    ariaLabel={l('ISRCs')}
-    buildRow={isSidebar ? buildIsrcSidebarRow : buildIsrcListRow}
-    className={isSidebar ? 'properties isrcs' : 'isrcs'}
-    rows={isrcs}
-    showAllTitle={l('Show all ISRCs')}
-    showLessTitle={l('Show less ISRCs')}
-    toShowAfter={1}
-    toShowBefore={2}
-  />
-);
-
-export default (hydrate<IsrcListProps>(
+export default (hydrate<React.PropsOf<IsrcList>>(
   'div.isrc-list-container',
   IsrcList,
-): React$AbstractComponent<IsrcListProps, void>);
+): React$AbstractComponent<React.PropsOf<IsrcList>>);

--- a/root/static/scripts/common/components/IswcList.js
+++ b/root/static/scripts/common/components/IswcList.js
@@ -29,30 +29,27 @@ const buildIswcSidebarRow = (iswc: IswcT) => (
   </SidebarProperty>
 );
 
-type IswcListProps = {|
-  +isSidebar?: boolean,
-  +iswcs: ?$ReadOnlyArray<IswcT>,
-|};
+component IswcList(
+  iswcs: ?$ReadOnlyArray<IswcT>,
+  isSidebar: boolean = false,
+) {
+  return (
+    <CollapsibleList
+      ContainerElement={isSidebar ? 'dl' : 'ul'}
+      InnerElement={isSidebar ? 'div' : 'li'}
+      ariaLabel={l('ISWCs')}
+      buildRow={isSidebar ? buildIswcSidebarRow : buildIswcListRow}
+      className={isSidebar ? 'properties iswcs' : 'iswcs'}
+      rows={iswcs}
+      showAllTitle={l('Show all ISWCs')}
+      showLessTitle={l('Show less ISWCs')}
+      toShowAfter={1}
+      toShowBefore={2}
+    />
+  );
+}
 
-const IswcList = ({
-  iswcs,
-  isSidebar = false,
-}: IswcListProps) => (
-  <CollapsibleList
-    ContainerElement={isSidebar ? 'dl' : 'ul'}
-    InnerElement={isSidebar ? 'div' : 'li'}
-    ariaLabel={l('ISWCs')}
-    buildRow={isSidebar ? buildIswcSidebarRow : buildIswcListRow}
-    className={isSidebar ? 'properties iswcs' : 'iswcs'}
-    rows={iswcs}
-    showAllTitle={l('Show all ISWCs')}
-    showLessTitle={l('Show less ISWCs')}
-    toShowAfter={1}
-    toShowBefore={2}
-  />
-);
-
-export default (hydrate<IswcListProps>(
+export default (hydrate<React.PropsOf<IswcList>>(
   'div.iswc-list-container',
   IswcList,
-): React$AbstractComponent<IswcListProps, void>);
+): React$AbstractComponent<React.PropsOf<IswcList>>);

--- a/root/static/scripts/common/components/MediumDescription.js
+++ b/root/static/scripts/common/components/MediumDescription.js
@@ -10,11 +10,7 @@
 import isolateText from '../utility/isolateText.js';
 import mediumFormatName from '../utility/mediumFormatName.js';
 
-type Props = {
-  +medium: MediumT,
-};
-
-const MediumDescription = ({medium}: Props): Expand2ReactOutput => {
+component MediumDescription(medium: MediumT) {
   const formatAndPosition = texp.l('{medium_format} {position}', {
     medium_format: mediumFormatName(medium),
     position: medium.position,
@@ -29,6 +25,6 @@ const MediumDescription = ({medium}: Props): Expand2ReactOutput => {
     );
   }
   return formatAndPosition;
-};
+}
 
 export default MediumDescription;

--- a/root/static/scripts/common/components/MediumLink.js
+++ b/root/static/scripts/common/components/MediumLink.js
@@ -12,21 +12,18 @@ import linkedEntities from '../linkedEntities.mjs';
 import DescriptiveLink from './DescriptiveLink.js';
 import MediumDescription from './MediumDescription.js';
 
-type Props = {
-  +allowNew?: boolean,
-  +medium: MediumT,
-};
-
-const MediumLink = ({allowNew, medium}: Props): Expand2ReactOutput => (
-  exp.l('{medium} on {release}', {
-    medium: <MediumDescription medium={medium} />,
-    release: (
-      <DescriptiveLink
-        allowNew={allowNew}
-        entity={linkedEntities.release[medium.release_id]}
-      />
-    ),
-  })
-);
+component MediumLink(allowNew?: boolean, medium: MediumT) {
+  return (
+    exp.l('{medium} on {release}', {
+      medium: <MediumDescription medium={medium} />,
+      release: (
+        <DescriptiveLink
+          allowNew={allowNew}
+          entity={linkedEntities.release[medium.release_id]}
+        />
+      ),
+    })
+  );
+}
 
 export default MediumLink;

--- a/root/static/scripts/common/components/MergeCheckboxElement.js
+++ b/root/static/scripts/common/components/MergeCheckboxElement.js
@@ -7,32 +7,28 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type Props = {
-  +entity: MergeableEntityT,
-  +form: MergeFormT | MergeReleasesFormT,
-  +index: number,
-};
-
-const MergeCheckboxElement = ({
-  entity,
-  form,
-  index,
-}: Props): React$MixedElement => (
-  <>
-    <input
-      name={'merge.merging.' + index}
-      type="hidden"
-      value={entity.id}
-    />
-    <input
-      defaultChecked={
-        String(entity.id) === String(form.field.target.value)
-      }
-      name="merge.target"
-      type="radio"
-      value={entity.id}
-    />
-  </>
-);
+component MergeCheckboxElement(
+  entity: MergeableEntityT,
+  form: MergeFormT | MergeReleasesFormT,
+  index: number,
+) {
+  return (
+    <>
+      <input
+        name={'merge.merging.' + index}
+        type="hidden"
+        value={entity.id}
+      />
+      <input
+        defaultChecked={
+          String(entity.id) === String(form.field.target.value)
+        }
+        name="merge.target"
+        type="radio"
+        value={entity.id}
+      />
+    </>
+  );
+}
 
 export default MergeCheckboxElement;

--- a/root/static/scripts/common/components/Modal.js
+++ b/root/static/scripts/common/components/Modal.js
@@ -24,24 +24,13 @@ import {findFirstTabbableElement} from '../utility/focusManagement.js';
 
 import ErrorBoundary from './ErrorBoundary.js';
 
-type PropsT = $ReadOnly<{
-  +children: React$Node,
-  +className?: string,
-  +id: string,
-  +onClick?: (SyntheticMouseEvent<HTMLDivElement>) => void,
-  +onEscape: (Event) => void,
-  +title: string,
-}>;
-
-const Modal = (props: PropsT): React$MixedElement => {
-  const {
-    children,
-    className,
-    id,
-    onEscape,
-    title,
-  } = props;
-
+component Modal(
+  children: React$Node,
+  className?: string,
+  id: string,
+  onEscape: (Event) => void,
+  title: string,
+) {
   const nodeId = useFloatingNodeId();
 
   const onOpenChange = React.useCallback((
@@ -141,6 +130,6 @@ const Modal = (props: PropsT): React$MixedElement => {
       </FloatingPortal>
     </FloatingNode>
   );
-};
+}
 
 export default Modal;

--- a/root/static/scripts/common/components/OrderableDirection.js
+++ b/root/static/scripts/common/components/OrderableDirection.js
@@ -9,13 +9,7 @@
 
 import {bracketedText} from '../utility/bracketed.js';
 
-type Props = {
-  +direction: number,
-};
-
-const OrderableDirection = ({
-  direction,
-}: Props): React$MixedElement => {
+component OrderableDirection(direction: number) {
   let directionName;
   switch (direction) {
     case 0:
@@ -36,6 +30,6 @@ const OrderableDirection = ({
       {bracketedText(direction.toString())}
     </>
   );
-};
+}
 
 export default OrderableDirection;

--- a/root/static/scripts/common/components/PostParameters.js
+++ b/root/static/scripts/common/components/PostParameters.js
@@ -16,15 +16,9 @@ export type PostParametersT = {
   ...
 };
 
-type PropsT = {
-  +params: PostParametersT,
-};
-
 const textAreaRegExp = /(^|\.)(annotation|edit_note)$/;
 
-const PostParameters = ({
-  params,
-}: PropsT): React$MixedElement => {
+component PostParameters(params: PostParametersT) {
   const [expanded, setExpanded] = React.useState(false);
 
   const sortedParams:
@@ -91,9 +85,9 @@ const PostParameters = ({
       </table>
     </>
   );
-};
+}
 
 export default (hydrate(
   'div.post-parameters',
   PostParameters,
-): React$AbstractComponent<PropsT, void>);
+): React$AbstractComponent<React.PropsOf<PostParameters>>);

--- a/root/static/scripts/common/components/PregapTrackIcon.js
+++ b/root/static/scripts/common/components/PregapTrackIcon.js
@@ -7,11 +7,13 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const PregapTrackIcon = (): React$Element<'div'> => (
-  <div
-    className="pregap-track icon img"
-    title={l('This track is hidden in the pregap.')}
-  />
-);
+component PregapTrackIcon() {
+  return (
+    <div
+      className="pregap-track icon img"
+      title={l('This track is hidden in the pregap.')}
+    />
+  );
+}
 
 export default PregapTrackIcon;

--- a/root/static/scripts/common/components/RatingStars.js
+++ b/root/static/scripts/common/components/RatingStars.js
@@ -29,17 +29,7 @@ const ratingURL = (
 
 const ratingInts = [1, 2, 3, 4, 5];
 
-type StaticRatingStarsProps = {
-  +rating: ?number,
-};
-
-type RatingStarsProps = {
-  +entity: RatableT,
-};
-
-export const StaticRatingStars = ({
-  rating,
-}: StaticRatingStarsProps): React$Element<'span'> => {
+export component StaticRatingStars(rating: ?number) {
   const starRating = rating == null ? 0 : (5 * rating / 100);
   return (
     <span className="inline-rating">
@@ -53,9 +43,9 @@ export const StaticRatingStars = ({
       </span>
     </span>
   );
-};
+}
 
-const RatingStars = ({entity}: RatingStarsProps): React$Element<'span'> => {
+component RatingStars(entity: RatableT) {
   const currentStarRating =
     entity.user_rating == null ? 0 : (5 * entity.user_rating / 100);
   const $c = React.useContext(SanitizedCatalystContext);
@@ -103,6 +93,6 @@ const RatingStars = ({entity}: RatingStarsProps): React$Element<'span'> => {
       </span>
     </span>
   );
-};
+}
 
 export default RatingStars;

--- a/root/static/scripts/common/components/RelatedSeries.js
+++ b/root/static/scripts/common/components/RelatedSeries.js
@@ -16,10 +16,6 @@ import groupRelationships from '../utility/groupRelationships.js';
 import EntityLink from './EntityLink.js';
 import StaticRelationshipsDisplay from './StaticRelationshipsDisplay.js';
 
-type Props = {
-  +seriesIds: $ReadOnlyArray<number>,
-};
-
 const seriesPartLinkTypes = new Set(
   Object.values(PART_OF_SERIES_LINK_TYPES),
 );
@@ -28,7 +24,7 @@ export function isNotSeriesPart(r: RelationshipT): boolean {
   return !seriesPartLinkTypes.has(linkedEntities.link_type[r.linkTypeID].gid);
 }
 
-const RelatedSeries = ({seriesIds}: Props): React$MixedElement => {
+component RelatedSeries(seriesIds: $ReadOnlyArray<number>) {
   const parts: Array<React$Node> = [
     /* eslint-disable react/jsx-key */
     <h2 className="related-series">
@@ -52,6 +48,6 @@ const RelatedSeries = ({seriesIds}: Props): React$MixedElement => {
     );
   }
   return React.createElement(React.Fragment, null, ...parts);
-};
+}
 
 export default RelatedSeries;

--- a/root/static/scripts/common/components/RelatedWorks.js
+++ b/root/static/scripts/common/components/RelatedWorks.js
@@ -24,11 +24,7 @@ const targetEntityTypes = [
   'work',
 ];
 
-type Props = {
-  +workIds: $ReadOnlyArray<number>,
-};
-
-const RelatedWorks = ({workIds}: Props): React$MixedElement => {
+component RelatedWorks(workIds: $ReadOnlyArray<number>) {
   const parts: Array<React$Node> = [
     /* eslint-disable react/jsx-key */
     <h2 className="related-works">
@@ -49,6 +45,6 @@ const RelatedWorks = ({workIds}: Props): React$MixedElement => {
     );
   }
   return React.createElement(React.Fragment, null, ...parts);
-};
+}
 
 export default RelatedWorks;

--- a/root/static/scripts/common/components/Relationship.js
+++ b/root/static/scripts/common/components/Relationship.js
@@ -20,21 +20,12 @@ import relationshipDateText from '../utility/relationshipDateText.js';
 
 import DescriptiveLink from './DescriptiveLink.js';
 
-type HistoricRelationshipPropsT = {
-  +relationship: RelationshipT,
-};
-
-type RelationshipPropsT = {
-  +allowNewEntity0?: boolean,
-  +allowNewEntity1?: boolean,
-  +makeEntityLink?: (
-    entity: RelatableEntityT,
-    content: string,
-    relationship: RelationshipT,
-    allowNew: ?boolean,
-  ) => React$MixedElement,
-  +relationship: RelationshipT,
-};
+type MakeEntityLinkT = (
+  entity: RelatableEntityT,
+  content: string,
+  relationship: RelationshipT,
+  allowNew: ?boolean,
+) => React$MixedElement;
 
 const makeDescriptiveLink = (
   entity: RelatableEntityT,
@@ -50,9 +41,7 @@ const makeDescriptiveLink = (
   />
 );
 
-const HistoricRelationshipContent = ({
-  relationship,
-}: {relationship: RelationshipT}) => {
+component HistoricRelationshipContent(relationship: RelationshipT) {
   const linkType = linkedEntities.link_type[relationship.linkTypeID];
   const source = linkedEntities[linkType.type0][relationship.entity0_id];
   const extraAttributes = getExtraAttributes(
@@ -85,14 +74,14 @@ const HistoricRelationshipContent = ({
       ) : null}
     </>
   );
-};
+}
 
-const RelationshipContent = ({
-  allowNewEntity0,
-  allowNewEntity1,
-  makeEntityLink = makeDescriptiveLink,
-  relationship,
-}: RelationshipPropsT) => {
+component RelationshipContent(
+  allowNewEntity0?: boolean,
+  allowNewEntity1?: boolean,
+  makeEntityLink: MakeEntityLinkT = makeDescriptiveLink,
+  relationship: RelationshipT,
+) {
   const backward = relationship.backward;
   const linkType = linkedEntities.link_type[relationship.linkTypeID];
   let entity0 = relationship.entity0;
@@ -153,26 +142,28 @@ const RelationshipContent = ({
       ) : null}
     </>
   );
-};
+}
 
-export const HistoricRelationship = ({
-  relationship,
-}: HistoricRelationshipPropsT): React$MixedElement => (
-  relationship.editsPending ? (
-    <span className="mp mp-rel">
-      <HistoricRelationshipContent relationship={relationship} />
-    </span>
-  ) : <HistoricRelationshipContent relationship={relationship} />
-);
+export component HistoricRelationship(relationship: RelationshipT) {
+  return (
+    relationship.editsPending ? (
+      <span className="mp mp-rel">
+        <HistoricRelationshipContent relationship={relationship} />
+      </span>
+    ) : <HistoricRelationshipContent relationship={relationship} />
+  );
+}
 
-const Relationship = (props: RelationshipPropsT): React$MixedElement => (
-  props.relationship.editsPending ? (
-    <span className="mp mp-rel">
+component Relationship(...props: React.PropsOf<RelationshipContent>) {
+  return (
+    props.relationship.editsPending ? (
+      <span className="mp mp-rel">
+        <RelationshipContent {...props} />
+      </span>
+    ) : (
       <RelationshipContent {...props} />
-    </span>
-  ) : (
-    <RelationshipContent {...props} />
-  )
-);
+    )
+  );
+}
 
 export default Relationship;

--- a/root/static/scripts/common/components/Relationships.js
+++ b/root/static/scripts/common/components/Relationships.js
@@ -58,19 +58,13 @@ const displayTargets: DisplayTargets = {
   ],
 };
 
-type PropsT = {
-  +noRelationshipsHeading?: boolean,
-  +relationships?: $ReadOnlyArray<RelationshipTargetTypeGroupT>,
-  +showIfEmpty?: boolean,
-  +source: RelatableEntityT,
-};
-
-const Relationships = (React.memo<PropsT>(({
-  noRelationshipsHeading = false,
-  relationships: passedRelationships,
-  showIfEmpty = false,
-  source,
-}: PropsT): React.MixedElement => {
+component _Relationship(
+  noRelationshipsHeading: boolean = false,
+  relationships as passedRelationships?:
+    $ReadOnlyArray<RelationshipTargetTypeGroupT>,
+  showIfEmpty: boolean = false,
+  source: RelatableEntityT,
+) {
   let srcRels = source.relationships;
   let relationships = passedRelationships;
   if (!relationships) {
@@ -131,6 +125,9 @@ const Relationships = (React.memo<PropsT>(({
       ) : null}
     </>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const Relationships: React$AbstractComponent<React.PropsOf<_Relationship>> =
+  React.memo(_Relationship);
 
 export default Relationships;

--- a/root/static/scripts/common/components/ReleaseEvent.js
+++ b/root/static/scripts/common/components/ReleaseEvent.js
@@ -12,24 +12,20 @@ import isDateEmpty from '../utility/isDateEmpty.js';
 
 import EntityLink from './EntityLink.js';
 
-type Props = {
-  +event: ReleaseEventT,
-};
-
-const ReleaseEvent = ({
-  event,
-}: Props): React.MixedElement => (
-  <>
-    {isDateEmpty(event.date) ? null : (
-      <>
-        <span className="release-date">
-          {formatDate(event.date)}
-        </span>
-        {' '}
-      </>
-    )}
-    {event.country ? <EntityLink entity={event.country} /> : null}
-  </>
-);
+component ReleaseEvent(event: ReleaseEventT) {
+  return (
+    <>
+      {isDateEmpty(event.date) ? null : (
+        <>
+          <span className="release-date">
+            {formatDate(event.date)}
+          </span>
+          {' '}
+        </>
+      )}
+      {event.country ? <EntityLink entity={event.country} /> : null}
+    </>
+  );
+}
 
 export default ReleaseEvent;

--- a/root/static/scripts/common/components/ReleaseEvents.js
+++ b/root/static/scripts/common/components/ReleaseEvents.js
@@ -76,29 +76,26 @@ const buildReleaseEventRow = (
   );
 };
 
-type ReleaseEventsProps = {|
-  +abbreviated?: boolean,
-  +events: ?$ReadOnlyArray<ReleaseEventT>,
-|};
+component ReleaseEvents(
+  abbreviated: boolean = true,
+  events: ?$ReadOnlyArray<ReleaseEventT>,
+) {
+  return (
+    <CollapsibleList
+      ariaLabel={l('Release events')}
+      buildRow={buildReleaseEventRow}
+      buildRowProps={{abbreviated: abbreviated}}
+      className={'release-events' + (abbreviated ? ' abbreviated' : ' links')}
+      rows={events}
+      showAllTitle={l('Show all release events')}
+      showLessTitle={l('Show less release events')}
+      toShowAfter={1}
+      toShowBefore={2}
+    />
+  );
+}
 
-const ReleaseEvents = ({
-  abbreviated = true,
-  events,
-}: ReleaseEventsProps) => (
-  <CollapsibleList
-    ariaLabel={l('Release events')}
-    buildRow={buildReleaseEventRow}
-    buildRowProps={{abbreviated: abbreviated}}
-    className={'release-events' + (abbreviated ? ' abbreviated' : ' links')}
-    rows={events}
-    showAllTitle={l('Show all release events')}
-    showLessTitle={l('Show less release events')}
-    toShowAfter={1}
-    toShowBefore={2}
-  />
-);
-
-export default (hydrate<ReleaseEventsProps>(
+export default (hydrate<React.PropsOf<ReleaseEvents>>(
   'div.release-events-container',
   ReleaseEvents,
-): React$AbstractComponent<ReleaseEventsProps, void>);
+): React$AbstractComponent<React.PropsOf<ReleaseEvents>>);

--- a/root/static/scripts/common/components/ReleaseGroupAppearances.js
+++ b/root/static/scripts/common/components/ReleaseGroupAppearances.js
@@ -15,13 +15,7 @@ const buildAppearancesRow = (releaseGroup: ReleaseGroupT) => (
   </li>
 );
 
-type ReleaseGroupAppearancesProps = {
-  +appearances: ReleaseGroupAppearancesT,
-};
-
-const ReleaseGroupAppearances = (
-  {appearances}: ReleaseGroupAppearancesProps,
-): React$Element<'ul'> | null => {
+component ReleaseGroupAppearances(appearances: ReleaseGroupAppearancesT) {
   const releaseGroups = appearances.results;
   const unloadedReleaseGroupCount = appearances.hits - releaseGroups.length;
   return (
@@ -43,6 +37,6 @@ const ReleaseGroupAppearances = (
       </ul>
     ) : null
   );
-};
+}
 
 export default ReleaseGroupAppearances;

--- a/root/static/scripts/common/components/SearchIcon.js
+++ b/root/static/scripts/common/components/SearchIcon.js
@@ -9,12 +9,14 @@
 
 import searchIconUrl from '../../../images/icons/search.svg';
 
-const SearchIcon = (): React$Element<'img'> => (
-  <img
-    alt={l('Search')}
-    className="search"
-    src={searchIconUrl}
-  />
-);
+component SearchIcon() {
+  return (
+    <img
+      alt={l('Search')}
+      className="search"
+      src={searchIconUrl}
+    />
+  );
+}
 
 export default SearchIcon;

--- a/root/static/scripts/common/components/SelectField.js
+++ b/root/static/scripts/common/components/SelectField.js
@@ -32,7 +32,7 @@ type SharedElementProps = {
   name?: string,
   onChange?: (event: SyntheticEvent<HTMLSelectElement>) => void,
   required?: boolean,
-  style?: {},
+  style?: {maxWidth?: string},
 };
 
 type MultipleSelectElementProps = {
@@ -50,53 +50,27 @@ type SelectElementProps = {
   ...
 };
 
-type SharedFieldProps = {
-  +allowEmpty?: boolean,
-  +className?: string,
-  +disabled?: boolean,
-  +onChange?: (event: SyntheticEvent<HTMLSelectElement>) => void,
-  +options: MaybeGroupedOptionsT,
-  +required?: boolean,
-  +uncontrolled?: boolean,
-};
-
-type MultipleSelectFieldProps = {
-  +field: FieldT<?Array<StrOrNum>>,
-  ...SharedFieldProps,
-  ...
-};
-
-type SelectFieldProps = {
-  +field: FieldT<?StrOrNum>,
-  ...SharedFieldProps,
-  ...
-};
-
-export const MultipleSelectField = ({
-  allowEmpty = true,
-  disabled = false,
-  field,
-  onChange,
-  options,
-  required,
-  uncontrolled = false,
-  ...props
-}: MultipleSelectFieldProps): React$Element<'select'> => {
-  const selectProps: MultipleSelectElementProps = {...props, multiple: true};
+export component MultipleSelectField(
+  allowEmpty: boolean = true,
+  field: FieldT<?Array<StrOrNum>>,
+  options: MaybeGroupedOptionsT,
+  uncontrolled: boolean = false,
+  ...passedSelectProps: MultipleSelectElementProps
+) {
+  const selectProps = {...passedSelectProps, multiple: true};
 
   if (selectProps.className === undefined) {
     selectProps.className = 'with-button';
   }
 
-  selectProps.disabled = disabled;
+  selectProps.disabled = passedSelectProps.disabled || false;
   selectProps.id = 'id-' + field.html_name;
   selectProps.name = field.html_name;
-  selectProps.required = required;
 
   if (uncontrolled) {
     selectProps.defaultValue = field.value || [];
+    selectProps.onChange = undefined;
   } else {
-    selectProps.onChange = onChange;
     selectProps.value = field.value || [];
   }
 
@@ -110,33 +84,29 @@ export const MultipleSelectField = ({
         : options.options.map(buildOption)}
     </select>
   );
-};
+}
 
-const SelectField = ({
-  allowEmpty = true,
-  disabled = false,
-  field,
-  onChange,
-  options,
-  required,
-  uncontrolled = false,
-  ...props
-}: SelectFieldProps): React$Element<'select'> => {
-  const selectProps: SelectElementProps = props;
+component SelectField(
+  allowEmpty: boolean = true,
+  field: FieldT<?StrOrNum>,
+  options: MaybeGroupedOptionsT,
+  uncontrolled: boolean = false,
+  ...passedSelectProps: SelectElementProps
+ ) {
+  const selectProps = {...passedSelectProps};
 
   if (selectProps.className === undefined) {
     selectProps.className = 'with-button';
   }
 
-  selectProps.disabled = disabled;
+  selectProps.disabled = passedSelectProps.disabled || false;
   selectProps.id = 'id-' + field.html_name;
   selectProps.name = field.html_name;
-  selectProps.required = required;
 
   if (uncontrolled) {
     selectProps.defaultValue = getSelectValue(field, options, allowEmpty);
+    selectProps.onChange = undefined;
   } else {
-    selectProps.onChange = onChange;
     selectProps.value = getSelectValue(field, options, allowEmpty);
   }
 
@@ -150,6 +120,6 @@ const SelectField = ({
         : options.options.map(buildOption)}
     </select>
   );
-};
+}
 
 export default SelectField;

--- a/root/static/scripts/common/components/StaticRelationshipsDisplay.js
+++ b/root/static/scripts/common/components/StaticRelationshipsDisplay.js
@@ -54,15 +54,11 @@ function getTrackRanges(trackSet: Set<TrackT>) {
   return commaOnlyListText(ranges.map(formatTrackRange));
 }
 
-type PropsT = {
-  +hiddenArtistCredit?: ?ArtistCreditT,
-  +relationships: $ReadOnlyArray<RelationshipTargetTypeGroupT>,
-};
-
-const StaticRelationshipsDisplay = (React.memo<PropsT>(({
-  hiddenArtistCredit,
-  relationships: groupedRelationships,
-}: PropsT): Array<React$Element<'table'>> => {
+component _StaticRelationshipsDisplay(
+  hiddenArtistCredit?: ?ArtistCreditT,
+  relationships as groupedRelationships:
+    $ReadOnlyArray<RelationshipTargetTypeGroupT>,
+) {
   const tables = [];
 
   for (let i = 0; i < groupedRelationships.length; i++) {
@@ -143,6 +139,10 @@ const StaticRelationshipsDisplay = (React.memo<PropsT>(({
   }
 
   return tables;
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const StaticRelationshipsDisplay: React$AbstractComponent<
+  React.PropsOf<_StaticRelationshipsDisplay>
+> = React.memo(_StaticRelationshipsDisplay);
 
 export default StaticRelationshipsDisplay;

--- a/root/static/scripts/common/components/TagLink.js
+++ b/root/static/scripts/common/components/TagLink.js
@@ -9,34 +9,26 @@
 
 import * as React from 'react';
 
-type UserTagLinkProps = {
-  +content?: string,
-  +showDownvoted?: boolean,
-  +subPath?: string,
-  +tag: string,
-  +username: string,
-};
-
-type TagLinkProps = {
-  +content?: string,
-  +showIcon?: boolean,
-  +subPath?: string,
-  +tag: string,
-};
-
-export const UserTagLink = (
-  {content, showDownvoted = false, subPath, tag, username}: UserTagLinkProps,
-): React$Element<'a'> => {
+export component UserTagLink(
+  content?: string,
+  showDownvoted: boolean = false,
+  subPath?: string,
+  tag: string,
+  username: string,
+) {
   const url = '/user/' + encodeURIComponent(username) +
               '/tag/' + encodeURIComponent(tag) +
               (subPath == null ? '' : '/' + subPath) +
               (showDownvoted ? '?show_downvoted=1' : '');
   return <a href={url}>{content == null ? tag : content}</a>;
-};
+}
 
-const TagLink = (
-  {content, showIcon = false, subPath, tag}: TagLinkProps,
-): Expand2ReactOutput => {
+component TagLink(
+  content?: string,
+  showIcon: boolean = false,
+  subPath?: string,
+  tag: string,
+) {
   const parts: Array<Expand2ReactOutput> = [];
 
   if (showIcon) {
@@ -52,6 +44,6 @@ const TagLink = (
   );
 
   return React.createElement(React.Fragment, null, ...parts);
-};
+}
 
 export default TagLink;

--- a/root/static/scripts/common/components/TaggerIcon.js
+++ b/root/static/scripts/common/components/TaggerIcon.js
@@ -26,15 +26,7 @@ function buildTaggerLink(
   return `http://127.0.0.1:${tport}/${path}?id=${gid}`;
 }
 
-type Props = {
-  +entityType: 'recording' | 'release',
-  +gid: string,
-};
-
-const TaggerIcon = ({
-  entityType,
-  gid,
-}: Props): React$MixedElement | null => {
+component TaggerIcon(entityType: 'recording' | 'release', gid: string) {
   const $c = React.useContext(SanitizedCatalystContext);
 
   const tport = $c.session?.tport;
@@ -84,11 +76,11 @@ const TaggerIcon = ({
       />
     </a>
   );
-};
+}
 
 export default (
-  hydrate<Props>(
+  hydrate<React.PropsOf<TaggerIcon>>(
     'span.tagger-icon',
     TaggerIcon,
-  ): React$AbstractComponent<Props, void>
+  ): React$AbstractComponent<React.PropsOf<TaggerIcon>, void>
 );

--- a/root/static/scripts/common/components/Warning.js
+++ b/root/static/scripts/common/components/Warning.js
@@ -9,27 +9,22 @@
 
 import WarningIcon from './WarningIcon.js';
 
-type Props = {
-  +className?: string,
-  +message: string,
-};
-
-const Warning = ({
-  className,
-  message,
-  ...divProps
-}: Props): React$Element<'div'> => (
-  <div
-    className={'warning' + (nonEmpty(className) ? ' ' + className : '')}
-    {...divProps}
-  >
-    <WarningIcon />
-    <p>
-      <strong>{addColonText(l('Warning'))}</strong>
-      {' '}
-      {message}
-    </p>
-  </div>
-);
+component Warning(
+  className?: string,
+  message: string,
+) {
+  return (
+    <div
+      className={'warning' + (nonEmpty(className) ? ' ' + className : '')}
+    >
+      <WarningIcon />
+      <p>
+        <strong>{addColonText(l('Warning'))}</strong>
+        {' '}
+        {message}
+      </p>
+    </div>
+  );
+}
 
 export default Warning;

--- a/root/static/scripts/common/components/WarningIcon.js
+++ b/root/static/scripts/common/components/WarningIcon.js
@@ -9,12 +9,14 @@
 
 import warningIconUrl from '../../../images/icons/warning.png';
 
-const WarningIcon = (): React$Element<'img'> => (
-  <img
-    alt={l('Warning')}
-    className="warning"
-    src={warningIconUrl}
-  />
-);
+component WarningIcon() {
+  return (
+    <img
+      alt={l('Warning')}
+      className="warning"
+      src={warningIconUrl}
+    />
+  );
+}
 
 export default WarningIcon;

--- a/root/static/scripts/common/components/WorkArtists.js
+++ b/root/static/scripts/common/components/WorkArtists.js
@@ -18,24 +18,22 @@ const buildWorkArtistRow = (artistCredit: ArtistCreditT) => {
   );
 };
 
-type WorkArtistsProps = {
-  +artists: ?$ReadOnlyArray<ArtistCreditT>,
-};
+component WorkArtists(artists: ?$ReadOnlyArray<ArtistCreditT>) {
+  return (
+    <CollapsibleList
+      ariaLabel={l('Work artists')}
+      buildRow={buildWorkArtistRow}
+      className="work-artists"
+      rows={artists}
+      showAllTitle={l('Show all artists')}
+      showLessTitle={l('Show less artists')}
+      toShowAfter={0}
+      toShowBefore={4}
+    />
+  );
+}
 
-const WorkArtists = ({artists}: WorkArtistsProps) => (
-  <CollapsibleList
-    ariaLabel={l('Work artists')}
-    buildRow={buildWorkArtistRow}
-    className="work-artists"
-    rows={artists}
-    showAllTitle={l('Show all artists')}
-    showLessTitle={l('Show less artists')}
-    toShowAfter={0}
-    toShowBefore={4}
-  />
-);
-
-export default (hydrate<WorkArtistsProps>(
+export default (hydrate<React.PropsOf<WorkArtists>>(
   'div.work-artists-container',
   WorkArtists,
-): React$AbstractComponent<WorkArtistsProps, void>);
+): React$AbstractComponent<React.PropsOf<WorkArtists>, void>);

--- a/root/static/scripts/common/components/WorkListEntry.js
+++ b/root/static/scripts/common/components/WorkListEntry.js
@@ -21,34 +21,14 @@ import IswcList from './IswcList.js';
 import RatingStars from './RatingStars.js';
 import WorkArtists from './WorkArtists.js';
 
-type WorkListRowProps = {
-  ...SeriesItemNumbersRoleT,
-  +checkboxes?: string,
-  +showAttributes?: boolean,
-  +showIswcs?: boolean,
-  +showRatings?: boolean,
-  +work: WorkT,
-};
-
-type WorkListEntryProps = {
-  ...SeriesItemNumbersRoleT,
-  +checkboxes?: string,
-  +index: number,
-  +score?: number,
-  +showAttributes?: boolean,
-  +showIswcs?: boolean,
-  +showRatings?: boolean,
-  +work: WorkT,
-};
-
-export const WorkListRow = ({
-  checkboxes,
-  seriesItemNumbers,
-  showAttributes = false,
-  showIswcs = false,
-  showRatings = false,
-  work,
-}: WorkListRowProps): React.MixedElement => {
+export component WorkListRow(
+  checkboxes?: string,
+  seriesItemNumbers?: $ReadOnlyArray<string>,
+  showAttributes: boolean = false,
+  showIswcs: boolean = false,
+  showRatings: boolean = false,
+  work: WorkT,
+) {
   const $c = React.useContext(CatalystContext);
 
   return (
@@ -128,28 +108,18 @@ export const WorkListRow = ({
       ) : null}
     </>
   );
-};
+}
 
-const WorkListEntry = ({
-  checkboxes,
-  index,
-  score,
-  seriesItemNumbers,
-  showAttributes,
-  showIswcs,
-  showRatings,
-  work,
-}: WorkListEntryProps): React$Element<'tr'> => (
-  <tr className={loopParity(index)} data-score={score ?? null}>
-    <WorkListRow
-      checkboxes={checkboxes}
-      seriesItemNumbers={seriesItemNumbers}
-      showAttributes={showAttributes}
-      showIswcs={showIswcs}
-      showRatings={showRatings}
-      work={work}
-    />
-  </tr>
-);
+component WorkListEntry(
+  index: number,
+  score?: number,
+  ...rowProps: React.PropsOf<WorkListRow>
+) {
+  return (
+    <tr className={loopParity(index)} data-score={score ?? null}>
+      <WorkListRow {...rowProps} />
+    </tr>
+  );
+}
 
 export default WorkListEntry;

--- a/root/static/scripts/edit/components/AddEntityDialog.js
+++ b/root/static/scripts/edit/components/AddEntityDialog.js
@@ -50,16 +50,6 @@ const AddEntityDialog = ({
   const instanceRef = React.useRef<InstanceT | null>(null);
   const [isLoading, setLoading] = React.useState(true);
 
-  /*
-   * Make sure click events within the dialog don't bubble and cause
-   * side-effects.
-   */
-  const handleModalClick = React.useCallback((
-    event: SyntheticMouseEvent<HTMLDivElement>,
-  ) => {
-    event.stopPropagation();
-  }, []);
-
   const handlePageLoad = (event: SyntheticEvent<HTMLIFrameElement>) => {
     const contentWindow: WindowProxy = event.currentTarget.contentWindow;
 
@@ -95,7 +85,6 @@ const AddEntityDialog = ({
     <Modal
       className="iframe-dialog"
       id={'add-' + entityType + '-dialog'}
-      onClick={handleModalClick}
       onEscape={close}
       title={isLoading ? l('Loading...') : TITLES[entityType]()}
     >

--- a/root/static/scripts/edit/components/AddEntityDialog.js
+++ b/root/static/scripts/edit/components/AddEntityDialog.js
@@ -29,23 +29,16 @@ export const TITLES: {+[entityType: string]: () => string} = {
   work: N_l('Add a new work'),
 };
 
-type PropsT = {
-  +callback: (NonUrlRelatableEntityT) => void,
-  +close: () => void,
-  +entityType: string,
-  +name?: string,
-};
-
 type InstanceT = {
   +close: () => void,
 };
 
-const AddEntityDialog = ({
-  callback,
-  close,
-  entityType,
-  name,
-}: PropsT): React$Element<typeof Modal> => {
+component AddEntityDialog(
+  callback: (NonUrlRelatableEntityT) => void,
+  close: () => void,
+  entityType: string,
+  name?: string,
+) {
   const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
   const instanceRef = React.useRef<InstanceT | null>(null);
   const [isLoading, setLoading] = React.useState(true);
@@ -71,9 +64,11 @@ const AddEntityDialog = ({
     findFirstTabbableElement(iframeBody, /* skipAnchors = */ true)?.focus();
   };
 
-  instanceRef.current = {
-    close,
-  };
+  React.useEffect(() => {
+    instanceRef.current = {
+      close,
+    };
+  }, [close, instanceRef]);
 
   let dialogPath = '/' + entityType + '/create';
   if (nonEmpty(name)) {
@@ -98,6 +93,6 @@ const AddEntityDialog = ({
       />
     </Modal>
   );
-};
+}
 
 export default AddEntityDialog;

--- a/root/static/scripts/edit/components/AddIcon.js
+++ b/root/static/scripts/edit/components/AddIcon.js
@@ -9,11 +9,13 @@
 
 import addIconUrl from '../../../images/icons/add.png';
 
-const AddIcon = (): React$Element<'img'> => (
-  <img
-    className="bottom"
-    src={addIconUrl}
-  />
-);
+component AddIcon() {
+  return (
+    <img
+      className="bottom"
+      src={addIconUrl}
+    />
+  );
+}
 
 export default AddIcon;

--- a/root/static/scripts/edit/components/ArtistCreditBubble.js
+++ b/root/static/scripts/edit/components/ArtistCreditBubble.js
@@ -156,79 +156,65 @@ const ArtistCreditPreview = (React.memo<ArtistCreditPreviewPropsT>(({
   );
 }));
 
-type AddArtistCreditRowPropsT = {
-  +dispatch: (ActionT) => void,
-};
+component _AddArtistCreditRow(dispatch: (ActionT) => void) {
+  return (
+    <tr>
+      <td className="align-right" colSpan="4">
+        <button
+          className="add-item with-label"
+          onClick={() => dispatch({type: 'add-name'})}
+          type="button"
+        >
+          {lp('Add artist credit', 'interactive')}
+        </button>
+      </td>
+    </tr>
+  );
+}
 
-const AddArtistCreditRow = (React.memo<
-  AddArtistCreditRowPropsT,
->(({
-  dispatch,
-}) => (
-  <tr>
-    <td className="align-right" colSpan="4">
-      <button
-        className="add-item with-label"
-        onClick={() => dispatch({type: 'add-name'})}
-        type="button"
-      >
-        {lp('Add artist credit', 'interactive')}
-      </button>
-    </td>
-  </tr>
-)));
+const AddArtistCreditRow = React.memo(_AddArtistCreditRow);
 
-type ChangeMatchingTrackArtistsRowPropsT = {
-  +changeMatchingTrackArtists: boolean | void,
-  +dispatch: (ActionT) => void,
-  +initialArtistCreditString: string,
-};
+component _ChangeMatchingTrackArtistsRow(
+  changeMatchingTrackArtists: boolean | void,
+  dispatch: (ActionT) => void,
+  initialArtistCreditString: string,
+) {
+  return (
+    <div>
+      <label>
+        <input
+          checked={changeMatchingTrackArtists === true}
+          id="change-matching-artists"
+          onChange={
+            (event: SyntheticEvent<HTMLInputElement>) => dispatch({
+              checked: event.currentTarget.checked,
+              type: 'set-change-matching-artists',
+            })
+          }
+          type="checkbox"
+        />
+        {initialArtistCreditString ? (
+          texp.l(
+            'Change all artists on this release that match “{name}”',
+            {name: initialArtistCreditString},
+          )
+        ) : (
+          l('Change all artists on this release that are currently empty')
+        )}
+      </label>
+    </div>
+  );
+}
 
-const ChangeMatchingTrackArtistsRow = (React.memo<
-  ChangeMatchingTrackArtistsRowPropsT,
->(({
-  changeMatchingTrackArtists,
-  dispatch,
-  initialArtistCreditString,
-}) => (
-  <div>
-    <label>
-      <input
-        checked={changeMatchingTrackArtists === true}
-        id="change-matching-artists"
-        onChange={
-          (event: SyntheticEvent<HTMLInputElement>) => dispatch({
-            checked: event.currentTarget.checked,
-            type: 'set-change-matching-artists',
-          })
-        }
-        type="checkbox"
-      />
-      {initialArtistCreditString ? (
-        texp.l(
-          'Change all artists on this release that match “{name}”',
-          {name: initialArtistCreditString},
-        )
-      ) : (
-        l('Change all artists on this release that are currently empty')
-      )}
-    </label>
-  </div>
-)));
+const ChangeMatchingTrackArtistsRow =
+  React.memo(_ChangeMatchingTrackArtistsRow);
 
-type ArtistCreditBubblePropsT = {
-  +closeAndReturnFocus: () => void,
-  +dispatch: (ActionT) => void,
-  +initialFocusRef: {-current: HTMLElement | null},
-  +state: ArtistCreditStateT,
-};
-
-const ArtistCreditBubble = (React.memo<ArtistCreditBubblePropsT>(({
-  closeAndReturnFocus,
-  dispatch,
-  initialFocusRef,
-  state,
-}: ArtistCreditBubblePropsT): React$MixedElement => {
+component _ArtistCreditBubble(
+  closeAndReturnFocus: () => void,
+  dispatch: (ActionT) => void,
+  initialFocusRef: {-current: HTMLElement | null},
+  state: ArtistCreditStateT,
+) {
   const {
     changeMatchingTrackArtists,
     editsPending,
@@ -314,6 +300,10 @@ const ArtistCreditBubble = (React.memo<ArtistCreditBubblePropsT>(({
       />
     </form>
   );
-}): React.AbstractComponent<ArtistCreditBubblePropsT>);
+}
+
+const ArtistCreditBubble: React.AbstractComponent<
+  React.PropsOf<_ArtistCreditBubble>
+> = React.memo(_ArtistCreditBubble);
 
 export default ArtistCreditBubble;

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -33,7 +33,6 @@ import type {
   ActionT,
   ArtistCreditableT,
   ArtistCreditNameStateT,
-  PropsT,
   StateT,
 } from './ArtistCreditEditor/types.js';
 import {
@@ -455,10 +454,10 @@ export function createInitialState(
   };
 }
 
-const ArtistCreditEditor = (React.memo<PropsT>(({
-  dispatch,
-  state,
-}: PropsT): React.MixedElement => {
+component _ArtistCreditEditor(
+  dispatch: (ActionT) => void,
+  state: StateT,
+) {
   const {
     entity,
     formName,
@@ -555,6 +554,10 @@ const ArtistCreditEditor = (React.memo<PropsT>(({
       ) : null}
     </>
   );
-}): React.AbstractComponent<PropsT>);
+}
+
+const ArtistCreditEditor: React.AbstractComponent<
+  React.PropsOf<_ArtistCreditEditor>
+> = React.memo(_ArtistCreditEditor);
 
 export default ArtistCreditEditor;

--- a/root/static/scripts/edit/components/ArtistCreditEditor/types.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor/types.js
@@ -47,11 +47,6 @@ export type StateT = {
   +singleArtistAutocomplete: AutocompleteStateT<ArtistT>,
 };
 
-export type PropsT = {
-  +dispatch: (ActionT) => void,
-  +state: StateT,
-};
-
 /* eslint-disable ft-flow/sort-keys */
 export type EditArtistActionT = {
   +type: 'edit-artist',

--- a/root/static/scripts/edit/components/ArtistCreditNameEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditNameEditor.js
@@ -20,19 +20,12 @@ import type {
   ArtistCreditNameStateT,
 } from './ArtistCreditEditor/types.js';
 
-type PropsT = {
-  +artistCreditEditorId: string,
-  +dispatch: (ActionT) => void,
-  +index: number,
-  +name: ArtistCreditNameStateT,
-};
-
-const ArtistCreditNameEditor = (React.memo<PropsT>(({
-  artistCreditEditorId,
-  dispatch,
-  index,
-  name: artistCreditName,
-}: PropsT): React.MixedElement => {
+component _ArtistCreditNameEditor(
+  artistCreditEditorId: string,
+  dispatch: (ActionT) => void,
+  index: number,
+  name as artistCreditName: ArtistCreditNameStateT,
+) {
   const artistDispatch = React.useCallback((
     action: AutocompleteActionT<ArtistT>,
   ) => {
@@ -193,6 +186,10 @@ const ArtistCreditNameEditor = (React.memo<PropsT>(({
       </td>
     </tr>
   );
-}): React.AbstractComponent<PropsT>);
+}
+
+const ArtistCreditNameEditor: React.AbstractComponent<
+  React.PropsOf<_ArtistCreditNameEditor>
+> = React.memo(_ArtistCreditNameEditor);
 
 export default ArtistCreditNameEditor;

--- a/root/static/scripts/edit/components/DateRangeFieldset.js
+++ b/root/static/scripts/edit/components/DateRangeFieldset.js
@@ -31,13 +31,6 @@ export type ActionT =
   | {+type: 'copy-date'};
 /* eslint-enable ft-flow/sort-keys */
 
-type PropsT = {
-  +disabled?: boolean,
-  +dispatch: (ActionT) => void,
-  +endedLabel: string,
-  +field: DatePeriodFieldT,
-};
-
 export type StateT = DatePeriodFieldT;
 
 export function partialDateFromField(
@@ -168,12 +161,12 @@ export function reducer(
   return ctx.final();
 }
 
-const DateRangeFieldset = (React.memo<PropsT>(({
-  disabled = false,
-  dispatch,
-  endedLabel,
-  field,
-}: PropsT): React.MixedElement => {
+component _DateRangeFieldset(
+  disabled: boolean = false,
+  dispatch: (ActionT) => void,
+  endedLabel: string,
+  field: DatePeriodFieldT,
+) {
   const subfields = field.field;
 
   const hooks = useDateRangeFieldset(dispatch);
@@ -225,6 +218,10 @@ const DateRangeFieldset = (React.memo<PropsT>(({
       </fieldset>
     </>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const DateRangeFieldset: React$AbstractComponent<
+  React.PropsOf<_DateRangeFieldset>
+> = React.memo(_DateRangeFieldset);
 
 export default DateRangeFieldset;

--- a/root/static/scripts/edit/components/EnterEdit.js
+++ b/root/static/scripts/edit/components/EnterEdit.js
@@ -7,43 +7,29 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type CommonProps = {
-  +children?: React$Node,
-  +childrenFirst?: boolean,
-  +disabled?: boolean,
-  +form: FormT<{
-    +make_votable: FieldT<boolean>,
-    ...
-  }>,
-};
-
-type Props =
+type ControlledPropsT =
   | $ReadOnly<{
-      ...CommonProps,
       controlled: true,
       onChange: (event: SyntheticEvent<HTMLInputElement>) => void,
     }>
-  | $ReadOnly<{
-      ...CommonProps,
-      controlled?: false,
-    }>;
+  | $ReadOnly<{controlled?: false}>;
 
-const EnterEdit = ({
-  children,
-  childrenFirst = false,
-  disabled = false,
-  form,
-  ...otherProps
-}: Props): React$MixedElement => {
+component EnterEdit(
+  children?: React$Node,
+  childrenFirst: boolean = false,
+  disabled: boolean = false,
+  form: FormT<{+make_votable: FieldT<boolean>, ...}>,
+  ...controlledProps: ControlledPropsT
+) {
   const isMakeVotableChecked = form.field.make_votable.value;
   const makeVotableProps: {
     checked?: boolean,
     defaultChecked?: boolean,
     onChange?: (event: SyntheticEvent<HTMLInputElement>) => void,
   } = {};
-  if (otherProps.controlled) {
+  if (controlledProps.controlled /*:: === true */) {
     makeVotableProps.checked = isMakeVotableChecked;
-    makeVotableProps.onChange = otherProps.onChange;
+    makeVotableProps.onChange = controlledProps.onChange;
   } else {
     makeVotableProps.defaultChecked = isMakeVotableChecked;
   }
@@ -77,6 +63,6 @@ const EnterEdit = ({
       </div>
     </>
   );
-};
+}
 
 export default EnterEdit;

--- a/root/static/scripts/edit/components/EnterEditNote.js
+++ b/root/static/scripts/edit/components/EnterEditNote.js
@@ -10,36 +10,26 @@
 import FieldErrors from './FieldErrors.js';
 import FormRow from './FormRow.js';
 
-type CommonProps = {
-  +field: FieldT<string>,
-  +hideHelp?: boolean,
-};
-
-type Props =
+type ControlledPropsT =
   | $ReadOnly<{
-      ...CommonProps,
       controlled: true,
       onChange: (event: SyntheticEvent<HTMLTextAreaElement>) => void,
     }>
-  | $ReadOnly<{
-      ...CommonProps,
-      controlled?: false,
-    }>;
+  | $ReadOnly<{controlled?: false}>;
 
-const EnterEditNote = ({
-  field,
-  hideHelp = false,
-  ...otherProps
-}: Props):
-React$Element<'fieldset'> => {
+component EnterEditNote(
+  field: FieldT<string>,
+  hideHelp: boolean = false,
+  ...controlledProps: ControlledPropsT
+) {
   const textAreaProps: {
     defaultValue?: string,
     onChange?: (event: SyntheticEvent<HTMLTextAreaElement>) => void,
     value?: string,
   } = {};
-  if (otherProps.controlled) {
+  if (controlledProps.controlled /*:: === true */) {
     textAreaProps.value = field.value;
-    textAreaProps.onChange = otherProps.onChange;
+    textAreaProps.onChange = controlledProps.onChange;
   } else {
     textAreaProps.defaultValue = field.value;
   }
@@ -87,6 +77,6 @@ React$Element<'fieldset'> => {
       </FormRow>
     </fieldset>
   );
-};
+}
 
 export default EnterEditNote;

--- a/root/static/scripts/edit/components/EntityPendingEditsWarning.js
+++ b/root/static/scripts/edit/components/EntityPendingEditsWarning.js
@@ -13,13 +13,7 @@ import entityHref from '../../common/utility/entityHref.js';
 
 import Tooltip from './Tooltip.js';
 
-type PropsT = {
-  +entity: RelatableEntityT,
-};
-
-const EntityPendingEditsWarning = ({
-  entity,
-}: PropsT): React.MixedElement | null => {
+component EntityPendingEditsWarning(entity: RelatableEntityT) {
   const hasPendingEdits = Boolean(entity.editsPending);
   const openEditsLink = entityHref(entity, '/open_edits');
 
@@ -43,6 +37,6 @@ const EntityPendingEditsWarning = ({
       />
     </>
   ) : null;
-};
+}
 
 export default EntityPendingEditsWarning;

--- a/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
+++ b/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
@@ -33,12 +33,6 @@ import DateRangeFieldset, {
 import UrlRelationshipCreditFieldset
   from './UrlRelationshipCreditFieldset.js';
 
-type PropsT = {
-  creditableEntityProp: 'entity0_credit' | 'entity1_credit' | null,
-  onConfirm: ($ReadOnly<Partial<LinkStateT>>) => void,
-  relationship: LinkRelationshipT,
-};
-
 type StateT = {
   +credit: FieldT<string | null>,
   +datePeriodField: DatePeriodFieldT,
@@ -51,14 +45,16 @@ type ActionT =
       +type: 'update-date-period',
     }
   | {
-      +props: PropsT,
+      +props: React.PropsOf<ExternalLinkAttributeDialog>,
       +type: 'update-initial-date-period',
     }
   | {+credit: string, +type: 'update-relationship-credit'}
   | {+type: 'reset'}
   | {+type: 'show-all-pending-errors'};
 
-const createInitialState = (props: PropsT): StateT => {
+const createInitialState = (
+  props: React.PropsOf<ExternalLinkAttributeDialog>,
+): StateT => {
   const relationship = props.relationship;
   const beginDate = relationship.begin_date;
   const endDate = relationship.end_date;
@@ -139,7 +135,11 @@ const reducer = (state: StateT, action: ActionT): StateT => {
   return ctx.final();
 };
 
-const ExternalLinkAttributeDialog = (props: PropsT): React$MixedElement => {
+component ExternalLinkAttributeDialog(...props: {
+  creditableEntityProp: 'entity0_credit' | 'entity1_credit' | null,
+  onConfirm: ($ReadOnly<Partial<LinkStateT>>) => void,
+  relationship: LinkRelationshipT,
+}) {
   const [open, setOpen] = React.useState(false);
 
   const [state, dispatch] = React.useReducer(
@@ -262,6 +262,6 @@ const ExternalLinkAttributeDialog = (props: PropsT): React$MixedElement => {
       toggle={onToggle}
     />
   );
-};
+}
 
 export default ExternalLinkAttributeDialog;

--- a/root/static/scripts/edit/components/FieldErrors.js
+++ b/root/static/scripts/edit/components/FieldErrors.js
@@ -24,19 +24,10 @@ const buildErrorListItem = (
   return <li key={index}>{error}</li>;
 };
 
-type Props = {
-  +field: AnyFieldT,
-  +hasHtmlErrors?: boolean,
-  +includeSubFields?: boolean,
-};
-
-export const FieldErrorsList = ({
-  hasHtmlErrors,
-  errors,
-}: {
-  +errors: ?$ReadOnlyArray<string>,
-  +hasHtmlErrors: boolean,
-}): React$Element<'ul'> | null => {
+export component FieldErrorsList(
+  errors: ?$ReadOnlyArray<string>,
+  hasHtmlErrors: boolean,
+) {
   if (errors?.length) {
     return (
       <ul className="errors">
@@ -47,13 +38,13 @@ export const FieldErrorsList = ({
     );
   }
   return null;
-};
+}
 
-const FieldErrors = ({
-  field,
-  hasHtmlErrors = false,
-  includeSubFields = true,
-}: Props): React$Element<typeof FieldErrorsList> | null => {
+component FieldErrors(
+  field: AnyFieldT,
+  hasHtmlErrors: boolean = false,
+  includeSubFields: boolean = true,
+ ) {
   if (!field) {
     return null;
   }
@@ -66,6 +57,6 @@ const FieldErrors = ({
       hasHtmlErrors={hasHtmlErrors}
     />
   );
-};
+}
 
 export default FieldErrors;

--- a/root/static/scripts/edit/components/FormCsrfToken.js
+++ b/root/static/scripts/edit/components/FormCsrfToken.js
@@ -7,15 +7,13 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type PropsT = {
-  +form: FormT<{
-    +csrf_session_key?: FieldT<string>,
-    +csrf_token?: FieldT<string>,
-    ...
-  }>,
-};
+type CsrfFormT = FormT<{
+  +csrf_session_key?: FieldT<string>,
+  +csrf_token?: FieldT<string>,
+  ...
+}>;
 
-const FormCsrfToken = ({form}: PropsT): React$Node => {
+component FormCsrfToken(form: CsrfFormT) {
   const sessionKeyField = form.field.csrf_session_key;
   const tokenField = form.field.csrf_token;
   return (sessionKeyField && tokenField) ? (
@@ -42,6 +40,6 @@ const FormCsrfToken = ({form}: PropsT): React$Node => {
       />
     </>
   ) : null;
-};
+}
 
 export default FormCsrfToken;

--- a/root/static/scripts/edit/components/FormLabel.js
+++ b/root/static/scripts/edit/components/FormLabel.js
@@ -7,19 +7,19 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type Props = {
-  +forField?: {+html_name: string, ...},
-  +label: React$Node,
-  +required?: boolean,
-};
-
-const FormLabel = (props: Props): React$Element<'label'> => (
-  <label
-    className={props.required /*:: === true */ ? 'required' : ''}
-    htmlFor={props.forField ? 'id-' + props.forField.html_name : null}
-  >
-    {props.label}
-  </label>
-);
+component FormLabel(
+  forField?: {+html_name: string, ...},
+  label: React$Node,
+  required?: boolean,
+) {
+  return (
+    <label
+      className={required /*:: === true */ ? 'required' : ''}
+      htmlFor={forField ? 'id-' + forField.html_name : null}
+    >
+      {label}
+    </label>
+  );
+}
 
 export default FormLabel;

--- a/root/static/scripts/edit/components/FormRow.js
+++ b/root/static/scripts/edit/components/FormRow.js
@@ -7,28 +7,22 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type Props = {
-  +children: React$Node,
-  +hasNoLabel?: boolean,
-  +hasNoMargin?: boolean,
-};
-
-const FormRow = ({
-  children,
-  hasNoLabel = false,
-  hasNoMargin = false,
-  ...props
-}: Props): React$Element<'div'> => (
-  <div
-    className={
-      'row' +
-      (hasNoLabel ? ' no-label' : '') +
-      (hasNoMargin ? ' no-margin' : '')
-    }
-    {...props}
-  >
-    {children}
-  </div>
-);
+component FormRow(
+  children: React$Node,
+  hasNoLabel: boolean = false,
+  hasNoMargin: boolean = false,
+) {
+  return (
+    <div
+      className={
+        'row' +
+        (hasNoLabel ? ' no-label' : '') +
+        (hasNoMargin ? ' no-margin' : '')
+      }
+    >
+      {children}
+    </div>
+  );
+}
 
 export default FormRow;

--- a/root/static/scripts/edit/components/FormRowCheckbox.js
+++ b/root/static/scripts/edit/components/FormRowCheckbox.js
@@ -10,46 +10,31 @@
 import FieldErrors from './FieldErrors.js';
 import FormRow from './FormRow.js';
 
-type CommonProps = {
-  +disabled?: boolean,
-  +field: FieldT<boolean>,
-  +hasNoLabel?: boolean,
-  +hasNoMargin?: boolean,
-  +help?: React$Node,
-  +label: React$Node,
-};
-
-type Props =
+type ControlledPropsT =
   | $ReadOnly<{
-      ...CommonProps,
       onChange: (event: SyntheticEvent<HTMLInputElement>) => void,
       uncontrolled?: false,
     }>
-  | $ReadOnly<{
-      ...CommonProps,
-      onChange?: void,
-      uncontrolled: true,
-    }>;
+  | $ReadOnly<{onChange?: void, uncontrolled: true}>;
 
-const FormRowCheckbox = ({
-  disabled,
-  field,
-  hasNoLabel = true,
-  hasNoMargin = false,
-  help,
-  label,
-  onChange,
-  uncontrolled,
-}: Props): React$Element<typeof FormRow> => {
+component FormRowCheckbox(
+  disabled?: boolean,
+  field: FieldT<boolean>,
+  hasNoLabel: boolean = true,
+  hasNoMargin: boolean = false,
+  help?: React$Node,
+  label: React$Node,
+  ...controlledProps: ControlledPropsT
+) {
   const extraProps: {
     checked?: boolean,
     defaultChecked?: boolean,
     onChange?: (event: SyntheticEvent<HTMLInputElement>) => void,
   } = {};
-  if (uncontrolled) {
+  if (controlledProps.uncontrolled /*:: === true */) {
     extraProps.defaultChecked = field.value;
   } else {
-    extraProps.onChange = onChange;
+    extraProps.onChange = controlledProps.onChange;
     extraProps.checked = field.value;
   }
 
@@ -63,7 +48,6 @@ const FormRowCheckbox = ({
           disabled={disabled}
           id={'id-' + String(field.html_name)}
           name={field.html_name}
-          onChange={onChange}
           type="checkbox"
           value="1"
           {...extraProps}
@@ -79,6 +63,6 @@ const FormRowCheckbox = ({
       ) : null}
     </FormRow>
   );
-};
+}
 
 export default FormRowCheckbox;

--- a/root/static/scripts/edit/components/FormRowEmailLong.js
+++ b/root/static/scripts/edit/components/FormRowEmailLong.js
@@ -7,13 +7,12 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import type {Props as FormRowTextProps} from './FormRowText.js';
 import FormRowTextLong from './FormRowTextLong.js';
 
-const FormRowEmailLong = (
-  props: FormRowTextProps,
-): React$Element<typeof FormRowTextLong> => (
-  <FormRowTextLong type="email" {...props} />
-);
+component FormRowEmailLong(...props: React.PropsOf<FormRowTextLong>) {
+  return (
+    <FormRowTextLong type="email" {...props} />
+  );
+}
 
 export default FormRowEmailLong;

--- a/root/static/scripts/edit/components/FormRowNameWithGuessCase.js
+++ b/root/static/scripts/edit/components/FormRowNameWithGuessCase.js
@@ -37,16 +37,6 @@ export type ActionT =
   | {+type: 'set-name', +name: string};
 /* eslint-enable ft-flow/sort-keys */
 
-type PropsT = {
-  +dispatch: (ActionT) => void,
-  +entity: NamedEntityT,
-  +field: FieldT<string | null>,
-  +guessCaseOptions: GuessCaseOptionsStateT,
-  +guessFeat?: boolean,
-  +isGuessCaseOptionsOpen: boolean,
-  +label?: React$Node,
-};
-
 export type StateT = {
   +field: FieldT<string | null>,
   +guessCaseOptions: GuessCaseOptionsStateT,
@@ -99,15 +89,15 @@ export function runReducer(
   }
 }
 
-export const FormRowNameWithGuessCase = ({
-  dispatch,
-  entity,
-  field,
-  guessCaseOptions,
-  guessFeat = false,
-  isGuessCaseOptionsOpen = false,
-  label = addColonText(l('Name')),
-}: PropsT): React$Element<typeof FormRowText> => {
+export component FormRowNameWithGuessCase(
+  dispatch: (ActionT) => void,
+  entity: NamedEntityT,
+  field: FieldT<string | null>,
+  guessCaseOptions: GuessCaseOptionsStateT,
+  guessFeat: boolean = false,
+  isGuessCaseOptionsOpen: boolean = false,
+  label: React$Node = addColonText(l('Name')),
+) {
   const inputRef = React.useRef<HTMLInputElement | null>(null);
 
   function handleNameChange(event: SyntheticKeyboardEvent<HTMLInputElement>) {
@@ -175,6 +165,6 @@ export const FormRowNameWithGuessCase = ({
       />
     </FormRowText>
   );
-};
+}
 
 export default FormRowNameWithGuessCase;

--- a/root/static/scripts/edit/components/FormRowNameWithGuessCase.js
+++ b/root/static/scripts/edit/components/FormRowNameWithGuessCase.js
@@ -89,7 +89,7 @@ export function runReducer(
   }
 }
 
-export component FormRowNameWithGuessCase(
+component FormRowNameWithGuessCase(
   dispatch: (ActionT) => void,
   entity: NamedEntityT,
   field: FieldT<string | null>,

--- a/root/static/scripts/edit/components/FormRowPartialDate.js
+++ b/root/static/scripts/edit/components/FormRowPartialDate.js
@@ -17,52 +17,43 @@ import PartialDateInput, {
 
 export type ActionT = PartialDateInputActionT;
 
-type CommonProps = {
-  +children?: React$Node,
-  +disabled?: boolean,
-  +field: PartialDateFieldT,
-  +label: React$Node,
-  +required?: boolean,
-  +yearInputRef?: {current: HTMLInputElement | null},
-};
-
-type Props =
+type ControlledPropsT =
   | $ReadOnly<{
-      ...CommonProps,
       +dispatch: (PartialDateInputActionT) => void,
       +uncontrolled?: false,
     }>
-  | $ReadOnly<{
-      ...CommonProps,
-      +uncontrolled: true,
-    }>;
+  | $ReadOnly<{+uncontrolled: true}>;
 
 export type StateT = PartialDateFieldT;
 
 export const runReducer = runPartialDateInputReducer;
 
-const FormRowPartialDate = ({
-  children,
-  disabled = false,
-  field,
-  label,
-  required = false,
-  ...inputProps
-}: Props): React$Element<typeof FormRow> => (
-  <FormRow>
-    <FormLabel
-      forField={field.field.year}
-      label={label}
-      required={required}
-    />
-    <PartialDateInput
-      disabled={disabled}
-      field={field}
-      {...inputProps}
-    />
-    {children}
-    <FieldErrors field={field} />
-  </FormRow>
-);
+component FormRowPartialDate(
+  children?: React$Node,
+  disabled: boolean = false,
+  field: PartialDateFieldT,
+  label: React$Node,
+  required: boolean = false,
+  yearInputRef?: {current: HTMLInputElement | null},
+  ...controlledProps: ControlledPropsT
+) {
+  return (
+    <FormRow>
+      <FormLabel
+        forField={field.field.year}
+        label={label}
+        required={required}
+      />
+      <PartialDateInput
+        disabled={disabled}
+        field={field}
+        yearInputRef={yearInputRef}
+        {...controlledProps}
+      />
+      {children}
+      <FieldErrors field={field} />
+    </FormRow>
+  );
+}
 
 export default FormRowPartialDate;

--- a/root/static/scripts/edit/components/FormRowRadio.js
+++ b/root/static/scripts/edit/components/FormRowRadio.js
@@ -20,41 +20,36 @@ type RadioOptionsT = $ReadOnlyArray<{
   +value: number | string,
 }>;
 
-type Props = {
-  +field: FieldT<string>,
-  +label: React$Node,
-  +options: RadioOptionsT,
-  +required?: boolean,
-};
-
-const FormRowRadio = ({
-  field,
-  label,
-  options,
-  required = false,
-}: Props): React$Element<typeof FormRow> => (
-  <FormRow>
-    <FormLabel label={label} required={required} />
-    <div className="no-label">
-      {options.map((option, index) => (
-        <React.Fragment key={option.value}>
-          <label className="inline">
-            <input
-              defaultChecked={field.value === option.value}
-              name={field.html_name}
-              required={required}
-              type="radio"
-              value={option.value}
-            />
-            {' '}
-            {unwrapNl<Expand2ReactOutput>(option.label)}
-          </label>
-          {index < options.length - 1 ? <br /> : null}
-        </React.Fragment>
-      ))}
-    </div>
-    <FieldErrors field={field} />
-  </FormRow>
-);
+component FormRowRadio(
+  field: FieldT<string>,
+  label: React$Node,
+  options: RadioOptionsT,
+  required: boolean = false,
+) {
+  return (
+    <FormRow>
+      <FormLabel label={label} required={required} />
+      <div className="no-label">
+        {options.map((option, index) => (
+          <React.Fragment key={option.value}>
+            <label className="inline">
+              <input
+                defaultChecked={field.value === option.value}
+                name={field.html_name}
+                required={required}
+                type="radio"
+                value={option.value}
+              />
+              {' '}
+              {unwrapNl<Expand2ReactOutput>(option.label)}
+            </label>
+            {index < options.length - 1 ? <br /> : null}
+          </React.Fragment>
+        ))}
+      </div>
+      <FieldErrors field={field} />
+    </FormRow>
+  );
+}
 
 export default FormRowRadio;

--- a/root/static/scripts/edit/components/FormRowSelect.js
+++ b/root/static/scripts/edit/components/FormRowSelect.js
@@ -14,38 +14,24 @@ import FormLabel from './FormLabel.js';
 import FormRow from './FormRow.js';
 import HiddenField from './HiddenField.js';
 
-type Props = {
+component FormRowSelect(
   // `allowEmpty` prepends an empty default option to the list.
-  +allowEmpty?: boolean,
-  +disabled?: boolean,
-  +field: FieldT<number | string>,
-  +frozen?: boolean,
-  +hasHtmlErrors?: boolean,
-  +helpers?: React$Node,
-  +label: React$Node,
-  +onChange?: (event: SyntheticEvent<HTMLSelectElement>) => void,
-  +options: MaybeGroupedOptionsT,
+  allowEmpty: boolean = false,
+  disabled: boolean = false,
+  field: FieldT<number | string>,
+  frozen: boolean = false,
+  hasHtmlErrors?: boolean,
+  helpers?: React$Node,
+  label: React$Node,
+  onChange?: (event: SyntheticEvent<HTMLSelectElement>) => void,
+  options: MaybeGroupedOptionsT,
   /*
    * `required` makes the field text bold to indicate a selection is required.
    * Only useful when `allowEmpty` is true.
    */
-  +required?: boolean,
-  +uncontrolled?: boolean,
-};
-
-const FormRowSelect = ({
-  allowEmpty = false,
-  disabled = false,
-  frozen = false,
-  field,
-  hasHtmlErrors,
-  helpers,
-  label,
-  onChange,
-  options,
-  required: passedRequired = false,
-  uncontrolled = false,
-}: Props): React$Element<typeof FormRow> => {
+  required as passedRequired: boolean = false,
+  uncontrolled: boolean = false,
+) {
   let required = passedRequired;
   if (!allowEmpty) {
     // If the field can't be unset, there's nothing required from the user.
@@ -68,6 +54,6 @@ const FormRowSelect = ({
       <FieldErrors field={field} hasHtmlErrors={hasHtmlErrors} />
     </FormRow>
   );
-};
+}
 
 export default FormRowSelect;

--- a/root/static/scripts/edit/components/FormRowSelectList.js
+++ b/root/static/scripts/edit/components/FormRowSelectList.js
@@ -12,69 +12,56 @@ import SelectField from '../../common/components/SelectField.js';
 import FieldErrors from './FieldErrors.js';
 import FormRow from './FormRow.js';
 
-type Props<S> = {
-  +addId: string,
-  +addLabel: string,
-  +getSelectField: (S) => FieldT<?StrOrNum>,
-  +hideAddButton?: boolean,
-  +label: React$Node,
-  +onAdd: (event: SyntheticEvent<HTMLButtonElement>) => void,
-  +onEdit: (index: number, value: string) => void,
-  +onRemove: (index: number) => void,
-  +options: MaybeGroupedOptionsT,
-  +removeClassName: string,
-  +removeLabel: string,
-  +repeatable: RepeatableFieldT<S>,
-};
-
-const FormRowSelectList = <S: {+id: number, ...}>({
-  addId,
-  addLabel,
-  getSelectField,
-  hideAddButton = false,
-  label,
-  onAdd,
-  onEdit,
-  onRemove,
-  options,
-  removeClassName,
-  removeLabel,
-  repeatable,
-}: Props<S>): React$Element<typeof FormRow> => (
-  <FormRow>
-    <label>{label}</label>
-    <div className="form-row-select-list">
-      {repeatable.field.map((subfield, index) => (
-        <div className="select-list-row" key={subfield.id}>
-          <SelectField
-            field={getSelectField(subfield)}
-            onChange={event => onEdit(index, event.currentTarget.value)}
-            options={options}
-          />
-          {' '}
-          <button
-            className={`nobutton icon remove-item ${removeClassName}`}
-            onClick={() => onRemove(index)}
-            title={removeLabel}
-            type="button"
-          />
-          <FieldErrors field={getSelectField(subfield)} />
-        </div>
-      ))}
-      {hideAddButton ? null : (
-        <div className="form-row-add">
-          <button
-            className="with-label add-item"
-            id={addId}
-            onClick={onAdd}
-            type="button"
-          >
-            {addLabel}
-          </button>
-        </div>
-      )}
-    </div>
-  </FormRow>
-);
+component FormRowSelectList<S: {+id: number, ...}>(
+  addId: string,
+  addLabel: string,
+  getSelectField: (S) => FieldT<?StrOrNum>,
+  hideAddButton: boolean = false,
+  label: React$Node,
+  onAdd: (event: SyntheticEvent<HTMLButtonElement>) => void,
+  onEdit: (index: number, value: string) => void,
+  onRemove: (index: number) => void,
+  options: MaybeGroupedOptionsT,
+  removeClassName: string,
+  removeLabel: string,
+  repeatable: RepeatableFieldT<S>,
+) {
+  return (
+    <FormRow>
+      <label>{label}</label>
+      <div className="form-row-select-list">
+        {repeatable.field.map((subfield, index) => (
+          <div className="select-list-row" key={subfield.id}>
+            <SelectField
+              field={getSelectField(subfield)}
+              onChange={event => onEdit(index, event.currentTarget.value)}
+              options={options}
+            />
+            {' '}
+            <button
+              className={`nobutton icon remove-item ${removeClassName}`}
+              onClick={() => onRemove(index)}
+              title={removeLabel}
+              type="button"
+            />
+            <FieldErrors field={getSelectField(subfield)} />
+          </div>
+        ))}
+        {hideAddButton ? null : (
+          <div className="form-row-add">
+            <button
+              className="with-label add-item"
+              id={addId}
+              onClick={onAdd}
+              type="button"
+            >
+              {addLabel}
+            </button>
+          </div>
+        )}
+      </div>
+    </FormRow>
+  );
+}
 
 export default FormRowSelectList;

--- a/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
+++ b/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
@@ -28,15 +28,6 @@ export type ActionT =
   | {+type: 'copy-sortname'};
 /* eslint-enable ft-flow/sort-keys */
 
-type PropsT = {
-  +disabled?: boolean,
-  +dispatch: (ActionT) => void,
-  +entity: SortNamedEntityT,
-  +field: FieldT<string | null>,
-  +label?: React$Node,
-  +required?: boolean,
-};
-
 export type StateT = {
   +nameField: FieldT<string | null>,
   +sortNameField: FieldT<string | null>,
@@ -74,14 +65,14 @@ export function runReducer(
   }
 }
 
-export const FormRowSortNameWithGuessCase = ({
-  disabled = false,
-  dispatch,
-  entity,
-  field,
-  label = addColonText(l('Sort name')),
-  required = false,
-}: PropsT): React$Element<typeof FormRowText> => {
+export component FormRowSortNameWithGuessCase(
+  disabled: boolean = false,
+  dispatch: (ActionT) => void,
+  entity: SortNamedEntityT,
+  field: FieldT<string | null>,
+  label: React$Node = addColonText(l('Sort name')),
+  required: boolean = false,
+) {
   const handleSortNameChange = React.useCallback((
     event: SyntheticKeyboardEvent<HTMLInputElement>,
   ) => {
@@ -124,6 +115,6 @@ export const FormRowSortNameWithGuessCase = ({
       />
     </FormRowText>
   );
-};
+}
 
 export default FormRowSortNameWithGuessCase;

--- a/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
+++ b/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
@@ -65,7 +65,7 @@ export function runReducer(
   }
 }
 
-export component FormRowSortNameWithGuessCase(
+component FormRowSortNameWithGuessCase(
   disabled: boolean = false,
   dispatch: (ActionT) => void,
   entity: SortNamedEntityT,

--- a/root/static/scripts/edit/components/FormRowText.js
+++ b/root/static/scripts/edit/components/FormRowText.js
@@ -28,63 +28,52 @@ type InputProps = {
   value?: string,
 };
 
-type CommonProps = {
-  +autoComplete?: string,
-  +children?: React$Node,
-  +className?: string,
-  +disabled?: boolean,
-  +field: FieldT<?string>,
-  +inputRef?: {-current: HTMLInputElement | null},
-  +label: React$Node,
-  +required?: boolean,
-  +size?: number,
-  +type?: string,
-};
+type ControlledPropsT =
+  | $ReadOnly<{onChange: InputOnChange, uncontrolled?: false}>
+  | $ReadOnly<{uncontrolled: true}>;
 
-export type Props =
-  | $ReadOnly<{
-      ...CommonProps,
-      onChange: InputOnChange,
-      uncontrolled?: false,
-    }>
-  | $ReadOnly<{
-      ...CommonProps,
-      uncontrolled: true,
-    }>;
-
-const FormRowText = (props: Props): React$Element<typeof FormRow> => {
-  const field = props.field;
-  const required = props.required ?? false;
-
+component FormRowText(
+  autoComplete?: string,
+  children?: React$Node,
+  className?: string,
+  disabled: boolean = false,
+  field: FieldT<?string>,
+  inputRef?: {-current: HTMLInputElement | null},
+  label: React$Node,
+  required: boolean = false,
+  size?: number,
+  type: string = 'text',
+  ...controlledProps: ControlledPropsT
+) {
   const inputProps: InputProps = {
-    autoComplete: props.autoComplete,
-    className: props.className,
-    disabled: props.disabled ?? false,
+    autoComplete: autoComplete,
+    className: className,
+    disabled: disabled,
     id: 'id-' + field.html_name,
     name: field.html_name,
-    ref: props.inputRef,
+    ref: inputRef,
     required: required,
-    size: props.size,
-    type: props.type ?? 'text',
+    size: size,
+    type: type,
   };
 
   const inputValue = field.value ?? '';
 
-  if (props.uncontrolled /*:: === true */) {
+  if (controlledProps.uncontrolled /*:: === true */) {
     inputProps.defaultValue = inputValue;
   } else {
-    inputProps.onChange = props.onChange;
+    inputProps.onChange = controlledProps.onChange;
     inputProps.value = inputValue;
   }
 
   return (
     <FormRow>
-      <FormLabel forField={field} label={props.label} required={required} />
+      <FormLabel forField={field} label={label} required={required} />
       <input {...inputProps} />
-      {props.children}
+      {children}
       <FieldErrors field={field} />
     </FormRow>
   );
-};
+}
 
 export default FormRowText;

--- a/root/static/scripts/edit/components/FormRowTextArea.js
+++ b/root/static/scripts/edit/components/FormRowTextArea.js
@@ -11,35 +11,27 @@ import FieldErrors from './FieldErrors.js';
 import FormLabel from './FormLabel.js';
 import FormRow from './FormRow.js';
 
-type Props = {
-  +cols?: number,
-  +field: FieldT<string>,
-  +label: React$Node,
-  +required?: boolean,
-  +rows?: number,
-};
-
-const FormRowTextArea = ({
-  cols = 80,
-  field,
-  label,
-  required = false,
-  rows = 5,
-  ...textareaProps
-}: Props): React$Element<typeof FormRow> => (
-  <FormRow>
-    <FormLabel forField={field} label={label} required={required} />
-    <textarea
-      cols={cols}
-      defaultValue={field.value}
-      id={'id-' + field.html_name}
-      name={field.html_name}
-      required={required}
-      rows={rows}
-      {...textareaProps}
-    />
-    <FieldErrors field={field} />
-  </FormRow>
-);
+component FormRowTextArea(
+  cols: number = 80,
+  field: FieldT<string>,
+  label: React$Node,
+  required: boolean = false,
+  rows: number = 5,
+) {
+  return (
+    <FormRow>
+      <FormLabel forField={field} label={label} required={required} />
+      <textarea
+        cols={cols}
+        defaultValue={field.value}
+        id={'id-' + field.html_name}
+        name={field.html_name}
+        required={required}
+        rows={rows}
+      />
+      <FieldErrors field={field} />
+    </FormRow>
+  );
+}
 
 export default FormRowTextArea;

--- a/root/static/scripts/edit/components/FormRowTextLong.js
+++ b/root/static/scripts/edit/components/FormRowTextLong.js
@@ -7,13 +7,12 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import type {Props as FormRowTextProps} from './FormRowText.js';
 import FormRowText from './FormRowText.js';
 
-const FormRowTextLong = (
-  props: FormRowTextProps,
-): React$Element<typeof FormRowText> => (
-  <FormRowText size={47} {...props} />
-);
+component FormRowTextLong(...props: React.PropsOf<FormRowText>) {
+  return (
+    <FormRowText size={47} {...props} />
+  );
+}
 
 export default FormRowTextLong;

--- a/root/static/scripts/edit/components/FormRowURLLong.js
+++ b/root/static/scripts/edit/components/FormRowURLLong.js
@@ -7,13 +7,12 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import type {Props as FormRowTextProps} from './FormRowText.js';
 import FormRowTextLong from './FormRowTextLong.js';
 
-const FormRowURLLong = (
-  props: FormRowTextProps,
-): React$Element<typeof FormRowTextLong> => (
-  <FormRowTextLong type="url" {...props} />
-);
+component FormRowURLLong(...props: React.PropsOf<FormRowTextLong>) {
+  return (
+    <FormRowTextLong type="url" {...props} />
+  );
+}
 
 export default FormRowURLLong;

--- a/root/static/scripts/edit/components/FormSubmit.js
+++ b/root/static/scripts/edit/components/FormSubmit.js
@@ -7,31 +7,27 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type Props = {
-  +className?: string,
-  +inputClassName?: string,
-  +label: React$Node,
-  +name?: string,
-  +value?: string,
-};
-
-const FormSubmit = ({
-  className,
-  inputClassName,
-  label,
-  name,
-  value,
-}: Props): React$Element<'span'> => (
-  <span className={'buttons' + (nonEmpty(className) ? ' ' + className : '')}>
-    <button
-      className={inputClassName}
-      name={name}
-      type="submit"
-      value={value}
+component FormSubmit(
+  className?: string,
+  inputClassName?: string,
+  label: React$Node,
+  name?: string,
+  value?: string,
+) {
+  return (
+    <span
+      className={'buttons' + (nonEmpty(className) ? ' ' + className : '')}
     >
-      {label}
-    </button>
-  </span>
-);
+      <button
+        className={inputClassName}
+        name={name}
+        type="submit"
+        value={value}
+      >
+        {label}
+      </button>
+    </span>
+  );
+}
 
 export default FormSubmit;

--- a/root/static/scripts/edit/components/GuessCaseIcon.js
+++ b/root/static/scripts/edit/components/GuessCaseIcon.js
@@ -11,12 +11,14 @@ import guessCaseIconUrl from '../../../images/icons/guesscase.32x32.png';
 
 const style = {float: 'left', margin: '1em'};
 
-const GuessCaseIcon = (): React$Element<'img'> => (
-  <img
-    alt=""
-    src={guessCaseIconUrl}
-    style={style}
-  />
-);
+component GuessCaseIcon() {
+  return (
+    <img
+      alt=""
+      src={guessCaseIconUrl}
+      style={style}
+    />
+  );
+}
 
 export default GuessCaseIcon;

--- a/root/static/scripts/edit/components/GuessCaseOptions.js
+++ b/root/static/scripts/edit/components/GuessCaseOptions.js
@@ -31,11 +31,6 @@ export type StateT = {
   +upperCaseRoman: boolean,
 };
 
-export type PropsT = $ReadOnly<{
-  ...StateT,
-  +dispatch: (ActionT) => void,
-}>;
-
 export function createInitialState(): StateT {
   return {
     keepUpperCase: gc.CFG_KEEP_UPPERCASED,
@@ -72,12 +67,10 @@ export function runReducer(
   }
 }
 
-const GuessCaseOptions = ({
-  dispatch,
-  keepUpperCase,
-  modeName,
-  upperCaseRoman,
-}: PropsT): React$Element<'div'> => {
+component GuessCaseOptions(
+  dispatch: (ActionT) => void,
+  ...stateProps: StateT
+) {
   function handleModeChange(event: SyntheticEvent<HTMLSelectElement>) {
     const newModeName = event.currentTarget.value;
 
@@ -107,7 +100,7 @@ const GuessCaseOptions = ({
   return (
     <div id="guesscase-options">
       <h1>{l('Guess case options')}</h1>
-      <select onChange={handleModeChange} value={modeName}>
+      <select onChange={handleModeChange} value={stateProps.modeName}>
         <option value="English">{l('English')}</option>
         <option value="Sentence">{l('Sentence')}</option>
         <option value="French">{l('French')}</option>
@@ -120,11 +113,11 @@ const GuessCaseOptions = ({
         </a>,
       )}
       <p>
-        {expand2react(modes[modeName].description ?? '')}
+        {expand2react(modes[stateProps.modeName].description ?? '')}
       </p>
       <label>
         <input
-          checked={keepUpperCase}
+          checked={stateProps.keepUpperCase}
           onChange={handleKeepUpperCaseChanged}
           type="checkbox"
         />
@@ -133,7 +126,7 @@ const GuessCaseOptions = ({
       <br />
       <label>
         <input
-          checked={upperCaseRoman}
+          checked={stateProps.upperCaseRoman}
           onChange={handleUpperCaseRomanChanged}
           type="checkbox"
         />
@@ -141,6 +134,6 @@ const GuessCaseOptions = ({
       </label>
     </div>
   );
-};
+}
 
 export default GuessCaseOptions;

--- a/root/static/scripts/edit/components/GuessCaseOptionsPopover.js
+++ b/root/static/scripts/edit/components/GuessCaseOptionsPopover.js
@@ -11,29 +11,18 @@ import * as React from 'react';
 
 import ButtonPopover from '../../common/components/ButtonPopover.js';
 
-import GuessCaseOptions, {
-  type PropsT as GuessCaseOptionsPropsT,
-} from './GuessCaseOptions.js';
-
-type Props = $ReadOnly<{
-  +isOpen: boolean,
-  +toggle: (boolean) => void,
-  ...GuessCaseOptionsPropsT,
-}>;
+import GuessCaseOptions from './GuessCaseOptions.js';
 
 const buttonProps = {
   className: 'guesscase-options icon',
   title: N_l('Guess case options'),
 };
 
-const GuessCaseOptionsPopover = (React.memo(({
-  dispatch,
-  isOpen,
-  keepUpperCase,
-  modeName,
-  toggle,
-  upperCaseRoman,
-}: Props): React$Element<typeof ButtonPopover> => {
+component _GuessCaseOptionsPopover(
+  isOpen: boolean,
+  toggle: (boolean) => void,
+  ...guessCaseOptionsProps: React.PropsOf<GuessCaseOptions>
+) {
   const buildChildren = React.useCallback((
     closeAndReturnFocus: () => void,
   ) => (
@@ -43,12 +32,7 @@ const GuessCaseOptionsPopover = (React.memo(({
         closeAndReturnFocus();
       }}
     >
-      <GuessCaseOptions
-        dispatch={dispatch}
-        keepUpperCase={keepUpperCase}
-        modeName={modeName}
-        upperCaseRoman={upperCaseRoman}
-      />
+      <GuessCaseOptions {...guessCaseOptionsProps} />
       <div
         className="buttons"
         style={{marginTop: '1em'}}
@@ -64,12 +48,7 @@ const GuessCaseOptionsPopover = (React.memo(({
         </div>
       </div>
     </form>
-  ), [
-    dispatch,
-    keepUpperCase,
-    modeName,
-    upperCaseRoman,
-  ]);
+  ), [guessCaseOptionsProps]);
 
   return (
     <ButtonPopover
@@ -81,6 +60,10 @@ const GuessCaseOptionsPopover = (React.memo(({
       toggle={toggle}
     />
   );
-}): React$AbstractComponent<Props, void>);
+}
+
+const GuessCaseOptionsPopover: React$AbstractComponent<
+  React.PropsOf<_GuessCaseOptionsPopover>
+> = React.memo(_GuessCaseOptionsPopover);
 
 export default GuessCaseOptionsPopover;

--- a/root/static/scripts/edit/components/HelpIcon.js
+++ b/root/static/scripts/edit/components/HelpIcon.js
@@ -9,28 +9,24 @@
 
 import Tooltip from './Tooltip.js';
 
-type PropsT = {
-  +content: React$Node,
-};
-
 const ICON_STYLE = {
   display: 'inline-block',
   marginLeft: '10px',
   verticalAlign: 'text-top',
 };
 
-const HelpIcon = ({
-  content,
-}: PropsT): React$MixedElement => (
-  <Tooltip
-    content={content}
-    target={
-      <span
-        className="img icon help"
-        style={ICON_STYLE}
-      />
-    }
-  />
-);
+component HelpIcon(content: React$Node) {
+  return (
+    <Tooltip
+      content={content}
+      target={
+        <span
+          className="img icon help"
+          style={ICON_STYLE}
+        />
+      }
+    />
+  );
+}
 
 export default HelpIcon;

--- a/root/static/scripts/edit/components/HiddenField.js
+++ b/root/static/scripts/edit/components/HiddenField.js
@@ -7,18 +7,14 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type Props = {
-  +field: FieldT<number | string>,
-};
-
-const HiddenField = ({
-  field,
-}: Props): React$Element<'input'> => (
-  <input
-    name={field.html_name}
-    type="hidden"
-    value={field.value}
-  />
-);
+component HiddenField(field: FieldT<number | string>) {
+  return (
+    <input
+      name={field.html_name}
+      type="hidden"
+      value={field.value}
+    />
+  );
+}
 
 export default HiddenField;

--- a/root/static/scripts/edit/components/InformationIcon.js
+++ b/root/static/scripts/edit/components/InformationIcon.js
@@ -9,16 +9,13 @@
 
 import informationIconUrl from '../../../images/icons/information.png';
 
-type Props = {
-  className?: string,
-  title?: string,
-};
-
-const InformationIcon = (props: Props): React$Element<'img'> => (
-  <img
-    src={informationIconUrl}
-    {...props}
-  />
-);
+component InformationIcon(...props: {className?: string, title?: string}) {
+  return (
+    <img
+      src={informationIconUrl}
+      {...props}
+    />
+  );
+}
 
 export default InformationIcon;

--- a/root/static/scripts/edit/components/InlineSubmitButton.js
+++ b/root/static/scripts/edit/components/InlineSubmitButton.js
@@ -7,21 +7,17 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type PropsT = {
-  +label?: string,
-};
-
-const InlineSubmitButton = ({
-  label,
-}: PropsT): React.MixedElement => (
-  <>
-    {' '}
-    <span className="buttons inline">
-      <button type="submit">
-        {nonEmpty(label) ? label : l('Submit')}
-      </button>
-    </span>
-  </>
-);
+component InlineSubmitButton(label?: string) {
+  return (
+    <>
+      {' '}
+      <span className="buttons inline">
+        <button type="submit">
+          {nonEmpty(label) ? label : l('Submit')}
+        </button>
+      </span>
+    </>
+  );
+}
 
 export default InlineSubmitButton;

--- a/root/static/scripts/edit/components/NewNotesAlertCheckbox.js
+++ b/root/static/scripts/edit/components/NewNotesAlertCheckbox.js
@@ -9,13 +9,7 @@
 
 import setCookie from '../../common/utility/setCookie.js';
 
-type Props = {
-  +checked: boolean,
-};
-
-const NewNotesAlertCheckbox = ({
-  checked,
-}: Props): React$Element<'p'> => {
+component NewNotesAlertCheckbox(checked: boolean) {
   const handlePreferenceChange = (
     event: SyntheticMouseEvent<HTMLInputElement>,
   ) => {
@@ -36,11 +30,11 @@ const NewNotesAlertCheckbox = ({
       </label>
     </p>
   );
-};
+}
 
 export default (
-  hydrate<Props>(
+  hydrate<React.PropsOf<NewNotesAlertCheckbox>>(
     'span.new-notes-alert-checkbox',
     NewNotesAlertCheckbox,
-  ): React$AbstractComponent<Props, void>
+  ): React$AbstractComponent<React.PropsOf<NewNotesAlertCheckbox>, void>
 );

--- a/root/static/scripts/edit/components/PartialDateInput.js
+++ b/root/static/scripts/edit/components/PartialDateInput.js
@@ -21,23 +21,9 @@ export type ActionT =
   | {+type: 'show-pending-errors'};
 /* eslint-enable ft-flow/sort-keys */
 
-type CommonProps = {
-  +disabled?: boolean,
-  +field: PartialDateFieldT,
-  +yearInputRef?: {current: HTMLInputElement | null},
-};
-
-type Props =
-  | $ReadOnly<{
-      ...CommonProps,
-      +dispatch: (ActionT) => void,
-      +uncontrolled?: false,
-    }>
-  | $ReadOnly<{
-      ...CommonProps,
-      +dispatch?: void,
-      +uncontrolled: true,
-    }>;
+type ControlledPropsT =
+  | $ReadOnly<{+dispatch: (ActionT) => void, +uncontrolled?: false}>
+  | $ReadOnly<{+dispatch?: void, +uncontrolled: true}>;
 
 export type StateT = PartialDateFieldT;
 
@@ -101,16 +87,17 @@ type DatePartPropsT = {
   value?: StrOrNum,
 };
 
-const PartialDateInput = (props: Props): React$Element<'span'> => {
-  const disabled = props.disabled ?? false;
-  const field = props.field;
-  const yearInputRef = props.yearInputRef;
-
+component PartialDateInput(
+  disabled: boolean = false,
+  field: PartialDateFieldT,
+  yearInputRef?: {current: HTMLInputElement | null},
+  ...controlledProps: ControlledPropsT
+) {
   const yearProps: DatePartPropsT = {};
   const monthProps: DatePartPropsT = {};
   const dayProps: DatePartPropsT = {};
 
-  if (props.uncontrolled) {
+  if (controlledProps.uncontrolled /*:: === true */) {
     yearProps.defaultValue = field.field.year.value;
     monthProps.defaultValue = field.field.month.value;
     dayProps.defaultValue = field.field.day.value;
@@ -119,7 +106,7 @@ const PartialDateInput = (props: Props): React$Element<'span'> => {
       event: SyntheticEvent<HTMLInputElement>,
       fieldName: 'year' | 'month' | 'day',
     ) => {
-      props.dispatch({
+      controlledProps.dispatch({
         // $FlowIssue[invalid-computed-prop]
         date: {[fieldName]: event.currentTarget.value},
         type: 'set-date',
@@ -127,7 +114,7 @@ const PartialDateInput = (props: Props): React$Element<'span'> => {
     };
 
     const handleBlur = () => {
-      props.dispatch({type: 'show-pending-errors'});
+      controlledProps.dispatch({type: 'show-pending-errors'});
     };
 
     yearProps.onBlur = handleBlur;
@@ -192,6 +179,6 @@ const PartialDateInput = (props: Props): React$Element<'span'> => {
       />
     </span>
   );
-};
+}
 
 export default PartialDateInput;

--- a/root/static/scripts/edit/components/PossibleDuplicates.js
+++ b/root/static/scripts/edit/components/PossibleDuplicates.js
@@ -9,50 +9,46 @@
 
 import EntityLink from '../../common/components/EntityLink.js';
 
-type PropsT = {
+component PossibleDuplicates(
   duplicates: $ReadOnlyArray<EditableEntityT>,
   name: string,
   onCheckboxChange: (event: SyntheticEvent<HTMLInputElement>) => void,
-};
-
-const PossibleDuplicates = ({
-  duplicates,
-  name,
-  onCheckboxChange,
-}: PropsT): React$Element<'div'> => (
-  <div>
-    <h3>{l('Possible duplicates')}</h3>
-    <p>{l('We found the following entities with very similar names:')}</p>
-    <ul>
-      {duplicates.map(dupe => (
-        <li key={dupe.gid}>
-          <EntityLink entity={dupe} target="_blank" />
-        </li>
-      ))}
-    </ul>
-    <p>
-      <label>
-        <input onChange={onCheckboxChange} type="checkbox" />
-        {' '}
-        {texp.l(
-          'Yes, I still want to enter “{entity_name}”.',
-          {entity_name: name},
-        )}
-      </label>
-    </p>
-    <p>
-      {exp.l(
-        `Please enter a {doc_disambiguation|disambiguation}
-          to help distinguish this entity from the others.`,
-        {
-          doc_disambiguation: {
-            href: '/doc/Disambiguation_Comment',
-            target: '_blank',
+) {
+  return (
+    <div>
+      <h3>{l('Possible duplicates')}</h3>
+      <p>{l('We found the following entities with very similar names:')}</p>
+      <ul>
+        {duplicates.map(dupe => (
+          <li key={dupe.gid}>
+            <EntityLink entity={dupe} target="_blank" />
+          </li>
+        ))}
+      </ul>
+      <p>
+        <label>
+          <input onChange={onCheckboxChange} type="checkbox" />
+          {' '}
+          {texp.l(
+            'Yes, I still want to enter “{entity_name}”.',
+            {entity_name: name},
+          )}
+        </label>
+      </p>
+      <p>
+        {exp.l(
+          `Please enter a {doc_disambiguation|disambiguation}
+           to help distinguish this entity from the others.`,
+          {
+            doc_disambiguation: {
+              href: '/doc/Disambiguation_Comment',
+              target: '_blank',
+            },
           },
-        },
-      )}
-    </p>
-  </div>
-);
+        )}
+      </p>
+    </div>
+  );
+}
 
 export default PossibleDuplicates;

--- a/root/static/scripts/edit/components/RelationshipPendingEditsWarning.js
+++ b/root/static/scripts/edit/components/RelationshipPendingEditsWarning.js
@@ -20,13 +20,9 @@ import type {
 
 import Tooltip from './Tooltip.js';
 
-type PropsT = {
-  +relationship: LinkRelationshipT | RelationshipStateT,
-};
-
-const RelationshipPendingEditsWarning = ({
-  relationship,
-}: PropsT): React.MixedElement | null => {
+component RelationshipPendingEditsWarning(
+  relationship: LinkRelationshipT | RelationshipStateT
+) {
   const hasPendingEdits = relationship.editsPending;
   const openEditsLink = getOpenEditsLink(relationship);
 
@@ -50,6 +46,6 @@ const RelationshipPendingEditsWarning = ({
       />
     </>
   ) : null;
-};
+}
 
 export default RelationshipPendingEditsWarning;

--- a/root/static/scripts/edit/components/ReleaseMergeStrategy.js
+++ b/root/static/scripts/edit/components/ReleaseMergeStrategy.js
@@ -25,14 +25,6 @@ import isUselessMediumTitle from '../utility/isUselessMediumTitle.js';
 
 import FormRowSelect from './FormRowSelect.js';
 
-type Props = {
-  +badRecordingMerges?:
-    $ReadOnlyArray<$ReadOnlyArray<RecordingWithArtistCreditT>>,
-  +form: MergeReleasesFormT,
-  +mediums: $ReadOnlyArray<MediumT>,
-  +releases: {+[releaseID: number]: ReleaseT},
-};
-
 const mergeStrategyOptions = {
   grouped: false,
   options: [
@@ -41,34 +33,37 @@ const mergeStrategyOptions = {
   ],
 };
 
-const UselessMediumTitleWarning = ({name}: {name: string}) => (
-  <tr>
-    <td colSpan="4">
-      <span
-        className="error"
-        style={{margin: '0 12px 0 6px'}}
-      >
-        {exp.l(
-          `“{matched_text}” seems to indicate medium ordering rather than
-           a medium title. If this is the case, please set the appropriate
-           medium position instead of adding a title
-           (see {release_style|the guidelines}).`,
-          {
-            matched_text: name,
-            release_style: '/doc/Style/Release#Medium_title',
-          },
-        )}
-      </span>
-    </td>
-  </tr>
-);
+component UselessMediumTitleWarning(name: string) {
+  return (
+    <tr>
+      <td colSpan="4">
+        <span
+          className="error"
+          style={{margin: '0 12px 0 6px'}}
+        >
+          {exp.l(
+            `“{matched_text}” seems to indicate medium ordering rather than
+             a medium title. If this is the case, please set the appropriate
+             medium position instead of adding a title
+             (see {release_style|the guidelines}).`,
+            {
+              matched_text: name,
+              release_style: '/doc/Style/Release#Medium_title',
+            },
+          )}
+        </span>
+      </td>
+    </tr>
+  );
+}
 
-const ReleaseMergeStrategy = ({
-  badRecordingMerges,
-  form,
-  mediums,
-  releases,
-}: Props) => {
+component ReleaseMergeStrategy(
+  badRecordingMerges?:
+    $ReadOnlyArray<$ReadOnlyArray<RecordingWithArtistCreditT>>,
+  form: MergeReleasesFormT,
+  mediums: $ReadOnlyArray<MediumT>,
+  releases: {+[releaseID: number]: ReleaseT},
+) {
   const [mergeStrategy, setMergeStrategy] =
     React.useState(form.field.merge_strategy);
 
@@ -288,9 +283,9 @@ const ReleaseMergeStrategy = ({
       </div>
     </>
   );
-};
+}
 
-export default (hydrate<Props>(
+export default (hydrate<React.PropsOf<ReleaseMergeStrategy>>(
   'div.release-merge-strategy',
   ReleaseMergeStrategy,
-): React$AbstractComponent<Props, void>);
+): React$AbstractComponent<React.PropsOf<ReleaseMergeStrategy>, void>);

--- a/root/static/scripts/edit/components/RemoveButton.js
+++ b/root/static/scripts/edit/components/RemoveButton.js
@@ -7,24 +7,20 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type PropsT = {
+component RemoveButton(
   dataIndex?: number,
   onClick: (event: SyntheticEvent<HTMLInputElement>) => void,
   title: string,
-};
-
-const RemoveButton = ({
-  dataIndex,
-  onClick,
-  title,
-}: PropsT): React$Element<'button'> => (
-  <button
-    className="nobutton icon remove-item"
-    data-index={dataIndex}
-    onClick={onClick}
-    title={title}
-    type="button"
-  />
-);
+) {
+  return (
+    <button
+      className="nobutton icon remove-item"
+      data-index={dataIndex}
+      onClick={onClick}
+      title={title}
+      type="button"
+    />
+  );
+}
 
 export default RemoveButton;

--- a/root/static/scripts/edit/components/Tooltip.js
+++ b/root/static/scripts/edit/components/Tooltip.js
@@ -14,15 +14,7 @@
 
 import * as React from 'react';
 
-type TooltipProps = {
-  +content: React$Node,
-  +target: React$Node,
-};
-
-const Tooltip = ({
-  content,
-  target,
-}: TooltipProps): React$Element<'span'> => {
+component Tooltip(content: React$Node, target: React$Node) {
   const containerRef = React.useRef<HTMLSpanElement | null>(null);
 
   React.useEffect(() => {
@@ -46,6 +38,6 @@ const Tooltip = ({
       ) : null}
     </span>
   );
-};
+}
 
 export default Tooltip;

--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -17,25 +17,23 @@ import type {
 } from '../externalLinks.js';
 import {ERROR_TARGETS} from '../URLCleanup.js';
 
-type PropsT = {
+component URLInputPopover(
   cleanupUrl: (string) => string,
-  link: LinkRelationshipT,
+  link as passedLink: LinkRelationshipT,
   onConfirm: (string) => void,
   validateLink: (LinkRelationshipT | LinkStateT) => ErrorT | null,
-};
-
-const URLInputPopover = (props: PropsT): React$MixedElement => {
+) {
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
-  const [link, setLink] = React.useState<LinkRelationshipT>(props.link);
+  const [link, setLink] = React.useState<LinkRelationshipT>(passedLink);
 
   React.useEffect(() => {
-    setLink(props.link);
-  }, [props.link]);
+    setLink(passedLink);
+  }, [passedLink]);
 
   const toggle = (open: boolean) => {
     // Will be called by ButtonPopover when closed by losing focus
     if (!open) {
-      props.onConfirm(link.rawUrl);
+      onConfirm(link.rawUrl);
     }
     setIsOpen(open);
   };
@@ -45,19 +43,19 @@ const URLInputPopover = (props: PropsT): React$MixedElement => {
     setLink({
       ...link,
       rawUrl,
-      url: props.cleanupUrl(rawUrl),
+      url: cleanupUrl(rawUrl),
     });
   };
 
   const handleConfirm = (closeCallback: () => void) => {
-    props.onConfirm(link.rawUrl);
+    onConfirm(link.rawUrl);
     closeCallback();
   };
 
   const buildPopoverChildren = (
     closeAndReturnFocus: () => void,
   ) => {
-    const error = props.validateLink(link);
+    const error = validateLink(link);
     return (
       <form
         onSubmit={(event: SyntheticEvent<HTMLFormElement>) => {
@@ -116,7 +114,7 @@ const URLInputPopover = (props: PropsT): React$MixedElement => {
             className="negative"
             onClick={() => {
               // Reset input field value
-              setLink(props.link);
+              setLink(passedLink);
               // Avoid calling toggle() otherwise changes will be saved
               setIsOpen(false);
             }}
@@ -151,6 +149,6 @@ const URLInputPopover = (props: PropsT): React$MixedElement => {
       toggle={toggle}
     />
   );
-};
+}
 
 export default URLInputPopover;

--- a/root/static/scripts/edit/components/UrlRelationshipCreditFieldset.js
+++ b/root/static/scripts/edit/components/UrlRelationshipCreditFieldset.js
@@ -12,17 +12,12 @@ import FormRowText from './FormRowText.js';
 
 export type ActionT = {+credit: string, +type: 'update-relationship-credit'};
 
-type PropsT = {
-  +dispatch: (ActionT) => void,
-  +field: FieldT<string | null>,
-};
-
 export type StateT = DatePeriodFieldT;
 
-const UrlRelationshipCreditFieldset = ({
-  dispatch,
-  field,
-}: PropsT): React$Element<'fieldset'> => {
+component UrlRelationshipCreditFieldset(
+  dispatch: (ActionT) => void,
+  field: FieldT<string | null>,
+) {
   function handleCreditChange(
     event: SyntheticKeyboardEvent<HTMLInputElement>,
   ) {
@@ -46,6 +41,6 @@ const UrlRelationshipCreditFieldset = ({
       />
     </fieldset>
   );
-};
+}
 
 export default UrlRelationshipCreditFieldset;

--- a/root/static/scripts/edit/components/edit/Diff.js
+++ b/root/static/scripts/edit/components/edit/Diff.js
@@ -11,50 +11,39 @@ import {DELETE, INSERT} from '../../utility/editDiff.js';
 
 import DiffSide from './DiffSide.js';
 
-export type DiffProps = {
-  +extraNew?: React$Node,
-  +extraOld?: React$Node,
-  +label: string,
-  +newText: string,
-  +oldText: string,
-};
-
-type Props = {
-  ...DiffProps,
-  +split?: string,
-};
-
-const Diff = ({
-  extraNew,
-  extraOld,
-  label,
-  newText,
-  oldText,
-  split = '',
-}: Props): React$Element<'tr'> | null => (
-  oldText === newText ? null : (
-    <tr>
-      <th>{label}</th>
-      <td className="old">
-        <DiffSide
-          filter={DELETE}
-          newText={newText}
-          oldText={oldText}
-          split={split}
-        />
-        {extraOld}
-      </td>
-      <td className="new">
-        <DiffSide
-          filter={INSERT}
-          newText={newText}
-          oldText={oldText}
-          split={split}
-        />
-        {extraNew}
-      </td>
-    </tr>
-  )
-);
+component Diff(
+  extraNew?: React$Node,
+  extraOld?: React$Node,
+  label: string,
+  newText: string,
+  oldText: string,
+  split: string = '',
+) {
+  return (
+    oldText === newText ? null : (
+      <tr>
+        <th>{label}</th>
+        <td className="old">
+          <DiffSide
+            filter={DELETE}
+            newText={newText}
+            oldText={oldText}
+            split={split}
+          />
+          {extraOld}
+        </td>
+        <td className="new">
+          <DiffSide
+            filter={INSERT}
+            newText={newText}
+            oldText={oldText}
+            split={split}
+          />
+          {extraNew}
+        </td>
+      </tr>
+    )
+  );
+}
 
 export default Diff;

--- a/root/static/scripts/edit/components/edit/DiffSide.js
+++ b/root/static/scripts/edit/components/edit/DiffSide.js
@@ -34,19 +34,12 @@ function splitText(text: string, split: string = '') {
   return text.split(new RegExp(splitRegExp, 'u'));
 }
 
-type Props = {
-  +filter: EditType,
-  +newText: string,
-  +oldText: string,
-  +split?: string,
-};
-
-const DiffSide = ({
-  filter,
-  newText,
-  oldText,
-  split = '',
-}: Props): React$MixedElement | string => {
+component DiffSide(
+  filter: EditType,
+  newText: string,
+  oldText: string,
+  split: string = '',
+) {
   const stack = [];
   const splitMatch = new RegExp('^(?:' + split + ')$');
 
@@ -132,6 +125,6 @@ const DiffSide = ({
     null,
     ...children,
   ) : (children.length ? children[0] : '');
-};
+}
 
 export default DiffSide;

--- a/root/static/scripts/edit/components/edit/FullChangeDiff.js
+++ b/root/static/scripts/edit/components/edit/FullChangeDiff.js
@@ -7,24 +7,20 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type FullChangeDiffProps = {
-  +label: React$Node,
-  +newContent: React$Node,
-  +oldContent: React$Node,
-};
-
-const FullChangeDiff = ({
-  label,
-  newContent,
-  oldContent,
-}: FullChangeDiffProps): React$Element<'tr'> | null => (
-  oldContent === newContent ? null : (
-    <tr>
-      <th>{label}</th>
-      <td className="old">{oldContent}</td>
-      <td className="new">{newContent}</td>
-    </tr>
-  )
-);
+component FullChangeDiff(
+  label: React$Node,
+  newContent: React$Node,
+  oldContent: React$Node,
+) {
+  return (
+    oldContent === newContent ? null : (
+      <tr>
+        <th>{label}</th>
+        <td className="old">{oldContent}</td>
+        <td className="new">{newContent}</td>
+      </tr>
+    )
+  );
+}
 
 export default FullChangeDiff;

--- a/root/static/scripts/edit/components/edit/RelationshipDiff.js
+++ b/root/static/scripts/edit/components/edit/RelationshipDiff.js
@@ -38,15 +38,11 @@ const diffOnlyB = (
   content: Expand2ReactOutput,
 ) => <span className="diff-only-b">{content}</span>;
 
-type Props = {
-  makeEntityLink?: (
-    entity: RelatableEntityT,
-    content: string,
-    relationship: RelationshipT,
-  ) => React$MixedElement,
-  newRelationship: RelationshipT,
-  oldRelationship: RelationshipT,
-};
+type MakeEntityLinkT = (
+  entity: RelatableEntityT,
+  content: string,
+  relationship: RelationshipT,
+) => React$MixedElement;
 
 const getTypeId = (x: LinkAttrT) => String(x.typeID);
 
@@ -62,11 +58,11 @@ const makeDescriptiveLink = (
   />
 );
 
-const RelationshipDiff = (React.memo(({
-  newRelationship,
-  oldRelationship,
-  makeEntityLink = makeDescriptiveLink,
-}: Props): React.MixedElement => {
+component _RelationshipDiff(
+  makeEntityLink: MakeEntityLinkT = makeDescriptiveLink,
+  newRelationship: RelationshipT,
+  oldRelationship: RelationshipT,
+) {
   const oldAttrs = keyBy(oldRelationship.attributes, getTypeId);
   const newAttrs = keyBy(newRelationship.attributes, getTypeId);
 
@@ -224,6 +220,10 @@ const RelationshipDiff = (React.memo(({
       </tr>
     </>
   );
-}): React$AbstractComponent<Props, void>);
+}
+
+const RelationshipDiff: React$AbstractComponent<
+  React.PropsOf<_RelationshipDiff>
+> = React.memo(_RelationshipDiff);
 
 export default RelationshipDiff;

--- a/root/static/scripts/edit/components/edit/ReleaseEventsDiff.js
+++ b/root/static/scripts/edit/components/edit/ReleaseEventsDiff.js
@@ -71,15 +71,10 @@ const changeSide = (
   );
 };
 
-type Props = {
-  +newEvents: $ReadOnlyArray<ReleaseEventT>,
-  +oldEvents: $ReadOnlyArray<ReleaseEventT>,
-};
-
-const ReleaseEventsDiff = ({
-  newEvents,
-  oldEvents,
-}: Props): React$Element<'tr'> => {
+component ReleaseEventsDiff(
+  newEvents: $ReadOnlyArray<ReleaseEventT>,
+  oldEvents: $ReadOnlyArray<ReleaseEventT>,
+) {
   const oldEventsByCountry = keyBy(oldEvents, getCountryId);
   const newEventsByCountry = keyBy(newEvents, getCountryId);
 
@@ -132,6 +127,6 @@ const ReleaseEventsDiff = ({
       </td>
     </tr>
   );
-};
+}
 
 export default ReleaseEventsDiff;

--- a/root/static/scripts/edit/components/edit/WordDiff.js
+++ b/root/static/scripts/edit/components/edit/WordDiff.js
@@ -7,23 +7,12 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import Diff, {type DiffProps} from './Diff.js';
+import Diff from './Diff.js';
 
-const WordDiff = ({
-  extraNew,
-  extraOld,
-  label,
-  newText,
-  oldText,
-}: DiffProps): React$Element<typeof Diff> => (
-  <Diff
-    extraNew={extraNew}
-    extraOld={extraOld}
-    label={label}
-    newText={newText}
-    oldText={oldText}
-    split="\s+"
-  />
-);
+component WordDiff(...props: React.PropsOf<Diff>) {
+  return (
+    <Diff {...props} split="\s+" />
+  );
+}
 
 export default WordDiff;

--- a/root/static/scripts/genre/components/GenreEditForm.js
+++ b/root/static/scripts/genre/components/GenreEditForm.js
@@ -35,10 +35,6 @@ import {
   NonHydratedRelationshipEditorWrapper as RelationshipEditorWrapper,
 } from '../../relationship-editor/components/RelationshipEditorWrapper.js';
 
-type Props = {
-  +form: GenreFormT,
-};
-
 /* eslint-disable ft-flow/sort-keys */
 type ActionT =
   | {+type: 'update-name', +action: NameActionT};
@@ -83,9 +79,7 @@ function reducer(state: StateT, action: ActionT): StateT {
   return newState;
 }
 
-const GenreEditForm = ({
-  form: initialForm,
-}: Props): React$Element<'form'> => {
+component GenreEditForm(form as initialForm: GenreFormT) {
   const $c = React.useContext(SanitizedCatalystContext);
 
   const [state, dispatch] = React.useReducer(
@@ -166,9 +160,9 @@ const GenreEditForm = ({
       </div>
     </form>
   );
-};
+}
 
-export default (hydrate<Props>(
+export default (hydrate<React.PropsOf<GenreEditForm>>(
   'div.genre-edit-form',
   GenreEditForm,
-): React$AbstractComponent<Props, void>);
+): React$AbstractComponent<React.PropsOf<GenreEditForm>, void>);

--- a/root/static/scripts/main/components/ConfirmSeedButtons.js
+++ b/root/static/scripts/main/components/ConfirmSeedButtons.js
@@ -11,13 +11,7 @@ import * as React from 'react';
 
 import DBDefs from '../../common/DBDefs-client.mjs';
 
-type PropsT = {
-  +autoSubmit: boolean,
-};
-
-const ConfirmSeedButtons = ({
-  autoSubmit,
-}: PropsT): React$MixedElement => {
+component ConfirmSeedButtons(autoSubmit: boolean) {
   const submitRef = React.useRef<HTMLButtonElement | null>(null);
   React.useEffect(() => {
     if (autoSubmit) {
@@ -48,9 +42,9 @@ const ConfirmSeedButtons = ({
       </button>
     </>
   );
-};
+}
 
 export default (hydrate(
   'span.buttons.confirm-seed',
   ConfirmSeedButtons,
-): React$AbstractComponent<PropsT, void>);
+): React$AbstractComponent<React.PropsOf<ConfirmSeedButtons>, void>);

--- a/root/static/scripts/recording/RecordingName.js
+++ b/root/static/scripts/recording/RecordingName.js
@@ -17,14 +17,6 @@ import FormRowNameWithGuessCase, {
   runReducer as runFormRowNameWithGuessCaseReducer,
 } from '../edit/components/FormRowNameWithGuessCase.js';
 
-type Props = {
-  +field: FieldT<string>,
-  +recording: {
-    +entityType: 'recording',
-    +name: string,
-  },
-};
-
 function reducer(
   state: NameStateT,
   action: NameActionT,
@@ -34,10 +26,10 @@ function reducer(
   return ctx.final();
 }
 
-export const RecordingName = ({
-  field,
-  recording,
-}: Props): React$Element<typeof FormRowNameWithGuessCase> => {
+export component RecordingName(
+  field: FieldT<string>,
+  recording: {+entityType: 'recording', +name: string},
+) {
   /*
    * State must be moved higher up in the component hierarchy once more
    * of the page is converted to React.
@@ -58,13 +50,13 @@ export const RecordingName = ({
       isGuessCaseOptionsOpen={state.isGuessCaseOptionsOpen}
     />
   );
-};
+}
 
 /*
  * Hydration must be moved higher up in the component hierarchy once
  * more of the page is converted to React.
  */
-export default (hydrate<Props>(
+export default (hydrate<React.PropsOf<RecordingName>>(
   'div.recording-name',
   RecordingName,
-): React$AbstractComponent<Props, void>);
+): React$AbstractComponent<React.PropsOf<RecordingName>, void>);

--- a/root/static/scripts/relationship-editor/components/DialogAttribute/BooleanAttribute.js
+++ b/root/static/scripts/relationship-editor/components/DialogAttribute/BooleanAttribute.js
@@ -17,14 +17,6 @@ import type {
   DialogBooleanAttributeActionT,
 } from '../../types/actions.js';
 
-type PropsT = {
-  +dispatch: (
-    rootKey: number,
-    action: DialogBooleanAttributeActionT,
-  ) => void,
-  +state: DialogBooleanAttributeStateT,
-};
-
 export function reducer(
   state: DialogBooleanAttributeStateT,
   action: DialogBooleanAttributeActionT,
@@ -45,26 +37,35 @@ export function reducer(
   return newState;
 }
 
-const BooleanAttribute = (React.memo(({
-  state,
-  dispatch,
-}: PropsT) => (
-  <label>
-    <input
-      checked={state.enabled}
-      className="boolean"
-      id={kebabCase(state.type.name) + '-checkbox'}
-      onChange={(event: SyntheticEvent<HTMLInputElement>) => {
-        dispatch(state.key, {
-          enabled: event.currentTarget.checked,
-          type: 'toggle',
-        });
-      }}
-      type="checkbox"
-    />
-    {' '}
-    {state.type.l_name}
-  </label>
-)): React$AbstractComponent<PropsT, mixed>);
+component _BooleanAttribute(
+  dispatch: (
+    rootKey: number,
+    action: DialogBooleanAttributeActionT,
+  ) => void,
+  state: DialogBooleanAttributeStateT,
+) {
+  return (
+    <label>
+      <input
+        checked={state.enabled}
+        className="boolean"
+        id={kebabCase(state.type.name) + '-checkbox'}
+        onChange={(event: SyntheticEvent<HTMLInputElement>) => {
+          dispatch(state.key, {
+            enabled: event.currentTarget.checked,
+            type: 'toggle',
+          });
+        }}
+        type="checkbox"
+      />
+      {' '}
+      {state.type.l_name}
+    </label>
+  );
+}
+
+const BooleanAttribute: React$AbstractComponent<
+  React.PropsOf<_BooleanAttribute>
+> = React.memo(_BooleanAttribute);
 
 export default BooleanAttribute;

--- a/root/static/scripts/relationship-editor/components/DialogAttribute/MultiselectAttribute.js
+++ b/root/static/scripts/relationship-editor/components/DialogAttribute/MultiselectAttribute.js
@@ -46,14 +46,6 @@ function addAttributeLabel(attributeTypeId: ?number): string {
   }
 }
 
-type PropsT = {
-  +dispatch: (
-    rootKey: number,
-    action: DialogMultiselectAttributeActionT,
-  ) => void,
-  +state: DialogMultiselectAttributeStateT,
-};
-
 export function _createLinkAttributeTypeOptions(
   attr: LinkAttrTypeT,
   level: number = 0,
@@ -178,10 +170,13 @@ export function reducer(
   return newState;
 }
 
-const MultiselectAttribute = (React.memo<PropsT>(({
-  state,
-  dispatch,
-}: PropsT): React$MixedElement => {
+component MultiselectAttributeComponent(
+  dispatch: (
+    rootKey: number,
+    action: DialogMultiselectAttributeActionT,
+  ) => void,
+  state: DialogMultiselectAttributeStateT,
+) {
   const linkTypeAttributeType = state.type;
   const addLabel = addAttributeLabel(linkTypeAttributeType.id);
 
@@ -246,6 +241,12 @@ const MultiselectAttribute = (React.memo<PropsT>(({
       state={state}
     />
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+type MultiselectAttributeMemoT =
+  React$AbstractComponent<React.PropsOf<MultiselectAttributeComponent>>;
+
+const MultiselectAttribute: MultiselectAttributeMemoT =
+  React.memo(MultiselectAttributeComponent);
 
 export default MultiselectAttribute;

--- a/root/static/scripts/relationship-editor/components/DialogAttribute/TextAttribute.js
+++ b/root/static/scripts/relationship-editor/components/DialogAttribute/TextAttribute.js
@@ -16,15 +16,6 @@ import type {
   DialogTextAttributeActionT,
 } from '../../types/actions.js';
 
-type PropsT = {
-  +dispatch: (
-    rootKey: number,
-    action: DialogTextAttributeActionT,
-  ) => void,
-  +inputId: string,
-  +state: DialogTextAttributeStateT,
-};
-
 export function reducer(
   state: DialogTextAttributeStateT,
   action: DialogTextAttributeActionT,
@@ -45,22 +36,31 @@ export function reducer(
   return newState;
 }
 
-const TextAttribute = (React.memo(({
-  dispatch,
-  inputId,
-  state,
-}) => (
-  <input
-    id={inputId}
-    onChange={(event) => {
-      dispatch(state.key, {
-        textValue: event.target.value,
-        type: 'set-text-value',
-      });
-    }}
-    type="text"
-    value={state.textValue}
-  />
-)): React$AbstractComponent<PropsT, mixed>);
+component _TextAttribute(
+  dispatch: (
+    rootKey: number,
+    action: DialogTextAttributeActionT,
+  ) => void,
+  inputId: string,
+  state: DialogTextAttributeStateT,
+) {
+  return (
+    <input
+      id={inputId}
+      onChange={(event) => {
+        dispatch(state.key, {
+          textValue: event.target.value,
+          type: 'set-text-value',
+        });
+      }}
+      type="text"
+      value={state.textValue}
+    />
+  );
+}
+
+const TextAttribute: React$AbstractComponent<
+  React.PropsOf<_TextAttribute>
+> = React.memo(_TextAttribute);
 
 export default TextAttribute;

--- a/root/static/scripts/relationship-editor/components/DialogAttributes.js
+++ b/root/static/scripts/relationship-editor/components/DialogAttributes.js
@@ -47,12 +47,6 @@ import TextAttribute, {
   reducer as textAttributeReducer,
 } from './DialogAttribute/TextAttribute.js';
 
-type PropsT = {
-  +dispatch: (DialogAttributeActionT) => void,
-  +isHelpVisible: boolean,
-  +state: $ReadOnly<{...DialogAttributesStateT, ...}>,
-};
-
 const DIALOG_ATTRIBUTE_ORDER = {
   checkbox: 1,
   multiselect: 3,
@@ -341,11 +335,11 @@ const wrapAttributeElement = (
   </div>
 );
 
-const DialogAttributes = (React.memo<PropsT>(({
-  dispatch,
-  isHelpVisible,
-  state,
-}: PropsT): React$MixedElement | null => {
+component _DialogAttributes(
+  dispatch: (DialogAttributeActionT) => void,
+  isHelpVisible: boolean,
+  state: $ReadOnly<{...DialogAttributesStateT, ...}>,
+) {
   const booleanAttributeDispatch = React.useCallback((
     rootKey: number,
     action: DialogBooleanAttributeActionT,
@@ -477,6 +471,10 @@ const DialogAttributes = (React.memo<PropsT>(({
       ))}
     </>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const DialogAttributes: React$AbstractComponent<
+  React.PropsOf<_DialogAttributes>
+> = React.memo(_DialogAttributes);
 
 export default DialogAttributes;

--- a/root/static/scripts/relationship-editor/components/DialogButtons.js
+++ b/root/static/scripts/relationship-editor/components/DialogButtons.js
@@ -9,35 +9,35 @@
 
 import * as React from 'react';
 
-type PropsT = {
-  +isDoneDisabled: boolean,
-  +onCancel: () => void,
-  +onDone: () => void,
-};
-
-const DialogButtons = (React.memo<PropsT>(({
-  isDoneDisabled,
-  onCancel,
-  onDone,
-}: PropsT): React$Element<'div'> => (
-  <div
-    className="buttons"
-    style={{marginTop: '1em'}}
-  >
-    <button className="negative" onClick={onCancel} type="button">
-      {l('Cancel')}
-    </button>
-    <div className="buttons-right">
-      <button
-        className="positive"
-        disabled={isDoneDisabled}
-        onClick={onDone}
-        type="button"
-      >
-        {l('Done')}
+component _DialogButtons(
+  isDoneDisabled: boolean,
+  onCancel: () => void,
+  onDone: () => void,
+) {
+  return (
+    <div
+      className="buttons"
+      style={{marginTop: '1em'}}
+    >
+      <button className="negative" onClick={onCancel} type="button">
+        {l('Cancel')}
       </button>
+      <div className="buttons-right">
+        <button
+          className="positive"
+          disabled={isDoneDisabled}
+          onClick={onDone}
+          type="button"
+        >
+          {l('Done')}
+        </button>
+      </div>
     </div>
-  </div>
-)): React$AbstractComponent<PropsT, mixed>);
+  );
+}
+
+const DialogButtons: React$AbstractComponent<
+  React.PropsOf<_DialogButtons>
+> = React.memo(_DialogButtons);
 
 export default DialogButtons;

--- a/root/static/scripts/relationship-editor/components/DialogDatePeriod.js
+++ b/root/static/scripts/relationship-editor/components/DialogDatePeriod.js
@@ -29,12 +29,6 @@ import {
 } from '../../edit/utility/createField.js';
 import type {DialogDatePeriodStateT} from '../types.js';
 
-type PropsT = {
-  +dispatch: (DateRangeFieldsetActionT) => void,
-  +isHelpVisible: boolean,
-  +state: DialogDatePeriodStateT,
-};
-
 export type ActionT = DateRangeFieldsetActionT;
 
 export function createInitialState(
@@ -145,11 +139,11 @@ export function updateDialogDatePeriodState(
   return newState;
 }
 
-const DialogDatePeriod = (React.memo<PropsT>(({
-  dispatch,
-  isHelpVisible,
-  state,
-}: PropsT): React$MixedElement | null => {
+component _DialogDatePeriod(
+  dispatch: (DateRangeFieldsetActionT) => void,
+  isHelpVisible: boolean,
+  state: DialogDatePeriodStateT,
+) {
   const hooks = useDateRangeFieldset(dispatch);
 
   const field = state.field;
@@ -232,6 +226,10 @@ const DialogDatePeriod = (React.memo<PropsT>(({
       ) : null}
     </>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const DialogDatePeriod: React$AbstractComponent<
+  React.PropsOf<_DialogDatePeriod>
+> = React.memo(_DialogDatePeriod);
 
 export default DialogDatePeriod;

--- a/root/static/scripts/relationship-editor/components/DialogEntityCredit.js
+++ b/root/static/scripts/relationship-editor/components/DialogEntityCredit.js
@@ -19,16 +19,6 @@ import type {
   DialogEntityCreditActionT,
 } from '../types/actions.js';
 
-type PropsT = {
-  +backward: boolean,
-  +dispatch: (DialogEntityCreditActionT) => void,
-  +entityName: string,
-  +forEntity: string,
-  +linkType: ?LinkTypeT,
-  +state: $ReadOnly<{...DialogEntityCreditStateT, ...}>,
-  +targetType: RelatableEntityTypeT,
-};
-
 export function createInitialState(
   creditedAs: string,
   releaseHasUnloadedTracks: boolean,
@@ -64,15 +54,15 @@ export function reducer<T: $ReadOnly<{...DialogEntityCreditStateT, ...}>>(
   return newState;
 }
 
-const DialogEntityCredit = (React.memo<PropsT, void>(({
-  backward,
-  dispatch,
-  entityName,
-  forEntity,
-  linkType,
-  state,
-  targetType,
-}: PropsT): React$MixedElement => {
+component _DialogEntityCredit(
+  backward: boolean,
+  dispatch: (DialogEntityCreditActionT) => void,
+  entityName: string,
+  forEntity: string,
+  linkType: ?LinkTypeT,
+  state: $ReadOnly<{...DialogEntityCreditStateT, ...}>,
+  targetType: RelatableEntityTypeT,
+) {
   const origCredit = React.useRef(state.creditedAs || '');
   const inputRef = React.useRef<HTMLInputElement | null>(null);
   const inputId = React.useId();
@@ -222,6 +212,10 @@ const DialogEntityCredit = (React.memo<PropsT, void>(({
       {changeCreditsSection}
     </div>
   );
-}): React$AbstractComponent<PropsT, void>);
+}
+
+const DialogEntityCredit: React$AbstractComponent<
+  React.PropsOf<_DialogEntityCredit>
+> = React.memo(_DialogEntityCredit);
 
 export default DialogEntityCredit;

--- a/root/static/scripts/relationship-editor/components/DialogLinkOrder.js
+++ b/root/static/scripts/relationship-editor/components/DialogLinkOrder.js
@@ -15,15 +15,10 @@ import type {
   DialogLinkOrderActionT,
 } from '../types/actions.js';
 
-type PropsT = {
-  +dispatch: (DialogLinkOrderActionT) => void,
-  +linkOrder: number,
-};
-
-const DialogLinkOrder = (React.memo<PropsT>(({
-  dispatch,
-  linkOrder,
-}: PropsT): React$Element<'tr'> => {
+component _DialogLinkOrder(
+  dispatch: (DialogLinkOrderActionT) => void,
+  linkOrder: number,
+) {
   const handleLinkOrderChange = React.useCallback((
     event: SyntheticEvent<HTMLInputElement>,
   ) => {
@@ -61,6 +56,10 @@ const DialogLinkOrder = (React.memo<PropsT>(({
       </td>
     </tr>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const DialogLinkOrder: React$AbstractComponent<
+  React.PropsOf<_DialogLinkOrder>
+> = React.memo(_DialogLinkOrder);
 
 export default DialogLinkOrder;

--- a/root/static/scripts/relationship-editor/components/DialogLinkType.js
+++ b/root/static/scripts/relationship-editor/components/DialogLinkType.js
@@ -42,14 +42,6 @@ import {
   createInitialState as createDialogAttributesState,
 } from './DialogAttributes.js';
 
-type PropsT = {
-  +dispatch: (DialogLinkTypeActionT) => void,
-  +isHelpVisible: boolean,
-  +source: RelatableEntityT,
-  +state: DialogLinkTypeStateT,
-  +targetType: RelatableEntityTypeT,
-};
-
 function getLinkTypeError(
   linkType: ?LinkTypeT,
   source: RelatableEntityT,
@@ -274,13 +266,13 @@ const LinkTypeAutocomplete:
   // $FlowIgnore
   Autocomplete2;
 
-const DialogLinkType = (React.memo<PropsT>(({
-  dispatch,
-  isHelpVisible,
-  source,
-  state,
-  targetType,
-}: PropsT): React$Element<'tr'> => {
+component _DialogLinkType(
+  dispatch: (DialogLinkTypeActionT) => void,
+  isHelpVisible: boolean,
+  source: RelatableEntityT,
+  state: DialogLinkTypeStateT,
+  targetType: RelatableEntityTypeT,
+) {
   const {
     autocomplete,
     error,
@@ -343,6 +335,10 @@ const DialogLinkType = (React.memo<PropsT>(({
       </td>
     </tr>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const DialogLinkType: React$AbstractComponent<
+  React.PropsOf<_DialogLinkType>
+> = React.memo(_DialogLinkType);
 
 export default DialogLinkType;

--- a/root/static/scripts/relationship-editor/components/DialogPreview.js
+++ b/root/static/scripts/relationship-editor/components/DialogPreview.js
@@ -24,15 +24,6 @@ import getBatchSelectionMessage from '../utility/getBatchSelectionMessage.js';
 import relationshipsHaveSamePhraseGroup
   from '../utility/relationshipsHaveSamePhraseGroup.js';
 
-type PropsT = {
-  +backward: boolean,
-  +batchSelectionCount: number | void,
-  +dispatch: ({+type: 'change-direction'}) => void,
-  +newRelationship: RelationshipStateT | null,
-  +oldRelationship: RelationshipStateT | null,
-  +source: RelatableEntityT,
-};
-
 const createRelationshipTFromState = (
   relationship: RelationshipStateT,
   source: RelatableEntityT,
@@ -75,14 +66,14 @@ function relationshipsAreIdenticalIgnoringLinkOrder(
   );
 }
 
-const DialogPreview = (React.memo<PropsT>(({
-  backward,
-  batchSelectionCount,
-  dispatch,
-  source,
-  newRelationship,
-  oldRelationship,
-}: PropsT): React$MixedElement => {
+component _DialogPreview(
+  backward: boolean,
+  batchSelectionCount: number | void,
+  dispatch: ({+type: 'change-direction'}) => void,
+  newRelationship: RelationshipStateT | null,
+  oldRelationship: RelationshipStateT | null,
+  source: RelatableEntityT,
+) {
   function changeDirection() {
     dispatch({type: 'change-direction'});
   }
@@ -239,6 +230,10 @@ const DialogPreview = (React.memo<PropsT>(({
       ) : null}
     </>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const DialogPreview: React$AbstractComponent<
+  React.PropsOf<_DialogPreview>
+> = React.memo(_DialogPreview);
 
 export default DialogPreview;

--- a/root/static/scripts/relationship-editor/components/DialogSourceEntity.js
+++ b/root/static/scripts/relationship-editor/components/DialogSourceEntity.js
@@ -31,16 +31,6 @@ import DialogEntityCredit, {
   reducer as dialogEntityCreditReducer,
 } from './DialogEntityCredit.js';
 
-type PropsT = {
-  +backward: boolean,
-  +batchSelectionCount?: number,
-  +dispatch: (DialogEntityCreditActionT) => void,
-  +linkType: ?LinkTypeT,
-  +source: RelatableEntityT,
-  +state: DialogSourceEntityStateT,
-  +targetType: RelatableEntityTypeT,
-};
-
 export function getSourceError(
   source: RelatableEntityT | null,
   linkType: LinkTypeT | null,
@@ -93,15 +83,15 @@ export function reducer(
   return dialogEntityCreditReducer(state, action);
 }
 
-const DialogSourceEntity = (React.memo<PropsT>(({
-  backward,
-  batchSelectionCount,
-  dispatch,
-  linkType,
-  source,
-  state,
-  targetType,
-}: PropsT): React$MixedElement => {
+component _DialogSourceEntity(
+  backward: boolean,
+  batchSelectionCount?: number,
+  dispatch: (DialogEntityCreditActionT) => void,
+  linkType: ?LinkTypeT,
+  source: RelatableEntityT,
+  state: DialogSourceEntityStateT,
+  targetType: RelatableEntityTypeT,
+) {
   const sourceType = source.entityType;
   return (
     <tr>
@@ -141,6 +131,10 @@ const DialogSourceEntity = (React.memo<PropsT>(({
       </td>
     </tr>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const DialogSourceEntity: React$AbstractComponent<
+  React.PropsOf<_DialogSourceEntity>
+> = React.memo(_DialogSourceEntity);
 
 export default DialogSourceEntity;

--- a/root/static/scripts/relationship-editor/components/DialogTargetEntity.js
+++ b/root/static/scripts/relationship-editor/components/DialogTargetEntity.js
@@ -48,15 +48,6 @@ import DialogEntityCredit, {
   reducer as dialogEntityCreditReducer,
 } from './DialogEntityCredit.js';
 
-type PropsT = {
-  +allowedTypes: TargetTypeOptionsT | null,
-  +backward: boolean,
-  +dispatch: (DialogTargetEntityActionT) => void,
-  +linkType: ?LinkTypeT,
-  +source: RelatableEntityT,
-  +state: DialogTargetEntityStateT,
-};
-
 const INCORRECT_SERIES_ENTITY_MESSAGES = {
   artist: N_l('The series you’ve selected is for artists.'),
   event: N_l('The series you’ve selected is for events.'),
@@ -312,17 +303,13 @@ const TargetAutocomplete:
   // $FlowIgnore[incompatible-type]
   Autocomplete2;
 
-const DialogTargetEntity = (React.memo<PropsT>((
-  props: PropsT,
-): React$MixedElement => {
-  const {
-    backward,
-    dispatch,
-    linkType,
-    source,
-    state,
-  } = props;
-
+component _DialogTargetEntity(
+  backward: boolean,
+  dispatch: (DialogTargetEntityActionT) => void,
+  linkType: ?LinkTypeT,
+  source: RelatableEntityT,
+  state: DialogTargetEntityStateT,
+) {
   const autocomplete = state.autocomplete;
   const targetType = state.targetType;
 
@@ -398,6 +385,10 @@ const DialogTargetEntity = (React.memo<PropsT>((
       </td>
     </tr>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const DialogTargetEntity: React$AbstractComponent<
+  React.PropsOf<_DialogTargetEntity>
+> = React.memo(_DialogTargetEntity);
 
 export default DialogTargetEntity;

--- a/root/static/scripts/relationship-editor/components/DialogTargetType.js
+++ b/root/static/scripts/relationship-editor/components/DialogTargetType.js
@@ -16,27 +16,13 @@ import type {
   DialogActionT,
 } from '../types/actions.js';
 
-/* eslint-enable ft-flow/sort-keys */
-
-type PropsT = {
-  +dispatch: (DialogActionT) => void,
-  +initialFocusRef?: {-current: HTMLElement | null},
-  +options: ?TargetTypeOptionsT,
-  +source: RelatableEntityT,
-  +targetType: RelatableEntityTypeT,
-};
-
-const DialogTargetType = (React.memo<PropsT>((
-  props: PropsT,
-): React$MixedElement => {
-  const {
-    dispatch,
-    initialFocusRef,
-    options,
-    source,
-    targetType,
-  } = props;
-
+component _DialogTargetType(
+  dispatch: (DialogActionT) => void,
+  initialFocusRef?: {-current: HTMLElement | null},
+  options: ?TargetTypeOptionsT,
+  source: RelatableEntityT,
+  targetType: RelatableEntityTypeT,
+) {
   function handleTargetTypeChange(event: SyntheticEvent<HTMLSelectElement>) {
     dispatch({
       source,
@@ -71,6 +57,10 @@ const DialogTargetType = (React.memo<PropsT>((
       </td>
     </tr>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const DialogTargetType: React$AbstractComponent<
+  React.PropsOf<_DialogTargetType>
+> = React.memo(_DialogTargetType);
 
 export default DialogTargetType;

--- a/root/static/scripts/relationship-editor/components/NewWorkLink.js
+++ b/root/static/scripts/relationship-editor/components/NewWorkLink.js
@@ -9,20 +9,16 @@
 
 import {DeletedLink} from '../../common/components/EntityLink.js';
 
-type PropsT = {
-  +work: WorkT,
-};
-
-const NewWorkLink = ({
-  work,
-}: PropsT): React$Element<'a'> => (
-  <a href={'#new-work-' + String(work.id)}>
-    <DeletedLink
-      allowNew
-      className="rel-add wrap-anywhere"
-      name={work.name}
-    />
-  </a>
-);
+component NewWorkLink(work: WorkT) {
+  return (
+    <a href={'#new-work-' + String(work.id)}>
+      <DeletedLink
+        allowNew
+        className="rel-add wrap-anywhere"
+        name={work.name}
+      />
+    </a>
+  );
+}
 
 export default NewWorkLink;

--- a/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
@@ -509,21 +509,13 @@ export function reducer(
   return newState;
 }
 
-type AttributesSectionPropsT = {
-  +attributesState: DialogAttributesStateT,
-  +canEditDates: boolean,
-  +datePeriod: DialogDatePeriodStateT,
-  +dispatch: (DialogActionT) => void,
-  +isHelpVisible: boolean,
-};
-
-const AttributesSection = (React.memo<AttributesSectionPropsT>(({
-  attributesState,
-  canEditDates,
-  datePeriod,
-  dispatch,
-  isHelpVisible,
-}) => {
+component _AttributesSection(
+  attributesState: DialogAttributesStateT,
+  canEditDates: boolean,
+  datePeriod: DialogDatePeriodStateT,
+  dispatch: (DialogActionT) => void,
+  isHelpVisible: boolean,
+) {
   const attributesDispatch = React.useCallback((
     action: DialogAttributeActionT,
   ) => {
@@ -567,11 +559,11 @@ const AttributesSection = (React.memo<AttributesSectionPropsT>(({
       </table>
     </>
   ) : null;
-}): React$AbstractComponent<AttributesSectionPropsT, mixed>);
+}
 
-const RelationshipDialogContent = (React.memo<PropsT>((
-  props: PropsT,
-): React$MixedElement => {
+const AttributesSection = React.memo(_AttributesSection);
+
+component _RelationshipDialogContent(...props: PropsT) {
   const {
     batchSelectionCount,
     closeDialog,
@@ -967,7 +959,6 @@ const RelationshipDialogContent = (React.memo<PropsT>((
             targetType={targetEntityState.targetType}
           />
           <DialogTargetEntity
-            allowedTypes={targetTypeOptions}
             backward={backward}
             dispatch={targetEntityDispatch}
             linkType={selectedLinkType}
@@ -1019,7 +1010,11 @@ const RelationshipDialogContent = (React.memo<PropsT>((
       />
     </div>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const RelationshipDialogContent: React$AbstractComponent<
+  React.PropsOf<_RelationshipDialogContent>
+> = React.memo(_RelationshipDialogContent);
 
 function getBatchSelectionMessage(sourceType: RelatableEntityTypeT) {
   switch (sourceType) {

--- a/root/static/scripts/relationship-editor/components/RelationshipEditor.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipEditor.js
@@ -85,12 +85,6 @@ import RelationshipTargetTypeGroups from './RelationshipTargetTypeGroups.js';
 MB.relationshipEditor.getRelationshipStateId = getRelationshipStateId;
 MB.tree = tree;
 
-export type PropsT = {
-  +dispatch: (RelationshipEditorActionT) => void,
-  +formName: string,
-  +state: RelationshipEditorStateT,
-};
-
 export type InitialStateArgsT = {
   +formName: string,
   +seededRelationships: ?$ReadOnlyArray<SeededRelationshipT>,
@@ -577,15 +571,11 @@ export const ErrorMessage:
     </div>
   ));
 
-const RelationshipEditor = (
-  props: PropsT,
-): React$Element<'fieldset'> | null => {
-  const {
-    dispatch,
-    formName,
-    state,
-  } = props;
-
+component RelationshipEditor(
+  dispatch: (RelationshipEditorActionT) => void,
+  formName: string,
+  state: RelationshipEditorStateT,
+) {
   const reducerError = state.reducerError;
 
   const submissionInProgress = React.useRef(false);
@@ -671,6 +661,6 @@ const RelationshipEditor = (
       </div>
     </fieldset>
   );
-};
+}
 
 export default RelationshipEditor;

--- a/root/static/scripts/relationship-editor/components/RelationshipEditorWrapper.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipEditorWrapper.js
@@ -34,9 +34,7 @@ import RelationshipEditor, {
 
 type PropsT = InitialStateArgsT;
 
-let RelationshipEditorWrapper:
-  React$AbstractComponent<PropsT, void> =
-(props: PropsT) => {
+component _RelationshipEditorWrapper(...props: PropsT) {
   const [state, dispatch] = React.useReducer(
     reducer,
     props,
@@ -56,19 +54,17 @@ let RelationshipEditorWrapper:
       state={state}
     />
   );
-};
+}
 
-RelationshipEditorWrapper =
-  withLoadedTypeInfoForRelationshipEditor<PropsT, void>(
-    RelationshipEditorWrapper,
+export const NonHydratedRelationshipEditorWrapper:
+  React$AbstractComponent<PropsT> =
+  withLoadedTypeInfoForRelationshipEditor<PropsT>(
+    _RelationshipEditorWrapper,
   );
 
-export const NonHydratedRelationshipEditorWrapper =
-  RelationshipEditorWrapper;
-
-RelationshipEditorWrapper = hydrate<PropsT>(
+const RelationshipEditorWrapper = (hydrate<PropsT>(
   'div.relationship-editor',
-  RelationshipEditorWrapper,
-);
+  NonHydratedRelationshipEditorWrapper,
+): React$AbstractComponent<PropsT>);
 
 export default RelationshipEditorWrapper;

--- a/root/static/scripts/relationship-editor/components/RelationshipItem.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipItem.js
@@ -52,27 +52,16 @@ import isRelationshipBackward from '../utility/isRelationshipBackward.js';
 
 import NewWorkLink from './NewWorkLink.js';
 
-type PropsT = {
-  +canBeOrdered: boolean,
-  +dispatch: (RelationshipEditorActionT) => void,
-  +hasOrdering: boolean,
-  +isDialogOpen: boolean,
-  +relationship: RelationshipStateT,
-  +releaseHasUnloadedTracks: boolean,
-  +source: RelatableEntityT,
-  +track: TrackWithRecordingT | null,
-};
-
-const RelationshipItem = (React.memo<PropsT>(({
-  canBeOrdered,
-  dispatch,
-  isDialogOpen,
-  hasOrdering,
-  relationship,
-  releaseHasUnloadedTracks,
-  source,
-  track,
-}: PropsT): React$MixedElement => {
+component _RelationshipItem(
+  canBeOrdered: boolean,
+  dispatch: (RelationshipEditorActionT) => void,
+  hasOrdering: boolean,
+  isDialogOpen: boolean,
+  relationship: RelationshipStateT,
+  releaseHasUnloadedTracks: boolean,
+  source: RelatableEntityT,
+  track: TrackWithRecordingT | null,
+) {
   const backward = isRelationshipBackward(relationship, source);
   const target: RelatableEntityT = backward
     ? relationship.entity0
@@ -290,7 +279,11 @@ const RelationshipItem = (React.memo<PropsT>(({
       ) : null}
     </>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const RelationshipItem: React$AbstractComponent<
+  React.PropsOf<_RelationshipItem>
+> = React.memo(_RelationshipItem);
 
 function getRelationshipStyling(relationship: RelationshipStateT) {
   return 'rel-' + getRelationshipStatusName(relationship);

--- a/root/static/scripts/relationship-editor/components/RelationshipLinkTypeGroup.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipLinkTypeGroup.js
@@ -18,25 +18,15 @@ import type {RelationshipEditorActionT} from '../types/actions.js';
 
 import RelationshipPhraseGroup from './RelationshipPhraseGroup.js';
 
-type PropsT = {
-  +dialogLocation: RelationshipDialogLocationT | null,
-  +dispatch: (RelationshipEditorActionT) => void,
-  +linkTypeGroup: RelationshipLinkTypeGroupT,
-  +releaseHasUnloadedTracks: boolean,
-  +source: RelatableEntityT,
-  +targetType: RelatableEntityTypeT,
-  +track: TrackWithRecordingT | null,
-};
-
-const RelationshipLinkTypeGroup = (React.memo<PropsT>(({
-  dialogLocation,
-  dispatch,
-  linkTypeGroup,
-  releaseHasUnloadedTracks,
-  source,
-  targetType,
-  track,
-}: PropsT) => {
+component _RelationshipLinkTypeGroup(
+  dialogLocation: RelationshipDialogLocationT | null,
+  dispatch: (RelationshipEditorActionT) => void,
+  linkTypeGroup: RelationshipLinkTypeGroupT,
+  releaseHasUnloadedTracks: boolean,
+  source: RelatableEntityT,
+  targetType: RelatableEntityTypeT,
+  track: TrackWithRecordingT | null,
+) {
   const elements = [];
   for (const linkPhraseGroup of tree.iterate(linkTypeGroup.phraseGroups)) {
     elements.push(
@@ -60,6 +50,10 @@ const RelationshipLinkTypeGroup = (React.memo<PropsT>(({
     );
   }
   return elements;
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const RelationshipLinkTypeGroup: React$AbstractComponent<
+  React.PropsOf<_RelationshipLinkTypeGroup>
+> = React.memo(_RelationshipLinkTypeGroup);
 
 export default RelationshipLinkTypeGroup;

--- a/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
@@ -45,18 +45,6 @@ const addAnotherEntityLabels = {
   work: N_l('Add another work'),
 };
 
-type PropsT = {
-  +backward: boolean,
-  +dialogLocation: RelationshipDialogLocationT | null,
-  +dispatch: (RelationshipEditorActionT) => void,
-  +linkPhraseGroup: RelationshipPhraseGroupT,
-  +linkTypeId: number,
-  +releaseHasUnloadedTracks: boolean,
-  +source: RelatableEntityT,
-  +targetType: RelatableEntityTypeT,
-  +track: TrackWithRecordingT | null,
-};
-
 function someRelationshipsHaveLinkOrder(
   relationships: tree.ImmutableTree<RelationshipStateT> | null,
 ): boolean {
@@ -68,17 +56,17 @@ function someRelationshipsHaveLinkOrder(
   return false;
 }
 
-const RelationshipPhraseGroup = (React.memo<PropsT>(({
-  backward,
-  dialogLocation,
-  dispatch,
-  linkPhraseGroup,
-  linkTypeId,
-  releaseHasUnloadedTracks,
-  source,
-  targetType,
-  track,
-}: PropsT) => {
+component _RelationshipPhraseGroup(
+  backward: boolean,
+  dialogLocation: RelationshipDialogLocationT | null,
+  dispatch: (RelationshipEditorActionT) => void,
+  linkPhraseGroup: RelationshipPhraseGroupT,
+  linkTypeId: number,
+  releaseHasUnloadedTracks: boolean,
+  source: RelatableEntityT,
+  targetType: RelatableEntityTypeT,
+  track: TrackWithRecordingT | null,
+) {
   const relationships = linkPhraseGroup.relationships;
   const relationshipCount = relationships?.size || 0;
 
@@ -312,6 +300,10 @@ const RelationshipPhraseGroup = (React.memo<PropsT>(({
       ) : null}
     </>
   ) : null;
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const RelationshipPhraseGroup: React$AbstractComponent<
+  React.PropsOf<_RelationshipPhraseGroup>
+> = React.memo(_RelationshipPhraseGroup);
 
 export default RelationshipPhraseGroup;

--- a/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroup.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroup.js
@@ -19,25 +19,15 @@ import {getLinkTypeGroupKey} from '../utility/updateRelationships.js';
 
 import RelationshipLinkTypeGroup from './RelationshipLinkTypeGroup.js';
 
-type Props = {
-  +dialogLocation: RelationshipDialogLocationT | null,
-  +dispatch: (RelationshipEditorActionT) => void,
-  +linkTypeGroups: RelationshipLinkTypeGroupsT,
-  +releaseHasUnloadedTracks: boolean,
-  +source: RelatableEntityT,
-  +targetType: RelatableEntityTypeT,
-  +track: TrackWithRecordingT | null,
-};
-
-const RelationshipTargetTypeGroup = (React.memo<Props>(({
-  dialogLocation,
-  dispatch,
-  linkTypeGroups,
-  releaseHasUnloadedTracks,
-  source,
-  targetType,
-  track,
-}: Props) => {
+component _RelationshipTargetTypeGroup(
+  dialogLocation: RelationshipDialogLocationT | null,
+  dispatch: (RelationshipEditorActionT) => void,
+  linkTypeGroups: RelationshipLinkTypeGroupsT,
+  releaseHasUnloadedTracks: boolean,
+  source: RelatableEntityT,
+  targetType: RelatableEntityTypeT,
+  track: TrackWithRecordingT | null,
+) {
   const elements = [];
   for (const linkTypeGroup of tree.iterate(linkTypeGroups)) {
     elements.push(
@@ -63,6 +53,10 @@ const RelationshipTargetTypeGroup = (React.memo<Props>(({
     );
   }
   return elements;
-}): React$AbstractComponent<Props, mixed>);
+}
+
+const RelationshipTargetTypeGroup: React$AbstractComponent<
+  React.PropsOf<_RelationshipTargetTypeGroup>
+> = React.memo(_RelationshipTargetTypeGroup);
 
 export default RelationshipTargetTypeGroup;

--- a/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroups.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroups.js
@@ -25,25 +25,15 @@ import {
 
 import RelationshipTargetTypeGroup from './RelationshipTargetTypeGroup.js';
 
-type PropsT = {
-  +dialogLocation: RelationshipDialogLocationT | null,
-  +dispatch: (RelationshipEditorActionT) => void,
-  +filter?: (RelatableEntityTypeT) => boolean,
-  +releaseHasUnloadedTracks: boolean,
-  +source: RelatableEntityT,
-  +targetTypeGroups: RelationshipTargetTypeGroupsT,
-  +track: TrackWithRecordingT | null,
-};
-
-const RelationshipTargetTypeGroups = (React.memo<PropsT>(({
-  dialogLocation,
-  dispatch,
-  filter,
-  releaseHasUnloadedTracks,
-  source,
-  targetTypeGroups,
-  track,
-}: PropsT): React$MixedElement => {
+component _RelationshipTargetTypeGroups(
+  dialogLocation: RelationshipDialogLocationT | null,
+  dispatch: (RelationshipEditorActionT) => void,
+  filter?: (RelatableEntityTypeT) => boolean,
+  releaseHasUnloadedTracks: boolean,
+  source: RelatableEntityT,
+  targetTypeGroups: RelationshipTargetTypeGroupsT,
+  track: TrackWithRecordingT | null,
+) {
   const buildPopoverContent = useAddRelationshipDialogContent({
     dispatch,
     preselectedTargetType: null,
@@ -121,6 +111,10 @@ const RelationshipTargetTypeGroups = (React.memo<PropsT>(({
       </tbody>
     </table>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const RelationshipTargetTypeGroups: React$AbstractComponent<
+  React.PropsOf<_RelationshipTargetTypeGroups>
+> = React.memo(_RelationshipTargetTypeGroups);
 
 export default RelationshipTargetTypeGroups;

--- a/root/static/scripts/release/components/BatchCreateWorksDialog.js
+++ b/root/static/scripts/release/components/BatchCreateWorksDialog.js
@@ -137,19 +137,11 @@ export function reducer(
   return newState;
 }
 
-type BatchCreateWorksDialogContentPropsT = {
-  +closeDialog: () => void,
-  +initialFocusRef: {-current: HTMLElement | null},
-  +sourceDispatch: (AcceptBatchCreateWorksDialogActionT) => void,
-};
-
-const BatchCreateWorksDialogContent = React.memo<
-  BatchCreateWorksDialogContentPropsT,
->(({
-  closeDialog,
-  initialFocusRef,
-  sourceDispatch,
-}: BatchCreateWorksDialogContentPropsT): React$Element<'div'> => {
+component _BatchCreateWorksDialogContent(
+  closeDialog: () => void,
+  initialFocusRef: {-current: HTMLElement | null},
+  sourceDispatch: (AcceptBatchCreateWorksDialogActionT) => void,
+) {
   const [state, dispatch] = React.useReducer(
     reducer,
     null,
@@ -282,21 +274,16 @@ const BatchCreateWorksDialogContent = React.memo<
       />
     </div>
   );
-});
+}
 
-type BatchCreateWorksButtonPopoverPropsT = {
-  +dispatch: (ReleaseRelationshipEditorActionT) => void,
-  +isDisabled: boolean,
-  +isOpen: boolean,
-};
+const BatchCreateWorksDialogContent =
+  React.memo(_BatchCreateWorksDialogContent);
 
-export const BatchCreateWorksButtonPopover = (React.memo<
-  BatchCreateWorksButtonPopoverPropsT,
->(({
-  dispatch,
-  isDisabled,
-  isOpen,
-}: BatchCreateWorksButtonPopoverPropsT): React$MixedElement => {
+component _BatchCreateWorksButtonPopover(
+  dispatch: (ReleaseRelationshipEditorActionT) => void,
+  isDisabled: boolean,
+  isOpen: boolean,
+) {
   const setOpen = React.useCallback((open: boolean) => {
     dispatch({
       location: open ? {
@@ -347,4 +334,8 @@ export const BatchCreateWorksButtonPopover = (React.memo<
       }
     />
   );
-}): React$AbstractComponent<BatchCreateWorksButtonPopoverPropsT, mixed>);
+}
+
+export const BatchCreateWorksButtonPopover: React$AbstractComponent<
+  React.PropsOf<_BatchCreateWorksButtonPopover>
+> = React.memo(_BatchCreateWorksButtonPopover);

--- a/root/static/scripts/release/components/EditWorkDialog.js
+++ b/root/static/scripts/release/components/EditWorkDialog.js
@@ -89,24 +89,12 @@ function reducer(
   return newState;
 }
 
-type EditWorkDialogPropsT = {
-  +closeDialog: () => void,
-  +initialFocusRef?: {-current: HTMLElement | null},
-  +rootDispatch: (ReleaseRelationshipEditorActionT) => void,
-  +work: WorkT,
-};
-
-const EditWorkDialog: React$AbstractComponent<
-  EditWorkDialogPropsT,
-  mixed,
-> = React.memo<
-  EditWorkDialogPropsT,
->(({
-  closeDialog,
-  initialFocusRef,
-  rootDispatch,
-  work,
-}: EditWorkDialogPropsT): React$MixedElement => {
+component _EditWorkDialog(
+  closeDialog: () => void,
+  initialFocusRef?: {-current: HTMLElement | null},
+  rootDispatch: (ReleaseRelationshipEditorActionT) => void,
+  work: WorkT,
+) {
   const [state, dispatch] = React.useReducer(
     reducer,
     work,
@@ -197,6 +185,10 @@ const EditWorkDialog: React$AbstractComponent<
       />
     </div>
   );
-});
+}
+
+const EditWorkDialog: React$AbstractComponent<
+  React.PropsOf<_EditWorkDialog>
+> = React.memo(_EditWorkDialog);
 
 export default EditWorkDialog;

--- a/root/static/scripts/release/components/MediumRelationshipEditor.js
+++ b/root/static/scripts/release/components/MediumRelationshipEditor.js
@@ -27,18 +27,6 @@ import type {
 
 import TrackRelationshipEditor from './TrackRelationshipEditor.js';
 
-type PropsT = {
-  +dialogLocation: RelationshipDialogLocationT | null,
-  +dispatch: (ReleaseRelationshipEditorActionT) => void,
-  +hasUnloadedTracks: boolean,
-  +isExpanded: boolean,
-  +medium: MediumWithRecordingsT,
-  +recordingStates: MediumRecordingStateTreeT | null,
-  +release: ReleaseWithMediumsT,
-  +releaseHasUnloadedTracks: boolean,
-  +tracks: $ReadOnlyArray<TrackWithRecordingT> | null,
-};
-
 export type WritableReleasePathsT = Map<number, Set<number>>;
 
 const getColumnCount = () => 3;
@@ -71,17 +59,17 @@ function handleLinkedEntitiesForMedium(
   }
 }
 
-const MediumRelationshipEditor = (React.memo<PropsT>(({
-  dialogLocation,
-  dispatch,
-  hasUnloadedTracks,
-  isExpanded,
-  medium,
-  recordingStates,
-  release,
-  releaseHasUnloadedTracks,
-  tracks,
-}: PropsT) => {
+component _MediumRelationshipEditor(
+  dialogLocation: RelationshipDialogLocationT | null,
+  dispatch: (ReleaseRelationshipEditorActionT) => void,
+  hasUnloadedTracks: boolean,
+  isExpanded: boolean,
+  medium: MediumWithRecordingsT,
+  recordingStates: MediumRecordingStateTreeT | null,
+  release: ReleaseWithMediumsT,
+  releaseHasUnloadedTracks: boolean,
+  tracks: $ReadOnlyArray<TrackWithRecordingT> | null,
+) {
   const tableVars = usePagedMediumTable({
     dispatch,
     getColumnCount,
@@ -198,6 +186,10 @@ const MediumRelationshipEditor = (React.memo<PropsT>(({
       </tbody>
     </>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const MediumRelationshipEditor: React$AbstractComponent<
+  React.PropsOf<_MediumRelationshipEditor>
+> = React.memo(_MediumRelationshipEditor);
 
 export default MediumRelationshipEditor;

--- a/root/static/scripts/release/components/MediumTable.js
+++ b/root/static/scripts/release/components/MediumTable.js
@@ -17,27 +17,16 @@ import type {ActionT, CreditsModeT} from '../types.js';
 
 import MediumTrackRow from './MediumTrackRow.js';
 
-type PropsT = {
-  +creditsMode: CreditsModeT,
-  +dispatch: (ActionT) => void,
-  +hasUnloadedTracks: boolean,
-  +isExpanded: boolean,
-  +medium: MediumWithRecordingsT,
-  +noScript: boolean,
-  +release: ReleaseWithMediumsT,
-  +tracks: $ReadOnlyArray<TrackWithRecordingT> | null,
-};
-
-const MediumTable = (React.memo<PropsT>(({
-  creditsMode,
-  dispatch,
-  hasUnloadedTracks,
-  isExpanded,
-  medium,
-  noScript,
-  release,
-  tracks,
-}: PropsT) => {
+component _MediumTable(
+  creditsMode: CreditsModeT,
+  dispatch: (ActionT) => void,
+  hasUnloadedTracks: boolean,
+  isExpanded: boolean,
+  medium: MediumWithRecordingsT,
+  noScript: boolean,
+  release: ReleaseWithMediumsT,
+  tracks: $ReadOnlyArray<TrackWithRecordingT> | null,
+) {
   const tableVars = usePagedMediumTable({
     dispatch,
     getColumnCount: (showArtists) => 4 + (showArtists ? 1 : 0),
@@ -146,6 +135,10 @@ const MediumTable = (React.memo<PropsT>(({
       </tbody>
     </table>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const MediumTable: React$AbstractComponent<
+  React.PropsOf<_MediumTable>
+> = React.memo(_MediumTable);
 
 export default MediumTable;

--- a/root/static/scripts/release/components/MediumToolbox.js
+++ b/root/static/scripts/release/components/MediumToolbox.js
@@ -15,84 +15,83 @@ import type {
   LazyReleaseActionT,
 } from '../types.js';
 
-type ToggleAllMediumsButtonsPropsT = {
-  +dispatch: (LazyReleaseActionT) => void,
-  +mediums: $ReadOnlyArray<MediumWithRecordingsT>,
-};
+component _ToggleAllMediumsButtons(
+  dispatch: (LazyReleaseActionT) => void,
+  mediums: $ReadOnlyArray<MediumWithRecordingsT>,
+) {
+  return (
+    <>
+      <button
+        className="btn-link"
+        id="expand-all-mediums"
+        onClick={() => {
+          dispatch({
+            expanded: true,
+            mediums,
+            type: 'toggle-all-mediums',
+          });
+        }}
+        type="button"
+      >
+        {l('Expand all mediums')}
+      </button>
+      {' | '}
+      <button
+        className="btn-link"
+        id="collapse-all-mediums"
+        onClick={() => {
+          dispatch({
+            expanded: false,
+            mediums,
+            type: 'toggle-all-mediums',
+          });
+        }}
+        type="button"
+      >
+        {l('Collapse all mediums')}
+      </button>
+    </>
+  );
+}
 
-export const ToggleAllMediumsButtons = (React.memo<
-  ToggleAllMediumsButtonsPropsT,
->(({
-  dispatch,
-  mediums,
-}: ToggleAllMediumsButtonsPropsT): React$MixedElement => (
-  <>
-    <button
-      className="btn-link"
-      id="expand-all-mediums"
-      onClick={() => {
-        dispatch({
-          expanded: true,
-          mediums,
-          type: 'toggle-all-mediums',
-        });
-      }}
-      type="button"
-    >
-      {l('Expand all mediums')}
-    </button>
-    {' | '}
-    <button
-      className="btn-link"
-      id="collapse-all-mediums"
-      onClick={() => {
-        dispatch({
-          expanded: false,
-          mediums,
-          type: 'toggle-all-mediums',
-        });
-      }}
-      type="button"
-    >
-      {l('Collapse all mediums')}
-    </button>
-  </>
-)): React$AbstractComponent<ToggleAllMediumsButtonsPropsT, mixed>);
+export const ToggleAllMediumsButtons: React$AbstractComponent<
+  React.PropsOf<_ToggleAllMediumsButtons>
+> = React.memo(_ToggleAllMediumsButtons);
 
-type MediumToolboxPropsT = {
-  +creditsMode: CreditsModeT,
-  +dispatch: (ActionT) => void,
-  +mediums: $ReadOnlyArray<MediumWithRecordingsT>,
-};
+component _MediumToolbox(
+  creditsMode: CreditsModeT,
+  dispatch: (ActionT) => void,
+  mediums: $ReadOnlyArray<MediumWithRecordingsT>,
+) {
+  return (
+    <span id="medium-toolbox">
+      {mediums.length > 1 ? (
+        <>
+          <ToggleAllMediumsButtons
+            dispatch={dispatch}
+            mediums={mediums}
+          />
+          {' | '}
+        </>
+      ) : null}
+      <button
+        className="btn-link"
+        id="toggle-credits"
+        onClick={() => {
+          dispatch({type: 'toggle-credits-mode'});
+        }}
+        type="button"
+      >
+        {creditsMode === 'bottom'
+          ? l('Display credits inline')
+          : l('Display credits at bottom')}
+      </button>
+    </span>
+  );
+}
 
-const MediumToolbox = (React.memo<MediumToolboxPropsT>(({
-  creditsMode,
-  dispatch,
-  mediums,
-}: MediumToolboxPropsT): React$Element<'span'> => (
-  <span id="medium-toolbox">
-    {mediums.length > 1 ? (
-      <>
-        <ToggleAllMediumsButtons
-          dispatch={dispatch}
-          mediums={mediums}
-        />
-        {' | '}
-      </>
-    ) : null}
-    <button
-      className="btn-link"
-      id="toggle-credits"
-      onClick={() => {
-        dispatch({type: 'toggle-credits-mode'});
-      }}
-      type="button"
-    >
-      {creditsMode === 'bottom'
-        ? l('Display credits inline')
-        : l('Display credits at bottom')}
-    </button>
-  </span>
-)): React$AbstractComponent<MediumToolboxPropsT, mixed>);
+const MediumToolbox: React$AbstractComponent<
+  React.PropsOf<_MediumToolbox>
+> = React.memo(_MediumToolbox);
 
 export default MediumToolbox;

--- a/root/static/scripts/release/components/MediumTrackRow.js
+++ b/root/static/scripts/release/components/MediumTrackRow.js
@@ -21,19 +21,12 @@ import formatTrackLength
   from '../../common/utility/formatTrackLength.js';
 import type {CreditsModeT} from '../types.js';
 
-type PropsT = {
-  +creditsMode: CreditsModeT,
-  +index: number,
-  +showArtists?: boolean,
-  +track: TrackWithRecordingT,
-};
-
-const MediumTrackRow = (React.memo<PropsT>(({
-  creditsMode,
-  index,
-  track,
-  showArtists = false,
-}: PropsT) => {
+component _MediumTrackRow(
+  creditsMode: CreditsModeT,
+  index: number,
+  showArtists: boolean = false,
+  track: TrackWithRecordingT,
+) {
   const $c = React.useContext(SanitizedCatalystContext);
   const recordingAC = track.recording?.artistCredit;
 
@@ -89,6 +82,10 @@ const MediumTrackRow = (React.memo<PropsT>(({
       </td>
     </tr>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const MediumTrackRow: React$AbstractComponent<
+  React.PropsOf<_MediumTrackRow>
+> = React.memo(_MediumTrackRow);
 
 export default MediumTrackRow;

--- a/root/static/scripts/release/components/RelationshipEditorBatchTools.js
+++ b/root/static/scripts/release/components/RelationshipEditorBatchTools.js
@@ -24,37 +24,17 @@ import type {
 
 import {BatchCreateWorksButtonPopover} from './BatchCreateWorksDialog.js';
 
-type PropsT = {
-  +dialogLocation: RelationshipDialogLocationT | null,
-  +dispatch: (ReleaseRelationshipEditorActionT) => void,
-  +recordingSelectionCount: number,
-  +releaseHasUnloadedTracks: boolean,
-  +workSelectionCount: number,
-};
-
-type BatchAddRelationshipButtonPopoverPropsT = {
-  +batchSelectionCount: number,
-  +buttonClassName: string,
-  +buttonContent: string,
-  +dispatch: (ReleaseRelationshipEditorActionT) => void,
-  +entityPlaceholder: string,
-  +isOpen: boolean,
-  +popoverId: string,
-  +releaseHasUnloadedTracks: boolean,
-  +sourceType: RelatableEntityTypeT,
-};
-
-const BatchAddRelationshipButtonPopover = ({
-  batchSelectionCount,
-  buttonClassName,
-  buttonContent,
-  dispatch,
-  entityPlaceholder,
-  isOpen,
-  popoverId,
-  releaseHasUnloadedTracks,
-  sourceType,
-}: BatchAddRelationshipButtonPopoverPropsT) => {
+component BatchAddRelationshipButtonPopover(
+  batchSelectionCount: number,
+  buttonClassName: string,
+  buttonContent: string,
+  dispatch: (ReleaseRelationshipEditorActionT) => void,
+  entityPlaceholder: string,
+  isOpen: boolean,
+  popoverId: string,
+  releaseHasUnloadedTracks: boolean,
+  sourceType: RelatableEntityTypeT,
+) {
   const sourcePlaceholder = createRelatableEntityObject(sourceType, {
     name: entityPlaceholder,
   });
@@ -122,15 +102,15 @@ const BatchAddRelationshipButtonPopover = ({
       }
     />
   );
-};
+}
 
-const RelationshipEditorBatchTools = (React.memo<PropsT>(({
-  dialogLocation,
-  dispatch,
-  recordingSelectionCount,
-  releaseHasUnloadedTracks,
-  workSelectionCount,
-}: PropsT): React$Element<'table'> => {
+component _RelationshipEditorBatchTools(
+  dialogLocation: RelationshipDialogLocationT | null,
+  dispatch: (ReleaseRelationshipEditorActionT) => void,
+  recordingSelectionCount: number,
+  releaseHasUnloadedTracks: boolean,
+  workSelectionCount: number,
+) {
   return (
     <table id="batch-tools">
       <tbody>
@@ -183,6 +163,10 @@ const RelationshipEditorBatchTools = (React.memo<PropsT>(({
       </tbody>
     </table>
   );
-}): React$AbstractComponent<PropsT, mixed>);
+}
+
+const RelationshipEditorBatchTools: React$AbstractComponent<
+  React.PropsOf<_RelationshipEditorBatchTools>
+> = React.memo(_RelationshipEditorBatchTools);
 
 export default RelationshipEditorBatchTools;

--- a/root/static/scripts/release/components/ReleaseRelationshipEditor.js
+++ b/root/static/scripts/release/components/ReleaseRelationshipEditor.js
@@ -1414,23 +1414,14 @@ export const reducer: ((
   return newState;
 });
 
-type MediumRelationshipEditorsPropsT = {
-  +dialogLocation: RelationshipDialogLocationT | null,
-  +dispatch: (ReleaseRelationshipEditorActionT) => void,
-  +expandedMediums: $ReadOnlyMap<number, boolean>,
-  +loadedTracks: LoadedTracksMapT,
-  +mediums: MediumStateTreeT,
-  +release: ReleaseWithMediumsT,
-};
-
-const MediumRelationshipEditors = React.memo(({
-  dialogLocation,
-  dispatch,
-  expandedMediums,
-  loadedTracks,
-  mediums,
-  release,
-}: MediumRelationshipEditorsPropsT) => {
+component _MediumRelationshipEditors(
+  dialogLocation: RelationshipDialogLocationT | null,
+  dispatch: (ReleaseRelationshipEditorActionT) => void,
+  expandedMediums: $ReadOnlyMap<number, boolean>,
+  loadedTracks: LoadedTracksMapT,
+  mediums: MediumStateTreeT,
+  release: ReleaseWithMediumsT,
+) {
   const hasUnloadedTracksPerMedium =
     useUnloadedTracksMap(release.mediums, loadedTracks);
   const hasUnloadedTracks =
@@ -1459,31 +1450,21 @@ const MediumRelationshipEditors = React.memo(({
     );
   }
   return mediumElements;
-});
+}
 
-type TrackRelationshipsSectionPropsT = {
-  +dialogLocation: RelationshipDialogLocationT | null,
-  +dispatch: (ReleaseRelationshipEditorActionT) => void,
-  +expandedMediums: $ReadOnlyMap<number, boolean>,
-  +loadedTracks: LoadedTracksMapT,
-  +mediums: MediumStateTreeT,
-  +release: ReleaseWithMediumsT,
-  +releaseHasUnloadedTracks: boolean,
-  +selectedRecordings: tree.ImmutableTree<RecordingT> | null,
-  +selectedWorks: tree.ImmutableTree<WorkT> | null,
-};
+const MediumRelationshipEditors = React.memo(_MediumRelationshipEditors);
 
-const TrackRelationshipsSection = React.memo(({
-  dialogLocation,
-  dispatch,
-  expandedMediums,
-  loadedTracks,
-  mediums,
-  release,
-  releaseHasUnloadedTracks,
-  selectedRecordings,
-  selectedWorks,
-}: TrackRelationshipsSectionPropsT) => {
+component _TrackRelationshipsSection(
+  dialogLocation: RelationshipDialogLocationT | null,
+  dispatch: (ReleaseRelationshipEditorActionT) => void,
+  expandedMediums: $ReadOnlyMap<number, boolean>,
+  loadedTracks: LoadedTracksMapT,
+  mediums: MediumStateTreeT,
+  release: ReleaseWithMediumsT,
+  releaseHasUnloadedTracks: boolean,
+  selectedRecordings: tree.ImmutableTree<RecordingT> | null,
+  selectedWorks: tree.ImmutableTree<WorkT> | null,
+) {
   const recordingCount = selectedRecordings ? selectedRecordings.size : 0;
   const workCount = selectedWorks ? selectedWorks.size : 0;
 
@@ -1613,23 +1594,17 @@ const TrackRelationshipsSection = React.memo(({
       )}
     </>
   );
-});
+}
 
-type ReleaseRelationshipSectionPropsT = {
-  +dialogLocation: RelationshipDialogLocationT | null,
-  +dispatch: (ReleaseRelationshipEditorActionT) => void,
-  +relationshipsBySource: RelationshipSourceGroupsT,
-  +release: ReleaseWithMediumsT,
-  +releaseHasUnloadedTracks: boolean,
-};
+const TrackRelationshipsSection = React.memo(_TrackRelationshipsSection);
 
-const ReleaseRelationshipSection = React.memo(({
-  dialogLocation,
-  dispatch,
-  relationshipsBySource,
-  release,
-  releaseHasUnloadedTracks,
-}: ReleaseRelationshipSectionPropsT) => {
+component _ReleaseRelationshipSection(
+  dialogLocation: RelationshipDialogLocationT | null,
+  dispatch: (ReleaseRelationshipEditorActionT) => void,
+  relationshipsBySource: RelationshipSourceGroupsT,
+  release: ReleaseWithMediumsT,
+  releaseHasUnloadedTracks: boolean,
+) {
   if (dialogLocation != null) {
     invariant(dialogLocation.source.id === release.id);
   }
@@ -1656,23 +1631,17 @@ const ReleaseRelationshipSection = React.memo(({
       </div>
     </>
   );
-});
+}
 
-type ReleaseGroupRelationshipSectionPropsT = {
-  +dialogLocation: RelationshipDialogLocationT | null,
-  +dispatch: (ReleaseRelationshipEditorActionT) => void,
-  +relationshipsBySource: RelationshipSourceGroupsT,
-  +releaseGroup: ReleaseGroupT,
-  +releaseHasUnloadedTracks: boolean,
-};
+const ReleaseRelationshipSection = React.memo(_ReleaseRelationshipSection);
 
-const ReleaseGroupRelationshipSection = React.memo(({
-  dialogLocation,
-  dispatch,
-  relationshipsBySource,
-  releaseGroup,
-  releaseHasUnloadedTracks,
-}: ReleaseGroupRelationshipSectionPropsT) => {
+component _ReleaseGroupRelationshipSection(
+  dialogLocation: RelationshipDialogLocationT | null,
+  dispatch: (ReleaseRelationshipEditorActionT) => void,
+  relationshipsBySource: RelationshipSourceGroupsT,
+  releaseGroup: ReleaseGroupT,
+  releaseHasUnloadedTracks: boolean,
+) {
   if (dialogLocation != null) {
     invariant(dialogLocation.source.id === releaseGroup.id);
   }
@@ -1699,10 +1668,12 @@ const ReleaseGroupRelationshipSection = React.memo(({
       </div>
     </>
   );
-});
+}
 
-let ReleaseRelationshipEditor: React$AbstractComponent<{}, void> = (
-): React$MixedElement => {
+const ReleaseGroupRelationshipSection =
+  React.memo(_ReleaseGroupRelationshipSection);
+
+component _ReleaseRelationshipEditor() {
   const [state, dispatch] = React.useReducer(
     reducer,
     null,
@@ -1873,17 +1844,17 @@ let ReleaseRelationshipEditor: React$AbstractComponent<{}, void> = (
       </form>
     </RelationshipSourceGroupsContext.Provider>
   );
-};
+}
 
-ReleaseRelationshipEditor =
-  withLoadedTypeInfoForRelationshipEditor<{}, void>(
-    ReleaseRelationshipEditor,
+const NonHydratedReleaseRelationshipEditor: React$AbstractComponent<{}> =
+  withLoadedTypeInfoForRelationshipEditor<{}>(
+    _ReleaseRelationshipEditor,
     ['language', 'work_type'],
   );
 
-ReleaseRelationshipEditor = hydrate<{}>(
+const ReleaseRelationshipEditor = (hydrate<{}>(
   'div.release-relationship-editor',
-  ReleaseRelationshipEditor,
-);
+  NonHydratedReleaseRelationshipEditor,
+): React$AbstractComponent<{}, void>);
 
 export default ReleaseRelationshipEditor;

--- a/root/static/scripts/release/components/TrackRelationshipEditor.js
+++ b/root/static/scripts/release/components/TrackRelationshipEditor.js
@@ -43,15 +43,10 @@ import {
 
 import EditWorkDialog from './EditWorkDialog.js';
 
-type TrackLinkPropsT = {
-  +showArtists: boolean,
-  +track: TrackWithRecordingT,
-};
-
-const TrackLink = React.memo<TrackLinkPropsT>(({
-  showArtists,
-  track,
-}) => {
+component _TrackLink(
+  showArtists: boolean,
+  track: TrackWithRecordingT,
+) {
   let trackLink: Expand2ReactOutput;
   if (showArtists) {
     trackLink = (
@@ -82,38 +77,30 @@ const TrackLink = React.memo<TrackLinkPropsT>(({
       {bracketedText(formatTrackLength(track.length))}
     </>
   );
-});
+}
 
-type WorkLinkPropsT = {
-  +work: WorkT,
-};
+const TrackLink = React.memo(_TrackLink);
 
-const WorkLink = React.memo<WorkLinkPropsT>(({
-  work,
-}) => (
-  <EntityLink
-    allowNew
-    className="wrap-anywhere"
-    entity={work}
-    target="_blank"
-  />
-));
+component _WorkLink(work: WorkT) {
+  return (
+    <EntityLink
+      allowNew
+      className="wrap-anywhere"
+      entity={work}
+      target="_blank"
+    />
+  );
+}
 
-type RelatedWorkHeadingPropsT = {
-  +dispatch: (ReleaseRelationshipEditorActionT) => void,
-  +isRemoved: boolean,
-  +isSelected: boolean,
-  +removeWorkButton: React$MixedElement,
-  +work: WorkT,
-};
+const WorkLink = React.memo(_WorkLink);
 
-const RelatedWorkHeading = ({
-  dispatch,
-  isRemoved,
-  isSelected,
-  removeWorkButton,
-  work,
-}: RelatedWorkHeadingPropsT) => {
+component RelatedWorkHeading(
+  dispatch: (ReleaseRelationshipEditorActionT) => void,
+  isRemoved: boolean,
+  isSelected: boolean,
+  removeWorkButton: React$MixedElement,
+  work: WorkT,
+) {
   const selectWork = React.useCallback((
     event: SyntheticEvent<HTMLInputElement>,
   ) => {
@@ -147,14 +134,14 @@ const RelatedWorkHeading = ({
       {workLink}
     </h3>
   );
-};
+}
 
-const NewRelatedWorkHeading = ({
-  dispatch,
-  isSelected,
-  removeWorkButton,
-  work,
-}: RelatedWorkHeadingPropsT) => {
+component NewRelatedWorkHeading(
+  dispatch: (ReleaseRelationshipEditorActionT) => void,
+  isSelected: boolean,
+  removeWorkButton: React$MixedElement,
+  work: WorkT,
+) {
   const selectWork = React.useCallback((
     event: SyntheticEvent<HTMLInputElement>,
   ) => {
@@ -208,29 +195,19 @@ const NewRelatedWorkHeading = ({
       <NewWorkLink work={work} />
     </h3>
   );
-};
-
-type RelatedWorkRelationshipEditorPropsT = {
-  +dialogLocation: RelationshipDialogLocationT | null,
-  +dispatch: (ReleaseRelationshipEditorActionT) => void,
-  +relatedWork: MediumWorkStateT,
-  +releaseHasUnloadedTracks: boolean,
-  +track: TrackWithRecordingT,
-};
+}
 
 const filterRecordings = (
   targetType: RelatableEntityTypeT,
 ) => targetType !== 'recording';
 
-const RelatedWorkRelationshipEditor = React.memo<
-  RelatedWorkRelationshipEditorPropsT,
->(({
-  dialogLocation,
-  dispatch,
-  relatedWork,
-  releaseHasUnloadedTracks,
-  track,
-}) => {
+component _RelatedWorkRelationshipEditor(
+  dialogLocation: RelationshipDialogLocationT | null,
+  dispatch: (ReleaseRelationshipEditorActionT) => void,
+  relatedWork: MediumWorkStateT,
+  releaseHasUnloadedTracks: boolean,
+  track: TrackWithRecordingT,
+) {
   const work = relatedWork.work;
   const isNewWork = work._fromBatchCreateWorksDialog === true;
   const hasLoadedRelationships = work.relationships != null;
@@ -313,18 +290,24 @@ const RelatedWorkRelationshipEditor = React.memo<
     relatedWork.targetTypeGroups,
   ]);
 
-  const RelatedWorkHeadingComponent =
-    isNewWork ? NewRelatedWorkHeading : RelatedWorkHeading;
-
   return (
     <>
-      <RelatedWorkHeadingComponent
-        dispatch={dispatch}
-        isRemoved={isWorkRemoved}
-        isSelected={relatedWork.isSelected}
-        removeWorkButton={removeWorkButton}
-        work={work}
-      />
+      {isNewWork ? (
+        <NewRelatedWorkHeading
+          dispatch={dispatch}
+          isSelected={relatedWork.isSelected}
+          removeWorkButton={removeWorkButton}
+          work={work}
+        />
+      ) : (
+        <RelatedWorkHeading
+          dispatch={dispatch}
+          isRemoved={isWorkRemoved}
+          isSelected={relatedWork.isSelected}
+          removeWorkButton={removeWorkButton}
+          work={work}
+        />
+      )}
       <RelationshipTargetTypeGroups
         dialogLocation={dialogLocation}
         dispatch={dispatch}
@@ -344,27 +327,19 @@ const RelatedWorkRelationshipEditor = React.memo<
       ) : null}
     </>
   );
-});
+}
 
-type RelatedWorksRelationshipEditorPropsT = {
-  +dialogLocation: RelationshipDialogLocationT | null,
-  +dispatch: (ReleaseRelationshipEditorActionT) => void,
-  +recording: RecordingT,
-  +relatedWorks: MediumWorkStateTreeT | null,
-  +releaseHasUnloadedTracks: boolean,
-  +track: TrackWithRecordingT,
-};
+const RelatedWorkRelationshipEditor =
+  React.memo(_RelatedWorkRelationshipEditor);
 
-const RelatedWorksRelationshipEditor = React.memo<
-  RelatedWorksRelationshipEditorPropsT,
->(({
-  dialogLocation,
-  dispatch,
-  recording,
-  relatedWorks,
-  releaseHasUnloadedTracks,
-  track,
-}) => {
+component _RelatedWorksRelationshipEditor(
+  dialogLocation: RelationshipDialogLocationT | null,
+  dispatch: (ReleaseRelationshipEditorActionT) => void,
+  recording: RecordingT,
+  relatedWorks: MediumWorkStateTreeT | null,
+  releaseHasUnloadedTracks: boolean,
+  track: TrackWithRecordingT,
+) {
   const relatedWorkElements = [];
   for (const relatedWork of tree.iterate(relatedWorks)) {
     relatedWorkElements.push(
@@ -436,25 +411,19 @@ const RelatedWorksRelationshipEditor = React.memo<
       {relatedWorkElements}
     </td>
   );
-});
+}
 
-type TrackRelationshipEditorPropsT = {
-  +dialogLocation: RelationshipDialogLocationT | null,
-  +dispatch: (ReleaseRelationshipEditorActionT) => void,
-  +recordingState: MediumRecordingStateT,
-  +releaseHasUnloadedTracks: boolean,
-  +showArtists: boolean,
-  +track: TrackWithRecordingT,
-};
+const RelatedWorksRelationshipEditor =
+  React.memo(_RelatedWorksRelationshipEditor);
 
-const TrackRelationshipEditor = (React.memo<TrackRelationshipEditorPropsT>(({
-  dialogLocation,
-  dispatch,
-  recordingState,
-  releaseHasUnloadedTracks,
-  showArtists,
-  track,
-}: TrackRelationshipEditorPropsT) => {
+component _TrackRelationshipEditor(
+  dialogLocation: RelationshipDialogLocationT | null,
+  dispatch: (ReleaseRelationshipEditorActionT) => void,
+  recordingState: MediumRecordingStateT,
+  releaseHasUnloadedTracks: boolean,
+  showArtists: boolean,
+  track: TrackWithRecordingT,
+) {
   const selectRecording = React.useCallback((
     event: SyntheticEvent<HTMLInputElement>,
   ) => {
@@ -525,7 +494,11 @@ const TrackRelationshipEditor = (React.memo<TrackRelationshipEditorPropsT>(({
       />
     </tr>
   );
-}): React$AbstractComponent<TrackRelationshipEditorPropsT, mixed>);
+}
+
+const TrackRelationshipEditor: React$AbstractComponent<
+  React.PropsOf<_TrackRelationshipEditor>
+> = React.memo(_TrackRelationshipEditor);
 
 TrackRelationshipEditor.displayName = 'TrackRelationshipEditor';
 

--- a/root/static/scripts/release/components/TracklistAndCredits.js
+++ b/root/static/scripts/release/components/TracklistAndCredits.js
@@ -18,6 +18,7 @@ import StaticRelationshipsDisplay
   from '../../common/components/StaticRelationshipsDisplay.js';
 import WarningIcon from '../../common/components/WarningIcon.js';
 import {l} from '../../common/i18n.js';
+import type {LinkedEntitiesT} from '../../common/linkedEntities.mjs';
 import {
   mergeLinkedEntities,
 } from '../../common/linkedEntities.mjs';
@@ -31,7 +32,6 @@ import type {
   LazyReleaseActionT,
   LazyReleaseStateT,
   LoadedTracksMapT,
-  PropsT,
   StateT,
 } from '../types.js';
 
@@ -244,13 +244,12 @@ export function useReleaseHasUnloadedTracks(
   }, [hasUnloadedTracksPerMedium]);
 }
 
-const TracklistAndCredits = React.memo<PropsT>((props: PropsT) => {
-  const {
-    noScript,
-    release,
-    initialLinkedEntities,
-  } = props;
-
+component _TracklistAndCredits(
+  initialCreditsMode: CreditsModeT,
+  initialLinkedEntities: $ReadOnly<Partial<LinkedEntitiesT>>,
+  noScript: boolean,
+  release: ReleaseWithMediumsT,
+) {
   const setLinkedEntitiesRef = React.useRef(false);
   if (!setLinkedEntitiesRef.current) {
     mergeLinkedEntities(initialLinkedEntities);
@@ -259,7 +258,7 @@ const TracklistAndCredits = React.memo<PropsT>((props: PropsT) => {
 
   const [state, dispatch] = React.useReducer(
     reducer,
-    props.initialCreditsMode,
+    initialCreditsMode,
     createInitialState,
   );
 
@@ -409,9 +408,13 @@ const TracklistAndCredits = React.memo<PropsT>((props: PropsT) => {
       ) : null}
     </>
   );
-});
+}
 
-export default (hydrate<PropsT>(
+const TracklistAndCredits: React$AbstractComponent<
+  React.PropsOf<_TracklistAndCredits>
+> = React.memo(_TracklistAndCredits);
+
+export default (hydrate<React.PropsOf<_TracklistAndCredits>>(
   'div.tracklist-and-credits',
   TracklistAndCredits,
-): React$AbstractComponent<PropsT, void>);
+): React$AbstractComponent<React.PropsOf<_TracklistAndCredits>, void>);

--- a/root/static/scripts/release/components/WorkTypeSelect.js
+++ b/root/static/scripts/release/components/WorkTypeSelect.js
@@ -25,20 +25,11 @@ function workTypeValue(workType: number | null): string {
   return String(workType);
 }
 
-type WorkTypeSelectPropsT = {
-  +dispatch: (WorkTypeSelectActionT) => void,
-  +initialFocusRef?: {-current: HTMLElement | null},
-  +workType: number | null,
-};
-
-const WorkTypeSelect: React$AbstractComponent<
-  WorkTypeSelectPropsT,
-  mixed,
-> = React.memo<WorkTypeSelectPropsT>(({
-  dispatch,
-  initialFocusRef,
-  workType,
-}: WorkTypeSelectPropsT) => {
+component _WorkTypeSelect(
+  dispatch: (WorkTypeSelectActionT) => void,
+  initialFocusRef?: {-current: HTMLElement | null},
+  workType: number | null,
+) {
   const workTypeOptions: OptionListT = React.useMemo(() => {
     const workTypes: $ReadOnlyArray<WorkTypeT> =
       Object.values(linkedEntities.work_type);
@@ -75,6 +66,10 @@ const WorkTypeSelect: React$AbstractComponent<
       </td>
     </tr>
   );
-});
+}
+
+const WorkTypeSelect: React$AbstractComponent<
+  React.PropsOf<_WorkTypeSelect>
+> = React.memo(_WorkTypeSelect);
 
 export default WorkTypeSelect;

--- a/root/static/scripts/release/types.js
+++ b/root/static/scripts/release/types.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import type {LinkedEntitiesT} from '../common/linkedEntities.mjs';
-
 export type CreditsModeT = 'bottom' | 'inline';
 
 export type LazyReleaseActionT =
@@ -30,13 +28,6 @@ export type LazyReleaseActionT =
 export type ActionT =
   | {+type: 'toggle-credits-mode'}
   | LazyReleaseActionT;
-
-export type PropsT = {
-  +initialCreditsMode: CreditsModeT,
-  +initialLinkedEntities: $ReadOnly<Partial<LinkedEntitiesT>>,
-  +noScript: boolean,
-  +release: ReleaseWithMediumsT,
-};
 
 export type LoadedTracksMapT =
   $ReadOnlyMap<number, $ReadOnlyArray<TrackWithRecordingT>>;

--- a/root/static/scripts/series/components/SeriesRelationshipEditor.js
+++ b/root/static/scripts/series/components/SeriesRelationshipEditor.js
@@ -42,9 +42,7 @@ function getSeriesType(typeId: number | null): SeriesTypeT | null {
     : linkedEntities.series_type[String(typeId)];
 }
 
-let SeriesRelationshipEditor:
-  React$AbstractComponent<PropsT, void> =
-(props: PropsT) => {
+component _SeriesRelationshipEditor(...props: PropsT) {
   const [state, dispatch] = React.useReducer(
     reducer,
     props,
@@ -179,16 +177,16 @@ let SeriesRelationshipEditor:
       state={state}
     />
   );
-};
+}
 
-SeriesRelationshipEditor =
-  withLoadedTypeInfoForRelationshipEditor<PropsT, void>(
-    SeriesRelationshipEditor,
+const NonHydratedSeriesRelationshipEditor: React$AbstractComponent<PropsT> =
+  withLoadedTypeInfoForRelationshipEditor<PropsT>(
+    _SeriesRelationshipEditor,
   );
 
-SeriesRelationshipEditor = hydrate<PropsT>(
+const SeriesRelationshipEditor = (hydrate<PropsT>(
   'div.relationship-editor',
-  SeriesRelationshipEditor,
-);
+  NonHydratedSeriesRelationshipEditor,
+): React$AbstractComponent<PropsT>);
 
 export default SeriesRelationshipEditor;

--- a/root/static/scripts/url/components/UrlRelationshipEditor.js
+++ b/root/static/scripts/url/components/UrlRelationshipEditor.js
@@ -24,9 +24,7 @@ import useEntityNameFromField
 
 type PropsT = InitialStateArgsT;
 
-let UrlRelationshipEditor:
-  React$AbstractComponent<PropsT, void> =
-(props: PropsT) => {
+component _UrlRelationshipEditor(...props: PropsT) {
   const [state, dispatch] = React.useReducer(
     reducer,
     props,
@@ -63,16 +61,16 @@ let UrlRelationshipEditor:
       state={state}
     />
   );
-};
+}
 
-UrlRelationshipEditor =
-  withLoadedTypeInfoForRelationshipEditor<PropsT, void>(
-    UrlRelationshipEditor,
+const NonHydratedUrlRelationshipEditor: React$AbstractComponent<PropsT> =
+  withLoadedTypeInfoForRelationshipEditor<PropsT>(
+    _UrlRelationshipEditor,
   );
 
-UrlRelationshipEditor = hydrate<PropsT>(
+const UrlRelationshipEditor = (hydrate<PropsT>(
   'div.relationship-editor',
-  UrlRelationshipEditor,
-);
+  NonHydratedUrlRelationshipEditor,
+): React$AbstractComponent<PropsT>);
 
 export default UrlRelationshipEditor;

--- a/root/utility/hydrate.js
+++ b/root/utility/hydrate.js
@@ -99,7 +99,7 @@ export default function hydrate<
   SanitizedConfig = Config,
 >(
   containerSelector: string,
-  Component: React$AbstractComponent<Config | SanitizedConfig, void>,
+  Component: React$AbstractComponent<Config | SanitizedConfig>,
   mungeProps?: (Config) => SanitizedConfig,
 ): React$AbstractComponent<Config, void> {
   const [containerTag, ...classes] = containerSelector.split('.');


### PR DESCRIPTION
Flow now supports a specific [React Component Syntax](https://flow.org/en/docs/react/component-syntax/) which reduces the amount of types we need to define manually, and is supposed to be better for type checking as well. I'm converting our React components to this syntax bit by bit with this PR.

This changes all stuff in the `static` subfolder, except for class components which require a lot more changes and can be done later.

Note: To be reviewed without whitespace changes (since this adds explicit `return()` calls that require spacing things one more tab in many cases).

On top of https://github.com/metabrainz/musicbrainz-server/pull/3236