### PR TITLE
MBS-13540: Update track credits in a few more cases

### DIFF
--- a/root/static/scripts/tests/edit/utility/getUpdatedTrackArtists.js
+++ b/root/static/scripts/tests/edit/utility/getUpdatedTrackArtists.js
@@ -121,11 +121,7 @@ test('getUpdatedTrackArtists', function (t) {
       oldRel: [name('A', '1', ' & ', 'a'), name('B', '2')],
       newRel: [name('A', '1', ' & '), name('B', '2')],
       want: [
-        /*
-         * TODO: As discussed in MBS-13273, the first artist's credited-as
-         * name should be removed here.
-         */
-        name('A', '1', ' & ', 'a'),
+        name('A', '1', ' & '),
         name('B', '2', ' feat. '),
         name('C', '3'),
       ],
@@ -156,8 +152,7 @@ test('getUpdatedTrackArtists', function (t) {
       track: [name('A & B', '1', ' feat. '), name('C', '2')],
       oldRel: [name('A', '3', ' & '), name('B', '4')],
       newRel: [name('D', '5')],
-      // TODO: This should be updated like the non-feat. version.
-      want: [name('A & B', '1', ' feat. '), name('C', '2')],
+      want: [name('D', '5', ' feat. '), name('C', '2')],
     },
     {
       desc: 'old name but diff. entity (multiple vs. single)',
@@ -175,10 +170,8 @@ test('getUpdatedTrackArtists', function (t) {
       ],
       oldRel: [name('A & B', '4')],
       newRel: [name('D', '5')],
-      // TODO: This should be updated like the non-feat. version.
       want: [
-        name('A', '1', ' & '),
-        name('B', '2', ' feat. '),
+        name('D', '5', ' feat. '),
         name('C', '3'),
       ],
     },


### PR DESCRIPTION
# MBS-13540

Rework getUpdatedTrackArtists() to make the release editor update track credits in a few additional cases where featured artists are present.

# Problem

There are a few cases where tracks with featured artists inconsistently still don't automatically get updated:
* The release was credited to multiple artists and the credited-as text for one of them is changed.
* The track credit is rendered identically to the old release credit but uses different underlying entities (possibly even a different number of entities).

# Solution

`getUpdatedTrackArtists()` tries harder to find a prefix of the track credits that match the old release credits. Failing that, it checks if the track credits use the same entities as the new release credits (to handle credited-as and join phrase changes).

# Testing

The existing unit tests for `getUpdatedTrackArtists()` (added by 9873cffe20e2bf67fcbb98e1a48941e6d9aa2bf5 and e4fbad0363781d0840f98d17a3f6d5fd8f418042) pass after updating them to check for the desired behavior.