### PR TITLE
MBS-13541: Accept uppercase MBIDs in JavaScript

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -494,7 +494,7 @@ const Autocomplete2 = (React.memo(<T: EntityItemT>(
         }
       });
 
-      lookupXhr.open('GET', '/ws/js/entity/' + mbidMatch[0]);
+      lookupXhr.open('GET', '/ws/js/entity/' + mbidMatch[0].toLowerCase());
       lookupXhr.send();
     } else if (oldInputValue !== newInputValue) {
       stopRequests();

--- a/root/static/scripts/common/constants.js
+++ b/root/static/scripts/common/constants.js
@@ -321,7 +321,7 @@ export const SERIES_ORDERING_TYPE_AUTOMATIC = 1;
 export const SERIES_ORDERING_TYPE_MANUAL = 2;
 
 export const MBID_REGEXP: RegExp =
-  /[0-9a-f]{8}-[0-9a-f]{4}-[345][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/;
+  /[0-9a-f]{8}-[0-9a-f]{4}-[345][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
 
 export const VARTIST_GID = '89ad4ac3-39f7-470e-963a-56509c546377';
 

--- a/root/static/scripts/common/utility/isGuid.js
+++ b/root/static/scripts/common/utility/isGuid.js
@@ -9,7 +9,7 @@
 
 import {MBID_REGEXP} from '../constants.js';
 
-const MBID_ONLY_REGEXP = new RegExp('^' + MBID_REGEXP.source + '$');
+const MBID_ONLY_REGEXP = new RegExp('^' + MBID_REGEXP.source + '$', 'i');
 
 export default function isGuid(str: string): boolean {
   return str.length === 36 && MBID_ONLY_REGEXP.test(str);

--- a/root/static/scripts/tests/utility/isGuid.js
+++ b/root/static/scripts/tests/utility/isGuid.js
@@ -12,7 +12,7 @@ import test from 'tape';
 import isGuid from '../../common/utility/isGuid.js';
 
 test('isGuid', function (t) {
-  t.plan(4);
+  t.plan(5);
 
   t.ok(
     !isGuid('lol-nope'),
@@ -31,6 +31,11 @@ test('isGuid', function (t) {
 
   t.ok(
     isGuid('89ad4ac3-39f7-470e-963a-56509c546377'),
-    'Valid MBID is a GUID',
+    'Valid MBID with lowercase letters is a GUID',
+  );
+
+  t.ok(
+    isGuid('89AD4AC3-39F7-470E-963A-56509C546377'),
+    'Valid MBID with capital letters is a GUID',
   );
 });


### PR DESCRIPTION
# MBS-13541

Update MBID_REGEXP and isGuid() to additionally match UUIDs containing uppercase letters (as recommended by RFC 4122). Previously, Autocomplete 2 would fail to extract MBIDs containing uppercase letters within pasted URLs.

# Problem

As discussed in https://community.metabrainz.org/t/boom-boom-not-recognized-as-a-work-when-pasting-in-add-relationship-dialog-on-add-standalone-recording/690757, the relationship editor doesn't recognize MBIDs with capital A-F within pasted URLs.

(This seems like a minor issue since the MBS always lowercases MBIDs, as far as I can tell, but URLs like https://musicbrainz.org/artist/65F4F0C5-EF9E-490C-AEE3-909E7AE6B2AB work and don't get redirected or rewritten automatically.)

Per https://datatracker.ietf.org/doc/html/rfc4122#section-3, uppercase letters should be accepted in UUIDs:

> "The hexadecimal values "a" through "f" are output as lower case characters and are case insensitive on input.

# Solution

This change updates the `MBID_REGEXP` regular expression to be case-insensitive, and also updates the `MBID_ONLY_REGEXP` regexp used by `isGuid()`.

I'm still making `Autocomplete2` lowercase extracted MBIDs before passing them to the `/ws/js/entity` endpoint.

Per @mwiencek at https://tickets.metabrainz.org/browse/MBS-13541?focusedId=71904&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-71904, this shouldn't affect database validation since MBIDs are only generated in Perl and are stored using the case-insensitive `UUID` PostgreSQL type.

# Testing

I added a new test case for `isGuid()` and have manually tested that the relationship editor now recognizes MBIDs containing capital letters.