### PR TITLE
Migrate React /component components to Flow component syntax

### DIFF
--- a/root/components/Aliases/AliasTable.js
+++ b/root/components/Aliases/AliasTable.js
@@ -9,29 +9,25 @@
 
 import AliasTableBody from './AliasTableBody.js';
 
-type Props = {
-  +aliases: $ReadOnlyArray<AnyAliasT>,
-  +allowEditing: boolean,
-  +entity: EntityWithAliasesT,
-};
-
-const AliasTable = (props: Props): React$Element<'table'> => (
-  <table className="tbl">
-    <thead>
-      <tr>
-        <th>{l('Alias')}</th>
-        <th>{l('Sort name')}</th>
-        <th>{l('Begin date')}</th>
-        <th>{l('End date')}</th>
-        <th>{l('Type')}</th>
-        <th>{l('Locale')}</th>
-        {props.allowEditing
-          ? <th className="actions">{l('Actions')}</th>
-          : null}
-      </tr>
-    </thead>
-    <AliasTableBody {...props} />
-  </table>
-);
+component AliasTable(...props: React.PropsOf<AliasTableBody>) {
+  return (
+    <table className="tbl">
+      <thead>
+        <tr>
+          <th>{l('Alias')}</th>
+          <th>{l('Sort name')}</th>
+          <th>{l('Begin date')}</th>
+          <th>{l('End date')}</th>
+          <th>{l('Type')}</th>
+          <th>{l('Locale')}</th>
+          {props.allowEditing
+            ? <th className="actions">{l('Actions')}</th>
+            : null}
+        </tr>
+      </thead>
+      <AliasTableBody {...props} />
+    </table>
+  );
+}
 
 export default AliasTable;

--- a/root/components/Aliases/AliasTableBody.js
+++ b/root/components/Aliases/AliasTableBody.js
@@ -9,16 +9,13 @@
 
 import AliasTableRow from './AliasTableRow.js';
 
-type Props = {
-  +aliases: $ReadOnlyArray<AnyAliasT>,
-  +allowEditing: boolean,
-  +entity: EntityWithAliasesT,
-};
-
-const AliasTableBody = ({
-  aliases,
-  ...props
-}: Props): React$Element<'tbody'> => {
+component AliasTableBody(
+  aliases: $ReadOnlyArray<AnyAliasT>,
+  ...rowProps: {
+    +allowEditing: boolean,
+    +entity: EntityWithAliasesT,
+  }
+ ) {
   const aliasRows = [];
   for (let i = 0; i < aliases.length; i++) {
     const alias = aliases[i];
@@ -27,11 +24,11 @@ const AliasTableBody = ({
         alias={alias}
         key={alias.id}
         row={i % 2 ? 'even' : 'odd'}
-        {...props}
+        {...rowProps}
       />,
     );
   }
   return <tbody>{aliasRows}</tbody>;
-};
+}
 
 export default AliasTableBody;

--- a/root/components/Aliases/AliasTableRow.js
+++ b/root/components/Aliases/AliasTableRow.js
@@ -15,61 +15,56 @@ import formatEndDate
   from '../../static/scripts/common/utility/formatEndDate.js';
 import isolateText from '../../static/scripts/common/utility/isolateText.js';
 
-type Props = {
-  +alias: AnyAliasT,
-  +allowEditing: boolean,
-  +entity: EntityWithAliasesT,
-  +row: string,
-};
-
-const AliasTableRow = ({
-  alias,
-  allowEditing,
-  entity,
-  row,
-}: Props): React$Element<'tr'> => (
-  <tr className={row}>
-    <td colSpan={alias.name === alias.sort_name ? 2 : 1}>
-      {alias.editsPending
-        ? <span className="mp">{isolateText(alias.name)}</span>
-        : isolateText(alias.name)}
-    </td>
-    {alias.name === alias.sort_name
-      ? null
-      : <td>{isolateText(alias.sort_name)}</td>}
-    <td>{formatDate(alias.begin_date)}</td>
-    <td>{formatEndDate(alias)}</td>
-    <td>
-      {alias.typeName ? lp_attributes(alias.typeName, 'alias_type') : ''}
-    </td>
-    <td>
-      {alias.locale ? locales[alias.locale] : null}
-      {alias.primary_for_locale
-        ? (
-          <>
-            {' '}
-            {bracketed(<span className="comment">{l('primary')}</span>)}
-          </>
-        )
-        : null}
-    </td>
-    <td className="actions">
-      {allowEditing
-        ? (
-          <>
-            <a href={entityHref(entity, `/alias/${alias.id}/edit`)}>
-              {lp('Edit', 'verb, interactive')}
-            </a>
-            {' | '}
-            <a href={entityHref(entity, `/alias/${alias.id}/delete`)}>
-              {l('Remove')}
-            </a>
-          </>
-        )
-        : null
-      }
-    </td>
-  </tr>
-);
+component AliasTableRow(
+  alias: AnyAliasT,
+  allowEditing: boolean,
+  entity: EntityWithAliasesT,
+  row: string,
+) {
+  return (
+    <tr className={row}>
+      <td colSpan={alias.name === alias.sort_name ? 2 : 1}>
+        {alias.editsPending
+          ? <span className="mp">{isolateText(alias.name)}</span>
+          : isolateText(alias.name)}
+      </td>
+      {alias.name === alias.sort_name
+        ? null
+        : <td>{isolateText(alias.sort_name)}</td>}
+      <td>{formatDate(alias.begin_date)}</td>
+      <td>{formatEndDate(alias)}</td>
+      <td>
+        {alias.typeName ? lp_attributes(alias.typeName, 'alias_type') : ''}
+      </td>
+      <td>
+        {alias.locale ? locales[alias.locale] : null}
+        {alias.primary_for_locale
+          ? (
+            <>
+              {' '}
+              {bracketed(<span className="comment">{l('primary')}</span>)}
+            </>
+          )
+          : null}
+      </td>
+      <td className="actions">
+        {allowEditing
+          ? (
+            <>
+              <a href={entityHref(entity, `/alias/${alias.id}/edit`)}>
+                {lp('Edit', 'verb, interactive')}
+              </a>
+              {' | '}
+              <a href={entityHref(entity, `/alias/${alias.id}/delete`)}>
+                {l('Remove')}
+              </a>
+            </>
+          )
+          : null
+        }
+      </td>
+    </tr>
+  );
+}
 
 export default AliasTableRow;

--- a/root/components/Aliases/ArtistCreditList.js
+++ b/root/components/Aliases/ArtistCreditList.js
@@ -18,15 +18,10 @@ import EntityLink from '../../static/scripts/common/components/EntityLink.js';
 import bracketed from '../../static/scripts/common/utility/bracketed.js';
 import loopParity from '../../utility/loopParity.js';
 
-type Props = {
-  +artistCredits: $ReadOnlyArray<{+id: number} & ArtistCreditT>,
-  +entity: ArtistT,
-};
-
-const ArtistCreditList = ({
-  artistCredits,
-  entity,
-}: Props): React.MixedElement => {
+component ArtistCreditList(
+  artistCredits: $ReadOnlyArray<{+id: number} & ArtistCreditT>,
+  entity: ArtistT,
+) {
   const $c = React.useContext(SanitizedCatalystContext);
   return (
     <>
@@ -89,6 +84,6 @@ const ArtistCreditList = ({
       </table>
     </>
   );
-};
+}
 
 export default ArtistCreditList;

--- a/root/components/Artwork.js
+++ b/root/components/Artwork.js
@@ -24,61 +24,53 @@ function artworkHover(artwork: ArtworkT) {
   return result;
 }
 
-type Props = {
-  +artwork: ArtworkT,
-  +hover?: string,
-  +message?: string,
-};
+export component ArtworkImage(
+  artwork: ArtworkT,
+  hover?: string,
+  message?: string,
+) {
+  return (
+    <>
+      <noscript>
+        <img src={artwork.small_ia_thumbnail} />
+      </noscript>
+      <span
+        className="cover-art-image"
+        data-huge-thumbnail={artwork.huge_ia_thumbnail}
+        data-large-thumbnail={artwork.large_ia_thumbnail}
+        data-message={nonEmpty(message)
+          ? message
+          : l('Image not available, please try again later.')}
+        data-small-thumbnail={artwork.small_ia_thumbnail}
+        data-title={nonEmpty(hover) ? hover : artworkHover(artwork)}
+      />
+    </>
+  );
+}
 
-export const ArtworkImage = ({
-  artwork,
-  hover,
-  message,
-}: Props): React.MixedElement => (
-  <>
-    <noscript>
-      <img src={artwork.small_ia_thumbnail} />
-    </noscript>
-    <span
-      className="cover-art-image"
-      data-huge-thumbnail={artwork.huge_ia_thumbnail}
-      data-large-thumbnail={artwork.large_ia_thumbnail}
-      data-message={nonEmpty(message)
-        ? message
-        : l('Image not available, please try again later.')}
-      data-small-thumbnail={artwork.small_ia_thumbnail}
-      data-title={nonEmpty(hover) ? hover : artworkHover(artwork)}
-    />
-  </>
-);
+export component Artwork(...props: React.PropsOf<ArtworkImage>) {
+  const artwork = props.artwork;
 
-export const Artwork = ({
-  artwork,
-  hover,
-  message,
-}: Props): React$Element<'a'> => (
-  <a
-    className={artwork.mime_type === 'application/pdf'
-      ? 'artwork-pdf'
-      : 'artwork-image'}
-    href={artwork.image}
-    title={nonEmpty(hover) ? hover : artworkHover(artwork)}
-  >
-    {artwork.mime_type === 'application/pdf' ? (
-      <div
-        className="file-format-tag"
-        title={l(
-          `This is a PDF file, the thumbnail may not show
-           the entire contents of the file.`,
-        )}
-      >
-        {l('PDF file')}
-      </div>
-    ) : null}
-    <ArtworkImage
-      artwork={artwork}
-      hover={hover}
-      message={message}
-    />
-  </a>
-);
+  return (
+    <a
+      className={artwork.mime_type === 'application/pdf'
+        ? 'artwork-pdf'
+        : 'artwork-image'}
+      href={artwork.image}
+      title={nonEmpty(props.hover) ? props.hover : artworkHover(artwork)}
+    >
+      {artwork.mime_type === 'application/pdf' ? (
+        <div
+          className="file-format-tag"
+          title={l(
+            `This is a PDF file, the thumbnail may not show
+             the entire contents of the file.`,
+          )}
+        >
+          {l('PDF file')}
+        </div>
+      ) : null}
+      <ArtworkImage {...props} />
+    </a>
+  );
+}

--- a/root/components/CleanupBanner.js
+++ b/root/components/CleanupBanner.js
@@ -46,14 +46,12 @@ const cleanupBannerStrings = {
   ),
 };
 
-type Props = {
-  +entityType: string,
-};
-
-const CleanupBanner = ({entityType}: Props): React$Element<'p'> => (
-  <p className="cleanup">
-    {cleanupBannerStrings[entityType]()}
-  </p>
-);
+component CleanupBanner(entityType: string) {
+  return (
+    <p className="cleanup">
+      {cleanupBannerStrings[entityType]()}
+    </p>
+  );
+}
 
 export default CleanupBanner;

--- a/root/components/ConfirmLayout.js
+++ b/root/components/ConfirmLayout.js
@@ -11,43 +11,38 @@ import Layout from '../layout/index.js';
 import FormCsrfToken
   from '../static/scripts/edit/components/FormCsrfToken.js';
 
-type Props = {
-  +action?: string,
-  +form: ConfirmFormT | SecureConfirmFormT,
-  +question: Expand2ReactOutput,
-  +title: string,
-};
-
-const ConfirmLayout = ({
-  action,
-  form,
-  question,
-  title,
-}: Props): React$Element<typeof Layout> => (
-  <Layout fullWidth title={title}>
-    <h1>{title}</h1>
-    <p>{question}</p>
-    <form action={action} method="post">
-      <FormCsrfToken form={form} />
-      <span className="buttons">
-        <button
-          name="confirm.submit"
-          type="submit"
-          value="1"
-        >
-          {l('Yes, I am sure')}
-        </button>
-        <button
-          className="negative"
-          name="confirm.cancel"
-          type="submit"
-          value="1"
-        >
-          {l('Cancel')}
-        </button>
-      </span>
-    </form>
-  </Layout>
-);
+component ConfirmLayout(
+  action?: string,
+  form: ConfirmFormT | SecureConfirmFormT,
+  question: Expand2ReactOutput,
+  title: string,
+) {
+  return (
+    <Layout fullWidth title={title}>
+      <h1>{title}</h1>
+      <p>{question}</p>
+      <form action={action} method="post">
+        <FormCsrfToken form={form} />
+        <span className="buttons">
+          <button
+            name="confirm.submit"
+            type="submit"
+            value="1"
+          >
+            {l('Yes, I am sure')}
+          </button>
+          <button
+            className="negative"
+            name="confirm.cancel"
+            type="submit"
+            value="1"
+          >
+            {l('Cancel')}
+          </button>
+        </span>
+      </form>
+    </Layout>
+  );
+}
 
 export default ConfirmLayout;

--- a/root/components/CritiqueBrainzLinks.js
+++ b/root/components/CritiqueBrainzLinks.js
@@ -27,15 +27,10 @@ const writeReviewLink = (entity: ReviewableT) => (
   entity.gid
 );
 
-type Props = {
-  +entity: ReviewableT,
-  +isSidebar?: boolean,
-};
-
-const CritiqueBrainzLinks = ({
-  entity,
-  isSidebar = false,
-}: Props): null | Expand2ReactOutput => {
+component CritiqueBrainzLinks(
+  entity: ReviewableT,
+  isSidebar: boolean = false,
+) {
   const reviewCount = entity.review_count;
   const linkClassName = isSidebar ? 'wrap-anywhere' : '';
 
@@ -64,6 +59,6 @@ const CritiqueBrainzLinks = ({
       write_link: writeReviewLink(entity),
     },
   );
-};
+}
 
 export default CritiqueBrainzLinks;

--- a/root/components/EntityDeletionHelp.js
+++ b/root/components/EntityDeletionHelp.js
@@ -9,33 +9,30 @@
 
 import EntityLink from '../static/scripts/common/components/EntityLink.js';
 
-type Props = {
-  +children?: React$Node,
-  +entity: ManuallyRemovableEntityT,
-};
-
-const EntityDeletionHelp = ({
-  children,
-  entity,
-}: Props): React$Element<'div'> => (
-  <div id="removal-help">
-    <p>
-      {exp.l(
-        'Are you sure you wish to remove {entity} from MusicBrainz?',
-        {entity: <EntityLink entity={entity} />},
-      )}
-    </p>
-    <p>
-      {exp.l(
-        `If it’s a duplicate,
-        {doc_merge|you should probably merge it instead}.
-        If it just has some small errors, it’s usually better
-        to just fix those.`,
-        {doc_merge: '/doc/Merge_Rather_Than_Delete'},
-      )}
-    </p>
-    {children}
-  </div>
-);
+component EntityDeletionHelp(
+  children?: React$Node,
+  entity: ManuallyRemovableEntityT,
+) {
+  return (
+    <div id="removal-help">
+      <p>
+        {exp.l(
+          'Are you sure you wish to remove {entity} from MusicBrainz?',
+          {entity: <EntityLink entity={entity} />},
+        )}
+      </p>
+      <p>
+        {exp.l(
+          `If it’s a duplicate,
+           {doc_merge|you should probably merge it instead}.
+           If it just has some small errors, it’s usually better
+           to just fix those.`,
+          {doc_merge: '/doc/Merge_Rather_Than_Delete'},
+        )}
+      </p>
+      {children}
+    </div>
+  );
+}
 
 export default EntityDeletionHelp;

--- a/root/components/EntityHeader.js
+++ b/root/components/EntityHeader.js
@@ -13,39 +13,31 @@ import typeof EntityTabLink from './EntityTabLink.js';
 import EntityTabs from './EntityTabs.js';
 import SubHeader from './SubHeader.js';
 
-type Props = {
-  +editTab?: React$Element<EntityTabLink>,
-  +entity: RelatableEntityT,
-  +headerClass: string,
-  +heading?: Expand2ReactOutput,
-  +page?: string,
-  +preHeader?: Expand2ReactOutput,
-  +subHeading: Expand2ReactOutput,
-};
-
-const EntityHeader = ({
-  editTab,
-  entity,
-  headerClass,
-  heading,
-  page,
-  preHeader,
-  subHeading,
-}: Props): React.MixedElement => (
-  <>
-    <div className={'wrap-anywhere ' + headerClass}>
-      {nonEmpty(preHeader) ? preHeader : null}
-      <h1>
-        {nonEmpty(heading) ? heading : <EntityLink entity={entity} />}
-      </h1>
-      <SubHeader subHeading={subHeading} />
-    </div>
-    <EntityTabs
-      editTab={editTab}
-      entity={entity}
-      page={page}
-    />
-  </>
-);
+component EntityHeader(
+  editTab?: React$Element<EntityTabLink>,
+  entity: RelatableEntityT,
+  headerClass: string,
+  heading?: Expand2ReactOutput,
+  page?: string,
+  preHeader?: Expand2ReactOutput,
+  subHeading: Expand2ReactOutput,
+) {
+  return (
+    <>
+      <div className={'wrap-anywhere ' + headerClass}>
+        {nonEmpty(preHeader) ? preHeader : null}
+        <h1>
+          {nonEmpty(heading) ? heading : <EntityLink entity={entity} />}
+        </h1>
+        <SubHeader subHeading={subHeading} />
+      </div>
+      <EntityTabs
+        editTab={editTab}
+        entity={entity}
+        page={page}
+      />
+    </>
+  );
+}
 
 export default EntityHeader;

--- a/root/components/EntityTabLink.js
+++ b/root/components/EntityTabLink.js
@@ -9,30 +9,28 @@
 
 import EntityLink from '../static/scripts/common/components/EntityLink.js';
 
-type Props = {
-  +content: string,
-  +disabled?: boolean,
-  +entity: RelatableEntityT | CollectionT,
-  +selected: boolean,
-  +subPath: string,
-};
-
-const EntityTabLink = ({
-  disabled = false,
-  selected,
-  ...linkProps
-}: Props): React$Element<'li'> => (
-  <li
-    className={
-      selected || disabled
-        ? (selected ? 'sel' : '') +
-          (selected && disabled ? ' ' : '') +
-          (disabled ? 'disabled' : '')
-        : null
-    }
-  >
-    <EntityLink {...linkProps} />
-  </li>
-);
+component EntityTabLink(
+  disabled: boolean = false,
+  selected: boolean,
+  ...linkProps: {
+    +content: string,
+    +entity: RelatableEntityT | CollectionT,
+    +subPath: string,
+  }
+) {
+  return (
+    <li
+      className={
+        selected || disabled
+          ? (selected ? 'sel' : '') +
+            (selected && disabled ? ' ' : '') +
+            (disabled ? 'disabled' : '')
+          : null
+      }
+    >
+      <EntityLink {...linkProps} />
+    </li>
+  );
+}
 
 export default EntityTabLink;

--- a/root/components/EntityTabs.js
+++ b/root/components/EntityTabs.js
@@ -169,22 +169,18 @@ function buildLinks(
   return links;
 }
 
-type Props = {
-  +editTab: ?React$Element<typeof EntityTabLink>,
-  +entity: RelatableEntityT,
-  +page?: string,
-};
-
-const EntityTabs = ({
-  editTab,
-  entity,
-  page,
-}: Props): React$Element<typeof Tabs> => (
-  <Tabs>
-    <CatalystContext.Consumer>
-      {($c: CatalystContextT) => buildLinks($c, entity, page, editTab)}
-    </CatalystContext.Consumer>
-  </Tabs>
-);
+component EntityTabs(
+  editTab: ?React$Element<typeof EntityTabLink>,
+  entity: RelatableEntityT,
+  page?: string,
+) {
+  return (
+    <Tabs>
+      <CatalystContext.Consumer>
+        {($c: CatalystContextT) => buildLinks($c, entity, page, editTab)}
+      </CatalystContext.Consumer>
+    </Tabs>
+  );
+}
 
 export default EntityTabs;

--- a/root/components/GroupedTrackRelationships.js
+++ b/root/components/GroupedTrackRelationships.js
@@ -23,10 +23,6 @@ import {interpolate} from '../static/scripts/edit/utility/linkPhrase.js';
 
 import RelationshipTargetLinks from './RelationshipTargetLinks.js';
 
-type Props = {
-  +source: RelatableEntityT,
-};
-
 const renderTargetGroup = (targetGroup: RelationshipTargetGroupT) => (
   <RelationshipTargetLinks relationship={targetGroup} />
 );
@@ -130,9 +126,7 @@ export function isIrrelevantLinkType(
     relationship.backward;
 }
 
-const GroupedTrackRelationships = ({
-  source,
-}: Props): Array<React$Element<'dl'>> => {
+component GroupedTrackRelationships(source: RelatableEntityT) {
   const workRelationships = [];
 
   const groupedRelationships = groupRelationships(
@@ -183,6 +177,6 @@ const GroupedTrackRelationships = ({
   }
 
   return arsList;
-};
+}
 
 export default GroupedTrackRelationships;

--- a/root/components/InstrumentRelTypes.js
+++ b/root/components/InstrumentRelTypes.js
@@ -11,32 +11,29 @@ import {commaOnlyListText}
   from '../static/scripts/common/i18n/commaOnlyList.js';
 import {bracketedText} from '../static/scripts/common/utility/bracketed.js';
 
-type Props = {
-  ...InstrumentCreditsAndRelTypesRoleT,
-  +entity: ArtistT | RecordingT | ReleaseT,
-};
-
-const InstrumentRelTypes = ({
-  entity,
-  instrumentCreditsAndRelTypes,
-}: Props): string | null => (
-  instrumentCreditsAndRelTypes &&
-    instrumentCreditsAndRelTypes[entity.gid] ? (
-      commaOnlyListText(
-        instrumentCreditsAndRelTypes[entity.gid].map(json => {
-          const relType = JSON.parse(json);
-          let listElement = l_relationships(relType.typeName);
-          if (relType.credit) {
-            listElement = listElement + ' ' +
-              bracketedText(texp.l(
-                'as “{credit}”',
-                {credit: relType.credit},
-              ));
-          }
-          return listElement;
-        }),
-      )
-    ) : null
-);
+component InstrumentRelTypes(
+  entity: ArtistT | RecordingT | ReleaseT,
+  instrumentCreditsAndRelTypes?: InstrumentCreditsAndRelTypesT,
+) {
+  return (
+    instrumentCreditsAndRelTypes &&
+      instrumentCreditsAndRelTypes[entity.gid] ? (
+        commaOnlyListText(
+          instrumentCreditsAndRelTypes[entity.gid].map(json => {
+            const relType = JSON.parse(json);
+            let listElement = l_relationships(relType.typeName);
+            if (relType.credit) {
+              listElement = listElement + ' ' +
+                bracketedText(texp.l(
+                  'as “{credit}”',
+                  {credit: relType.credit},
+                ));
+            }
+            return listElement;
+          }),
+        )
+      ) : null
+  );
+}
 
 export default InstrumentRelTypes;

--- a/root/components/LinkSearchableEditType.js
+++ b/root/components/LinkSearchableEditType.js
@@ -11,15 +11,7 @@ import * as React from 'react';
 
 import {CatalystContext} from '../context.mjs';
 
-type Props = {
-  +editTypeId: string,
-  +text: string,
-};
-
-const LinkSearchableEditType = ({
-  editTypeId,
-  text,
-}: Props): React$MixedElement => {
+component LinkSearchableEditType(editTypeId: string, text: string) {
   const $c = React.useContext(CatalystContext);
   const url = new URL($c.req.uri);
   url.pathname = 'search/edits';
@@ -28,6 +20,6 @@ const LinkSearchableEditType = ({
     '&conditions.0.field=type&conditions.0.operator=%3D' +
     '&conditions.0.args=' + editTypeId;
   return <a href={url.toString()}>{text}</a>;
-};
+}
 
 export default LinkSearchableEditType;

--- a/root/components/LinkSearchableLanguage.js
+++ b/root/components/LinkSearchableLanguage.js
@@ -12,21 +12,15 @@ import localizeLanguageName
 
 import LinkSearchableProperty from './LinkSearchableProperty.js';
 
-type Props = {
-  +entityType: string,
-  +language: LanguageT,
-};
-
-const LinkSearchableLanguage = ({
-  entityType,
-  language,
-}: Props): React$Element<typeof LinkSearchableProperty> => (
-  <LinkSearchableProperty
-    entityType={entityType}
-    searchField="lang"
-    searchValue={language.iso_code_3 || ''}
-    text={localizeLanguageName(language, entityType === 'work')}
-  />
-);
+component LinkSearchableLanguage(entityType: string, language: LanguageT) {
+  return (
+    <LinkSearchableProperty
+      entityType={entityType}
+      searchField="lang"
+      searchValue={language.iso_code_3 || ''}
+      text={localizeLanguageName(language, entityType === 'work')}
+    />
+  );
+}
 
 export default LinkSearchableLanguage;

--- a/root/components/LinkSearchableProperty.js
+++ b/root/components/LinkSearchableProperty.js
@@ -11,34 +11,29 @@ import {CatalystContext} from '../context.mjs';
 import escapeLuceneValue
   from '../static/scripts/common/utility/escapeLuceneValue.js';
 
-type Props = {
-  +entityType: string,
-  +searchField: string,
-  +searchValue: string,
-  +text?: string,
-};
-
-const LinkSearchableProperty = ({
-  entityType,
-  searchField,
-  searchValue,
-  text = searchValue,
-}: Props): React$MixedElement => (
-  <CatalystContext.Consumer>
-    {$c => {
-      const url = new URL($c.req.uri);
-      url.pathname = '/search';
-      url.search =
-        'query=' +
-        encodeURIComponent(
-          (searchValue === '*' ? '-' + searchField : searchField) + ':"' +
-          escapeLuceneValue(searchValue) + '"',
-        ) +
-        '&type=' + encodeURIComponent(entityType) +
-        '&limit=25&method=advanced';
-      return <a href={url.toString()}>{text}</a>;
-    }}
-  </CatalystContext.Consumer>
-);
+component LinkSearchableProperty(
+  entityType: string,
+  searchField: string,
+  searchValue: string,
+  text?: string,
+) {
+  return (
+    <CatalystContext.Consumer>
+      {$c => {
+        const url = new URL($c.req.uri);
+        url.pathname = '/search';
+        url.search =
+          'query=' +
+          encodeURIComponent(
+            (searchValue === '*' ? '-' + searchField : searchField) + ':"' +
+            escapeLuceneValue(searchValue) + '"',
+          ) +
+          '&type=' + encodeURIComponent(entityType) +
+          '&limit=25&method=advanced';
+        return <a href={url.toString()}>{text}</a>;
+      }}
+    </CatalystContext.Consumer>
+  );
+}
 
 export default LinkSearchableProperty;

--- a/root/components/PaginatedResults.js
+++ b/root/components/PaginatedResults.js
@@ -14,25 +14,15 @@ import {formatCount} from '../statistics/utilities.js';
 
 import Paginator from './Paginator.js';
 
-type Props = {
-  +children: React$Node,
-  +guessSearch?: boolean,
-  +pager: PagerT,
-  +pageVar?: 'apps_page' | 'page' | 'tokens_page',
-  +query?: string,
-  +search?: boolean,
-  +total?: boolean,
-};
-
-const PaginatedResults = ({
-  children,
-  guessSearch = false,
-  pager,
-  pageVar,
-  query,
-  search = false,
-  total = false,
-}: Props): React.MixedElement => {
+component PaginatedResults(
+  children: React$Node,
+  guessSearch: boolean = false,
+  pager: PagerT,
+  pageVar?: 'apps_page' | 'page' | 'tokens_page',
+  query?: string,
+  search: boolean = false,
+  total: boolean = false,
+) {
   const $c = React.useContext(CatalystContext);
   const paginator = (
     <Paginator
@@ -70,6 +60,6 @@ const PaginatedResults = ({
       {paginator}
     </>
   );
-};
+}
 
 export default PaginatedResults;

--- a/root/components/Paginator.js
+++ b/root/components/Paginator.js
@@ -16,13 +16,6 @@ import uriWith from '../utility/uriWith.js';
 type PageQueryParam = 'apps_page' | 'page' | 'tokens_page';
 type PageQueryObject = {[pageVar: PageQueryParam]: number, ...};
 
-type Props = {
-  +guessSearch?: boolean,
-  +hash?: string,
-  +pager: PagerT,
-  +pageVar?: PageQueryParam,
-};
-
 function uriPage(
   uri: string,
   pageVar: PageQueryParam,
@@ -39,12 +32,12 @@ function uriPage(
     (nonEmpty(hash) ? '#' + hash : '');
 }
 
-const Paginator = ({
-  guessSearch = false,
-  hash,
-  pager,
-  pageVar = 'page',
-}: Props): React$Element<'nav'> | null => {
+component Paginator(
+  guessSearch: boolean = false,
+  hash?: string,
+  pager: PagerT,
+  pageVar?: PageQueryParam = 'page',
+) {
   const $c = React.useContext(SanitizedCatalystContext);
 
   const lastPage = pager.last_page;
@@ -150,6 +143,6 @@ const Paginator = ({
       </ul>
     </nav>
   );
-};
+}
 
 export default Paginator;

--- a/root/components/RelatedEntitiesDisplay.js
+++ b/root/components/RelatedEntitiesDisplay.js
@@ -7,19 +7,14 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type Props = {
-  +children: React$Node,
-  +title: string,
-};
-
-const RelatedEntitiesDisplay = (
-  {children, title}: Props,
-): React$Element<'p'> => (
-  <p>
-    <strong>{addColonText(title)}</strong>
-    {' '}
-    {children}
-  </p>
-);
+component RelatedEntitiesDisplay(children: React$Node, title: string) {
+  return (
+    <p>
+      <strong>{addColonText(title)}</strong>
+      {' '}
+      {children}
+    </p>
+  );
+}
 
 export default RelatedEntitiesDisplay;

--- a/root/components/RelationshipTargetLinks.js
+++ b/root/components/RelationshipTargetLinks.js
@@ -54,15 +54,10 @@ export function displayDatedExtraAttributes(
   return renderedExtraAttributes;
 }
 
-type Props = {
-  +hiddenArtistCredit?: ?ArtistCreditT,
-  +relationship: RelationshipTargetGroupT,
-};
-
-const RelationshipTargetLinks = ({
-  hiddenArtistCredit,
-  relationship,
-}: Props): React$MixedElement => {
+component RelationshipTargetLinks(
+  hiddenArtistCredit?: ?ArtistCreditT,
+  relationship: RelationshipTargetGroupT,
+) {
   const target = relationship.target;
   const targetCredit = relationship.targetCredit;
   const disableLink = isDisabledLink(relationship.earliestDatePeriod, target);
@@ -100,6 +95,6 @@ const RelationshipTargetLinks = ({
     result = <span className="mp mp-rel">{result}</span>;
   }
   return result;
-};
+}
 
 export default RelationshipTargetLinks;

--- a/root/components/RelationshipsTable.js
+++ b/root/components/RelationshipsTable.js
@@ -29,14 +29,6 @@ import uriWith from '../utility/uriWith.js';
 
 import PaginatedResults from './PaginatedResults.js';
 
-type Props = {
-  +entity: RelatableEntityT,
-  +fallbackMessage?: string,
-  +heading: string,
-  +pagedLinkTypeGroup: ?PagedLinkTypeGroupT,
-  +pager: ?PagerT,
-};
-
 const generalTypesList = ['recording', 'release', 'release_group', 'work'];
 const recordingOnlyTypesList = ['recording'];
 
@@ -75,13 +67,13 @@ const getDirectionInteger = (backward: boolean) => {
   return backward ? 2 : 1;
 };
 
-const RelationshipsTable = ({
-  entity,
-  fallbackMessage,
-  heading,
-  pagedLinkTypeGroup,
-  pager,
-}: Props): React$MixedElement | null => {
+component RelationshipsTable(
+  entity: RelatableEntityT,
+  fallbackMessage?: string,
+  heading: string,
+  pagedLinkTypeGroup: ?PagedLinkTypeGroupT,
+  pager: ?PagerT,
+) {
   const $c = React.useContext(CatalystContext);
 
   if (pagedLinkTypeGroup && !pager) {
@@ -375,6 +367,6 @@ const RelationshipsTable = ({
       {pageContent}
     </>
   );
-};
+}
 
 export default RelationshipsTable;

--- a/root/components/ReleaseCatnoList.js
+++ b/root/components/ReleaseCatnoList.js
@@ -15,13 +15,9 @@ const displayCatno = (catno: string): React$Element<'span'> => (
   </span>
 );
 
-type ReleaseLabelsProps = {
-  +labels?: $ReadOnlyArray<ReleaseLabelT>,
-};
-
-const ReleaseCatnoList = ({
-  labels: releaseLabels,
-}: ReleaseLabelsProps): Expand2ReactOutput | null => {
+component ReleaseCatnoList(
+  labels as releaseLabels: ?$ReadOnlyArray<ReleaseLabelT>,
+) {
   if (!releaseLabels || !releaseLabels.length) {
     return null;
   }
@@ -33,6 +29,6 @@ const ReleaseCatnoList = ({
     }
   }
   return commaOnlyList(Array.from(catnos.values()).map(displayCatno));
-};
+}
 
 export default ReleaseCatnoList;

--- a/root/components/ReleaseLabelList.js
+++ b/root/components/ReleaseLabelList.js
@@ -15,15 +15,11 @@ const displayLabel = (label: LabelT) => (
   <EntityLink entity={label} />
 );
 
-type ReleaseLabelsProps = {
-  +labels: ?$ReadOnlyArray<ReleaseLabelT>,
-};
-
 const getLabelGid = (x: LabelT) => x.gid;
 
-const ReleaseLabelList = ({
-  labels: releaseLabels,
-}: ReleaseLabelsProps): Expand2ReactOutput | null => {
+component ReleaseLabelList(
+  labels as releaseLabels: ?$ReadOnlyArray<ReleaseLabelT>,
+) {
   if (!releaseLabels || !releaseLabels.length) {
     return null;
   }
@@ -35,6 +31,6 @@ const ReleaseLabelList = ({
     }
   }
   return commaOnlyList(uniqBy(labels, getLabelGid).map(displayLabel));
-};
+}
 
 export default ReleaseLabelList;

--- a/root/components/ReleaseLanguageScript.js
+++ b/root/components/ReleaseLanguageScript.js
@@ -7,9 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const ReleaseLanguageScript = ({
-  release,
-}: {release: ReleaseT}): React.MixedElement => {
+component ReleaseLanguageScript(release: ReleaseT) {
   const language = release.language;
   const script = release.script;
 
@@ -28,6 +26,6 @@ const ReleaseLanguageScript = ({
       ) : lp('-', 'missing data')}
     </>
   );
-};
+}
 
 export default ReleaseLanguageScript;

--- a/root/components/RemoveFromMergeTableCell.js
+++ b/root/components/RemoveFromMergeTableCell.js
@@ -13,16 +13,11 @@ import ENTITIES from '../../entities.mjs';
 import {SanitizedCatalystContext} from '../context.mjs';
 import {returnToCurrentPage} from '../utility/returnUri.js';
 
-type Props = {
-  +entity: MergeableEntityT,
-  +toMerge: $ReadOnlyArray<MergeableEntityT>,
-};
-
 // Converted to react-table at root/utility/tableColumns.js
-const RemoveFromMergeTableCell = ({
-  entity,
-  toMerge,
-}: Props): React$Element<'td'> | null => {
+component RemoveFromMergeTableCell(
+  entity: MergeableEntityT,
+  toMerge: $ReadOnlyArray<MergeableEntityT>,
+) {
   const $c = React.useContext(SanitizedCatalystContext);
   const url = ENTITIES[entity.entityType].url;
   return (
@@ -43,6 +38,6 @@ const RemoveFromMergeTableCell = ({
       </td>
     ) : null
   );
-};
+}
 
 export default RemoveFromMergeTableCell;

--- a/root/components/RequestLogin.js
+++ b/root/components/RequestLogin.js
@@ -12,17 +12,13 @@ import * as React from 'react';
 import {CatalystContext} from '../context.mjs';
 import returnUri from '../utility/returnUri.js';
 
-type Props = {
-  +text?: string,
-};
-
-const RequestLogin = ({text}: Props): React$Element<'a'> => {
+component RequestLogin(text?: string) {
   const $c = React.useContext(CatalystContext);
   return (
     <a href={returnUri($c, '/login')}>
       {nonEmpty(text) ? text : lp('Log in', 'interactive')}
     </a>
   );
-};
+}
 
 export default RequestLogin;

--- a/root/components/SortableTableHeader.js
+++ b/root/components/SortableTableHeader.js
@@ -24,30 +24,22 @@ function printSortArrows(name: string, order: ?string) {
   );
 }
 
-type Props = {
-  +label: string,
-  +name: string,
-  +order: ?string,
-};
-
-const SortableTableHeader = ({
-  label,
-  name,
-  order,
-}: Props): React$MixedElement => (
-  <CatalystContext.Consumer>
-    {$c => (
-      <a
-        href={uriWith(
-          $c.req.uri,
-          {order: order === name ? '-' + name : name},
-        )}
-      >
-        {label}
-        {printSortArrows(name, order)}
-      </a>
-    )}
-  </CatalystContext.Consumer>
-);
+component SortableTableHeader(label: string, name: string, order: ?string) {
+  return (
+    <CatalystContext.Consumer>
+      {$c => (
+        <a
+          href={uriWith(
+            $c.req.uri,
+            {order: order === name ? '-' + name : name},
+          )}
+        >
+          {label}
+          {printSortArrows(name, order)}
+        </a>
+      )}
+    </CatalystContext.Consumer>
+  );
+}
 
 export default SortableTableHeader;

--- a/root/components/StatusPage.js
+++ b/root/components/StatusPage.js
@@ -9,16 +9,13 @@
 
 import Layout from '../layout/index.js';
 
-type Props = {
-  +children: React$Node,
-  +title: string,
-};
-
-const StatusPage = ({title, children}: Props): React$MixedElement => (
-  <Layout fullWidth title={title}>
-    <h1>{title}</h1>
-    {children}
-  </Layout>
-);
+component StatusPage(children: React$Node, title: string) {
+  return (
+    <Layout fullWidth title={title}>
+      <h1>{title}</h1>
+      {children}
+    </Layout>
+  );
+}
 
 export default StatusPage;

--- a/root/components/SubHeader.js
+++ b/root/components/SubHeader.js
@@ -7,14 +7,14 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type Props = {+subHeading: React$Node};
-
-const SubHeader = ({subHeading}: Props): React$Element<'p'> => (
-  <p className="subheader">
-    <span className="prefix">{'~'}</span>
-    {' '}
-    {subHeading}
-  </p>
-);
+component SubHeader(subHeading: React$Node) {
+  return (
+    <p className="subheader">
+      <span className="prefix">{'~'}</span>
+      {' '}
+      {subHeading}
+    </p>
+  );
+}
 
 export default SubHeader;

--- a/root/components/Tabs.js
+++ b/root/components/Tabs.js
@@ -7,16 +7,14 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-type Props = {
-  +children: React$Node,
-};
-
-const Tabs = ({children}: Props): React$Element<'div'> => (
-  <div className="tabs">
-    <ul className="tabs">
-      {children}
-    </ul>
-  </div>
-);
+component Tabs(children: React$Node) {
+  return (
+    <div className="tabs">
+      <ul className="tabs">
+        {children}
+      </ul>
+    </div>
+  );
+}
 
 export default Tabs;

--- a/root/components/UserAccountLayout.js
+++ b/root/components/UserAccountLayout.js
@@ -28,13 +28,6 @@ export type AccountLayoutUserT = {
   +privileges: number,
 };
 
-type Props = {
-  +children: React$Node,
-  +entity: AccountLayoutUserT,
-  +page: string,
-  +title?: string,
-};
-
 export function sanitizedAccountLayoutUser(
   editor: UnsanitizedEditorT,
 ): AccountLayoutUserT {
@@ -49,26 +42,26 @@ export function sanitizedAccountLayoutUser(
   };
 }
 
-const UserAccountLayout = ({
-  children,
-  entity: user,
-  page,
-  title,
-  ...layoutProps
-}: Props): React$Element<typeof Layout> => (
-  <Layout
-    fullWidth
-    title={nonEmpty(title)
-      ? hyphenateTitle(texp.l('Editor “{user}”', {user: user.name}), title)
-      : texp.l('Editor “{user}”', {user: user.name})}
-    {...layoutProps}
-  >
-    <h1>
-      <EditorLink avatarSize={32} editor={user} />
-    </h1>
-    <UserAccountTabs page={page} user={user} />
-    {children}
-  </Layout>
-);
+component UserAccountLayout(
+  children: React$Node,
+  entity as user: AccountLayoutUserT,
+  page: string,
+  title?: string,
+) {
+  return (
+    <Layout
+      fullWidth
+      title={nonEmpty(title)
+        ? hyphenateTitle(texp.l('Editor “{user}”', {user: user.name}), title)
+        : texp.l('Editor “{user}”', {user: user.name})}
+    >
+      <h1>
+        <EditorLink avatarSize={32} editor={user} />
+      </h1>
+      <UserAccountTabs page={page} user={user} />
+      {children}
+    </Layout>
+  );
+}
 
 export default UserAccountLayout;

--- a/root/components/UserAccountTabs.js
+++ b/root/components/UserAccountTabs.js
@@ -128,20 +128,14 @@ function buildTabs(
   return tabs;
 }
 
-type Props = {
-  +page: string,
-  +user: AccountLayoutUserT,
-};
-
-const UserAccountTabs = ({
-  user,
-  page,
-}: Props): React$Element<typeof Tabs> => (
-  <Tabs>
-    <CatalystContext.Consumer>
-      {($c: CatalystContextT) => buildTabs($c, user, page)}
-    </CatalystContext.Consumer>
-  </Tabs>
-);
+component UserAccountTabs(page: string, user: AccountLayoutUserT) {
+  return (
+    <Tabs>
+      <CatalystContext.Consumer>
+        {($c: CatalystContextT) => buildTabs($c, user, page)}
+      </CatalystContext.Consumer>
+    </Tabs>
+  );
+}
 
 export default UserAccountTabs;

--- a/root/components/VotingPeriod.js
+++ b/root/components/VotingPeriod.js
@@ -13,13 +13,7 @@ import {SanitizedCatalystContext} from '../context.mjs';
 import {formatUserDateObject} from '../utility/formatUserDate.js';
 import parseIsoDate from '../utility/parseIsoDate.js';
 
-type PropsT = {
-  +closingDate: string,
-};
-
-const VotingPeriod = ({
-  closingDate,
-}: PropsT): Expand2ReactOutput | null => {
+component VotingPeriod(closingDate: string) {
   const $c = React.useContext(SanitizedCatalystContext);
   const date = parseIsoDate(closingDate);
   if (!date) {
@@ -64,6 +58,6 @@ const VotingPeriod = ({
     );
   }
   return l('About to close');
-};
+}
 
 export default VotingPeriod;

--- a/root/components/list/AreaList.js
+++ b/root/components/list/AreaList.js
@@ -18,21 +18,13 @@ import {
   removeFromMergeColumn,
 } from '../../utility/tableColumns.js';
 
-type Props = {
-  +areas: $ReadOnlyArray<AreaT>,
-  +checkboxes?: string,
-  +mergeForm?: MergeFormT,
-  +order?: string,
-  +sortable?: boolean,
-};
-
-const AreaList = ({
-  areas,
-  checkboxes,
-  mergeForm,
-  order,
-  sortable,
-}: Props): React$Element<'table'> => {
+component AreaList(
+  areas: $ReadOnlyArray<AreaT>,
+  checkboxes?: string,
+  mergeForm?: MergeFormT,
+  order?: string,
+  sortable?: boolean,
+) {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -62,6 +54,6 @@ const AreaList = ({
   );
 
   return useTable<AreaT>({columns, data: areas});
-};
+}
 
 export default AreaList;

--- a/root/components/list/ArtistList.js
+++ b/root/components/list/ArtistList.js
@@ -25,33 +25,19 @@ import {
   removeFromMergeColumn,
 } from '../../utility/tableColumns.js';
 
-type Props = {
-  ...InstrumentCreditsAndRelTypesRoleT,
-  ...SeriesItemNumbersRoleT,
-  +artists: $ReadOnlyArray<ArtistT>,
-  +checkboxes?: string,
-  +mergeForm?: MergeFormT,
-  +order?: string,
-  +showBeginEnd?: boolean,
-  +showInstrumentCreditsAndRelTypes?: boolean,
-  +showRatings?: boolean,
-  +showSortName?: boolean,
-  +sortable?: boolean,
-};
-
-const ArtistList = ({
-  artists,
-  checkboxes,
-  instrumentCreditsAndRelTypes,
-  mergeForm,
-  order,
-  seriesItemNumbers,
-  showBeginEnd = false,
-  showInstrumentCreditsAndRelTypes = false,
-  showRatings = false,
-  showSortName = false,
-  sortable,
-}: Props): React$Element<'table'> => {
+component ArtistList(
+  artists: $ReadOnlyArray<ArtistT>,
+  checkboxes?: string,
+  instrumentCreditsAndRelTypes?: InstrumentCreditsAndRelTypesT,
+  mergeForm?: MergeFormT,
+  order?: string,
+  seriesItemNumbers?: $ReadOnlyArray<string>,
+  showBeginEnd: boolean = false,
+  showInstrumentCreditsAndRelTypes: boolean = false,
+  showRatings: boolean = false,
+  showSortName: boolean = false,
+  sortable?: boolean,
+) {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -154,6 +140,6 @@ const ArtistList = ({
   );
 
   return useTable<ArtistT>({columns, data: artists});
-};
+}
 
 export default ArtistList;

--- a/root/components/list/EventList.js
+++ b/root/components/list/EventList.js
@@ -29,35 +29,20 @@ import {
   removeFromMergeColumn,
 } from '../../utility/tableColumns.js';
 
-type Props = {
-  ...SeriesItemNumbersRoleT,
-  +artist?: ArtistT,
-  +artistRoles?: boolean,
-  +checkboxes?: string,
-  +events: $ReadOnlyArray<EventT>,
-  +mergeForm?: MergeFormT,
-  +order?: string,
-  +showArtists?: boolean,
-  +showLocation?: boolean,
-  +showRatings?: boolean,
-  +showType?: boolean,
-  +sortable?: boolean,
-};
-
-const EventList = ({
-  artist,
-  artistRoles = false,
-  checkboxes,
-  events,
-  mergeForm,
-  order,
-  seriesItemNumbers,
-  showArtists = false,
-  showLocation = false,
-  showRatings = false,
-  showType = false,
-  sortable,
-}: Props): React.MixedElement => {
+component EventList(
+  artist?: ArtistT,
+  artistRoles: boolean = false,
+  checkboxes?: string,
+  events: $ReadOnlyArray<EventT>,
+  mergeForm?: MergeFormT,
+  order?: string,
+  seriesItemNumbers?: $ReadOnlyArray<string>,
+  showArtists: boolean = false,
+  showLocation: boolean = false,
+  showRatings: boolean = false,
+  showType: boolean = false,
+  sortable?: boolean,
+) {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -157,6 +142,6 @@ const EventList = ({
       {manifest.js('common/components/ArtistRoles', {async: 'async'})}
     </>
   );
-};
+}
 
 export default EventList;

--- a/root/components/list/InstrumentList.js
+++ b/root/components/list/InstrumentList.js
@@ -19,21 +19,13 @@ import {
   removeFromMergeColumn,
 } from '../../utility/tableColumns.js';
 
-type Props = {
-  +checkboxes?: string,
-  +instruments: $ReadOnlyArray<InstrumentT>,
-  +mergeForm?: MergeFormT,
-  +order?: string,
-  +sortable?: boolean,
-};
-
-const InstrumentList = ({
-  checkboxes,
-  instruments,
-  mergeForm,
-  order,
-  sortable,
-}: Props): React$Element<'table'> => {
+component InstrumentList(
+  checkboxes?: string,
+  instruments: $ReadOnlyArray<InstrumentT>,
+  mergeForm?: MergeFormT,
+  order?: string,
+  sortable?: boolean,
+ ) {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -66,6 +58,6 @@ const InstrumentList = ({
   );
 
   return useTable<InstrumentT>({columns, data: instruments});
-};
+}
 
 export default InstrumentList;

--- a/root/components/list/LabelList.js
+++ b/root/components/list/LabelList.js
@@ -24,23 +24,14 @@ import {
   removeFromMergeColumn,
 } from '../../utility/tableColumns.js';
 
-type Props = {
-  +checkboxes?: string,
-  +labels: $ReadOnlyArray<LabelT>,
-  +mergeForm?: MergeFormT,
-  +order?: string,
-  +showRatings?: boolean,
-  +sortable?: boolean,
-};
-
-const LabelList = ({
-  checkboxes,
-  labels,
-  mergeForm,
-  order,
-  showRatings = false,
-  sortable,
-}: Props): React$Element<'table'> => {
+component LabelList(
+  checkboxes?: string,
+  labels: $ReadOnlyArray<LabelT>,
+  mergeForm?: MergeFormT,
+  order?: string,
+  showRatings: boolean = false,
+  sortable?: boolean,
+) {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -110,6 +101,6 @@ const LabelList = ({
   );
 
   return useTable<LabelT>({columns, data: labels});
-};
+}
 
 export default LabelList;

--- a/root/components/list/PlaceList.js
+++ b/root/components/list/PlaceList.js
@@ -23,23 +23,14 @@ import {
   removeFromMergeColumn,
 } from '../../utility/tableColumns.js';
 
-type Props = {
-  +checkboxes?: string,
-  +mergeForm?: MergeFormT,
-  +order?: string,
-  +places: $ReadOnlyArray<PlaceT>,
-  +showRatings?: boolean,
-  +sortable?: boolean,
-};
-
-const PlaceList = ({
-  checkboxes,
-  mergeForm,
-  order,
-  places,
-  showRatings = false,
-  sortable,
-}: Props): React$Element<'table'> => {
+component PlaceList(
+  checkboxes?: string,
+  mergeForm?: MergeFormT,
+  order?: string,
+  places: $ReadOnlyArray<PlaceT>,
+  showRatings: boolean = false,
+  sortable?: boolean,
+) {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -100,6 +91,6 @@ const PlaceList = ({
   );
 
   return useTable<PlaceT>({columns, data: places});
-};
+}
 
 export default PlaceList;

--- a/root/components/list/RecordingList.js
+++ b/root/components/list/RecordingList.js
@@ -31,26 +31,8 @@ import {
   removeFromMergeColumn,
 } from '../../utility/tableColumns.js';
 
-type Props = {
-  ...InstrumentCreditsAndRelTypesRoleT,
-  ...ReleaseGroupAppearancesRoleT,
-  ...SeriesItemNumbersRoleT,
-  +checkboxes?: string,
-  +lengthClass?: string,
-  +mergeForm?: MergeFormT,
-  +order?: string,
-  +recordings: $ReadOnlyArray<RecordingWithArtistCreditT>,
-  +showAcoustIds?: boolean,
-  +showExpandedArtistCredits?: boolean,
-  +showInstrumentCreditsAndRelTypes?: boolean,
-  +showRatings?: boolean,
-  +showReleaseGroups?: boolean,
-  +sortable?: boolean,
-};
-
 function defineReleaseGroupAppearancesColumn(
-  releaseGroupAppearances:
-    ReleaseGroupAppearancesRoleT['releaseGroupAppearances'] | void,
+  releaseGroupAppearances: ReleaseGroupAppearancesMapT | void,
 ): ColumnOptions<RecordingT, ReleaseGroupAppearancesT> {
   return {
     Cell: ({row: {original}}) => releaseGroupAppearances &&
@@ -64,22 +46,22 @@ function defineReleaseGroupAppearancesColumn(
   };
 }
 
-const RecordingList = ({
-  checkboxes,
-  instrumentCreditsAndRelTypes,
-  lengthClass,
-  mergeForm,
-  order,
-  recordings,
-  releaseGroupAppearances,
-  seriesItemNumbers,
-  showAcoustIds = false,
-  showExpandedArtistCredits = false,
-  showInstrumentCreditsAndRelTypes = false,
-  showRatings = false,
-  showReleaseGroups = false,
-  sortable,
-}: Props): React$MixedElement => {
+component RecordingList(
+  checkboxes?: string,
+  instrumentCreditsAndRelTypes?: InstrumentCreditsAndRelTypesT,
+  lengthClass?: string,
+  mergeForm?: MergeFormT,
+  order?: string,
+  recordings: $ReadOnlyArray<RecordingWithArtistCreditT>,
+  releaseGroupAppearances?: ReleaseGroupAppearancesMapT,
+  seriesItemNumbers?: $ReadOnlyArray<string>,
+  showAcoustIds: boolean = false,
+  showExpandedArtistCredits: boolean = false,
+  showInstrumentCreditsAndRelTypes: boolean = false,
+  showRatings: boolean = false,
+  showReleaseGroups: boolean = false,
+  sortable?: boolean,
+) {
   const $c = React.useContext(SanitizedCatalystContext);
 
   const columns = React.useMemo(
@@ -175,6 +157,6 @@ const RecordingList = ({
       {manifest.js('common/components/IsrcList', {async: 'async'})}
     </>
   );
-};
+}
 
 export default RecordingList;

--- a/root/components/list/ReleaseGroupList.js
+++ b/root/components/list/ReleaseGroupList.js
@@ -25,37 +25,16 @@ import {
   removeFromMergeColumn,
 } from '../../utility/tableColumns.js';
 
-type ReleaseGroupListTableProps = {
-  ...SeriesItemNumbersRoleT,
-  +checkboxes?: string,
-  +mergeForm?: MergeFormT,
-  +order?: string,
-  +releaseGroups: $ReadOnlyArray<ReleaseGroupT>,
-  +showRatings?: boolean,
-  +showType?: boolean,
-  +sortable?: boolean,
-};
-
-type ReleaseGroupListProps = {
-  ...SeriesItemNumbersRoleT,
-  +checkboxes?: string,
-  +mergeForm?: MergeFormT,
-  +order?: string,
-  +releaseGroups: $ReadOnlyArray<ReleaseGroupT>,
-  +showRatings?: boolean,
-  +sortable?: boolean,
-};
-
-export const ReleaseGroupListTable = ({
-  checkboxes,
-  mergeForm,
-  order,
-  releaseGroups,
-  seriesItemNumbers,
-  showRatings = false,
-  showType = true,
-  sortable,
-}: ReleaseGroupListTableProps): React$Element<'table'> => {
+export component ReleaseGroupListTable(
+  checkboxes?: string,
+  mergeForm?: MergeFormT,
+  order?: string,
+  releaseGroups: $ReadOnlyArray<ReleaseGroupT>,
+  seriesItemNumbers?: $ReadOnlyArray<string>,
+  showRatings: boolean = false,
+  showType: boolean = true,
+  sortable?: boolean,
+) {
   const $c = React.useContext(CatalystContext);
 
   function getFirstReleaseYear(entity: ReleaseGroupT) {
@@ -145,18 +124,11 @@ export const ReleaseGroupListTable = ({
     columns,
     data: releaseGroups,
   });
-};
+}
 
-const ReleaseGroupList = ({
-  checkboxes,
-  mergeForm,
-  order,
-  releaseGroups,
-  seriesItemNumbers,
-  showRatings,
-  sortable,
-}: ReleaseGroupListProps): Array<React.MixedElement> => {
-  const groupedReleaseGroups = groupBy(releaseGroups, x => x.typeName ?? '');
+component ReleaseGroupList(...props: React.PropsOf<ReleaseGroupListTable>) {
+  const groupedReleaseGroups =
+    groupBy(props.releaseGroups, x => x.typeName ?? '');
   const tables: Array<React.MixedElement> = [];
   for (const [type, releaseGroupsOfType] of groupedReleaseGroups) {
     tables.push(
@@ -168,19 +140,14 @@ const ReleaseGroupList = ({
           }
         </h3>
         <ReleaseGroupListTable
-          checkboxes={checkboxes}
-          mergeForm={mergeForm}
-          order={order}
+          {...props}
           releaseGroups={releaseGroupsOfType}
-          seriesItemNumbers={seriesItemNumbers}
-          showRatings={showRatings}
           showType={false}
-          sortable={sortable}
         />
       </React.Fragment>,
     );
   }
   return tables;
-};
+}
 
 export default ReleaseGroupList;

--- a/root/components/list/ReleaseList.js
+++ b/root/components/list/ReleaseList.js
@@ -32,37 +32,21 @@ import {
   taggerColumn,
 } from '../../utility/tableColumns.js';
 
-type Props = {
-  ...InstrumentCreditsAndRelTypesRoleT,
-  ...SeriesItemNumbersRoleT,
-  +checkboxes?: string,
-  +filterLabel?: LabelT,
-  +mergeForm?: MergeReleasesFormT,
-  +order?: string,
-  +releases: $ReadOnlyArray<ReleaseT>,
-  +showInstrumentCreditsAndRelTypes?: boolean,
-  +showLanguages?: boolean,
-  +showRatings?: boolean,
-  +showStatus?: boolean,
-  +showType?: boolean,
-  +sortable?: boolean,
-};
-
-const ReleaseList = ({
-  checkboxes,
-  filterLabel,
-  instrumentCreditsAndRelTypes,
-  mergeForm,
-  order,
-  releases,
-  seriesItemNumbers,
-  showInstrumentCreditsAndRelTypes = false,
-  showLanguages = false,
-  showRatings = false,
-  showStatus = false,
-  showType = false,
-  sortable,
-}: Props): React$MixedElement => {
+component ReleaseList(
+  checkboxes?: string,
+  filterLabel?: LabelT,
+  instrumentCreditsAndRelTypes?: InstrumentCreditsAndRelTypesT,
+  mergeForm?: MergeReleasesFormT,
+  order?: string,
+  releases: $ReadOnlyArray<ReleaseT>,
+  seriesItemNumbers?: $ReadOnlyArray<string>,
+  showInstrumentCreditsAndRelTypes: boolean = false,
+  showLanguages: boolean = false,
+  showRatings: boolean = false,
+  showStatus: boolean = false,
+  showType: boolean = false,
+  sortable?: boolean,
+) {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -216,6 +200,6 @@ const ReleaseList = ({
       {manifest.js('common/components/TaggerIcon', {async: 'async'})}
     </>
   );
-};
+}
 
 export default ReleaseList;

--- a/root/components/list/SeriesList.js
+++ b/root/components/list/SeriesList.js
@@ -19,21 +19,13 @@ import {
   seriesOrderingTypeColumn,
 } from '../../utility/tableColumns.js';
 
-type Props = {
-  +checkboxes?: string,
-  +mergeForm?: MergeFormT,
-  +order?: string,
-  +series: $ReadOnlyArray<SeriesT>,
-  +sortable?: boolean,
-};
-
-const SeriesList = ({
-  checkboxes,
-  mergeForm,
-  order,
-  series,
-  sortable,
-}: Props): React$Element<'table'> => {
+component SeriesList(
+  checkboxes?: string,
+  mergeForm?: MergeFormT,
+  order?: string,
+  series: $ReadOnlyArray<SeriesT>,
+  sortable?: boolean,
+) {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -64,6 +56,6 @@ const SeriesList = ({
   );
 
   return useTable<SeriesT>({columns, data: series});
-};
+}
 
 export default SeriesList;

--- a/root/components/list/WorkList.js
+++ b/root/components/list/WorkList.js
@@ -26,25 +26,15 @@ import {
   workLanguagesColumn,
 } from '../../utility/tableColumns.js';
 
-type Props = {
-  ...SeriesItemNumbersRoleT,
-  +checkboxes?: string,
-  +mergeForm?: MergeFormT,
-  +order?: string,
-  +showRatings?: boolean,
-  +sortable?: boolean,
-  +works: $ReadOnlyArray<WorkT>,
-};
-
-const WorkList = ({
-  checkboxes,
-  mergeForm,
-  order,
-  seriesItemNumbers,
-  showRatings = false,
-  sortable,
-  works,
-}: Props): React.MixedElement => {
+component WorkList(
+  checkboxes?: string,
+  mergeForm?: MergeFormT,
+  order?: string,
+  seriesItemNumbers?: $ReadOnlyArray<string>,
+  showRatings: boolean = false,
+  sortable?: boolean,
+  works: $ReadOnlyArray<WorkT>,
+) {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -111,6 +101,6 @@ const WorkList = ({
       {manifest.js('common/components/WorkArtists', {async: 'async'})}
     </>
   );
-};
+}
 
 export default WorkList;

--- a/root/types/recording.js
+++ b/root/types/recording.js
@@ -38,7 +38,3 @@ declare type ReleaseGroupAppearancesT = {
 declare type ReleaseGroupAppearancesMapT = {
   +[recordingId: number]: ReleaseGroupAppearancesT,
 };
-
-declare type ReleaseGroupAppearancesRoleT = {
-  +releaseGroupAppearances?: ReleaseGroupAppearancesMapT,
-};


### PR DESCRIPTION
Flow now supports a specific [React Component Syntax](https://flow.org/en/docs/react/component-syntax/) which reduces the amount of types we need to define manually, and is supposed to be better for type checking as well. I'm converting our React components to this syntax bit by bit with this PR.

This changes all stuff in the `components` subfolder.

Note: To be reviewed without whitespace changes (since this adds explicit `return()` calls that require spacing things one more tab in many cases).

On top of https://github.com/metabrainz/musicbrainz-server/pull/3230