### PR TITLE
MBS-13533: Fix order of cover art in release group artwork

### DIFF
--- a/lib/MusicBrainz/Server/Data/Artwork.pm
+++ b/lib/MusicBrainz/Server/Data/Artwork.pm
@@ -197,7 +197,9 @@ sub load_for_release_groups
         WHERE release.release_group IN (' . placeholders(@ids) . q{)
         AND is_front = true
         AND cover_art_presence != 'darkened'
-        ORDER BY release.release_group, release.status, release_group_cover_art.release,
+        ORDER BY release.release_group, release_group_cover_art.release,
+          (CASE WHEN release.status = 3
+           THEN 1 ELSE 0 END),
           (CASE WHEN 'Raw/Unedited' = any(cover_art_archive.index_listing.types)
            THEN 1 ELSE 0 END),
           release_event.date_year, release_event.date_month,

--- a/lib/MusicBrainz/Server/Data/Artwork.pm
+++ b/lib/MusicBrainz/Server/Data/Artwork.pm
@@ -197,7 +197,7 @@ sub load_for_release_groups
         WHERE release.release_group IN (' . placeholders(@ids) . q{)
         AND is_front = true
         AND cover_art_presence != 'darkened'
-        ORDER BY release.release_group, release_group_cover_art.release,
+        ORDER BY release.release_group, release.status, release_group_cover_art.release,
           (CASE WHEN 'Raw/Unedited' = any(cover_art_archive.index_listing.types)
            THEN 1 ELSE 0 END),
           release_event.date_year, release_event.date_month,


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
Release group pages should prioritize non-bootleg album art
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

[MBS-13533](https://tickets.metabrainz.org/browse/MBS-13533)


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Since we need to prioritize non-bootleg album art, we can order the Artwork we get from `load_for_release_groups` method, wrt `release_status`, the order being:
![image](https://github.com/metabrainz/musicbrainz-server/assets/75999921/325cf9ce-e637-41ec-bf07-e7a6e00a8af6)
Since the query in the method has a `DISTINCT ON (release.release_group)` expression, we will get the top result from the order by `release.status` clause, hence official artwork will get more priority. 


# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

Tested manually on multiple release groups. Got no errors on different RGs.
