### PR TITLE
MBS-13548: obey returnto for already logged in users

### DIFF
--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -190,8 +190,7 @@ sub login : Path('/login') ForbiddenOnMirrors RequireSSL SecureForm
     my ($self, $c) = @_;
 
     if ($c->user_exists) {
-        $c->response->redirect($c->uri_for_action('/user/profile',
-                                                 [ $c->user->name ]));
+        $c->redirect_back(fallback => $c->uri_for_action('/user/profile', [ $c->user->name ]));
         $c->detach;
     }
 

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Login.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Login.pm
@@ -180,6 +180,27 @@ test 'MBS-12720: remember_login cookie is HttpOnly' => sub {
     $enable_ssl->DESTROY;
 };
 
+test 'MBS-13548: obey returnto for already logged in users' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c = $test->c;
+    my $enable_ssl = enable_ssl();
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+editor');
+    $mech->get_ok('https://localhost/login');
+    $mech->submit_form(
+        with_fields => {
+            username => 'new_editor',
+            password => 'password',
+            remember_me => '1',
+        },
+    );
+    is($mech->uri->path, '/user/new_editor');
+
+    $mech->get_ok('https://localhost/login?returnto=/doc/About');
+    is($mech->uri->path, '/doc/About');
+};
+
 sub enable_ssl {
     my $dbdefs = ref(*DBDefs::SSL_REDIRECTS_ENABLED) ? 'DBDefs' : 'DBDefs::Default';
     my $wrapper = wrap "${dbdefs}::SSL_REDIRECTS_ENABLED",

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Login.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Login.pm
@@ -199,6 +199,8 @@ test 'MBS-13548: obey returnto for already logged in users' => sub {
 
     $mech->get_ok('https://localhost/login?returnto=/doc/About');
     is($mech->uri->path, '/doc/About');
+
+    $enable_ssl->DESTROY;
 };
 
 sub enable_ssl {


### PR DESCRIPTION
# Problem
Currently if the user is already logged in, url redirects from the login page using the returnto query parameter don't work. This breaks certain workflows in the new OAuth testing.

MBS-13548

# Solution

Fixing it by obeying returnto for logged in users as well. If returnto is missing, fallback to existing redirect to user's profile.

# Testing

Add a perl test to make sure the added redirect behavior works and also did testing for the same on local server.

