### PR TITLE
MBS-11962: Update privileges for all database users on schema changes

### DIFF
--- a/admin/InitDb.pl
+++ b/admin/InitDb.pl
@@ -8,6 +8,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 
 use DBDefs;
+use MusicBrainz::Server::Constants qw( @FULL_SCHEMA_LIST );
 use MusicBrainz::Server::Replication qw( :replication_type );
 
 use aliased 'MusicBrainz::Server::DatabaseConnectionFactory' => 'Databases';
@@ -238,18 +239,7 @@ sub CreateRelations
     $ENV{'PGPASSWORD'} = $DB->password;
 
     system(sprintf(qq(echo "CREATE SCHEMA %s" | $psql $opts), $_))
-        for (qw(
-            musicbrainz
-            cover_art_archive
-            documentation
-            event_art_archive
-            json_dump
-            report
-            sitemaps
-            statistics
-            wikidocs
-            dbmirror2
-        ));
+        for @FULL_SCHEMA_LIST;
     die "\nFailed to create schema\n" if ($CHILD_ERROR >> 8);
 
     RunSQLScript($SYSMB, 'Extensions.sql', 'Installing extensions');

--- a/admin/UpdateDatabasePrivileges.pl
+++ b/admin/UpdateDatabasePrivileges.pl
@@ -1,0 +1,160 @@
+#!/usr/bin/env perl
+
+use warnings;
+use strict;
+
+use FindBin;
+use Getopt::Long qw( GetOptions );
+use lib "$FindBin::Bin/../lib";
+
+use MusicBrainz::Server::Constants qw( @FULL_SCHEMA_LIST );
+use MusicBrainz::Server::Context;
+use MusicBrainz::Server::Log qw( log_info );
+
+my $primary_ro_role = 'musicbrainz_ro';
+my @other_ro_roles = qw( caa_redirect sir );
+my $database = 'MAINTENANCE';
+my $grant_privileges = 1;
+
+my $help = <<EOF;
+Usage: UpdateDatabasePrivileges.pl [OPTIONS]
+
+By default, this command grants USAGE/SELECT privileges to a set of roles
+intended for read-only access. It revokes write privileges.
+
+If `--nogrant` is specified, then it also revokes read privileges
+(USAGE/SELECT).
+
+Options are:
+        --database          Database to connect to (default: MAINTENANCE)
+        --primary-ro-role   Name of the primary READONLY role
+                            (default: musicbrainz_ro)
+        --other-ro-role     Name of another role allowed RO access to the
+                            database (may be specified multiple times)
+                            (default: caa_redirect, sir)
+        --[no]grant         Whether to GRANT or REVOKE USAGE/SELECT privileges
+                            (default: GRANT)
+    -h, --help              Show this help
+
+EOF
+
+GetOptions(
+    'database=s'        => \$database,
+    'primary-ro-role=s' => \$primary_ro_role,
+    'other-ro-role=s'   => \@other_ro_roles,
+    'grant!'            => \$grant_privileges,
+    'help|h'            => sub { print $help; exit },
+) or exit 2;
+print($help), exit 2 if @ARGV;
+
+my $c = MusicBrainz::Server::Context->create_script_context(
+    database => 'SYSTEM_' . $database,
+);
+my $sql = $c->sql;
+
+$sql->auto_commit;
+my $existing_role_names = $sql->select_single_column_array(
+    <<~'SQL',
+    SELECT rolname
+      FROM pg_roles
+     WHERE rolname = any(?)
+    SQL
+    [$primary_ro_role, @other_ro_roles],
+);
+my %existing_role_names = map { $_ => 1 } @$existing_role_names;
+
+if ($existing_role_names{$primary_ro_role}) {
+    my $quoted_primary_role = $sql->dbh->quote_identifier($primary_ro_role);
+    $sql->begin;
+    my $existing_schemas = $sql->select_single_column_array(
+        <<~'SQL',
+        SELECT nspname
+          FROM pg_namespace
+         WHERE nspname = any(?)
+        SQL
+        [@FULL_SCHEMA_LIST],
+    );
+    for my $schema (@$existing_schemas) {
+        my $quoted_schema = $sql->dbh->quote_identifier($schema);
+        log_info {
+            "Updating privileges for $quoted_primary_role on $quoted_schema tables in $database"
+        };
+        my $revoked_privileges;
+        if ($grant_privileges) {
+            $sql->do(<<~"SQL");
+                GRANT USAGE
+                   ON SCHEMA $quoted_schema
+                   TO $quoted_primary_role;
+                SQL
+            $revoked_privileges =
+                'INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER';
+        } else {
+            $sql->do(<<~"SQL");
+                REVOKE USAGE
+                    ON SCHEMA $quoted_schema
+                  FROM $quoted_primary_role;
+                SQL
+            $revoked_privileges = 'ALL PRIVILEGES';
+        }
+        $sql->do(<<~"SQL");
+            REVOKE $revoked_privileges
+                ON ALL TABLES IN SCHEMA $quoted_schema
+              FROM $quoted_primary_role;
+            SQL
+        $sql->do(<<~"SQL") if $grant_privileges;
+            GRANT SELECT
+               ON ALL TABLES IN SCHEMA $quoted_schema
+               TO $quoted_primary_role;
+            SQL
+    }
+    for my $other_role (@other_ro_roles) {
+        unless ($existing_role_names{$other_role}) {
+            log_info {
+                qq(The role "$other_role" does not exist; skipping.)
+            };
+            next;
+        }
+
+        my $quoted_other_role = $sql->dbh->quote_identifier($other_role);
+        for my $schema (@$existing_schemas) {
+            my $quoted_schema = $sql->dbh->quote_identifier($schema);
+            log_info {
+                "Updating privileges for $quoted_other_role on $quoted_schema tables in $database"
+            };
+            $sql->do(<<~"SQL");
+                REVOKE ALL PRIVILEGES
+                    ON ALL TABLES IN SCHEMA $quoted_schema
+                  FROM $quoted_other_role;
+                REVOKE USAGE
+                    ON SCHEMA $quoted_schema
+                  FROM $quoted_other_role;
+                SQL
+        }
+        if ($grant_privileges) {
+            $sql->do(<<~"SQL");
+                GRANT $quoted_primary_role
+                   TO $quoted_other_role;
+                SQL
+        } else {
+            $sql->do(<<~"SQL");
+                REVOKE $quoted_primary_role
+                  FROM $quoted_other_role;
+                SQL
+        }
+    }
+    $sql->commit;
+} else {
+    log_info {
+        qq(The role "$primary_ro_role" does not exist; skipping.)
+    };
+}
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2024 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/docker/musicbrainz-tests/run_circleci_tests.sh
+++ b/docker/musicbrainz-tests/run_circleci_tests.sh
@@ -81,6 +81,7 @@ sudo -E -H -u musicbrainz carton exec -- prove \
     t/script/DumpJSON.t \
     t/script/ExportAllTables.t \
     t/script/dbmirror2.t \
+    t/script/UpdateDatabasePrivileges.t \
     t/tests.t \
     --harness=TAP::Harness::JUnit \
     -v

--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -76,7 +76,7 @@ our @EXPORT_OK = (
         $MAX_INITIAL_MEDIUMS $MAX_INITIAL_TRACKS
         $MAX_POSTGRES_INT $MAX_POSTGRES_BIGINT
         $MAX_ONELINE_STRING_LENGTH $MAX_POSTGRES_INDEXED_STRING_BYTES
-        @FULL_TABLE_LIST
+        @FULL_SCHEMA_LIST @FULL_TABLE_LIST
         @CORE_TABLE_LIST
         @DERIVED_TABLE_LIST
         @STATS_TABLE_LIST
@@ -511,6 +511,19 @@ sub entities_with {
 
 Readonly our @RELATABLE_ENTITIES =>
     sort { $a cmp $b } entities_with(['mbid', 'relatable']);
+
+Readonly our @FULL_SCHEMA_LIST => qw(
+    musicbrainz
+    cover_art_archive
+    documentation
+    event_art_archive
+    json_dump
+    report
+    sitemaps
+    statistics
+    wikidocs
+    dbmirror2
+);
 
 Readonly our @CORE_TABLE_LIST => qw(
     alternative_medium

--- a/t/script/UpdateDatabasePrivileges.t
+++ b/t/script/UpdateDatabasePrivileges.t
@@ -1,0 +1,111 @@
+use strict;
+use warnings;
+
+use Test::Fatal;
+use Test::More;
+use Test::Routine;
+use Test::Routine::Util;
+
+use DBDefs;
+use MusicBrainz::Server::Context;
+use aliased 'MusicBrainz::Server::DatabaseConnectionFactory' => 'Databases';
+
+$ENV{MUSICBRAINZ_RUNNING_TESTS} = 1;
+
+test all => sub {
+    my $c = MusicBrainz::Server::Context->create_script_context(
+        database => 'SYSTEM_TEST',
+    );
+
+    $c->sql->auto_commit;
+    $c->sql->do(<<~'SQL');
+        CREATE ROLE db_priv_test_musicbrainz_ro WITH LOGIN;
+        CREATE ROLE db_priv_test_caa_redirect WITH LOGIN;
+        CREATE ROLE db_priv_test_sir WITH LOGIN;
+        CREATE TABLE musicbrainz.db_priv_test ( val INTEGER );
+        SQL
+
+    my $test_db = Databases->get('SYSTEM_TEST');
+    my @roles = qw( musicbrainz_ro caa_redirect sir );
+
+    Databases->register_databases(
+        map {
+            ("db_priv_test_${_}" => {
+                database    => $test_db->database,
+                host        => $test_db->host,
+                password    => $test_db->password,
+                port        => $test_db->port,
+                username    => "db_priv_test_${_}",
+            })
+        } @roles,
+    );
+
+    for my $role (@roles) {
+        my $conn = Databases->get_connection("db_priv_test_${role}");
+        my $sql = Sql->new($conn->conn);
+
+        $sql->auto_commit;
+        like exception {
+            $sql->do('SELECT * FROM musicbrainz.db_priv_test;');
+        }, qr/permission denied for schema musicbrainz/,
+            "$role cannot SELECT from musicbrainz.db_priv_test before running script";
+
+        $sql->auto_commit;
+        like exception {
+            $sql->do('INSERT INTO musicbrainz.db_priv_test VALUES (1);');
+        }, qr/permission denied for schema musicbrainz/,
+            "$role cannot INSERT INTO musicbrainz.db_priv_test before running script";
+    }
+
+    system(
+        File::Spec->catfile(
+            DBDefs->MB_SERVER_ROOT,
+            'admin/UpdateDatabasePrivileges.pl',
+        ),
+        '--database', 'SYSTEM_TEST',
+        '--primary-ro-role', 'db_priv_test_musicbrainz_ro',
+        '--other-ro-role', 'db_priv_test_caa_redirect',
+        '--other-ro-role', 'db_priv_test_sir',
+    );
+
+    for my $role (@roles) {
+        my $conn = Databases->get_connection("db_priv_test_${role}");
+        my $sql = Sql->new($conn->conn);
+
+        $sql->auto_commit;
+        ok !exception {
+            $sql->do('SELECT * FROM musicbrainz.db_priv_test;');
+        }, "$role can SELECT from musicbrainz.db_priv_test after running script";
+
+        $sql->auto_commit;
+        like exception {
+            $sql->do('INSERT INTO musicbrainz.db_priv_test VALUES (1);');
+        }, qr/permission denied for table db_priv_test/,
+            "$role can INSERT into musicbrainz.db_priv_test after running script";
+    }
+
+    system(
+        File::Spec->catfile(
+            DBDefs->MB_SERVER_ROOT,
+            'admin/UpdateDatabasePrivileges.pl',
+        ),
+        '--database', 'SYSTEM_TEST',
+        '--primary-ro-role', 'db_priv_test_musicbrainz_ro',
+        '--other-ro-role', 'db_priv_test_caa_redirect',
+        '--other-ro-role', 'db_priv_test_sir',
+        '--nogrant',
+    );
+
+    $c->sql->auto_commit;
+    $c->sql->do(<<~'SQL');
+        DROP ROLE IF EXISTS db_priv_test_musicbrainz_ro;
+        DROP ROLE IF EXISTS db_priv_test_caa_redirect;
+        DROP ROLE IF EXISTS db_priv_test_sir;
+        DROP TABLE IF EXISTS musicbrainz.db_priv_test;
+        SQL
+};
+
+run_me;
+done_testing;
+
+1;

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -109,6 +109,12 @@ then
 fi
 
 ################################################################################
+# Update PostgreSQL user privileges
+
+echo `date` : Updating PostgreSQL user privileges
+OUTPUT=`./admin/UpdateDatabasePrivileges.pl 2>&1` || ( echo "$OUTPUT" ; exit 1 )
+
+################################################################################
 # Re-enable replication
 
 if [ "$REPLICATION_TYPE" = "$RT_MASTER" ]


### PR DESCRIPTION
# Problem

MBS-11962

When new tables or schemas are added, production database users like `musicbrainz_ro` may not be granted access to them.

# Solution

Adds a new script, admin/UpdateDatabasePrivileges.pl, which is invoked from upgrade.sh and updates privileges for the following users if they exist:

 * `musicbrainz_ro`
 * `caa_redirect`
 * `sir`

The script works by revoking all write privileges from `musicbrainz_ro`, and then granting `USAGE` on all schemas, and `SELECT` privileges on all tables in those schemas.

Next, for the last two schemas, it revokes all privileges from them (including `SELECT` and `USAGE`), and then simply grants them membership in the `musicbrainz_ro` role.

# Testing

I added the three roles in question to my local database and ran admin/UpdateDatabasePrivileges.pl. I observed that each of the three users could `SELECT` from any table in our schemas, but not modify them.