### PR TITLE
MBS-13337: Use standby Postgres instances for read-only queries

### DIFF
--- a/admin/InitDb.pl
+++ b/admin/InitDb.pl
@@ -410,7 +410,7 @@ sub SanityCheck
     if ($REPTYPE == RT_MIRROR)
     {
         warn "Warning: this is a mirror replication server, but there is no READONLY connection defined\n"
-            unless Databases->get('READONLY');
+            unless Databases->exists('READONLY');
     }
 
     if ($REPTYPE == RT_MASTER)

--- a/admin/SetLanguageFrequencies
+++ b/admin/SetLanguageFrequencies
@@ -23,6 +23,7 @@ use constant PRESELECTED_LANGUAGES => qw(
 
 my $c = MusicBrainz::Server::Context->create_script_context;
 my $sql = $c->sql;
+my $ro_sql = $c->prefer_ro_sql;
 
 #
 # Set the frequency attribute of the language table.
@@ -40,7 +41,7 @@ foreach my $code ( PRESELECTED_LANGUAGES )
 # Calculate language frequencies
 #
 
-$sql->select(<<'EOF', MAX_TOP_LANGUAGES + scalar(PRESELECTED_LANGUAGES));
+$ro_sql->select(<<'EOF', MAX_TOP_LANGUAGES + scalar(PRESELECTED_LANGUAGES));
     SELECT              language, COUNT(*)
     FROM                release
     WHERE NOT   language IS NULL
@@ -51,14 +52,14 @@ EOF
 
 
 # put at most MAX_TOP_LANGUAGES into %languages
-while ( my ($language, $count) = $sql->next_row() )
+while ( my ($language, $count) = $ro_sql->next_row() )
 {
     last if keys(%languages) >= MAX_TOP_LANGUAGES;
 
     $languages{ $language } = 1;
 }
 
-$sql->finish();
+$ro_sql->finish();
 
 print 'New top languages: ', join(' ', keys %languages), "\n";
 

--- a/admin/cleanup/FixTrackLength.pl
+++ b/admin/cleanup/FixTrackLength.pl
@@ -51,7 +51,7 @@ my $c = MusicBrainz::Server::Context->create_script_context;
 
 # Find mediums with at least one track to fix
 log_info { 'Finding candidate mediums' } if $verbose;
-my @medium_ids = @{ $c->sql->select_single_column_array(
+my @medium_ids = @{ $c->prefer_ro_sql->select_single_column_array(
     'SELECT DISTINCT m.id
        FROM medium m
        JOIN medium_cdtoc mcd ON mcd.medium = m.id

--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -60,6 +60,7 @@ MusicBrainz::Server::DatabaseConnectionFactory->register_databases(
         password        => 'musicbrainz',
 #       host            => '',
 #       port            => '',
+        read_only   => 1,
     },
     # How to connect for administrative access
     SYSTEM    => {
@@ -86,6 +87,7 @@ MusicBrainz::Server::DatabaseConnectionFactory->register_databases(
 #       password        => '',
 #       host            => '',
 #       port            => '5432',
+#       read_only    => 1,
 #   },
 );
 

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -442,6 +442,32 @@ sub DISCOURSE_SSO_SECRET { '' }
 # of security on the MusicBrainz production site.
 sub NONCE_SECRET { '' }
 
+# `USE_RO_DATABASE_CONNECTOR` signals to MusicBrainz Server that it may open
+# an additional database connector per request that it can send read-only
+# queries to. In production this may be used to distribute read-only queries
+# to a PostgreSQL standby instance. (We avoid using this connector on the
+# website if a logged-in user exists, so as not to subject them to potential
+# replication lag while editing.)
+#
+# `USE_RO_DATABASE_CONNECTOR` is not enabled by default, because it's only
+# useful if a separate standby exists. It's also wasteful to potentially open
+# another connector per request if it's otherwise identical to the default
+# connection handle.
+#
+# If enabled, the connector will point to the `READONLY` database.
+#
+# This setting is ignored if `DB_READ_ONLY` is enabled, or if the
+# `REPLICATION_TYPE` is `RT_MIRROR`, because the default connection handle
+# already points to the `READONLY` database in those cases. If it's needed to
+# distribute read-only queries for a mirror database to a standby, haproxy
+# can be used.
+#
+# We don't define which queries the server will send to the RO connector; any
+# transactions that don't perform writes may be redirected, but it depends on
+# which parts of the server code have been updated to actually use the
+# connector.
+sub USE_RO_DATABASE_CONNECTOR { 0 }
+
 # When enabled, if Catalyst receives a request with an `mb-set-database`
 # header, all database queries will go to the specified database instead of
 # READWRITE, as defined in the DatabaseConnectionFactory->register_databases

--- a/lib/MusicBrainz/Script/RemoveEmpty.pm
+++ b/lib/MusicBrainz/Script/RemoveEmpty.pm
@@ -101,7 +101,7 @@ sub run {
     my ($count, $removed) = (0, 0);
     my @entities = values %{
         $self->c->model(type_to_model($entity))->get_by_ids(
-            @{ $self->c->sql->select_single_column_array($query) },
+            @{ $self->c->prefer_ro_sql->select_single_column_array($query) },
         );
     };
     my $modbot = $self->c->model('Editor')->get_by_id($EDITOR_MODBOT);

--- a/lib/MusicBrainz/Script/RemoveUnreferencedRows.pm
+++ b/lib/MusicBrainz/Script/RemoveUnreferencedRows.pm
@@ -48,7 +48,7 @@ sub run {
     log_info { 'Checking all unreferenced rows.' };
 
     my @unreferenced_rows = @{
-        $self->c->sql->select_list_of_lists(<<~'SQL');
+        $self->c->prefer_ro_sql->select_list_of_lists(<<~'SQL');
               SELECT table_name,
                      array_agg(row_id) AS row_ids
                 FROM unreferenced_row_log

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -448,7 +448,7 @@ before dispatch => sub {
     } else {
         # Use a fresh database connection for every request, and
         # remember to disconnect at the end.
-        $ctx->connector->refresh;
+        $ctx->connector->refresh if $ctx->has_connector;
     }
 
     # Any time `TO_JSON` is called on an Entity, it may add other
@@ -463,7 +463,7 @@ after dispatch => sub {
 
     my $ctx = $self->model('MB')->context;
 
-    $ctx->connector->disconnect;
+    $ctx->connector->disconnect if $ctx->has_connector;
     $ctx->store->disconnect;
     $ctx->cache->disconnect;
 

--- a/lib/MusicBrainz/Server/Connector.pm
+++ b/lib/MusicBrainz/Server/Connector.pm
@@ -23,10 +23,18 @@ has 'sql' => (
     is => 'ro',
     default => sub {
         my $self = shift;
-        Sql->new( $self->conn );
+        my $sql = Sql->new( $self->conn );
+        $sql->read_only($self->read_only);
+        return $sql;
     },
     lazy => 1,
     clearer => '_clear_sql',
+);
+
+has 'read_only' => (
+    is => 'ro',
+    isa => 'Bool',
+    default => 0,
 );
 
 sub _build_conn

--- a/lib/MusicBrainz/Server/Connector.pm
+++ b/lib/MusicBrainz/Server/Connector.pm
@@ -11,6 +11,7 @@ has 'conn' => (
     handles    => [qw( dbh )],
     lazy_build => 1,
     clearer => '_clear_conn',
+    predicate => 'has_conn',
 );
 
 has 'database' => (
@@ -62,8 +63,8 @@ sub _build_conn
 
 sub _disconnect {
     my ($self) = @_;
-    if (my $conn = $self->conn) {
-        $conn->disconnect;
+    if ($self->has_conn) {
+        $self->conn->disconnect;
     }
 
     $self->_clear_conn;

--- a/lib/MusicBrainz/Server/Context.pm
+++ b/lib/MusicBrainz/Server/Context.pm
@@ -29,6 +29,7 @@ has 'connector' => (
     handles => [ 'dbh', 'sql', 'conn' ],
     lazy_build => 1,
     clearer => 'clear_connector',
+    predicate => 'has_connector',
 );
 
 has 'database' => (

--- a/lib/MusicBrainz/Server/Context.pm
+++ b/lib/MusicBrainz/Server/Context.pm
@@ -32,11 +32,15 @@ has 'connector' => (
     predicate => 'has_connector',
 );
 
+sub is_globally_read_only {
+    return DBDefs->DB_READ_ONLY || DBDefs->REPLICATION_TYPE == RT_MIRROR;
+}
+
 has 'database' => (
     is => 'rw',
     isa => 'Str',
     default => sub {
-        DBDefs->DB_READ_ONLY || DBDefs->REPLICATION_TYPE == RT_MIRROR
+        shift->is_globally_read_only
             ? 'READONLY'
             : 'READWRITE';
     },

--- a/lib/MusicBrainz/Server/Context.pm
+++ b/lib/MusicBrainz/Server/Context.pm
@@ -32,9 +32,49 @@ has 'connector' => (
     predicate => 'has_connector',
 );
 
+has 'ro_connector' => (
+    is => 'ro',
+    lazy_build => 1,
+    clearer => 'clear_ro_connector',
+    predicate => 'has_ro_connector',
+);
+
 sub is_globally_read_only {
     return DBDefs->DB_READ_ONLY || DBDefs->REPLICATION_TYPE == RT_MIRROR;
 }
+
+sub prefer_ro_connector {
+    my ($self) = @_;
+    # There are two cases where we cannot, or do not want to use the
+    # `ro_connector` (if available):
+    #  * Case 1:
+    #    There is a logged-in user. We want to ensure replication lag (no
+    #    matter how minimal) doesn't prevent just-applied edits from being
+    #    visible to them.
+    #  * Case 2:
+    #    We're in a current writable transaction. We should of course perform
+    #    our query in the same transaction for consistency and atomicity.
+    if (
+        (
+            defined $self->catalyst_context &&
+            $self->catalyst_context->user_exists
+        ) ||
+        (
+            $self->has_connector &&
+            $self->connector->sql->is_in_transaction
+        )
+    ) {
+        return $self->connector;
+    }
+    # `ro_connector` may be undef; see `_build_ro_connector`.
+    return $self->ro_connector // $self->connector;
+}
+
+sub prefer_ro_dbh { shift->prefer_ro_connector->dbh }
+
+sub prefer_ro_sql { shift->prefer_ro_connector->sql }
+
+sub prefer_ro_conn { shift->prefer_ro_connector->conn }
 
 has 'database' => (
     is => 'rw',
@@ -46,6 +86,14 @@ has 'database' => (
     },
     lazy => 1,
     clearer => 'clear_database',
+);
+
+has 'ro_database' => (
+    is => 'rw',
+    isa => 'Str',
+    default => sub { 'READONLY' },
+    lazy => 1,
+    clearer => 'clear_ro_database',
 );
 
 has 'fresh_connector' => (
@@ -68,6 +116,21 @@ sub _build_connector {
     }
 
     return $conn;
+}
+
+sub _build_ro_connector {
+    my $self = shift;
+
+    return unless (
+        DBDefs->USE_RO_DATABASE_CONNECTOR &&
+        !$self->is_globally_read_only
+    );
+
+    return DatabaseConnectionFactory->get_connection(
+        $self->ro_database,
+        fresh => $self->fresh_connector,
+        read_only => 1,
+    );
 }
 
 has 'models' => (
@@ -145,7 +208,37 @@ has 'max_request_time' => (
     isa => 'Maybe[Int]',
 );
 
+has 'catalyst_context' => (
+    is => 'rw',
+    isa => 'Maybe[MusicBrainz::Server]',
+    weak_ref => 1,
+);
+
 1;
+
+=head1 ATTRIBUTES
+
+=head2 ro_database
+
+String referencing a database name in C<DBDefs> that may be used to
+distribute read-only queries to PostgreSQL standby instance if
+`USE_RO_DATABASE_CONNECTOR` is enabled.
+
+=head2 ro_connector
+
+Connector (to `ro_database`) that may be used for read-only transactions.
+
+=head2 catalyst_context
+
+Provides access to the current Catalyst context. This should be used
+sparingly to avoid coupling the controller and data layers.
+
+=head1 METHODS
+
+=head2 prefer_ro_connector()
+
+Returns `ro_connector` unless `connector` is in a transaction, or unless
+there's a logged-in user.
 
 =head1 COPYRIGHT AND LICENSE
 

--- a/lib/MusicBrainz/Server/Data/Role/PendingEdits.pm
+++ b/lib/MusicBrainz/Server/Data/Role/PendingEdits.pm
@@ -14,8 +14,6 @@ role {
     my $params = shift;
     my $table = $params->table;
 
-    requires '_dbh';
-
     method 'adjust_edit_pending' => sub
     {
         my ($self, $adjust, @ids) = @_;

--- a/lib/MusicBrainz/Server/Data/Role/QueryToList.pm
+++ b/lib/MusicBrainz/Server/Data/Role/QueryToList.pm
@@ -16,7 +16,7 @@ sub query_to_list {
 
     map {
         $builder->($self, $_)
-    } @{ $self->c->sql->select_list_of_hashes($query, @$args) };
+    } @{ $self->c->prefer_ro_sql->select_list_of_hashes($query, @$args) };
 }
 
 sub query_to_list_limited {
@@ -77,7 +77,7 @@ sub query_to_list_limited {
         my $row = $_;
         $total_row_count = delete $row->{total_row_count};
         $builder->($self, $row);
-    } @{$self->c->sql->select_list_of_hashes($query, @args)};
+    } @{$self->c->prefer_ro_sql->select_list_of_hashes($query, @args)};
 
     if (!defined $hits) {
         $hits = ($total_row_count // 0) + ($offset // 0);

--- a/lib/MusicBrainz/Server/Data/Role/SelectAll.pm
+++ b/lib/MusicBrainz/Server/Data/Role/SelectAll.pm
@@ -9,7 +9,7 @@ parameter 'order_by' => (
 
 role
 {
-    requires '_columns', '_table', '_dbh', '_new_from_row', '_type';
+    requires '_columns', '_table', '_new_from_row', '_type';
 
     my $params = shift;
 

--- a/lib/MusicBrainz/Server/Data/Role/Sql.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Sql.pm
@@ -9,9 +9,4 @@ sub sql {
     return $self->c->sql;
 }
 
-sub _dbh
-{
-    shift->c->dbh;
-}
-
 1;

--- a/lib/MusicBrainz/Server/Data/Role/Sql.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Sql.pm
@@ -9,4 +9,8 @@ sub sql {
     return $self->c->sql;
 }
 
+sub ro_sql { shift->c->ro_connector->sql }
+
+sub prefer_ro_sql { shift->c->prefer_ro_sql }
+
 1;

--- a/lib/MusicBrainz/Server/Data/Statistics.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics.pm
@@ -2057,18 +2057,14 @@ sub recalculate {
     return if $definition->{NONREPLICATED} && DBDefs->REPLICATION_TYPE == RT_MIRROR;
     return if $definition->{PRIVATE} && DBDefs->REPLICATION_TYPE != RT_MASTER;
 
-    my $db = $definition->{DB} || 'READWRITE';
-    my $sql = $db eq 'READWRITE' ? $self->sql
-            : die "Unknown database: $db";
-
     if (my $query = $definition->{SQL}) {
-        my $value = $sql->select_single_value($query);
+        my $value = $self->sql->select_single_value($query);
                 $self->insert($output_file, $statistic => $value);
         return;
     }
 
     if (my $calculate = $definition->{CALC}) {
-        my $output = $calculate->($self, $sql);
+        my $output = $calculate->($self, $self->sql);
         if (ref($output) eq 'HASH')
         {
             $self->insert($output_file, %$output);

--- a/lib/MusicBrainz/Server/Data/Statistics.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics.pm
@@ -2064,7 +2064,7 @@ sub recalculate {
     }
 
     if (my $calculate = $definition->{CALC}) {
-        my $output = $calculate->($self, $self->sql);
+        my $output = $calculate->($self, $self->prefer_ro_sql);
         if (ref($output) eq 'HASH')
         {
             $self->insert($output_file, %$output);

--- a/lib/MusicBrainz/Server/Database.pm
+++ b/lib/MusicBrainz/Server/Database.pm
@@ -26,6 +26,12 @@ has 'port' => (
     is  => 'rw',
 );
 
+has 'read_only' => (
+    isa => 'Bool',
+    is  => 'rw',
+    default => 0,
+);
+
 sub shell_args
 {
     my $self = shift;

--- a/lib/MusicBrainz/Server/DatabaseConnectionFactory.pm
+++ b/lib/MusicBrainz/Server/DatabaseConnectionFactory.pm
@@ -48,6 +48,8 @@ sub get_connection
         $key eq 'PROD_STANDBY' ||
         $database->read_only
     ) {
+        # NOTE-ROFLAG-1: This is assumed in the READONLY fallback strategy
+        # below.
         $read_only = 1;
     }
 
@@ -87,6 +89,10 @@ sub get {
 
     unless (defined $database) {
         if ($name eq 'MAINTENANCE') {
+            $database = $databases{READWRITE};
+        } elsif ($name eq 'READONLY') {
+            # NOTE-ROFLAG-1: We still set the `read_only` flag in
+            # `get_connection` above.
             $database = $databases{READWRITE};
         } elsif ($name =~ /^SYSTEM_(.+)$/) {
             my $base_dbdef_key = $1;

--- a/lib/MusicBrainz/Server/DatabaseConnectionFactory.pm
+++ b/lib/MusicBrainz/Server/DatabaseConnectionFactory.pm
@@ -39,15 +39,13 @@ sub get_connection
     load_class($connector_class);
 
     my $database = $class->get($key);
+    confess "There is no configuration in DBDefs for database $key but one is required"
+        unless defined $database;
 
     if ($opts{fresh}) {
         return $connector_class->new( database => $database );
     } else {
-        $connections{ $key } ||= do {
-            confess "There is no configuration in DBDefs for database $key but one is required" unless defined($database);
-            $connector_class->new( database => $database );
-        };
-
+        $connections{ $key } ||= $connector_class->new( database => $database );
         return $connections{ $key };
     }
 }

--- a/lib/MusicBrainz/Server/DatabaseConnectionFactory.pm
+++ b/lib/MusicBrainz/Server/DatabaseConnectionFactory.pm
@@ -43,7 +43,11 @@ sub get_connection
         unless defined $database;
 
     my $read_only = 0;
-    if ($key eq 'READONLY' || $key eq 'PROD_STANDBY') {
+    if (
+        $key eq 'READONLY' ||
+        $key eq 'PROD_STANDBY' ||
+        $database->read_only
+    ) {
         $read_only = 1;
     }
 

--- a/lib/MusicBrainz/Server/DatabaseConnectionFactory.pm
+++ b/lib/MusicBrainz/Server/DatabaseConnectionFactory.pm
@@ -42,10 +42,21 @@ sub get_connection
     confess "There is no configuration in DBDefs for database $key but one is required"
         unless defined $database;
 
+    my $read_only = 0;
+    if ($key eq 'READONLY' || $key eq 'PROD_STANDBY') {
+        $read_only = 1;
+    }
+
     if ($opts{fresh}) {
-        return $connector_class->new( database => $database );
+        return $connector_class->new(
+            database => $database,
+            read_only => $read_only,
+        );
     } else {
-        $connections{ $key } ||= $connector_class->new( database => $database );
+        $connections{ $key } ||= $connector_class->new(
+            database => $database,
+            read_only => $read_only,
+        );
         return $connections{ $key };
     }
 }

--- a/lib/MusicBrainz/Server/DatabaseConnectionFactory.pm
+++ b/lib/MusicBrainz/Server/DatabaseConnectionFactory.pm
@@ -62,6 +62,11 @@ sub connector_class
     return $connector_class;
 }
 
+sub exists {
+    my ($class, $name) = @_;
+    return exists $databases{$name};
+}
+
 sub get {
     my ($class, $name) = @_;
 

--- a/lib/MusicBrainz/Server/DatabaseConnectionFactory.pm
+++ b/lib/MusicBrainz/Server/DatabaseConnectionFactory.pm
@@ -106,6 +106,14 @@ sub get {
             # NOTE-ROFLAG-1: We still set the `read_only` flag in
             # `get_connection` above.
             $database = $databases{READWRITE};
+        } elsif ($name =~ /^READONLY_(.+)$/) {
+            my $base_dbdef_key = $1;
+            my $base_db = $class->get($base_dbdef_key);
+            $database = $base_db->meta->clone_object(
+                $base_db,
+                read_only => 1,
+            );
+            $class->register_database($name, $database);
         } elsif ($name =~ /^SYSTEM_(.+)$/) {
             my $base_dbdef_key = $1;
             my $system = $class->get('SYSTEM');

--- a/lib/MusicBrainz/Server/EditQueue.pm
+++ b/lib/MusicBrainz/Server/EditQueue.pm
@@ -55,10 +55,11 @@ sub process_edits
     }
 
     my $sql = $self->c->sql;
+    my $ro_sql = $self->c->prefer_ro_sql;
 
     $self->log->debug("Selecting eligible edit IDs\n");
     my $interval = DateTime::Format::Pg->format_interval($MINIMUM_RESPONSE_PERIOD);
-    my $edit_ids = $sql->select_single_column_array('
+    my $edit_ids = $ro_sql->select_single_column_array('
         SELECT id
           FROM edit
                LEFT JOIN (

--- a/script/database_exists
+++ b/script/database_exists
@@ -14,10 +14,10 @@ if ($ARGV[0])
 {
     my $dbname = uc($ARGV[0]);
 
-    my $db = Databases->get($dbname);
     die "There is no configuration in DBDefs for database $dbname"
-        unless defined $db;
+        unless Databases->exists($dbname);
 
+    my $db = Databases->get($dbname);
     my $dbh = Databases->get_connection($dbname);
     $dbh->sql->quiet(1);
 


### PR DESCRIPTION
# Problem

We don't have any consistent way to make use of our standby for read-only queries; initially this was intended for background tasks (MBS-13337), but it could be used for all types of read-only server queries.

# Solution

This adds an `ro_connector` to the server context which is intended to be used to distribute read-only queries to our standby in production.

It requires a `READONLY` database configured. In production, `READONLY` will likely point to the `pgbouncer-any` (haproxy) service, which connects to either the primary or standby. `SET TRANSACTION READ ONLY` is always set on the `ro_connector` (which is desirable in case it connects to the primary).

It must be enabled via `USE_RO_DATABASE_CONNECTOR`; more information can be found in lib/DBDefs/Default.pm.

The `prefer_ro_*` methods were added to handle cases where use of the `ro_connector` depends on whether we're in an existing writable transaction. In that case we should use the existing writable connector for atomicity/consistency.

As a test, I've modified `query_to_list` and `query_to_list_limited` to use `$c->prefer_ro_sql`.

I've also made limited use of `prefer_ro_sql` in some background tasks (but not reports). More information about this can be found in MBS-13337.

# Testing

I have not tested this with a separate `READONLY` connector yet.