### PR TITLE
MBS-13557: Set a Referrer-Policy on login/register pages

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Account.pm
+++ b/lib/MusicBrainz/Server/Controller/Account.pm
@@ -602,6 +602,8 @@ sub register : Path('/register') ForbiddenOnMirrors RequireSSL DenyWhenReadonly 
 {
     my ($self, $c) = @_;
 
+    $c->res->header('Referrer-Policy' => 'strict-origin-when-cross-origin');
+
     if ($c->user_exists) {
         $c->response->redirect($c->uri_for_action('/user/profile',
                                                  [ $c->user->name ]));

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -189,6 +189,8 @@ sub login : Path('/login') ForbiddenOnMirrors RequireSSL SecureForm
 {
     my ($self, $c) = @_;
 
+    $c->res->header('Referrer-Policy' => 'strict-origin-when-cross-origin');
+
     if ($c->user_exists) {
         $c->redirect_back(fallback => $c->uri_for_action('/user/profile', [ $c->user->name ]));
         $c->detach;

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Login.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Login.pm
@@ -29,6 +29,7 @@ test all => sub {
 
     $mech->get_ok('https://localhost/login');
     html_ok($mech->content);
+    $mech->header_is('referrer-policy', 'strict-origin-when-cross-origin');
     $mech->submit_form( with_fields => { username => '', password => '' } );
     $mech->content_contains('Username field is required');
     $mech->content_contains('Password field is required');

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Register.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Register.pm
@@ -16,6 +16,7 @@ test 'Registering without verifying an email address' => sub {
     MusicBrainz::Server::Test->prepare_test_database($c, '+editor');
 
     $mech->get_ok('/register', 'Fetch registration page');
+    $mech->header_is('referrer-policy', 'strict-origin-when-cross-origin');
     $mech->submit_form( with_fields => {
         'register.username' => 'brand_new_editor',
         'register.password' => 'ıaa2',


### PR DESCRIPTION
# Problem

MBS-13557

# Solution

Set the `Referrer-Policy` header to `strict-origin-when-cross-origin` on these pages.

# Testing

Added some automated tests.