### PR TITLE
Reuse same 'view list' string everywhere

### DIFF
--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -305,15 +305,13 @@ const UserProfileInformation = ({
               <UserProfileProperty
                 name={addColonText(l('Authorized applications'))}
               >
-                {tokenCount}
-                {viewingOwnProfile ? (
-                  <>
-                    {' '}
-                    <a href="/account/applications" rel="nofollow">
-                      {bracketedText(l('see list'))}
-                    </a>
-                  </>
-                ) : null}
+                {viewingOwnProfile ? (exp.l(
+                  '{count} ({url|view list})',
+                  {
+                    count: tokenCount,
+                    url: '/account/applications',
+                  },
+                )) : tokenCount}
               </UserProfileProperty>
             ) : null}
 
@@ -321,15 +319,13 @@ const UserProfileInformation = ({
               <UserProfileProperty
                 name={addColonText(l('Developer applications'))}
               >
-                {applicationCount}
-                {viewingOwnProfile ? (
-                  <>
-                    {' '}
-                    <a href="/account/applications" rel="nofollow">
-                      {bracketedText(l('see list'))}
-                    </a>
-                  </>
-                ) : null}
+                {viewingOwnProfile ? (exp.l(
+                  '{count} ({url|view list})',
+                  {
+                    count: applicationCount,
+                    url: '/account/applications',
+                  },
+                )) : applicationCount}
               </UserProfileProperty>
             ) : null}
           </>


### PR DESCRIPTION
There's no great reason to have two strings, 'view list' and 'see list'. This was probably separate because we only show the count on viewingOwnProfile but there's no reason we can't just do like I do here instead. Suggested by @kellnerd.