### PR TITLE
MBS-13563: Italicize aliases and sort names in Autocomplete2

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2/formatters.js
+++ b/root/static/scripts/common/components/Autocomplete2/formatters.js
@@ -12,7 +12,7 @@ import * as React from 'react';
 import {stripAttributes} from '../../../edit/utility/linkPhrase.js';
 import {INSTRUMENT_ROOT_ID} from '../../constants.js';
 import {unwrapNl} from '../../i18n.js';
-import {commaOnlyListText} from '../../i18n/commaOnlyList.js';
+import commaOnlyList, {commaOnlyListText} from '../../i18n/commaOnlyList.js';
 import localizeLanguageName from '../../i18n/localizeLanguageName.js';
 import localizeLinkAttributeTypeDescription
   from '../../i18n/localizeLinkAttributeTypeDescription.js';
@@ -77,13 +77,13 @@ function formatGeneric(
           | PlaceT
           | ReleaseT
           | WorkT,
-  extraInfo: ?((Array<string>) => void),
+  extraInfo: ?((Array<React.MixedElement | string>) => void),
 ) {
   const name = formatName(entity);
-  const info = [];
+  const info: Array<React.MixedElement | string> = [];
 
   if (nonEmpty(entity.primaryAlias) && entity.primaryAlias !== name) {
-    info.push(entity.primaryAlias);
+    info.push(<i title={l('Primary alias')}>{entity.primaryAlias}</i>);
   }
 
   if (nonEmpty(entity.comment)) {
@@ -98,7 +98,7 @@ function formatGeneric(
     <>
       {name}
       {info.length ? (
-        showExtraInfo(bracketedText(commaOnlyListText(info)))
+        showExtraInfo(bracketed(commaOnlyList(info)))
       ) : null}
     </>
   );
@@ -115,8 +115,8 @@ function formatArtist(artist: ArtistT) {
     empty(artist.primaryAlias) &&
     isNonLatin(artist.name)
   ) {
-    extraInfo = (info: Array<string>) => {
-      info.unshift(sortName);
+    extraInfo = (info: Array<React.MixedElement | string>) => {
+      info.unshift(<i title={l('Sort name')}>{sortName}</i>);
     };
   }
 


### PR DESCRIPTION
# MBS-13563

Make the Autocomplete2 component italicize primary aliases and sort names to match d981ba8c4517's display of aliases in EntityLink for MBS-7646. Also add "Primary alias" and "Sort name" title text that gets shown on hover.

# Problem

It's hard to tell what's part of the disambiguation comment and what came from the primary alias or sort name in the rows displayed by the `Autocomplete2` component; it's all formatted as regular text.

# Solution

Wrap the primary alias and sort name in `<i>` elements, similar to how #3191 made `EntityLink` display primary aliases. Also add `Primary alias` and `Sort name` title text.

# Testing

Went to the add release page and checked that primary aliases and sort names are italicized when I search for artists with non-Latin entity names.