### PR TITLE
MBS-13562: Check editing unlimited strings

### DIFF
--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -854,6 +854,7 @@ sub TO_JSON {
         hide_merge_helper
         makes_no_changes
         new_edit_notes
+        overlong_string
     );
 
     my %stash;

--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -1097,7 +1097,8 @@ pieces of software accessing this data, and even to improve the data quality.
 Maximum number of bytes for a string to be indexable by Postgres.
 
 It is set to 2704, in order to prevent MBS-13555 from happening again,
-because Postgres actually fits up to three items on every page and
+because Postgres actually fits up to three items on every page
+following the btree method which is used by default and
 the block size is generally set to 8192 bytes when compiling Postgres.
 
 =back

--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -75,7 +75,7 @@ our @EXPORT_OK = (
         $LABEL_RENAME_LINK_TYPE
         $MAX_INITIAL_MEDIUMS $MAX_INITIAL_TRACKS
         $MAX_POSTGRES_INT $MAX_POSTGRES_BIGINT
-        $MAX_ONELINE_STRING_LENGTH
+        $MAX_ONELINE_STRING_LENGTH $MAX_POSTGRES_INDEXED_STRING_BYTES
         @FULL_TABLE_LIST
         @CORE_TABLE_LIST
         @DERIVED_TABLE_LIST
@@ -428,6 +428,7 @@ Readonly our $MAX_POSTGRES_INT => 2147483647;
 Readonly our $MAX_POSTGRES_BIGINT => 9223372036854775807;
 
 Readonly our $MAX_ONELINE_STRING_LENGTH => 1024;
+Readonly our $MAX_POSTGRES_INDEXED_STRING_BYTES => 2704;
 
 Readonly our $CONTACT_URL => 'https://metabrainz.org/contact'; # Converted to React/JSX at root/static/scripts/common/constants.js
 
@@ -1090,6 +1091,14 @@ legitimate examples have been found or are to be expected beyond this length.
 The main reason is to bring a reasonable bound for otherwise unlimited titles,
 not only to prevent index issues, but also to make it easier to use for other
 pieces of software accessing this data, and even to improve the data quality.
+
+=item $MAX_POSTGRES_INDEXED_STRING_BYTES
+
+Maximum number of bytes for a string to be indexable by Postgres.
+
+It is set to 2704, in order to prevent MBS-13555 from happening again,
+because Postgres actually fits up to three items on every page and
+the block size is generally set to 8192 bytes when compiling Postgres.
 
 =back
 

--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -75,6 +75,7 @@ our @EXPORT_OK = (
         $LABEL_RENAME_LINK_TYPE
         $MAX_INITIAL_MEDIUMS $MAX_INITIAL_TRACKS
         $MAX_POSTGRES_INT $MAX_POSTGRES_BIGINT
+        $MAX_ONELINE_STRING_LENGTH
         @FULL_TABLE_LIST
         @CORE_TABLE_LIST
         @DERIVED_TABLE_LIST
@@ -425,6 +426,8 @@ Readonly our $MAX_INITIAL_TRACKS => 100;
 
 Readonly our $MAX_POSTGRES_INT => 2147483647;
 Readonly our $MAX_POSTGRES_BIGINT => 9223372036854775807;
+
+Readonly our $MAX_ONELINE_STRING_LENGTH => 1024;
 
 Readonly our $CONTACT_URL => 'https://metabrainz.org/contact'; # Converted to React/JSX at root/static/scripts/common/constants.js
 
@@ -1072,6 +1075,21 @@ Row ID for the Deleted Artist entity
 =item $NOLABEL_ID, $NOLABEL_GID
 
 Row ID and GID for the special label "[no label]"
+
+=item $MAX_ONELINE_STRING_LENGTH
+
+Maximum number of characters for a one-line string that is otherwise unlimited
+in the database schema.
+
+It is set to 1024, initially in order to prevent MBS-13536 from happening
+again, because multiple-bytes characters in Postgres can take up to 4 bytes
+and the maximum size for the index type is affected by the block size which
+is generally set to 8192 bytes when compiling Postgres, and also because no
+legitimate examples have been found or are to be expected beyond this length.
+
+The main reason is to bring a reasonable bound for otherwise unlimited titles,
+not only to prevent index issues, but also to make it easier to use for other
+pieces of software accessing this data, and even to improve the data quality.
 
 =back
 

--- a/lib/MusicBrainz/Server/Controller.pm
+++ b/lib/MusicBrainz/Server/Controller.pm
@@ -80,6 +80,8 @@ sub _insert_edit {
             $c->stash(needs_disambiguation => 1);
         } elsif (ref($_) eq 'MusicBrainz::Server::Edit::Exceptions::DuplicateViolation') {
             $c->stash(duplicate_violation => 1);
+        } elsif (ref($_) eq 'MusicBrainz::Server::Edit::Exceptions::OverlongString') {
+            $c->stash(overlong_string => 1);
         } else {
             croak 'The edit could not be created. Exception (' . (ref ne '' ? ref : 'string') . '): ' . $_;
         }
@@ -199,7 +201,8 @@ sub edit_action
         if ($opts{redirect} && !$opts{no_redirect} &&
                 ($edit || !$c->stash->{makes_no_changes}) &&
                 !$c->stash->{needs_disambiguation} &&
-                !$c->stash->{duplicate_violation}) {
+                !$c->stash->{duplicate_violation} &&
+                !$c->stash->{overlong_string}) {
             $opts{redirect}->();
             $c->detach;
         }

--- a/lib/MusicBrainz/Server/Edit/Alias/Add.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Add.pm
@@ -22,6 +22,12 @@ role {
     with 'MusicBrainz::Server::Edit::Alias',
          "MusicBrainz::Server::Edit::$model",
          'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+         'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+            get_string => sub { shift->{name} },
+         },
+         'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+            get_string => sub { shift->{sort_name} },
+         },
          'MusicBrainz::Server::Edit::Role::DatePeriod';
 
     has data => (

--- a/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
@@ -21,6 +21,12 @@ extends 'MusicBrainz::Server::Edit::WithDifferences';
 with 'MusicBrainz::Server::Edit::Alias',
      'MusicBrainz::Server::Edit::CheckForConflicts',
      'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{new}{name} },
+     },
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{new}{sort_name} },
+     },
      'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 sub _alias_model { die 'Not implemented' }

--- a/lib/MusicBrainz/Server/Edit/Area/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Area/Create.pm
@@ -18,6 +18,9 @@ extends 'MusicBrainz::Server::Edit::Generic::Create';
 with 'MusicBrainz::Server::Edit::Role::Preview',
      'MusicBrainz::Server::Edit::Area',
      'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{name} },
+     },
      'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 sub edit_name { N_lp('Add area', 'edit type') }

--- a/lib/MusicBrainz/Server/Edit/Area/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Area/Edit.pm
@@ -26,6 +26,9 @@ extends 'MusicBrainz::Server::Edit::Generic::Edit';
 with 'MusicBrainz::Server::Edit::CheckForConflicts',
      'MusicBrainz::Server::Edit::Area',
      'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{new}{name} },
+     },
      'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 sub edit_name { N_lp('Edit area', 'edit type') }

--- a/lib/MusicBrainz/Server/Edit/Artist/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Create.pm
@@ -26,6 +26,12 @@ with 'MusicBrainz::Server::Edit::Role::Preview',
      'MusicBrainz::Server::Edit::Role::Insert',
      'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
      'MusicBrainz::Server::Edit::Role::CheckDuplicates',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{name} },
+     },
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{sort_name} },
+     },
      'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 sub edit_name { N_lp('Add artist', 'edit type') }

--- a/lib/MusicBrainz/Server/Edit/Artist/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Edit.pm
@@ -34,6 +34,12 @@ with 'MusicBrainz::Server::Edit::Artist',
      'MusicBrainz::Server::Edit::Role::ISNI',
      'MusicBrainz::Server::Edit::Role::DatePeriod',
      'MusicBrainz::Server::Edit::Role::CheckDuplicates',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{new}{name} },
+     },
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{new}{sort_name} },
+     },
      'MusicBrainz::Server::Edit::Role::AllowAmending' => {
         create_edit_type => $EDIT_ARTIST_CREATE,
         entity_type => 'artist',

--- a/lib/MusicBrainz/Server/Edit/Event/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Event/Create.pm
@@ -18,6 +18,9 @@ extends 'MusicBrainz::Server::Edit::Generic::Create';
 with 'MusicBrainz::Server::Edit::Role::Preview',
      'MusicBrainz::Server::Edit::Event',
      'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{name} },
+     },
      'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 sub edit_name { N_lp('Add event', 'edit type') }

--- a/lib/MusicBrainz/Server/Edit/Event/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Event/Edit.pm
@@ -35,6 +35,9 @@ with 'MusicBrainz::Server::Edit::CheckForConflicts',
         create_edit_type => $EDIT_EVENT_CREATE,
         entity_type => 'event',
      },
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{new}{name} },
+     },
      'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 sub edit_name { N_lp('Edit event', 'edit type') }

--- a/lib/MusicBrainz/Server/Edit/Exceptions.pm
+++ b/lib/MusicBrainz/Server/Edit/Exceptions.pm
@@ -14,6 +14,7 @@ use Exception::Class ( ## no critic 'ProhibitUnusedImport'
     'MusicBrainz::Server::Edit::Exceptions::NoLongerApplicable',
     'MusicBrainz::Server::Edit::Exceptions::Forbidden',
     'MusicBrainz::Server::Edit::Exceptions::NeedsDisambiguation',
+    'MusicBrainz::Server::Edit::Exceptions::OverlongString',
 );
 
 1;

--- a/lib/MusicBrainz/Server/Edit/Genre/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Genre/Create.pm
@@ -16,7 +16,10 @@ use aliased 'MusicBrainz::Server::Entity::Genre';
 extends 'MusicBrainz::Server::Edit::Generic::Create';
 with 'MusicBrainz::Server::Edit::Role::Preview',
      'MusicBrainz::Server::Edit::Genre',
-     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{name} },
+     };
 
 sub edit_name { N_lp('Add genre', 'edit type') }
 sub edit_type { $EDIT_GENRE_CREATE }

--- a/lib/MusicBrainz/Server/Edit/Genre/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Genre/Edit.pm
@@ -17,7 +17,10 @@ use aliased 'MusicBrainz::Server::Entity::Genre';
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
 with 'MusicBrainz::Server::Edit::CheckForConflicts',
      'MusicBrainz::Server::Edit::Genre',
-     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{new}{name} },
+     };
 
 sub edit_name { N_lp('Edit genre', 'edit type') }
 sub edit_type { $EDIT_GENRE_EDIT }

--- a/lib/MusicBrainz/Server/Edit/Instrument/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Instrument/Create.pm
@@ -15,7 +15,10 @@ use aliased 'MusicBrainz::Server::Entity::Instrument';
 extends 'MusicBrainz::Server::Edit::Generic::Create';
 with 'MusicBrainz::Server::Edit::Role::Preview',
      'MusicBrainz::Server::Edit::Instrument',
-     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{name} },
+     };
 
 sub edit_name { N_lp('Add instrument', 'edit type') }
 sub edit_type { $EDIT_INSTRUMENT_CREATE }

--- a/lib/MusicBrainz/Server/Edit/Instrument/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Instrument/Edit.pm
@@ -21,7 +21,10 @@ use aliased 'MusicBrainz::Server::Entity::Instrument';
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
 with 'MusicBrainz::Server::Edit::CheckForConflicts',
      'MusicBrainz::Server::Edit::Instrument',
-     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{new}{name} },
+     };
 
 sub edit_name { N_lp('Edit instrument', 'edit type') }
 sub edit_type { $EDIT_INSTRUMENT_EDIT }

--- a/lib/MusicBrainz/Server/Edit/Label/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Label/Create.pm
@@ -22,6 +22,9 @@ with 'MusicBrainz::Server::Edit::Role::Preview',
      'MusicBrainz::Server::Edit::Role::Insert',
      'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
      'MusicBrainz::Server::Edit::Role::CheckDuplicates',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{name} },
+     },
      'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 use aliased 'MusicBrainz::Server::Entity::Label';

--- a/lib/MusicBrainz/Server/Edit/Label/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Label/Edit.pm
@@ -33,6 +33,9 @@ with 'MusicBrainz::Server::Edit::Label',
      'MusicBrainz::Server::Edit::Role::ISNI',
      'MusicBrainz::Server::Edit::Role::DatePeriod',
      'MusicBrainz::Server::Edit::Role::CheckDuplicates',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{new}{name} },
+     },
      'MusicBrainz::Server::Edit::Role::AllowAmending' => {
         create_edit_type => $EDIT_LABEL_CREATE,
         entity_type => 'label',

--- a/lib/MusicBrainz/Server/Edit/Medium/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Create.pm
@@ -23,6 +23,9 @@ with 'MusicBrainz::Server::Edit::Role::Preview',
      'MusicBrainz::Server::Edit::Role::AllowAmending' => {
         create_edit_type => $EDIT_RELEASE_CREATE,
         entity_type => 'release',
+     },
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{name} },
      };
 
 use aliased 'MusicBrainz::Server::Entity::Release';

--- a/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
@@ -42,6 +42,9 @@ with 'MusicBrainz::Server::Edit::Role::Preview',
      'MusicBrainz::Server::Edit::Role::AllowAmending' => {
         create_edit_type => $EDIT_RELEASE_CREATE,
         entity_type => 'release',
+     },
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{new}{name} },
      };
 
 use aliased 'MusicBrainz::Server::Entity::Medium';

--- a/lib/MusicBrainz/Server/Edit/Place/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Place/Create.pm
@@ -21,7 +21,10 @@ with 'MusicBrainz::Server::Edit::Role::Preview',
      'MusicBrainz::Server::Edit::Place',
      'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
      'MusicBrainz::Server::Edit::Role::DatePeriod',
-     'MusicBrainz::Server::Edit::Role::CheckDuplicates';
+     'MusicBrainz::Server::Edit::Role::CheckDuplicates',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{name} },
+     };
 
 sub edit_name { N_lp('Add place', 'edit type') }
 sub edit_type { $EDIT_PLACE_CREATE }

--- a/lib/MusicBrainz/Server/Edit/Place/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Place/Edit.pm
@@ -38,7 +38,10 @@ with 'MusicBrainz::Server::Edit::CheckForConflicts',
         create_edit_type => $EDIT_PLACE_CREATE,
         entity_type => 'place',
      },
-     'MusicBrainz::Server::Edit::Role::CheckDuplicates';
+     'MusicBrainz::Server::Edit::Role::CheckDuplicates',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{new}{name} },
+     };
 
 sub edit_name { N_lp('Edit place', 'edit type') }
 sub edit_type { $EDIT_PLACE_EDIT }

--- a/lib/MusicBrainz/Server/Edit/Recording/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Recording/Create.pm
@@ -20,7 +20,10 @@ use aliased 'MusicBrainz::Server::Entity::Recording';
 extends 'MusicBrainz::Server::Edit::Generic::Create';
 with 'MusicBrainz::Server::Edit::Recording::RelatedEntities',
      'MusicBrainz::Server::Edit::Recording',
-     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{name} },
+     };
 
 sub edit_type { $EDIT_RECORDING_CREATE }
 sub edit_name { N_lp('Add standalone recording', 'edit type') }

--- a/lib/MusicBrainz/Server/Edit/Recording/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Recording/Edit.pm
@@ -33,6 +33,9 @@ with 'MusicBrainz::Server::Edit::Recording::RelatedEntities',
         create_edit_type => $EDIT_RECORDING_CREATE,
         entity_type => 'recording',
      },
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{new}{name} },
+     },
      'MusicBrainz::Server::Edit::Role::EditArtistCredit',
      'MusicBrainz::Server::Edit::Role::Preview',
      'MusicBrainz::Server::Edit::CheckForConflicts';

--- a/lib/MusicBrainz/Server/Edit/Release/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Create.pm
@@ -22,7 +22,10 @@ extends 'MusicBrainz::Server::Edit::Generic::Create';
 with 'MusicBrainz::Server::Edit::Role::Preview',
      'MusicBrainz::Server::Edit::Release::RelatedEntities',
      'MusicBrainz::Server::Edit::Release',
-     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{name} },
+     };
 
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 use aliased 'MusicBrainz::Server::Entity::Release';

--- a/lib/MusicBrainz/Server/Edit/Release/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Edit.pm
@@ -39,6 +39,9 @@ with 'MusicBrainz::Server::Edit::Role::EditArtistCredit',
      'MusicBrainz::Server::Edit::Role::AllowAmending' => {
         create_edit_type => $EDIT_RELEASE_CREATE,
         entity_type => 'release',
+     },
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{new}{name} },
      };
 
 use aliased 'MusicBrainz::Server::Entity::Release';

--- a/lib/MusicBrainz/Server/Edit/ReleaseGroup/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/ReleaseGroup/Create.pm
@@ -21,7 +21,10 @@ extends 'MusicBrainz::Server::Edit::Generic::Create';
 with 'MusicBrainz::Server::Edit::Role::Preview',
      'MusicBrainz::Server::Edit::ReleaseGroup::RelatedEntities',
      'MusicBrainz::Server::Edit::ReleaseGroup',
-     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{name} },
+     };
 
 use aliased 'MusicBrainz::Server::Entity::ReleaseGroup';
 

--- a/lib/MusicBrainz/Server/Edit/ReleaseGroup/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/ReleaseGroup/Edit.pm
@@ -35,6 +35,9 @@ with 'MusicBrainz::Server::Edit::ReleaseGroup::RelatedEntities',
         create_edit_type => $EDIT_RELEASEGROUP_CREATE,
         entity_type => 'release_group',
      },
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{new}{name} },
+     },
      'MusicBrainz::Server::Edit::Role::EditArtistCredit',
      'MusicBrainz::Server::Edit::Role::Preview';
 

--- a/lib/MusicBrainz/Server/Edit/Role/CheckOverlongString.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/CheckOverlongString.pm
@@ -1,0 +1,49 @@
+package MusicBrainz::Server::Edit::Role::CheckOverlongString;
+use MooseX::Role::Parameterized;
+use namespace::autoclean;
+use MusicBrainz::Server::Validation qw(
+    is_overlong_string
+);
+
+parameter get_string => ( isa => 'CodeRef', required => 1 );
+
+role {
+    my $params = shift;
+
+    after initialize => sub {
+        my ($self, %opts) = @_;
+
+        MusicBrainz::Server::Edit::Exceptions::OverlongString->throw
+            if is_overlong_string($params->get_string->($self->data));
+    };
+};
+
+1;
+
+=head1 NAME
+
+MusicBrainz::Server::Edit::Role::CheckOverlongString - check overlong string
+
+=head1 DESCRIPTION
+
+This role can be applied to edit types in order to add checking of string
+properties that can be of any length in the database schema (using unlimited
+C<VARCHAR> or C<TEXT>) but still have to hold in one line of limited length
+and to be indexable by Postgres. If any of these two conditions is unmet a
+L<MusicBrainz::Server::Edit::Exceptions::OverlongString> exception is raised
+causing the edit to not be created.
+
+To use this role, for each string property to be checked,
+you need to consume this role and provide the C<get_string> subroutine.
+
+String properties in array (such as tracks) have to be checked separately.
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2024 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Edit/Series/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Series/Create.pm
@@ -19,7 +19,10 @@ with 'MusicBrainz::Server::Edit::Role::Preview',
      },
      'MusicBrainz::Server::Edit::Role::Insert',
      'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
-     'MusicBrainz::Server::Edit::Role::CheckDuplicates';
+     'MusicBrainz::Server::Edit::Role::CheckDuplicates',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{name} },
+     };
 
 sub edit_name { N_lp('Add series', 'edit type') }
 sub edit_type { $EDIT_SERIES_CREATE }

--- a/lib/MusicBrainz/Server/Edit/Series/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Series/Edit.pm
@@ -24,7 +24,10 @@ with 'MusicBrainz::Server::Edit::Series',
         create_edit_type => $EDIT_SERIES_CREATE,
         entity_type => 'series',
      },
-     'MusicBrainz::Server::Edit::Role::CheckDuplicates';
+     'MusicBrainz::Server::Edit::Role::CheckDuplicates',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{new}{name} },
+     };
 
 sub edit_type { $EDIT_SERIES_EDIT }
 sub edit_name { N_lp('Edit series', 'edit type') }

--- a/lib/MusicBrainz/Server/Edit/Work/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/Create.pm
@@ -11,7 +11,10 @@ use MusicBrainz::Server::Translation qw( N_lp );
 extends 'MusicBrainz::Server::Edit::Generic::Create';
 with 'MusicBrainz::Server::Edit::Work::RelatedEntities',
      'MusicBrainz::Server::Edit::Work',
-     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{name} },
+     };
 
 use aliased 'MusicBrainz::Server::Entity::Work';
 

--- a/lib/MusicBrainz/Server/Edit/Work/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/Edit.pm
@@ -30,6 +30,9 @@ with 'MusicBrainz::Server::Edit::Work::RelatedEntities',
         create_edit_type => $EDIT_WORK_CREATE,
         entity_type => 'work',
      },
+     'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
+        get_string => sub { shift->{new}{name} },
+     },
      'MusicBrainz::Server::Edit::Role::ValueSet' => {
         prop_name => 'attributes',
         get_current => sub { shift->current_instance->attributes },

--- a/lib/MusicBrainz/Server/Exceptions.pm
+++ b/lib/MusicBrainz/Server/Exceptions.pm
@@ -16,6 +16,13 @@ extends 'MusicBrainz::Server::Exceptions::InvalidInput';
 
 has 'duplicates' => ( is => 'ro', isa => 'ArrayRef' );
 
+package MusicBrainz::Server::Exceptions::OverlongString;
+use Moose;
+use namespace::autoclean;
+extends 'MusicBrainz::Server::Exceptions::InvalidInput';
+
+has 'overlong' => ( is => 'ro', isa => 'ArrayRef[Str]' );
+
 package MusicBrainz::Server::Exceptions::DuplicateViolation;
 use Moose;
 use namespace::autoclean;

--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -17,6 +17,7 @@ use base 'Exporter';
         is_database_bigint_id
         is_database_indexable_string
         has_at_most_oneline_string_length
+        is_overlong_string
         is_guid
         trim_in_place
         is_valid_iswc
@@ -114,6 +115,15 @@ sub has_at_most_oneline_string_length {
     my $t = shift;
 
     length($t) <= $MAX_ONELINE_STRING_LENGTH;
+}
+
+sub is_overlong_string {
+    my $t = shift;
+
+    defined($t) && !(
+        has_at_most_oneline_string_length($t) &&
+        is_database_indexable_string($t)
+    );
 }
 
 sub is_guid

--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -15,6 +15,7 @@ use base 'Exporter';
         is_positive_integer
         is_database_row_id
         is_database_bigint_id
+        has_at_most_oneline_string_length
         is_guid
         trim_in_place
         is_valid_iswc
@@ -51,7 +52,10 @@ use List::AllUtils qw( any );
 use Encode qw( decode encode );
 use Scalar::Util qw( looks_like_number );
 use Text::Unaccent::PurePerl qw( unac_string_utf16 );
-use MusicBrainz::Server::Constants qw( $MAX_POSTGRES_INT $MAX_POSTGRES_BIGINT );
+use MusicBrainz::Server::Constants qw(
+    $MAX_POSTGRES_INT $MAX_POSTGRES_BIGINT
+    $MAX_ONELINE_STRING_LENGTH $MAX_POSTGRES_INDEXED_STRING_BYTES
+);
 use MusicBrainz::Server::Data::Utils qw(
     contains_number
     remove_lineformatting_characters
@@ -96,6 +100,12 @@ sub is_database_bigint_id {
     my $t = shift;
 
     is_positive_integer($t) and $t <= $MAX_POSTGRES_BIGINT;
+}
+
+sub has_at_most_oneline_string_length {
+    my $t = shift;
+
+    length($t) <= $MAX_ONELINE_STRING_LENGTH;
 }
 
 sub is_guid

--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -15,6 +15,7 @@ use base 'Exporter';
         is_positive_integer
         is_database_row_id
         is_database_bigint_id
+        is_database_indexable_string
         has_at_most_oneline_string_length
         is_guid
         trim_in_place
@@ -100,6 +101,13 @@ sub is_database_bigint_id {
     my $t = shift;
 
     is_positive_integer($t) and $t <= $MAX_POSTGRES_BIGINT;
+}
+
+sub is_database_indexable_string {
+    my $t = shift;
+
+    use bytes;
+    length($t) <= $MAX_POSTGRES_INDEXED_STRING_BYTES;
 }
 
 sub has_at_most_oneline_string_length {

--- a/root/layout.tt
+++ b/root/layout.tt
@@ -93,8 +93,8 @@
 
         [% IF overlong_string %]
         <div class="banner warning-header">
-            <p>[% l('Some text you entered is overlong, please fix the text or
-                     shorten it and use annotation for the full text instead.') %]</p>
+            <p>[% l('Some text you entered is overlong! Please shorten it,
+                     and if necessary enter the full text in the annotation for reference.') %]</p>
         </div>
         [% END %]
 

--- a/root/layout.tt
+++ b/root/layout.tt
@@ -91,6 +91,13 @@
         </div>
         [% END %]
 
+        [% IF overlong_string %]
+        <div class="banner warning-header">
+            <p>[% l('Some text you entered is overlong, please fix the text or
+                     shorten it and use annotation for the full text instead.') %]</p>
+        </div>
+        [% END %]
+
         [% IF c.sessionid.defined AND c.flash.message %]
             <div class="banner flash">
                 <p>

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -294,6 +294,17 @@ const Layout = ({
           </div>
         ) : null}
 
+        {$c.stash.overlong_string /*:: === true */ ? (
+          <div className="banner warning-header">
+            <p>
+              {l(
+                `Some text you entered is overlong, please fix the text or
+                 shorten it and use annotation for the full text instead.`,
+              )}
+            </p>
+          </div>
+        ) : null}
+
         {nonEmpty($c.sessionid) && nonEmpty($c.flash.message) ? (
           <div className="banner flash">
             <p dangerouslySetInnerHTML={{__html: $c.flash.message}} />

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -298,8 +298,9 @@ const Layout = ({
           <div className="banner warning-header">
             <p>
               {l(
-                `Some text you entered is overlong, please fix the text or
-                 shorten it and use annotation for the full text instead.`,
+                `Some text you entered is overlong! Please shorten it,
+                 and if necessary enter the full text in the annotation
+                 for reference.`,
               )}
             </p>
           </div>

--- a/root/types/catalyst.js
+++ b/root/types/catalyst.js
@@ -66,6 +66,7 @@ declare type CatalystStashT = {
   +new_edit_notes_mtime?: number | null,
   +number_of_collections?: number,
   +number_of_revisions?: number,
+  +overlong_string?: boolean,
   +own_collections?: $ReadOnlyArray<CollectionT>,
   +release_artwork?: ArtworkT,
   +release_artwork_count?: number,

--- a/t/lib/t/MusicBrainz/Server/Edit/Medium/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Medium/Edit.pm
@@ -1,4 +1,5 @@
 package t::MusicBrainz::Server::Edit::Medium::Edit;
+use utf8;
 use strict;
 use warnings;
 

--- a/t/lib/t/MusicBrainz/Server/Edit/Recording/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Recording/Edit.pm
@@ -14,6 +14,9 @@ BEGIN { use MusicBrainz::Server::Edit::Recording::Edit }
 use MusicBrainz::Server::Constants qw( $EDIT_RECORDING_EDIT );
 use MusicBrainz::Server::Test qw( accept_edit reject_edit );
 
+use aliased 'MusicBrainz::Server::Entity::ArtistCredit';
+use aliased 'MusicBrainz::Server::Entity::ArtistCreditName';
+
 test all => sub {
 
 my $test = shift;
@@ -145,6 +148,59 @@ test 'Submitting a recording edit with an undef comment' => sub {
     );
 
     ok !exception { $edit->accept }, 'accepted edit';
+};
+
+test 'Creating a recording edit with an overlong name (MBS-13555)' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+edit_recording');
+    my $recording = $c->model('Recording')->get_by_id(1);
+
+    my $exception = exception {
+        $c->model('Edit')->create(
+            edit_type => $EDIT_RECORDING_EDIT,
+            editor_id => 1,
+            to_edit => $recording,
+            name => ('𝄞𝄵𝅘𝅥𝅘𝅥𝅮𝅘𝅥𝅮𝅘𝅥𝅮𝄾𝅘𝅥𝄀𝅘𝅥𝅮𝅘𝅥𝅮𝅘𝅥𝅮𝄾𝆑𝅗𝅥𝄂' x 64),
+            comment => '',
+        );
+    };
+    ok (
+      defined $exception,
+      '1024 four-byte characters string is an overlong name for a recording',
+    );
+    isa_ok($exception, 'MusicBrainz::Server::Edit::Exceptions::OverlongString');
+};
+
+test 'Creating a recording edit with an overlong artist credit (MBS-13562)' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+edit_recording');
+    my $recording = $c->model('Recording')->get_by_id(1);
+
+    my $exception = exception {
+            $c->model('Edit')->create(
+                edit_type => $EDIT_RECORDING_EDIT,
+                editor_id => 1,
+                to_edit => $recording,
+                name => 'Recording',
+                comment => '',
+                artist_credit => ArtistCredit->new(
+                    names => [
+                        ArtistCreditName->new(
+                            name => 'ArtistCreditName',
+                            join_phrase => ('𝄞𝄵𝅘𝅥𝅘𝅥𝅮𝅘𝅥𝅮𝅘𝅥𝅮𝄾𝅘𝅥𝄀𝅘𝅥𝅮𝅘𝅥𝅮𝅘𝅥𝅮𝄾𝆑𝅗𝅥𝄂' x 64),
+                            artist => $c->model('Artist')->get_by_id(1),
+                        )]),
+            );
+    };
+    ok (
+      defined $exception,
+      '1024 four-byte characters string is an overlong artist credit for a recording',
+    );
+    isa_ok($exception, 'MusicBrainz::Server::Edit::Exceptions::OverlongString');
 };
 
 sub create_edit {

--- a/t/lib/t/MusicBrainz/Server/Edit/Recording/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Recording/Edit.pm
@@ -1,4 +1,5 @@
 package t::MusicBrainz::Server::Edit::Recording::Edit;
+use utf8;
 use strict;
 use warnings;
 

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -29,6 +29,7 @@ use MusicBrainz::Server::Validation qw(
     is_valid_partial_date
     is_database_row_id
     is_database_bigint_id
+    has_at_most_oneline_string_length
     is_valid_edit_note
 );
 
@@ -80,6 +81,13 @@ test 'Test is_database_bigint_id' => sub {
     ok(!is_database_bigint_id(9223372036854775808), '(max postgres bigint + 1) is not a bigint ID');
     ok(!is_database_bigint_id(0), 'zero is not a bigint ID');
     ok(!is_database_bigint_id(-1), 'negative integer is not a bigint ID');
+};
+
+test 'Test has_at_most_oneline_string_length' => sub {
+    ok(has_at_most_oneline_string_length(undef), 'undef has under one-line string length');
+    ok(has_at_most_oneline_string_length(''), '"" has under one-line string length');
+    ok(has_at_most_oneline_string_length('0123456789ABCDEF' x 64), '1024 characters string has one-line string length');
+    ok(!has_at_most_oneline_string_length(('0123456789ABCDEF' x 64) . '0'), '1025 characters string has over one-line string length');
 };
 
 test 'Test is_guid' => sub {

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -29,6 +29,7 @@ use MusicBrainz::Server::Validation qw(
     is_valid_partial_date
     is_database_row_id
     is_database_bigint_id
+    is_database_indexable_string
     has_at_most_oneline_string_length
     is_valid_edit_note
 );
@@ -81,6 +82,14 @@ test 'Test is_database_bigint_id' => sub {
     ok(!is_database_bigint_id(9223372036854775808), '(max postgres bigint + 1) is not a bigint ID');
     ok(!is_database_bigint_id(0), 'zero is not a bigint ID');
     ok(!is_database_bigint_id(-1), 'negative integer is not a bigint ID');
+};
+
+test 'Test is_database_indexable_string' => sub {
+    ok(is_database_indexable_string(undef), 'undef is an indexable string');
+    ok(is_database_indexable_string(''), '"" is an indexable string');
+    ok(is_database_indexable_string('0123456789ABCDEF' x 169), '2704 single-byte characters string is an indexable string');
+    ok(!is_database_indexable_string(('0123456789ABCDEF' x 169) . '0'), '2705 single-byte characters string is not an indexable string');
+    ok(!is_database_indexable_string('𝄞𝄵𝅘𝅥𝅘𝅥𝅮𝅘𝅥𝅮𝅘𝅥𝅮𝄾𝅘𝅥𝄀𝅘𝅥𝅮𝅘𝅥𝅮𝅘𝅥𝅮𝄾𝆑𝅗𝅥𝄂' x 64), '1024 four-byte characters string is not an indexable string');
 };
 
 test 'Test has_at_most_oneline_string_length' => sub {


### PR DESCRIPTION
# MBS-13562
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

See the commit messages for details.

The user interface has not been much updated for user-friendliness as this is an edge case.

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

Added automated:
* [x] unit tests for each validation subroutine
* [x] integration tests for each check implementation part (`Role::CheckOverlongString`, `Role::EditArtistCredit`, `Medium::Util`)

I didn’t add automated Selenium tests as there is no change to the user interface beyond the explanatory message.

Manually tested editing a sample database with:
* [x] creating/editing an artist with overlong name/sort name
* [x] creating/editing a recording with overlong name/artist credit join phrase
* [x] creating/editing a release with overlong name/artist credit join phrase
* [x] creating/editing a release with overlong track name/track artist credit join phrase

# Documenting
<!--
    List changes to the documentation, which can be placed in the WikiDoc pages,
    in this Git repository, in another repository, in the database...
-->

* [ ] Mention this edge case in the [Editing_FAQ page](https://wiki.musicbrainz.org/Editing_FAQ)
* [ ] Update the ticket according to the actual implementation.

# Further action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Deploy in production
2. Merge to master
3. Release beta
4. Make the updated Editing_FAQ page visible on MusicBrainz website
