### PR TITLE
MBS-13560: Sync `Entity::Artist` with beta

### DIFF
--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -11,6 +11,7 @@ use Data::Dumper;
 use Data::Page;
 use URI::Escape qw( uri_escape_utf8 );
 use List::AllUtils qw( any partition_by );
+use MusicBrainz::Server::Entity::Alias;
 use MusicBrainz::Server::Entity::Annotation;
 use MusicBrainz::Server::Entity::Area;
 use MusicBrainz::Server::Entity::AreaType;
@@ -738,6 +739,22 @@ sub schema_fixup
                     join_phrase => $namecredit->{joinphrase} || '' } );
         }
         $data->{'artist_credit'} = MusicBrainz::Server::Entity::ArtistCredit->new( { names => \@credits } );
+    }
+
+    if (defined $data->{aliases}) {
+        my @aliases = map {
+            MusicBrainz::Server::Entity::Alias->new(
+                name => $_->{name} // '',
+                sort_name => $_->{sort_name} // '',
+                locale => $_->{locale} // '',
+                primary_for_locale => $_->{primary},
+            )
+        } @{ $data->{aliases} };
+
+        # Save the new objects so validation will pass, but note that the search
+        # API doesn't include all attributes that are present in Entity::Alias,
+        # e.g. no IDs.
+        $data->{aliases} = \@aliases;
     }
 
     if ($type eq 'work') {

--- a/lib/MusicBrainz/Server/Entity/Artist.pm
+++ b/lib/MusicBrainz/Server/Entity/Artist.pm
@@ -25,6 +25,17 @@ has 'sort_name' => (
     isa => 'Str',
 );
 
+has 'aliases' => (
+    is => 'rw',
+    isa => 'ArrayRef[MusicBrainz::Server::Entity::Alias]',
+    default => sub { [] },
+);
+
+has 'primary_alias' => (
+    is => 'rw',
+    isa => 'Str',
+);
+
 has 'gender_id' => (
     is => 'rw',
     isa => 'Int',
@@ -82,6 +93,7 @@ around TO_JSON => sub {
         $self->begin_area ? (begin_area => $self->begin_area->TO_JSON) : (),
         $self->end_area ? (end_area => $self->end_area->TO_JSON) : (),
         $self->gender ? (gender => $self->gender->TO_JSON) : (),
+        $self->primary_alias ? (primaryAlias => $self->primary_alias) : (),
         begin_area_id => $self->begin_area_id,
         end_area_id => $self->end_area_id,
         gender_id => $self->gender_id,


### PR DESCRIPTION
# Problem

MBS-13560

`Entity::Artist` is missing a couple Moose attributes that were added to the beta code.  Entities that are cached on production but loaded on beta will be missing these, and cause beta to crash.

# Solution

The relevant changes have been synced from https://github.com/metabrainz/musicbrainz-server/commit/d981ba8c4517c88bb749119f12950cbac565dfe5.

# Testing

Just the existing automated tests.