### PR TITLE
MBS-13572 / MBS-13573: Don't break on more LiveNation and Ticketmaster links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5624,11 +5624,11 @@ const CLEANUPS: CleanupEntries = {
     )],
     restrict: [LINK_TYPES.ticketing],
     clean: function (url) {
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?ticketmaster\.((?:[a-z]{2,3}?\.)?[a-z]{2,4})\/(?:[\w-]+\/)?(artist|event|venue)\/(?:[\w-]+\/)?([0-9A-F]+).*$/, 'https://www.ticketmaster.$1/$2/$3');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?ticketmaster\.((?:[a-z]{2,3}?\.)?[a-z]{2,4})\/(?:[\w-]+\/)?(artist|event|venue)\/(?:[\w-]+\/)?(\w+).*$/, 'https://www.ticketmaster.$1/$2/$3');
       return url;
     },
     validate: function (url, id) {
-      const m = /^https:\/\/www\.ticketmaster\.(?:[a-z]{2,3}?\.)?[a-z]{2,4}\/(artist|event|venue)\/[0-9A-F]+$/.exec(url);
+      const m = /^https:\/\/www\.ticketmaster\.(?:[a-z]{2,3}?\.)?[a-z]{2,4}\/(artist|event|venue)\/\w+$/.exec(url);
       if (m) {
         const prefix = m[1];
         switch (id) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3697,14 +3697,14 @@ const CLEANUPS: CleanupEntries = {
     restrict: [LINK_TYPES.ticketing],
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?concerts\.livenation\.com\/(?:[\w\d-]+\/)?event\/([0-9A-F]+).*$/, 'https://concerts.livenation.com/event/$1');
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?livenation\.com\/(artist|event|venue)\/([0-9a-zA-Z]+).*$/, 'https://www.livenation.com/$1/$2');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?livenation\.com\/(artist|event|venue)\/([\w-]+).*$/, 'https://www.livenation.com/$1/$2');
       // International sites use somewhat different formats
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?livenation\.((?:[a-z]{2,3}?\.)?[a-z]{2,4})\/(show|venue)\/([0-9a-zA-Z]+).*$/, 'https://www.livenation.$1/$2/$3');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?livenation\.((?:[a-z]{2,3}?\.)?[a-z]{2,4})\/(show|venue)\/([\w-]+).*$/, 'https://www.livenation.$1/$2/$3');
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?livenation\.((?:[a-z]{2,3}?\.)?[a-z]{2,4})\/artist-[\w\d-]+-([0-9]+).*$/, 'https://www.livenation.$1/artist-$2');
       return url;
     },
     validate: function (url, id) {
-      let m = /^https:\/\/(concerts|www)\.livenation\.(?:[a-z]{2,3}?\.)?[a-z]{2,4}\/(artist|event|show|venue)\/[0-9a-zA-Z]+$/.exec(url);
+      let m = /^https:\/\/(concerts|www)\.livenation\.(?:[a-z]{2,3}?\.)?[a-z]{2,4}\/(artist|event|show|venue)\/[\w-]+$/.exec(url);
       if (!m) {
         m = /^https:\/\/(www)\.livenation\.(?:[a-z]{2,3}?\.)?[a-z]{2,4}\/(artist)-[0-9]+$/.exec(url);
       }

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3578,10 +3578,10 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['event'],
   },
   {
-                     input_url: 'https://www.livenation.com/event/vvG1YZ9E0hGPpD/the-smashing-pumpkins-the-world-is-a-vampire-tour',
+                     input_url: 'https://www.livenation.com/event/1A_Zkv-Gketafdb/conan-gray-found-heaven-on-tour',
              input_entity_type: 'event',
     expected_relationship_type: 'ticketing',
-            expected_clean_url: 'https://www.livenation.com/event/vvG1YZ9E0hGPpD',
+            expected_clean_url: 'https://www.livenation.com/event/1A_Zkv-Gketafdb',
        only_valid_entity_types: ['event'],
   },
   {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5571,6 +5571,13 @@ limited_link_type_combinations: ['downloadpurchase', 'mailorder'],
        only_valid_entity_types: ['event'],
   },
   {
+                     input_url: 'https://www.ticketmaster.com/event/Z7r9jZ1A7FeqE',
+             input_entity_type: 'event',
+    expected_relationship_type: 'ticketing',
+            expected_clean_url: 'https://www.ticketmaster.com/event/Z7r9jZ1A7FeqE',
+       only_valid_entity_types: ['event'],
+  },
+  {
                      input_url: 'https://www.ticketmaster.co.uk/pendulum-premium-package-suites-leeds-24-03-2024/event/1F005F0AFB9A3A6F',
              input_entity_type: 'event',
     expected_relationship_type: 'ticketing',


### PR DESCRIPTION
### Implement MBS-13572 / MBS-13573

# Problem
For LiveNation, I did not find links with `_` nor `-` when implementing this originally, but clearly they exist, as the example in the ticket (now added to the test) shows. We were breaking these with the cleanup. 

For Ticketmaster, there seems to be a second, less common type of links that can use all uppercase and lowercase letters in the IDs, which again I had not found when implementing this and was being rejected by the cleanup.

# Solution
Just accept `_` and `-` on LiveNation identifiers, and allow all of `\w` on Ticketmaster ones.

# Testing
Added the previously breaking example links to the automated tests.