### PR TITLE
MBS-13570: Avoid crash in artist collection load_related_info

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -125,7 +125,12 @@ sub show : Chained('load') PathPart('') {
     });
 
     if ($model->can('load_related_info')) {
-        $model->load_related_info(@$entities);
+        if ($entity_type eq 'artist') {
+            my $lang = $c->stash->{current_language} // 'en';
+            $model->load_related_info(\@$entities, $lang);
+        } else {
+            $model->load_related_info(@$entities);
+        }
     }
 
     if ($model->can('load_meta')) {


### PR DESCRIPTION
# MBS-13570

Make Controller::Collection pass an array ref rather than an array when calling Data::Artist's implementation of load_related_info.

Also pass the UI language so that localized primary aliases can be loaded for artists.

# Problem

`Controller::Collection` was using the same call signature for all entity types when calling `load_related_info`. d981ba8c4517c88bb749119f12950cbac565dfe5 made `Data::Artist`'s implementation take an array ref rather than an array, which caused a crash:

```
Not an ARRAY reference at lib/MusicBrainz/Server/Data/Artist.pm line 472. at lib/MusicBrainz/Server/Data/Artist.pm line 472
MusicBrainz::Server::Data::Artist::load_related_info(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) called at lib/MusicBrainz/Server/Controller/Collection.pm line 127
...
```

# Solution

Check the entity type and pass args accordingly. Also pass the UI language so that artists' localized primary aliases will be loaded and shown in collections.

I didn't see any other locations in the code with similar generic `load_related_info` calls. I think there are other `load_related_info` definitions with different signatures (e.g. `Data::Medium` and `Data::Track`), but I don't see any that can be placed in collections and thus would have a similar problem:

```
lib/MusicBrainz/Server/Data/Artist.pm:sub load_related_info {
lib/MusicBrainz/Server/Data/Artist.pm-    my ($self, $artists_ref, $user_lang) = @_;
--
lib/MusicBrainz/Server/Data/Event.pm:sub load_related_info {
lib/MusicBrainz/Server/Data/Event.pm-    my ($self, @events) = @_;
--
lib/MusicBrainz/Server/Data/Medium.pm:sub load_related_info {
lib/MusicBrainz/Server/Data/Medium.pm-    my ($self, $user_id, @mediums) = @_;
--
lib/MusicBrainz/Server/Data/Medium.pm:sub load_related_info_paged {
lib/MusicBrainz/Server/Data/Medium.pm-    my ($self, $user_id, $medium, $page) = @_;
--
lib/MusicBrainz/Server/Data/Release.pm:sub load_related_info {
lib/MusicBrainz/Server/Data/Release.pm-    my ($self, @entities) = @_;
--
lib/MusicBrainz/Server/Data/Track.pm:sub load_related_info {
lib/MusicBrainz/Server/Data/Track.pm-    my ($self, $user_id, @tracks) = @_;
--
lib/MusicBrainz/Server/Data/Work.pm:sub load_related_info {
lib/MusicBrainz/Server/Data/Work.pm-    my ($self, @works) = @_;
```

# Testing

Verified that artist collections can be viewed (both empty ones and ones containing artists) and that release collections also still work.