### PR TITLE
MBS-13559: Don't reject dailysomething Bandcamp pages

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1093,7 +1093,7 @@ const CLEANUPS: CleanupEntries = {
   },
   'bandcamp': {
     match: [new RegExp(
-      '^(https?://)?(((?!daily)[^/])+\\.)?bandcamp\\.com' +
+      '^(https?://)?(((?!daily\\.)[^/])+\\.)?bandcamp\\.com' +
       '(?!/(?:campaign|merch)/)',
       'i',
     )],
@@ -6970,7 +6970,7 @@ entitySpecificRules.release = function (url) {
 
 // Disallow non-daily Bandcamp URLs at release group level
 entitySpecificRules.release_group = function (url) {
-  if (/^(https?:\/\/)?(((?!daily)[^/])+\.)?bandcamp\.com/.test(url)) {
+  if (/^(https?:\/\/)?(((?!daily\.)[^/])+\.)?bandcamp\.com/.test(url)) {
     return {
       result: false,
       target: ERROR_TARGETS.ENTITY,

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -804,6 +804,13 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist', 'label'],
   },
   {
+                     input_url: 'https://dailythompsonband.bandcamp.com/',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'bandcamp',
+            expected_clean_url: 'https://dailythompsonband.bandcamp.com/',
+       only_valid_entity_types: ['artist', 'label'],
+  },
+  {
                      input_url: 'https://bandcamp.com/tag/ambient-noise-wall?tab=highlights',
              input_entity_type: 'genre',
     expected_relationship_type: 'bandcamp',


### PR DESCRIPTION
### Fix MBS-13559

# Problem
Our attempt to separate daily.bandcamp is a bit too eager and we are blocking any bandcamps by bands with names that start with "Daily". Whoops. Example given is https://dailythompsonband.bandcamp.com/

# Solution
Add a dot to the negative lookahead so we don't actually block anything else than `daily.`, which is what we want to use in the other rule.

# Testing
Added https://dailythompsonband.bandcamp.com/ to the automated tests.