### PR TITLE
MBS-13263: Align release titles despite indicators for cover art and data quality

### DIFF
--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -361,40 +361,63 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
   }
 
   if (showCaaPresence) {
-    if (entity.entityType === 'release' &&
-        entity.cover_art_presence === 'present') {
-      content = (
-        <React.Fragment key="caa">
-          <a href={'/release/' + entity.gid + '/cover-art'}>
+    if (entity.entityType === 'release') {
+      if (entity.cover_art_presence === 'present') {
+        content = (
+          <React.Fragment key="caa">
+            <a href={'/release/' + entity.gid + '/cover-art'}>
+              <span
+                className="caa-icon"
+                title={l('This release has artwork in the Cover Art Archive')}
+              />
+            </a>
+            {content}
+          </React.Fragment>
+        );
+      } else {
+        content = (
+          <React.Fragment key="caa">
             <span
-              className="caa-icon"
-              title={l('This release has artwork in the Cover Art Archive')}
+              className="blank-icon"
             />
-          </a>
-          {content}
-        </React.Fragment>
-      );
+            {content}
+          </React.Fragment>
+        );
+      }
     }
 
-    if (entity.entityType === 'release_group' && entity.hasCoverArt) {
-      content = (
-        <React.Fragment key="caa">
-          <span
-            className="caa-icon"
-            title={l(
-              'This release group has artwork in the Cover Art Archive',
-            )}
-          />
-          {content}
-        </React.Fragment>
-      );
+    if (entity.entityType === 'release_group') {
+      if (entity.hasCoverArt) {
+        content = (
+          <React.Fragment key="caa">
+            <span
+              className="caa-icon"
+              title={l(
+                'This release group has artwork in the Cover Art Archive',
+              )}
+            />
+            {content}
+          </React.Fragment>
+        );
+      } else {
+        content = (
+          <React.Fragment key="caa">
+            <span
+              className="blank-icon"
+            />
+            {content}
+          </React.Fragment>
+        );
+      }
     }
   }
+
 
   if (!hasSubPath && entity.entityType === 'release') {
     if (entity.quality === 2) {
       content = (
-        <>
+        <React.Fragment key="quality">
+          {content}
           <span
             className="high-data-quality"
             title={l(
@@ -402,12 +425,12 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
                including cover art with liner info that proves it`,
             )}
           />
-          {content}
-        </>
+        </React.Fragment>
       );
     } else if (entity.quality === 0) {
       content = (
         <React.Fragment key="quality">
+          {content}
           <span
             className="low-data-quality"
             title={l(
@@ -415,7 +438,6 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
                is hard to prove (but it’s not clearly fake)`,
             )}
           />
-          {content}
         </React.Fragment>
       );
     }

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -662,6 +662,14 @@ span.caa-icon {
     width: 18px;
 }
 
+span.blank-icon {
+    display: inline-block;
+    height: 18px;
+    padding-right: 5px;
+    vertical-align: bottom;
+    width: 18px;
+}
+
 span.video {
     background-image: data-uri('../images/icons/video.png');
     background-repeat: no-repeat;
@@ -676,7 +684,7 @@ span.video {
 
 span.high-data-quality {
     font-size: xx-small;
-    padding-right: 5px;
+    padding: 2px;
 }
 
 /* unicode large green circle U+1F7E2 */
@@ -686,7 +694,7 @@ span.high-data-quality::before {
 
 span.low-data-quality {
     font-size: xx-small;
-    padding-right: 5px;
+    padding: 2px;
 }
 
 /* unicode large orange circle U+1F7E0 */


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

This fixes [MBS-13263](https://tickets.metabrainz.org/browse/MBS-13263) - that releases without cover art were misaligned in release group listings. 

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This adds a blank space the size of the icon before releases without cover art, to align them properly. To do that, it also adds a `blank-icon` class. It also moves data quality indicators to the right


# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

I visually inspected the changes at `/release-group/6c08878c-d6a1-37b6-84c3-9566748545c1`, `/release-group/16a9cef3-b470-3ae1-bf10-cc04232d3e21` and `/artist/c0a1179b-b14a-4d68-a3c1-1fdab16ed602/releases` using the sample database. 


# Documenting
<!--
    List changes to the documentation, which can be placed in the WikiDoc pages,
    in this Git repository, in another repository, in the database...
-->

These changes should not impact the documentation.

# Further action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


