### PR TITLE
Add missing scripts required by JSON dumps/sitemaps

### DIFF
--- a/admin/cron/hourly-sitemaps.sh
+++ b/admin/cron/hourly-sitemaps.sh
@@ -14,13 +14,9 @@ cd "$MB_SERVER_ROOT"
 . ./admin/functions.sh
 make_temp_dir
 
-# Create a clean test database from which to dump foreign keys.
-export REPLICATION_TYPE=3 # RT_STANDALONE
-./script/create_test_db.sh TEST
-
 FK_DUMP="$TEMP_DIR"/foreign_keys
 ./script/dump_foreign_keys.pl \
-    --database TEST \
+    --database READONLY \
     --output "$FK_DUMP"
 
 ./admin/BuildIncrementalSitemaps.pl \

--- a/docker/templates/macros.m4
+++ b/docker/templates/macros.m4
@@ -283,7 +283,9 @@ copy_mb(``admin/ admin/'')
 copy_mb(``app.psgi entities.json entities.mjs ./'')
 copy_mb(``bin/ bin/'')
 copy_mb(``lib/ lib/'')
-copy_mb(``script/functions.sh script/git_info script/'')')
+copy_mb(``script/create_test_db.sh script/database_exists script/dump_foreign_keys.pl script/functions.sh script/git_info script/'')
+mkdir -p t/sql && \
+copy_mb(``t/sql/initial.sql t/sql/'')')
 
 m4_define(
     `git_info',


### PR DESCRIPTION
# Problems

* The hourly cron jobs for the JSON dumps and sitemaps are currently failing with:
   > ./script/create_test_db.sh: No such file or directory
* The sitemaps container connects to our main PostgreSQL cluster, which doesn't have access to a `musicbrainz_test` database configured in pg_hba.conf.

# Solution

* For the first problem, add this script to the Dockerfile. That's not the only script missing, though: we also need script/dump_foreign_keys.pl, plus script/database_exists and t/sql/initial.sql. (The latter two are required by create_test_db.sh.)
* For the second, use the `READONLY` database instead.

# Testing

I haven't tested building or deploying the image.