### PR TITLE
MBS-13579: Preserve existing release labels duplicated by seeded ones

### DIFF
--- a/root/static/scripts/release-editor/edits.js
+++ b/root/static/scripts/release-editor/edits.js
@@ -40,6 +40,11 @@ var newReleaseLabels = utils.withRelease(function (release) {
 
 const getReleaseLabel = x => String(x.release_label ?? '');
 
+const getReleaseLabelKey = (releaseLabel) => (
+  String(releaseLabel.label ?? '') + '\0' +
+  clean(releaseLabel.catalog_number)
+);
+
 releaseEditor.edits = {
 
   releaseGroup: function (release) {
@@ -106,10 +111,17 @@ releaseEditor.edits = {
 
   releaseLabel: function (release) {
     var newLabels = newReleaseLabels().map(MB.edit.fields.releaseLabel);
-    var oldLabels = release.labels.original();
+    var oldLabels = release.labels.original().slice(0);
 
-    var newLabelsByID = keyBy(newLabels, getReleaseLabel);
-    var oldLabelsByID = keyBy(oldLabels, getReleaseLabel);
+    const newLabelsByID = keyBy(
+      newLabels.filter((releaseLabel) => (
+        nonEmpty(getReleaseLabel(releaseLabel))
+      )),
+      getReleaseLabel,
+    );
+    const oldLabelsByID = keyBy(oldLabels, getReleaseLabel);
+    const newLabelsByKey = keyBy(newLabels, getReleaseLabelKey);
+    const oldLabelsByKey = keyBy(oldLabels, getReleaseLabelKey);
 
     var edits = [];
 
@@ -123,20 +135,57 @@ releaseEditor.edits = {
           // Edit ReleaseLabel
           edits.push(MB.edit.releaseEditReleaseLabel(newLabel));
         }
-      } else {
-        // Add ReleaseLabel
-        newLabel = {...newLabel};
+      } else if (!oldLabelsByKey.has(getReleaseLabelKey(newLabel))) {
+        /*
+         * If there's a removed release label with the same label or
+         * catalog number, we can edit rather than remove it.
+         */
+        let oldLabel;
+        let oldLabelIndex = -1;
 
-        if (newLabel.label || newLabel.catalog_number) {
-          newLabel.release = release.gid() || null;
-          edits.push(MB.edit.releaseAddReleaseLabel(newLabel));
+        if (newLabel.label) {
+          oldLabelIndex = oldLabels.findIndex(
+            (releaseLabel) => (
+              !newLabelsByKey.has(getReleaseLabelKey(releaseLabel)) &&
+              releaseLabel.label === newLabel.label
+            ),
+          );
+        }
+        if (oldLabelIndex < 0 && nonEmpty(newLabel.catalog_number)) {
+          oldLabelIndex = oldLabels.findIndex(
+            (releaseLabel) => (
+              !newLabelsByKey.has(getReleaseLabelKey(releaseLabel)) &&
+              releaseLabel.catalog_number === newLabel.catalog_number
+            ),
+          );
+        }
+        if (oldLabelIndex >= 0) {
+          oldLabel = oldLabels[oldLabelIndex];
+          oldLabels.splice(oldLabelIndex, 1);
+        }
+
+        if (oldLabel && !deepEqual(newLabel, oldLabel)) {
+          // Edit ReleaseLabel
+          edits.push(MB.edit.releaseEditReleaseLabel({
+            ...newLabel,
+            release_label: oldLabel.release_label,
+          }));
+        } else {
+          // Add ReleaseLabel
+          newLabel = {...newLabel};
+
+          if (newLabel.label || newLabel.catalog_number) {
+            newLabel.release = release.gid() || null;
+            edits.push(MB.edit.releaseAddReleaseLabel(newLabel));
+          }
         }
       }
     }
 
     for (let oldLabel of oldLabels) {
       const id = getReleaseLabel(oldLabel);
-      const newLabel = newLabelsByID.get(id);
+      const newLabel = newLabelsByID.get(id) ??
+        newLabelsByKey.get(getReleaseLabelKey(oldLabel));
 
       if (!newLabel || !(newLabel.label || newLabel.catalog_number)) {
         // Delete ReleaseLabel

--- a/root/static/scripts/tests/release-editor/seeds/mbs-13579-part1.html
+++ b/root/static/scripts/tests/release-editor/seeds/mbs-13579-part1.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <form action="/release/24d4159a-99d9-425d-a7b8-1b9ec0261a33/edit" method="POST">
+      <!-- Remove ISO Records -->
+      <!-- Add Columbia - 88875173862 -->
+      <input type="hidden" name="labels.0.mbid" value="011d1192-6f65-45bd-85c4-0400dd45693e" />
+      <input type="hidden" name="labels.0.catalog_number" value="88875173862" />
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>

--- a/root/static/scripts/tests/release-editor/seeds/mbs-13579-part2.html
+++ b/root/static/scripts/tests/release-editor/seeds/mbs-13579-part2.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <!-- This is intended to be run after mbs-13579-part1.html. -->
+    <form action="/release/24d4159a-99d9-425d-a7b8-1b9ec0261a33/edit" method="POST">
+      <!-- Add ISO Records -->
+      <!-- Preserve Columbia - 88875173862 -->
+      <input type="hidden" name="labels.0.mbid" value="10f97e56-1ebe-4b1e-848f-9c5ae0f292ec" />
+      <input type="hidden" name="labels.1.mbid" value="011d1192-6f65-45bd-85c4-0400dd45693e" />
+      <input type="hidden" name="labels.1.catalog_number" value="88875173862" />
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>

--- a/root/static/scripts/tests/release-editor/seeds/mbs-13579-part3.html
+++ b/root/static/scripts/tests/release-editor/seeds/mbs-13579-part3.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <!-- This is intended to be run after mbs-13579-part2.html. -->
+    <form action="/release/24d4159a-99d9-425d-a7b8-1b9ec0261a33/edit" method="POST">
+      <!-- Edit ISO Records (adding ISO-3103, seeding the label MBID) -->
+      <!-- Edit Columbia (with 88875173862-1, seeding only the label name) -->
+      <input type="hidden" name="labels.0.mbid" value="10f97e56-1ebe-4b1e-848f-9c5ae0f292ec" />
+      <input type="hidden" name="labels.0.catalog_number" value="ISO-3103" />
+      <input type="hidden" name="labels.1.name" value="Columbia" />
+      <input type="hidden" name="labels.1.catalog_number" value="88875173862-1" />
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>

--- a/root/static/scripts/tests/release-editor/seeds/mbs-13579-part4.html
+++ b/root/static/scripts/tests/release-editor/seeds/mbs-13579-part4.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <!-- This is intended to be run after mbs-13579-part3.html. -->
+    <form action="/release/24d4159a-99d9-425d-a7b8-1b9ec0261a33/edit" method="POST">
+      <!-- Preserve ISO Records - ISO-3103 (seeding only the label name) -->
+      <!-- Edit Columbia - 88875173862-1 (removing the label) -->
+      <input type="hidden" name="labels.0.name" value="ISO Records" />
+      <input type="hidden" name="labels.0.catalog_number" value="ISO-3103" />
+      <input type="hidden" name="labels.1.catalog_number" value="88875173862-1" />
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>

--- a/root/static/scripts/tests/release-editor/seeds/mbs-13579-part5.html
+++ b/root/static/scripts/tests/release-editor/seeds/mbs-13579-part5.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <!-- This is intended to be run after mbs-13579-part4.html. -->
+    <form action="/release/24d4159a-99d9-425d-a7b8-1b9ec0261a33/edit" method="POST">
+      <!-- Edit ISO Records - ISO-3103 (removing ISO-3103, seeding only the label name) -->
+      <!-- Add Columbia - 88875173862-2 -->
+      <!-- Edit 88875173862-1 (adding Columbia) -->
+      <input type="hidden" name="labels.0.name" value="ISO Records" />
+      <input type="hidden" name="labels.0.catalog_number" value="" />
+      <input type="hidden" name="labels.1.mbid" value="011d1192-6f65-45bd-85c4-0400dd45693e" />
+      <input type="hidden" name="labels.1.catalog_number" value="88875173862-2" />
+      <input type="hidden" name="labels.2.mbid" value="011d1192-6f65-45bd-85c4-0400dd45693e" />
+      <input type="hidden" name="labels.2.catalog_number" value="88875173862-1" />
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>

--- a/root/static/scripts/tests/release-editor/seeds/mbs-13579-part6.html
+++ b/root/static/scripts/tests/release-editor/seeds/mbs-13579-part6.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <!-- This is intended to be run after mbs-13579-part5.html. -->
+    <form action="/release/24d4159a-99d9-425d-a7b8-1b9ec0261a33/edit" method="POST">
+      <!-- Remove ISO Records -->
+      <!-- Edit Columbia - 88875173862-2 (removing 88875173862-2, seeding only the label name) -->
+      <input type="hidden" name="labels.0.name" value="Columbia" />
+      <input type="hidden" name="labels.0.catalog_number" value="" />
+      <input type="hidden" name="labels.1.mbid" value="011d1192-6f65-45bd-85c4-0400dd45693e" />
+      <input type="hidden" name="labels.1.catalog_number" value="88875173862-1" />
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>

--- a/root/types/release.js
+++ b/root/types/release.js
@@ -19,7 +19,7 @@ declare type ReleaseEventT = {
 declare type ReleaseLabelT = {
   +catalogNumber: string | null,
   +label: LabelT | null,
-  +label_id: number,
+  +label_id: number | null,
 };
 
 declare type ReleasePackagingT = OptionTreeT<'release_packaging'>;

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -714,6 +714,7 @@ const seleniumTests = [
   },
   {name: 'release-editor/MBS-13207.json5', login: true},
   {name: 'release-editor/MBS-13273.json5', login: true},
+  {name: 'release-editor/MBS-13579.json5', login: true},
   {
     name: 'Check_Duplicates.json5',
     login: true,

--- a/t/selenium/release-editor/MBS-13579.json5
+++ b/t/selenium/release-editor/MBS-13579.json5
@@ -1,0 +1,475 @@
+{
+  title: 'MBS-13579: Seeding release labels to an existing release',
+  commands: [
+    {
+      command: 'open',
+      target: '/static/scripts/tests/release-editor/seeds/mbs-13579-part1.html',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#edit-note']",
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'id=enter-edit',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 1,
+      value: {
+        type: 34,
+        status: 2,
+        data: {
+          catalog_number: "88875173862",
+          entity_id: 1,
+          label: {
+            gid: "011d1192-6f65-45bd-85c4-0400dd45693e",
+            id: 235,
+            name: "Columbia",
+          },
+          release: {
+            gid: "24d4159a-99d9-425d-a7b8-1b9ec0261a33",
+            id: 1693299,
+            name: "★",
+          },
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 2,
+      value: {
+        type: 36,
+        status: 2,
+        data: {
+          catalog_number: "",
+          label: {
+            gid: "10f97e56-1ebe-4b1e-848f-9c5ae0f292ec",
+            id: 62565,
+            name: "ISO Records",
+          },
+          release: {
+            gid: "24d4159a-99d9-425d-a7b8-1b9ec0261a33",
+            id: 1693299,
+            name: "★",
+          },
+          release_label_id: 1237936,
+        },
+      },
+    },
+    {
+      command: 'open',
+      target: '/static/scripts/tests/release-editor/seeds/mbs-13579-part2.html',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#edit-note']",
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'id=enter-edit',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 3,
+      value: {
+        type: 34,
+        status: 2,
+        data: {
+          catalog_number: null,
+          entity_id: 2,
+          label: {
+            gid: "10f97e56-1ebe-4b1e-848f-9c5ae0f292ec",
+            id: 62565,
+            name: "ISO Records",
+          },
+          release: {
+            gid: "24d4159a-99d9-425d-a7b8-1b9ec0261a33",
+            id: 1693299,
+            name: "★",
+          },
+        },
+      },
+    },
+    {
+      command: 'open',
+      target: '/static/scripts/tests/release-editor/seeds/mbs-13579-part3.html',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=label-1',
+      value: '011d1192-6f65-45bd-85c4-0400dd45693e',
+    },
+    {
+      command: 'fireEvent',
+      target: 'id=label-0',
+      value: 'input',
+    },
+    {
+      command: 'pause',
+      target: 1000,
+      value: '',
+    },
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#edit-note']",
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'id=enter-edit',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 4,
+      value: {
+        type: 37,
+        status: 2,
+        data: {
+          new: {
+            catalog_number: "ISO-3103",
+          },
+          old: {
+            catalog_number: null,
+            label: {
+              gid: "10f97e56-1ebe-4b1e-848f-9c5ae0f292ec",
+              id: 62565,
+              name: "ISO Records",
+            },
+          },
+          release: {
+            barcode: "888751738621",
+            events: [],
+            gid: "24d4159a-99d9-425d-a7b8-1b9ec0261a33",
+            id: 1693299,
+            medium_formats: ["CD"],
+            name: "★",
+          },
+          release_label_id: 2,
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 5,
+      value: {
+        type: 37,
+        status: 2,
+        data: {
+          new: {
+            catalog_number: "88875173862-1",
+          },
+          old: {
+            catalog_number: "88875173862",
+            label: {
+              gid: "011d1192-6f65-45bd-85c4-0400dd45693e",
+              id: 235,
+              name: "Columbia",
+            },
+          },
+          release: {
+            barcode: "888751738621",
+            events: [],
+            gid: "24d4159a-99d9-425d-a7b8-1b9ec0261a33",
+            id: 1693299,
+            medium_formats: ["CD"],
+            name: "★",
+          },
+          release_label_id: 1,
+        },
+      },
+    },
+    {
+      command: 'open',
+      target: '/static/scripts/tests/release-editor/seeds/mbs-13579-part4.html',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=label-0',
+      value: '10f97e56-1ebe-4b1e-848f-9c5ae0f292ec',
+    },
+    {
+      command: 'fireEvent',
+      target: 'id=label-0',
+      value: 'input',
+    },
+    {
+      command: 'pause',
+      target: 1000,
+      value: '',
+    },
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#edit-note']",
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'id=enter-edit',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 6,
+      value: {
+        type: 37,
+        status: 2,
+        data: {
+          new: {
+            label: null,
+          },
+          old: {
+            catalog_number: "88875173862-1",
+            label: {
+              gid: "011d1192-6f65-45bd-85c4-0400dd45693e",
+              id: 235,
+              name: "Columbia",
+            },
+          },
+          release: {
+            barcode: "888751738621",
+            events: [],
+            gid: "24d4159a-99d9-425d-a7b8-1b9ec0261a33",
+            id: 1693299,
+            medium_formats: ["CD"],
+            name: "★",
+          },
+          release_label_id: 1,
+        },
+      },
+    },
+    {
+      command: 'open',
+      target: '/static/scripts/tests/release-editor/seeds/mbs-13579-part5.html',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=label-0',
+      value: '10f97e56-1ebe-4b1e-848f-9c5ae0f292ec',
+    },
+    {
+      command: 'fireEvent',
+      target: 'id=label-0',
+      value: 'input',
+    },
+    {
+      command: 'pause',
+      target: 1000,
+      value: '',
+    },
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#edit-note']",
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'id=enter-edit',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 7,
+      value: {
+        type: 37,
+        status: 2,
+        data: {
+          new: {
+            catalog_number: null,
+          },
+          old: {
+            catalog_number: "ISO-3103",
+            label: {
+              gid: "10f97e56-1ebe-4b1e-848f-9c5ae0f292ec",
+              id: 62565,
+              name: "ISO Records",
+            },
+          },
+          release: {
+            barcode: "888751738621",
+            events: [],
+            gid: "24d4159a-99d9-425d-a7b8-1b9ec0261a33",
+            id: 1693299,
+            medium_formats: ["CD"],
+            name: "★",
+          },
+          release_label_id: 2,
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 8,
+      value: {
+        type: 34,
+        status: 2,
+        data: {
+          catalog_number: "88875173862-2",
+          entity_id: 3,
+          label: {
+            gid: "011d1192-6f65-45bd-85c4-0400dd45693e",
+            id: 235,
+            name: "Columbia",
+          },
+          release: {
+            gid: "24d4159a-99d9-425d-a7b8-1b9ec0261a33",
+            id: 1693299,
+            name: "★",
+          },
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 9,
+      value: {
+        type: 37,
+        status: 2,
+        data: {
+          new: {
+            label: {
+              gid: "011d1192-6f65-45bd-85c4-0400dd45693e",
+              id: 235,
+              name: "Columbia",
+            },
+          },
+          old: {
+            catalog_number: "88875173862-1",
+            label: null,
+          },
+          release: {
+            barcode: "888751738621",
+            events: [],
+            gid: "24d4159a-99d9-425d-a7b8-1b9ec0261a33",
+            id: 1693299,
+            medium_formats: ["CD"],
+            name: "★",
+          },
+          release_label_id: 1,
+        },
+      },
+    },
+    {
+      command: 'open',
+      target: '/static/scripts/tests/release-editor/seeds/mbs-13579-part6.html',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=label-0',
+      value: '011d1192-6f65-45bd-85c4-0400dd45693e',
+    },
+    {
+      command: 'fireEvent',
+      target: 'id=label-0',
+      value: 'input',
+    },
+    {
+      command: 'pause',
+      target: 1000,
+      value: '',
+    },
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#edit-note']",
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'id=enter-edit',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 10,
+      value: {
+        type: 37,
+        status: 2,
+        data: {
+          new: {
+            catalog_number: null,
+          },
+          old: {
+            catalog_number: "88875173862-2",
+            label: {
+              gid: "011d1192-6f65-45bd-85c4-0400dd45693e",
+              id: 235,
+              name: "Columbia",
+            },
+          },
+          release: {
+            barcode: "888751738621",
+            events: [],
+            gid: "24d4159a-99d9-425d-a7b8-1b9ec0261a33",
+            id: 1693299,
+            medium_formats: ["CD"],
+            name: "★",
+          },
+          release_label_id: 3,
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 11,
+      value: {
+        type: 36,
+        status: 2,
+        data: {
+          catalog_number: null,
+          label: {
+            gid: "10f97e56-1ebe-4b1e-848f-9c5ae0f292ec",
+            id: 62565,
+            name: "ISO Records",
+          },
+          release: {
+            gid: "24d4159a-99d9-425d-a7b8-1b9ec0261a33",
+            id: 1693299,
+            name: "★",
+          },
+          release_label_id: 2,
+        },
+      },
+    },
+  ],
+}

--- a/t/sql/selenium.sql
+++ b/t/sql/selenium.sql
@@ -101,9 +101,11 @@ INSERT INTO iso_3166_2 (area, code) VALUES
     (3813, 'GB-CRF');
 
 INSERT INTO label (id, gid, name, begin_date_year, begin_date_month, begin_date_day, end_date_year, end_date_month, end_date_day, label_code, type, area, comment, edits_pending, last_updated, ended) VALUES
+    (235, '011d1192-6f65-45bd-85c4-0400dd45693e',  'Columbia', 1887, NULL, NULL, NULL, NULL, NULL, 162, 9, 222, 'Sony Music, worldwide except JP; formerly owned by CBS between 1938–1990 within US/CA/MX', 0, '2022-12-29 22:00:37.139371+00', 'f'),
     (399, '4b5cba06-6a79-454c-91f5-3fe220d4950d', 'Nothing Records', 1992, NULL, NULL, 2004, NULL, NULL, NULL, 4, 222, 'US industrial/electronic founded by Trent Reznor', 0, '2012-05-15 19:04:49.109476+00', 'f'),
     (403, 'c9117237-b78b-4e47-b452-c9d94fb34916', 'TVT Records', 1985, NULL, NULL, 2008, 6, NULL, NULL, 4, 222, '', 0, '2012-08-30 19:40:44.521006+00', 't'),
-    (620, '2182a316-c4bd-4605-936a-5e2fac52bdd2', 'Interscope Records', 1990, NULL, NULL, NULL, NULL, NULL, 6406, 4, 222, '', 0, '2013-06-10 22:00:24.33737+00', 'f');
+    (620, '2182a316-c4bd-4605-936a-5e2fac52bdd2', 'Interscope Records', 1990, NULL, NULL, NULL, NULL, NULL, 6406, 4, 222, '', 0, '2013-06-10 22:00:24.33737+00', 'f'),
+    (62565, '10f97e56-1ebe-4b1e-848f-9c5ae0f292ec', 'ISO Records', NULL, NULL, NULL, NULL, NULL, NULL, 5534, 4, NULL, '', 0, '2012-06-22 15:01:56.439741+00', 'f');
 
 INSERT INTO label_gid_redirect (gid, new_id, created) VALUES
     ('8122a316-c4bd-936a-4605-5e2fac52bdd2', 620, '2012-04-09 20:07:05.161415+00');
@@ -152,6 +154,9 @@ INSERT INTO release (id, gid, name, artist_credit, release_group, status, packag
     (26, 'dd245091-b21e-48a3-b59a-f9b8ed8a0469', 'Demons', 20211, 94299, 1, NULL, 120, 28, NULL, '', -1),
     (1693299, '24d4159a-99d9-425d-a7b8-1b9ec0261a33', '★', 956, 1581583, 1, 3, 120, 28, '888751738621', '', -1),
     (2154808, '1bda2f85-0576-4077-b3fa-0fc939079b61', 'Weapons of Mass Seduction', 2196047, 1954919, 1, NULL, 120, 28, NULL, '', -1);
+
+INSERT INTO release_label (id, release, label, catalog_number, last_updated) VALUES
+    (1237936, 1693299, 62565, '', '2016-01-26 21:00:23.940303+00');
 
 INSERT INTO medium (id, release, position, format, name, edits_pending, last_updated, track_count) VALUES
     (1690850, 1693299, 1, 1, '', 0, '2015-05-18 20:20:39.009738+00', 0),


### PR DESCRIPTION
# Problem

MBS-13579

Prior to this commit, if you seeded a release label to an existing release that duplicated an existing release label on that release, the release editor would throw an error upon submission, as it would be trying to submit data that already exists.

# Solution

This patch preserves the existing release label (and its database row ID), discarding the seeded one. Note that a "release label" is a label and catalog number pair, meaning the catalog number is included for de-duplication purposes.

The ticket presents three use cases. The first one is still possible, the second one is still impossible, and the third one is now possible. An alternative implementation would be to concatenate the seeded release labels with the existing ones (discarding any duplicates, like here), and adding a `removed` field to allow removing existing release labels. However, you'd need to know the label IDs (and associated catalog numbers) of the release labels you'd like to remove in advance, which isn't currently a requirement: it becomes harder to replace all of the existing release labels with a new set.

There is one additional feature this commit implements: if you seed a release label, and there already exists one on the release with the same label (but different catalog number), we will edit the existing release label with the new catalog number. The same is true if the catalog number matches but not the label (but label matches are always preferred). An exception to this is if the existing release label is being preserved by the seeded parameters.

# Testing

Added a new Selenium test.