### PR TITLE
MBS-13584: Fix installing language packs in deployment

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -460,6 +460,7 @@ If you intend to run a server with translations, there are a few steps to follow
 
 5.  Add the languages to `MB_LANGUAGES` in DBDefs.pm. These should be formatted
     {lang}-{country}, such as 'es', or 'fr-ca', in a space-separated list.
+    The corresponding language packs must be installed.
 
 6.  Ensure you have a system locale for any languages you want to use. For many
     languages, this will suffice:

--- a/docker/templates/macros.m4
+++ b/docker/templates/macros.m4
@@ -252,7 +252,7 @@ m4_define(`with_beta_translations', m4_ifelse(GIT_BRANCH, `beta', 1, GIT_BRANCH,
 m4_define(`with_test_translations', m4_ifelse(GIT_BRANCH, `test', 1, 0))
 m4_define(
     `mbs_translations_deps',
-    `m4_dnl
+    `m4_dnl NOTE-LANGUAGES-1: These language packs must match the definition(s) of MB_LANGUAGES in deployment.
 gettext
 git
 language-pack-de

--- a/docker/templates/macros.m4
+++ b/docker/templates/macros.m4
@@ -248,22 +248,37 @@ RUN useradd --create-home --shell /bin/bash musicbrainz
 WORKDIR MBS_ROOT
 RUN chown_mb(`MBS_ROOT')')
 
+m4_define(`with_beta_translations', m4_ifelse(GIT_BRANCH, `beta', 1, GIT_BRANCH, `test', 1, 0))
+m4_define(`with_test_translations', m4_ifelse(GIT_BRANCH, `test', 1, 0))
 m4_define(
     `mbs_translations_deps',
     `m4_dnl
 gettext
 git
 language-pack-de
+language-pack-fr
+language-pack-it
+language-pack-nl
+m4_ifelse(with_beta_translations, 1, `m4_dnl
 language-pack-el
 language-pack-es
 language-pack-et
 language-pack-fi
-language-pack-fr
 language-pack-he
-language-pack-it
 language-pack-ja
-language-pack-nl
-language-pack-sq
+language-pack-sq')
+m4_ifelse(with_test_translations, 1, `m4_dnl
+language-pack-da
+language-pack-eo
+language-pack-hr
+language-pack-nb
+language-pack-oc
+language-pack-pl
+language-pack-ru
+language-pack-sv
+language-pack-tr
+language-pack-zh-hans
+language-pack-zh-hant')
 make
 ')
 

--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -384,6 +384,8 @@ sub WEB_SERVER                { 'www.musicbrainz.example.com' }
 # Please activate the officially approved languages here. Not every .po
 # file is active because we might have fully translated languages which
 # are not yet properly supported, like right-to-left languages
+#
+# The corresponding language packs must be installed; See NOTE-LANGUAGES-1
 # sub MB_LANGUAGES {qw()}
 
 # Should the site fall back to browser settings when trying to set a language

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -382,6 +382,8 @@ sub STAT_TTL { shift->DEVELOPMENT_SERVER() ? undef : 1200 }
 # Please activate the officially approved languages here. Not every .po
 # file is active because we might have fully translated languages which
 # are not yet properly supported, like right-to-left languages
+#
+# The corresponding language packs must be installed; See NOTE-LANGUAGES-1
 sub MB_LANGUAGES {qw()}
 
 # Should the site fall back to browser settings when trying to set a language


### PR DESCRIPTION
# Problem MBS-13584
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

_When switching to a language on test server to the one that's not officially supported yet it stayed with English._

This was due to some missing language packs for the test instance.

Actually, the installed language packs were matching translations in beta, even for the main instance.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

* Install extra languages packs only if `GIT_BRANCH` matches either `beta` or `test`.
  * It installs all the missing language packs for test.mb.o.
  * It installs only the needed language packs for the main mb.o.
* Add a NOTE anchor for reference from our deployment repository about keeping it in sync.

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

Installed additional language packs in the `test` branch, and it resolved the issue at https://test.musicbrainz.org.

Tested the macros locally by changing either `beta` or `test` to `fix-language-packs` and running `make -C docker config`.


# Further action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

If merged, document the need to keep these lists in sync with `MB_LANGUAGES` in our deployment repository, using a reference to the anchor `NOTE-LANGUAGES-1`.