### PR TITLE
MBS-13577 / MBS-13578: Release filtering for missing data

### DIFF
--- a/lib/MusicBrainz/Server/Form/Filter/Release.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Release.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use HTML::FormHandler::Moose;
 use MusicBrainz::Server::Data::Utils qw( non_empty );
-use MusicBrainz::Server::Translation qw( l );
+use MusicBrainz::Server::Translation qw( l lp );
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 
 extends 'MusicBrainz::Server::Form::Filter::Generic';
@@ -68,6 +68,7 @@ sub options_artist_credit_id {
 sub options_country_id {
     my ($self, $field) = @_;
     return [
+        { value => '-1', label => lp('[none]', 'release country') },
         map +{ value => $_->id, label => $_->name },
         @{ $self->countries },
     ];
@@ -76,6 +77,7 @@ sub options_country_id {
 sub options_label_id {
     my ($self, $field) = @_;
     return [
+        { value => '-1', label => lp('[none]', 'release label') },
         map +{ value => $_->id, label => $_->name },
         @{ $self->labels },
     ];
@@ -84,6 +86,7 @@ sub options_label_id {
 sub options_status_id {
     my ($self, $field) = @_;
     return [
+        { value => '-1', label => lp('[none]', 'release status') },
         map +{ value => $_->id, label => $_->name },
         @{ $self->statuses },
     ];

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
@@ -230,6 +230,23 @@ test 'Release page filtering' => sub {
     );
 
     $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/releases?filter.status_id=-1',
+        'Fetched artist releases page with status filter "[none]"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '1',
+        'There is one entry in the release table after filtering by no status',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[1]',
+        'String Quartet',
+        'The entry is named "String Quartet"',
+    );
+
+    $mech->get_ok(
         '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/releases?filter.date=2010',
         'Fetched artist releases page with date filter',
     );
@@ -264,6 +281,23 @@ test 'Release page filtering' => sub {
     );
 
     $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/releases?filter.label_id=-1',
+        'Fetched artist releases page with label filter "[none]"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '2',
+        'There are two entries in the release table after filtering by no label',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[1]',
+        'Concerto for Orchestra / Symphony no. 3',
+        'The first entry is named "Concerto for Orchestra / Symphony no. 3"',
+    );
+
+    $mech->get_ok(
         '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/releases?filter.country_id=221',
         'Fetched artist releases page with country filter',
     );
@@ -278,6 +312,40 @@ test 'Release page filtering' => sub {
         '//table[@class="tbl"]/tbody/tr[1]/td[1]',
         'Concerto for Orchestra / Symphony no. 3',
         'The first entry is named "Concerto for Orchestra / Symphony no. 3"',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/releases?filter.country_id=-1',
+        'Fetched artist releases page with country filter "[none]"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '4',
+        'There are four entries in the release table after filtering by no country',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[1]',
+        'Symphonies / Concertos / Choral and Vocal Works',
+        'The first entry is named "Symphonies / Concertos / Choral and Vocal Works"',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/releases?filter.country_id=-1&filter.date=2010',
+        'Fetched artist releases page with both date filter and country filter "[none]"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '2',
+        'There are two entries in the release table after filtering by no country + date 2010',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[1]',
+        'Lutosławski',
+        'The first entry is named "Lutosławski"',
     );
 
     $mech->get_ok(

--- a/t/sql/filtering.sql
+++ b/t/sql/filtering.sql
@@ -50,13 +50,12 @@ INSERT INTO medium (id, release, position)
            (3406, 3406, 1);
 
 INSERT INTO label (id, gid, name)
-    VALUES (3400, 'ed65f6e2-5454-45a7-8607-e1106d209734', 'Erato'),
-           (3401, '5a584032-dcef-41bb-9f8b-19540116fb1c', 'Deutsche Grammophon'),
+    VALUES (3401, '5a584032-dcef-41bb-9f8b-19540116fb1c', 'Deutsche Grammophon'),
            (3402, '615fa478-3901-42b8-80bc-bf58b1ff0e03', 'Naxos'),
            (3403, '157afde4-4bf5-4039-8ad2-5a15acc85176', '[no label]');
 
 INSERT INTO release_label (release, label, catalog_number)
-    VALUES (3400, 3400, '4509-91711-2'),
+    VALUES (3400, NULL, '4509-91711-2'),
            (3401, 3401, '0289 479 4518'),
            (3402, 3402, '8.501066'),
            (3403, 3403, NULL),


### PR DESCRIPTION
### Implement MBS-13577 / MBS-13578

# Problem
While we allow filtering release groups or works without a type, there's no way right now to filter for releases without a status or country.

# Solution
This adds the option to search for releases with no status, country or label when filtering an artist's release page, in the same way we already allowed searching for empty values for some work and release group filter options. Label wasn't actually requested, but it makes sense anyway.

# Testing
Added test cases for all of these to our `Filtering` test.