### PR TITLE
MBS-13581: Check "renamed into" in ArtistsThatMayBeGroups

### DIFF
--- a/lib/MusicBrainz/Server/Report/ArtistsThatMayBeGroups.pm
+++ b/lib/MusicBrainz/Server/Report/ArtistsThatMayBeGroups.pm
@@ -15,7 +15,11 @@ sub query {<<~'SQL'}
             OR
             artist.type IS NULL
          )
-         AND link.link_type IN (722)), -- subgroup
+         AND link.link_type IN (
+            722, -- subgroup
+            1079 -- renamed into
+         )
+       ),
        possible_groups_entity1 AS (
          SELECT artist.id, artist.name
          FROM artist
@@ -33,7 +37,8 @@ sub query {<<~'SQL'}
             305, -- conductor position
             965, -- artistic director
             855, -- composer-in-residence
-            722  -- subgroup
+            722, -- subgroup
+            1079 -- renamed into
          )
        )
   SELECT possible_groups.id AS artist_id,

--- a/root/report/ArtistsThatMayBeGroups.js
+++ b/root/report/ArtistsThatMayBeGroups.js
@@ -24,10 +24,14 @@ component ArtistsThatMayBeGroups(...{
       description={l(
         `This report lists artists that have their type set to other
          than Group (or a subtype of Group) but may be a group,
-         because they have other artists listed as members. If you find
-         that an artist here is indeed a group, change its type. If it is
-         not, please make sure that the “member of” relationships are
-         in the right direction and are correct.`,
+         because they have other artists listed as members or use other
+         relationships that are generally meant for groups only (either in
+         both directions, such as “subgroup” and “renamed”, or in one, such as
+         “artistic director”, “conductor” and “composer-in-residence”).
+         If you find that an artist here is indeed a group, change its type.
+         If it is not, please make sure that the “member of” relationships are
+         in the right direction and are correct, whether “renamed into” needs
+         to be turned into “performs as” relationships, and so on.`,
       )}
       entityType="artist"
       filtered={filtered}


### PR DESCRIPTION
### Implement MBS-13581

# Problem
The ["Renamed into" relationship](https://musicbrainz.org/relationship/9752bfdf-13ca-441a-a8bc-18928c600c73) is meant to generally be used for groups, but it gets used to link performance names instead of the correct "performs as" relatively often. There's no good way to find the misuses at the moment.

# Solution
This adds the non-group uses of "renamed into" to the `ArtistsThatMayBeGroups` report, so that they can be found and fixed as needed. It can cause false positives for cases where a character was renamed, but that should be very rare and it seems like an acceptable level of false positives. I expanded the text for the report a bit (since it only mentioned members but it hasn't been for members only for quite a while now).

# Testing
Tested with sample data, where the report goes from 27 to 29 artists with this change, and the new ones are indeed two names for a person linked as a rename.