### PR TITLE
MBS-13585: Report for non-video recordings with video relationships

### DIFF
--- a/lib/MusicBrainz/Server/Report/VideoRelationshipsOnNonVideos.pm
+++ b/lib/MusicBrainz/Server/Report/VideoRelationshipsOnNonVideos.pm
@@ -1,0 +1,43 @@
+package MusicBrainz::Server::Report::VideoRelationshipsOnNonVideos;
+use Moose;
+
+with 'MusicBrainz::Server::Report::RecordingReport',
+     'MusicBrainz::Server::Report::FilterForEditor::RecordingID';
+
+sub query {<<~'SQL'}
+  SELECT DISTINCT r.id AS recording_id,
+         row_number() OVER (ORDER BY ac.name COLLATE musicbrainz, r.name COLLATE musicbrainz)
+    FROM recording r
+    JOIN artist_credit ac ON r.artist_credit = ac.id
+   WHERE r.video IS FALSE
+     AND EXISTS (
+          SELECT TRUE
+            FROM l_artist_recording lar
+            JOIN link ON lar.link = link.id
+           WHERE lar.entity1 = r.id 
+             AND link.link_type IN (
+                  125,  -- graphic design
+                  858,  -- video appearance
+                  962,  -- video director
+                  1230, -- choreographer
+                  1241, -- artwork
+                  1242, -- design
+                  1244, -- illustration
+                  1245  -- cinematographer
+                 )
+         )
+  SQL
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2024 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -111,6 +111,7 @@ my @all = qw(
     TracksWithoutTimes
     TracksWithSequenceIssues
     UnlinkedPseudoReleases
+    VideoRelationshipsOnNonVideos
     VideosInNonVideoMediums
     WikidataLinksWithMultipleEntities
     WorkSameTypeAsParent
@@ -214,6 +215,7 @@ use MusicBrainz::Server::Report::TracksNamedWithSequence;
 use MusicBrainz::Server::Report::TracksWithoutTimes;
 use MusicBrainz::Server::Report::TracksWithSequenceIssues;
 use MusicBrainz::Server::Report::UnlinkedPseudoReleases;
+use MusicBrainz::Server::Report::VideoRelationshipsOnNonVideos;
 use MusicBrainz::Server::Report::VideosInNonVideoMediums;
 use MusicBrainz::Server::Report::WikidataLinksWithMultipleEntities;
 use MusicBrainz::Server::Report::WorkSameTypeAsParent;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -540,6 +540,10 @@ component ReportsIndex() {
             content={l('Video recordings in non-video mediums')}
             reportName="VideosInNonVideoMediums"
           />
+          <ReportsIndexEntry
+            content={l('Non-video recordings with video relationships')}
+            reportName="VideoRelationshipsOnNonVideos"
+          />
         </ul>
 
         <h2>{l('Places')}</h2>

--- a/root/report/VideoRelationshipsOnNonVideos.js
+++ b/root/report/VideoRelationshipsOnNonVideos.js
@@ -1,0 +1,59 @@
+/*
+ * @flow strict
+ * Copyright (C) 2022 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import commaOnlyList from '../static/scripts/common/i18n/commaOnlyList.js';
+
+import RecordingList from './components/RecordingList.js';
+import ReportLayout from './components/ReportLayout.js';
+import type {ReportDataT, ReportRecordingT} from './types.js';
+
+const videoRelationships = [
+  'artwork',
+  'choreographer',
+  'cinematographer',
+  'design',
+  'graphic design',
+  'illustration',
+  'video appearance',
+  'video director',
+];
+
+component VideoRelationshipsOnNonVideos(...{
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportRecordingT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report shows recordings not marked as video, but that use
+         relationships meant only for video recordings ({relationship_list}).
+         Either they should be marked as video, or the relationships should
+         be moved to a related video recording.`,
+        {
+          relationship_list: commaOnlyList(
+            videoRelationships.map(x => '“' + l_relationships(x) + '”'),
+          ),
+        },
+      )}
+      entityType="recording"
+      filtered={filtered}
+      generated={generated}
+      title={l('Non-video recordings with video relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <RecordingList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
+
+export default VideoRelationshipsOnNonVideos;

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -311,6 +311,7 @@ export default {
   'report/TracksWithoutTimes': (): Promise<mixed> => import('../report/TracksWithoutTimes.js'),
   'report/TracksWithSequenceIssues': (): Promise<mixed> => import('../report/TracksWithSequenceIssues.js'),
   'report/UnlinkedPseudoReleases': (): Promise<mixed> => import('../report/UnlinkedPseudoReleases.js'),
+  'report/VideoRelationshipsOnNonVideos': (): Promise<mixed> => import('../report/VideoRelationshipsOnNonVideos.js'),
   'report/VideosInNonVideoMediums': (): Promise<mixed> => import('../report/VideosInNonVideoMediums.js'),
   'report/WikidataLinksWithMultipleEntities': (): Promise<mixed> => import('../report/WikidataLinksWithMultipleEntities.js'),
   'report/WorkSameTypeAsParent': (): Promise<mixed> => import('../report/WorkSameTypeAsParent.js'),


### PR DESCRIPTION
### Implement MBS-13585

# Problem
People often misuse video related relationships in non-video recordings - possibly more common still is the case where the recording is indeed a video but has not been marked as one. There's currently no great way to find either.

# Solution
This adds a report that shows any recordings that have relationships specifically meant for videos. This allows users to find and fix both cases mentioned above.

# Testing
Tested with sample data, which contains a bunch of directed by credits.