### PR TITLE
MBS-13589: Handle Operabase /o links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4530,17 +4530,18 @@ const CLEANUPS: CleanupEntries = {
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?operabase\.com\//, 'https://operabase.com/');
       url = url.replace(/^https:\/\/operabase\.com\/(venues\/[\w-]+|works)\/(?:[^0-9]+)?([0-9]+).*$/, 'https://operabase.com/$1/$2');
-      url = url.replace(/^https:\/\/operabase\.com\/(?:artists\/(?:[^0-9]+)?|[\w-]+a)([0-9]+).*$/, 'https://operabase.com/a$1');
+      url = url.replace(/^https:\/\/operabase\.com\/artists\/(?:[^0-9]+)?([0-9]+).*$/, 'https://operabase.com/a$1');
+      url = url.replace(/^https:\/\/operabase\.com\/[\w-]+(a|o)([0-9]+).*$/, 'https://operabase.com/$1$2');
       return url;
     },
     validate: function (url, id) {
-      const m = /^https:\/\/operabase\.com\/(?:(a)|(venues)\/[\w-]+\/|(works)\/)[0-9]+$/.exec(url);
+      const m = /^https:\/\/operabase\.com\/(?:(a|o)|(venues)\/[\w-]+\/|(works)\/)[0-9]+$/.exec(url);
       if (m) {
         const prefix = m[1] || m[2] || m[3];
         switch (id) {
           case LINK_TYPES.otherdatabases.artist:
             return {
-              result: prefix === 'a',
+              result: prefix === 'a' || prefix === 'o',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.place:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4443,6 +4443,13 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist'],
   },
   {
+                     input_url: 'https://www.operabase.com/bbc-symphony-orchestra-o10152/en',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://operabase.com/o10152',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'operabase.com/venues/united-states/abravanel-hall-5916/en',
              input_entity_type: 'place',
     expected_relationship_type: 'otherdatabases',


### PR DESCRIPTION
### Fix MBS-13589

# Problem
We currently block (don't handle) `/o` links for Operabase. These are organization pages, which are used for things such as orchestras and opera companies (still artists in MB terms).

# Solution
Allow `o` prefix for artists as well as the already handled `a` prefix. Split the old-style artist links to a separate regex cleanup to make things clearer.

# Testing
Added a test case to the cleanup tests.