### PR TITLE
Replace /doc page query in Perl test

### DIFF
--- a/t/lib/t/MusicBrainz/Server/Controller/User/Login.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Login.pm
@@ -198,8 +198,8 @@ test 'MBS-13548: obey returnto for already logged in users' => sub {
     );
     is($mech->uri->path, '/user/new_editor');
 
-    $mech->get_ok('https://localhost/login?returnto=/doc/About');
-    is($mech->uri->path, '/doc/About');
+    $mech->get_ok('https://localhost/login?returnto=/statistics');
+    is($mech->uri->path, '/statistics');
 
     $enable_ssl->DESTROY;
 };


### PR DESCRIPTION
# Problem

da9a19b4f01f89ab6137cee16d79ebe29180bcb4 added a test to ensure that `/login?returnto=` is obeyed if the user is already logged in. The `returnto` page used in the test is a `/doc/` page, which actually depends on the production Wiki server and may fail if it's under maintenance.

# Solution

This commit just changes the page to one that doesn't require any production service to be available.

# Testing

Ran the modified test locally.