### PR TITLE
MBS-13599: Support any search server scheme

### DIFF
--- a/docker/musicbrainz-tests/DBDefs.pm
+++ b/docker/musicbrainz-tests/DBDefs.pm
@@ -142,6 +142,7 @@ sub PLUGIN_CACHE_OPTIONS {
 }
 
 sub SEARCH_SERVER { '127.0.0.1:8983/solr' }
+sub SEARCH_SCHEME { 'http' }
 sub SEARCH_ENGINE { 'SOLR' }
 
 sub USE_SET_DATABASE_HEADER { 1 }

--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -148,6 +148,7 @@ sub WEB_SERVER                { 'www.musicbrainz.example.com' }
 # Relevant only if SSL redirects are enabled
 # sub WEB_SERVER_SSL            { 'localhost' }
 # sub SEARCH_SERVER             { 'search.musicbrainz.org' }
+# sub SEARCH_SCHEME             { 'http' }
 # sub SEARCH_ENGINE             { 'SOLR' }
 # Used, for example, to have emails sent from the beta server list the
 # main server

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -83,6 +83,7 @@ sub WEB_SERVER                { 'localhost:5000' }
 # Relevant only if SSL redirects are enabled
 sub WEB_SERVER_SSL            { 'localhost' }
 sub SEARCH_SERVER             { 'search.musicbrainz.org' }
+sub SEARCH_SCHEME             { 'http' }
 sub SEARCH_ENGINE             { 'SOLR' }
 # Whether to use x-accel-redirect for webservice searches,
 # using /internal/search as the internal redirect

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -854,10 +854,10 @@ sub external_search
     $query = uri_escape_utf8($query);
     $type =~ s/release_group/release-group/;
 
-    my $search_url_string;
+    my $search_url_string = DBDefs->SEARCH_SCHEME;
     if (DBDefs->SEARCH_ENGINE eq 'LUCENE' || DBDefs->SEARCH_SERVER eq DBDefs::Default->SEARCH_SERVER) {
         my $dismax = $adv ? 'false' : 'true';
-        $search_url_string = "http://%s/ws/2/%s/?query=%s&offset=%s&max=%s&fmt=jsonnew&dismax=$dismax&web=1";
+        $search_url_string .= "://%s/ws/2/%s/?query=%s&offset=%s&max=%s&fmt=jsonnew&dismax=$dismax&web=1";
     } else {
         my $endpoint = 'advanced';
         if (!$adv)
@@ -871,7 +871,7 @@ sub external_search
                 $endpoint = 'select';
             }
         }
-        $search_url_string = "http://%s/%s/$endpoint?q=%s&start=%s&rows=%s&wt=mbjson";
+        $search_url_string .= "://%s/%s/$endpoint?q=%s&start=%s&rows=%s&wt=mbjson";
      }
 
     my $search_url = sprintf($search_url_string,

--- a/lib/MusicBrainz/Server/Data/WebService.pm
+++ b/lib/MusicBrainz/Server/Data/WebService.pm
@@ -238,7 +238,7 @@ sub xml_search
     if (DBDefs->SEARCH_X_ACCEL_REDIRECT) {
         return { redirect_url => '/internal/search/' . DBDefs->SEARCH_SERVER . $url_ext };
     } else {
-        my $url = 'http://' . DBDefs->SEARCH_SERVER . $url_ext;
+        my $url = DBDefs->SEARCH_SCHEME . '://' . DBDefs->SEARCH_SERVER . $url_ext;
         my $response = $self->c->lwp->get($url);
         if ( $response->is_success )
         {

--- a/script/purge_solr_cores.sh
+++ b/script/purge_solr_cores.sh
@@ -4,6 +4,7 @@ set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../"
 
+SEARCH_SCHEME=$(perl -Ilib -e 'use DBDefs; print DBDefs->SEARCH_SCHEME;')
 SEARCH_SERVER=$(perl -Ilib -e 'use DBDefs; print DBDefs->SEARCH_SERVER;')
 
 declare -a SOLR_CORES
@@ -28,7 +29,7 @@ SOLR_CORES=(
 
 for CORE in "${SOLR_CORES[@]}"; do
     curl -sSL \
-        "$SEARCH_SERVER/$CORE/update?softCommit=true" \
+        "$SEARCH_SCHEME://$SEARCH_SERVER/$CORE/update?softCommit=true" \
         --header 'Content-type: text/xml' \
         --data-binary '<delete><query>*:*</query></delete>'
 done


### PR DESCRIPTION
# MBS-13599

# Problem 
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

When the traffic between the MusicBrainz web server and its search server is traveling over external interfaces, it can be intercepted by anyone, as MusicBrainz Server is currently querying its search server using the unencrypted HTTP scheme (even though it doesn’t contain any credentials and it has limited access).

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Allow using another scheme than HTTP to query the search server through `SEARCH_SCHEME` definition. More specifically, allow for using HTTPS when the search server isn’t deployed in the same infrastructure.

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

Just tested that it still works in local development setup. No change is expected unless `SEARCH_SCHEME` is specifically set in your `lib/DBDefs.pm`.

# Further action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

The plan is to set `SEARCH_SCHEME` to `https` for querying the new SolrCloud 9 instance.