### PR TITLE
Support separate CAA and EAA access keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ branch_filters: &job_filters
 executors:
   musicbrainz-tests:
     docker:
-      - image: metabrainz/musicbrainz-tests:v-2024-05.eaa
+      - image: metabrainz/musicbrainz-tests:v-2024-05-23
         user: root
     working_directory: /home/musicbrainz/musicbrainz-server
 

--- a/contrib/ssssss.psgi
+++ b/contrib/ssssss.psgi
@@ -115,13 +115,21 @@ sub check_authorization_header
 {
     my ($request) = @_;
     my $auth = $request->header('authorization');
+    my $collection = $request->header('x-archive-meta-collection');
 
     my ($user, $pass) = $auth =~ /^LOW ([^:]+):(.+)$/;
     if (
         !defined $user ||
         !defined $pass ||
-        $user ne DBDefs->INTERNET_ARCHIVE_ACCESS_KEY ||
-        $pass ne DBDefs->INTERNET_ARCHIVE_SECRET_KEY
+        !((
+            $collection eq 'coverartarchive' &&
+            $user eq DBDefs->COVER_ART_ARCHIVE_ACCESS_KEY &&
+            $pass eq DBDefs->COVER_ART_ARCHIVE_SECRET_KEY
+        ) || (
+            $collection eq 'eventartarchive' &&
+            $user eq DBDefs->EVENT_ART_ARCHIVE_ACCESS_KEY &&
+            $pass eq DBDefs->EVENT_ART_ARCHIVE_SECRET_KEY
+        ))
     ) {
         my $response = $request->new_response(403);
         $response->content_type('text/xml');

--- a/docker/musicbrainz-tests/DBDefs.pm
+++ b/docker/musicbrainz-tests/DBDefs.pm
@@ -93,8 +93,12 @@ sub CACHE_MANAGER_OPTIONS {
 
 sub CATALYST_DEBUG { 0 }
 
-sub INTERNET_ARCHIVE_ACCESS_KEY { 'hi_im_public' }
-sub INTERNET_ARCHIVE_SECRET_KEY { 'hi_im_private' }
+sub COVER_ART_ARCHIVE_ACCESS_KEY { 'hi_im_public_caa' }
+sub COVER_ART_ARCHIVE_SECRET_KEY { 'bye_im_private_caa' }
+
+sub EVENT_ART_ARCHIVE_ACCESS_KEY { 'hi_im_public_eaa' }
+sub EVENT_ART_ARCHIVE_SECRET_KEY { 'bye_im_private_eaa' }
+
 sub INTERNET_ARCHIVE_UPLOAD_PREFIXER { shift; sprintf('//localhost:5050/%s', shift) }
 sub INTERNET_ARCHIVE_METADATA_PREFIX { 'http://localhost:5050/metadata' }
 sub INTERNET_ARCHIVE_IA_DOWNLOAD_PREFIX { '' }

--- a/docker/musicbrainz-tests/artwork-indexer-config.ini
+++ b/docker/musicbrainz-tests/artwork-indexer-config.ini
@@ -10,5 +10,7 @@ dbname=musicbrainz_selenium
 
 [s3]
 url=http://localhost:5050/{bucket}?file={file}
-access=hi_im_public
-secret=hi_im_private
+caa_access=hi_im_public_caa
+caa_secret=bye_im_private_caa
+eaa_access=hi_im_public_eaa
+eaa_secret=bye_im_private_eaa

--- a/docker/ssssss/DBDefs.pm
+++ b/docker/ssssss/DBDefs.pm
@@ -1,6 +1,9 @@
 package DBDefs;
 
-sub INTERNET_ARCHIVE_ACCESS_KEY { 'hi_im_public' }
-sub INTERNET_ARCHIVE_SECRET_KEY { 'hi_im_private' }
+sub COVER_ART_ARCHIVE_ACCESS_KEY { 'hi_im_public_caa' }
+sub COVER_ART_ARCHIVE_SECRET_KEY { 'bye_im_private_caa' }
+
+sub EVENT_ART_ARCHIVE_ACCESS_KEY { 'hi_im_public_eaa' }
+sub EVENT_ART_ARCHIVE_SECRET_KEY { 'bye_im_private_eaa' }
 
 1;

--- a/docker/templates/Dockerfile.tests.m4
+++ b/docker/templates/Dockerfile.tests.m4
@@ -111,7 +111,7 @@ RUN sudo -E -H -u musicbrainz git clone --branch $SIR_TAG https://github.com/met
     sudo -E -H -u musicbrainz sh -c 'virtualenv --python=python2 venv; . venv/bin/activate; pip install --upgrade pip; pip install -r requirements.txt; pip install git+https://github.com/esnme/ultrajson.git@7d0f4fb7e911120fd09075049233b587936b0a65' && \
     cd /home/musicbrainz
 
-ENV ARTWORK_INDEXER_COMMIT 78c5ee2
+ENV ARTWORK_INDEXER_COMMIT 776046c
 
 RUN sudo -E -H -u musicbrainz git clone https://github.com/metabrainz/artwork-indexer.git && \
     cd artwork-indexer && \

--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -358,8 +358,10 @@ sub WEB_SERVER                { 'www.musicbrainz.example.com' }
 
 # Internet Archive public/private keys
 # (for coverartarchive.org and eventartarchive.org).
-# sub INTERNET_ARCHIVE_ACCESS_KEY { }
-# sub INTERNET_ARCHIVE_SECRET_KEY { }
+# sub COVER_ART_ARCHIVE_ACCESS_KEY { }
+# sub COVER_ART_ARCHIVE_SECRET_KEY { }
+# sub EVENT_ART_ARCHIVE_ACCESS_KEY { }
+# sub EVENT_ART_ARCHIVE_SECRET_KEY { }
 # sub INTERNET_ARCHIVE_UPLOAD_PREFIXER { shift; sprintf('//%s.s3.us.archive.org/', shift) }
 
 # sub COVER_ART_ARCHIVE_DOWNLOAD_PREFIX { '//coverartarchive.org' }

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -351,8 +351,10 @@ sub RECAPTCHA_PRIVATE_KEY { return undef }
 
 # Internet Archive public/private keys
 # (for coverartarchive.org and eventartarchive.org).
-sub INTERNET_ARCHIVE_ACCESS_KEY { }
-sub INTERNET_ARCHIVE_SECRET_KEY { }
+sub COVER_ART_ARCHIVE_ACCESS_KEY { }
+sub COVER_ART_ARCHIVE_SECRET_KEY { }
+sub EVENT_ART_ARCHIVE_ACCESS_KEY { }
+sub EVENT_ART_ARCHIVE_SECRET_KEY { }
 sub INTERNET_ARCHIVE_UPLOAD_PREFIXER { shift; sprintf('//%s.s3.us.archive.org/', shift) }
 sub INTERNET_ARCHIVE_IA_DOWNLOAD_PREFIX { '//archive.org/download' }
 sub INTERNET_ARCHIVE_IA_METADATA_PREFIX { 'https://archive.org/metadata' }

--- a/lib/MusicBrainz/Server/Controller/Role/Art.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Art.pm
@@ -219,7 +219,7 @@ role {
             mime_types => [ map {
                 $_->{mime_type}
             } @{ $art_archive_model->mime_types } ],
-            access_key => DBDefs->INTERNET_ARCHIVE_ACCESS_KEY // '',
+            access_key => $art_archive_model->art_archive_s3_access_key // '',
             "${archive}_art_types_json" => $c->json->encode(
                 [ map {
                     { name => $_->name, l_name => $_->l_name, id => $_->id }

--- a/lib/MusicBrainz/Server/Controller/WS/js.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js.pm
@@ -395,8 +395,8 @@ sub _art_upload {
         $s3_request->header(
             'authorization' => sprintf(
                 'LOW %s:%s',
-                DBDefs->INTERNET_ARCHIVE_ACCESS_KEY,
-                DBDefs->INTERNET_ARCHIVE_SECRET_KEY,
+                $art_archive_model->art_archive_s3_access_key,
+                $art_archive_model->art_archive_s3_secret_key,
             ),
         );
         $s3_request->header('x-archive-meta-collection' => "${archive}artarchive");

--- a/lib/MusicBrainz/Server/Data/CoverArtArchive.pm
+++ b/lib/MusicBrainz/Server/Data/CoverArtArchive.pm
@@ -8,6 +8,8 @@ with 'MusicBrainz::Server::Data::Role::ArtArchive';
 sub art_archive_name { 'cover' }
 sub art_archive_entity { 'release' }
 sub art_archive_type_booleans { qw( is_front is_back ) }
+sub art_archive_s3_access_key { DBDefs->COVER_ART_ARCHIVE_ACCESS_KEY }
+sub art_archive_s3_secret_key { DBDefs->COVER_ART_ARCHIVE_SECRET_KEY }
 sub art_model_name { 'CoverArt' }
 sub download_prefix { DBDefs->COVER_ART_ARCHIVE_DOWNLOAD_PREFIX }
 

--- a/lib/MusicBrainz/Server/Data/EventArtArchive.pm
+++ b/lib/MusicBrainz/Server/Data/EventArtArchive.pm
@@ -8,6 +8,8 @@ with 'MusicBrainz::Server::Data::Role::ArtArchive';
 sub art_archive_name { 'event' }
 sub art_archive_entity { 'event' }
 sub art_archive_type_booleans { qw( is_front ) }
+sub art_archive_s3_access_key { DBDefs->EVENT_ART_ARCHIVE_ACCESS_KEY }
+sub art_archive_s3_secret_key { DBDefs->EVENT_ART_ARCHIVE_SECRET_KEY }
 sub art_model_name { 'EventArt' }
 sub download_prefix { DBDefs->EVENT_ART_ARCHIVE_DOWNLOAD_PREFIX }
 

--- a/lib/MusicBrainz/Server/Data/Role/ArtArchive.pm
+++ b/lib/MusicBrainz/Server/Data/Role/ArtArchive.pm
@@ -16,6 +16,8 @@ requires 'art_archive_entity';
 # Attributes in the index_listing view that indicate artwork type
 # (e.g. is_front, is_back).
 requires 'art_archive_type_booleans';
+requires 'art_archive_s3_access_key';
+requires 'art_archive_s3_secret_key';
 requires 'art_model_name';
 requires 'download_prefix';
 
@@ -141,8 +143,8 @@ sub post_fields {
     my $suffix = $self->image_type_suffix($mime_type);
 
     # We have one access key for both the coverartarchive and eventartarchive.
-    my $access_key = $opts->{access_key} // DBDefs->INTERNET_ARCHIVE_ACCESS_KEY;
-    my $secret_key = $opts->{secret_key} // DBDefs->INTERNET_ARCHIVE_SECRET_KEY;
+    my $access_key = $opts->{access_key} // $self->art_archive_s3_access_key;
+    my $secret_key = $opts->{secret_key} // $self->art_archive_s3_secret_key;
     my $filename = "mbid-$mbid-$id.$suffix";
 
     my $archive = $self->art_archive_name;

--- a/t/selenium/CAA.json5
+++ b/t/selenium/CAA.json5
@@ -118,7 +118,7 @@
     // Wait for the artwork-indexer to catch up.
     {
       command: 'pause',
-      target: '2000',
+      target: '3000',
       value: '',
     },
     {
@@ -172,7 +172,7 @@
     },
     {
       command: 'pause',
-      target: '2000',
+      target: '3000',
       value: '',
     },
     {
@@ -183,7 +183,7 @@
     // Wait for the artwork-indexer to catch up.
     {
       command: 'pause',
-      target: '2000',
+      target: '3000',
       value: '',
     },
     // `approved` should be true for both images in index.json now.
@@ -298,7 +298,7 @@
     // Wait for the artwork-indexer to catch up.
     {
       command: 'pause',
-      target: '2000',
+      target: '3000',
       value: '',
     },
     {
@@ -403,7 +403,7 @@
     // Wait for the artwork-indexer to catch up.
     {
       command: 'pause',
-      target: '2000',
+      target: '3000',
       value: '',
     },
     {
@@ -498,7 +498,7 @@
     // Wait for the artwork-indexer to catch up.
     {
       command: 'pause',
-      target: '2000',
+      target: '3000',
       value: '',
     },
     {

--- a/t/selenium/EAA.json5
+++ b/t/selenium/EAA.json5
@@ -113,7 +113,7 @@
     // Wait for the artwork-indexer to catch up.
     {
       command: 'pause',
-      target: '2000',
+      target: '3000',
       value: '',
     },
     {
@@ -165,7 +165,7 @@
     },
     {
       command: 'pause',
-      target: '2000',
+      target: '3000',
       value: '',
     },
     {
@@ -176,7 +176,7 @@
     // Wait for the artwork-indexer to catch up.
     {
       command: 'pause',
-      target: '2000',
+      target: '3000',
       value: '',
     },
     // `approved` should be true for both images in index.json now.
@@ -289,7 +289,7 @@
     // Wait for the artwork-indexer to catch up.
     {
       command: 'pause',
-      target: '2000',
+      target: '3000',
       value: '',
     },
     {
@@ -392,7 +392,7 @@
     // Wait for the artwork-indexer to catch up.
     {
       command: 'pause',
-      target: '2000',
+      target: '3000',
       value: '',
     },
     {
@@ -485,7 +485,7 @@
     // Wait for the artwork-indexer to catch up.
     {
       command: 'pause',
-      target: '2000',
+      target: '3000',
       value: '',
     },
     {


### PR DESCRIPTION
This follows https://github.com/metabrainz/artwork-indexer/pull/2 which is a prerequisite of IMG-84.

# Problem

The CAA and EAA actually use different IA credentials to manage their collections.

# Solution

This splits the current configuration options into per-project ones.

# Testing

Just the existing CAA/EAA tests.