### PR TITLE
MBS-13601: Bump DB_SCHEMA_SEQUENCE, ACTIVE_SCHEMA_SEQUENCE to 29

### DIFF
--- a/docker/config/services/dev.musicbrainz-server.json
+++ b/docker/config/services/dev.musicbrainz-server.json
@@ -1,7 +1,7 @@
 {
   "DBDefs": {
     "CATALYST_DEBUG": "0",
-    "DB_SCHEMA_SEQUENCE": "28",
+    "DB_SCHEMA_SEQUENCE": "29",
     "DB_STAGING_TESTING_FEATURES": "1",
     "DEVELOPMENT_SERVER": "1",
     "FORK_RENDERER": "0",

--- a/docker/musicbrainz-test-database/DBDefs.pm
+++ b/docker/musicbrainz-test-database/DBDefs.pm
@@ -34,6 +34,6 @@ MusicBrainz::Server::DatabaseConnectionFactory->register_databases(
     },
 );
 
-sub DB_SCHEMA_SEQUENCE { 28 }
+sub DB_SCHEMA_SEQUENCE { 29 }
 
 1;

--- a/docker/musicbrainz-tests/DBDefs.pm
+++ b/docker/musicbrainz-tests/DBDefs.pm
@@ -111,7 +111,7 @@ sub DATASTORE_REDIS_ARGS {
     };
 }
 
-sub DB_SCHEMA_SEQUENCE { 28 }
+sub DB_SCHEMA_SEQUENCE { 29 }
 
 sub DB_STAGING_TESTING_FEATURES { 1 }
 
@@ -129,7 +129,7 @@ sub HTML_VALIDATOR { 'http://localhost:8888?out=json' }
 
 sub MB_LANGUAGES { qw( de el es es-419 et fi fr he it ja nl sq en ) }
 
-sub ACTIVE_SCHEMA_SEQUENCE { 28 }
+sub ACTIVE_SCHEMA_SEQUENCE { 29 }
 
 sub PLUGIN_CACHE_OPTIONS {
     my $self = shift;

--- a/docs/database_schema_diagrams/write_graphs.pl
+++ b/docs/database_schema_diagrams/write_graphs.pl
@@ -79,7 +79,7 @@ Readonly my $DEF_DIR => realpath("$FindBin::Bin/source");
 Readonly my $SQL_DIR => realpath("$FindBin::Bin/../../admin/sql");
 Readonly my $OUTPUT_DIR => realpath($output_dir);
 
-Readonly my $DB_SCHEMA_SEQUENCE => 28;
+Readonly my $DB_SCHEMA_SEQUENCE => 29;
 
 Readonly my $TABLE_FONT_SIZE => '17';
 Readonly my $COLUMN_FONT_SIZE => '14';

--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -93,7 +93,7 @@ MusicBrainz::Server::DatabaseConnectionFactory->register_databases(
 # replication_control.current_schema_sequence.
 # This is required, there is no default in order to prevent it changing without
 # manual intervention.
-sub DB_SCHEMA_SEQUENCE { 28 }
+sub DB_SCHEMA_SEQUENCE { 29 }
 
 # What type of server is this?
 # * RT_MASTER - This is a master replication server.  Changes are allowed, and

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -369,7 +369,7 @@ sub MAPBOX_MAP_ID { 'mapbox/streets-v11' }
 sub MAPBOX_ACCESS_TOKEN { '' }
 
 # Feature toggle used for pre-schema change release of safe schema change code
-sub ACTIVE_SCHEMA_SEQUENCE { 28 }
+sub ACTIVE_SCHEMA_SEQUENCE { 29 }
 
 # Disallow OAuth2 requests over plain HTTP
 sub OAUTH2_ENFORCE_TLS { my $self = shift; !$self->DB_STAGING_SERVER || $self->IS_BETA }

--- a/t/script/CheckSchemaMigration.sh
+++ b/t/script/CheckSchemaMigration.sh
@@ -71,7 +71,7 @@ git clean --force -- admin/sql
 git restore admin/InitDb.pl
 
 export REPLICATION_TYPE
-DB_SCHEMA_SEQUENCE=28 DATABASE=$DB2 SKIP_EXPORT=1 ./upgrade.sh
+DB_SCHEMA_SEQUENCE=29 DATABASE=$DB2 SKIP_EXPORT=1 ./upgrade.sh
 
 DB1SCHEMA="$DB1.schema.sql"
 DB2SCHEMA="$DB2.schema.sql"


### PR DESCRIPTION
We forgot to do this during the schema change release. See https://github.com/metabrainz/musicbrainz-server/pull/2940 for last year's version of this.