### PR TITLE
MBS-13600: Display event art indicator for events

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -189,6 +189,7 @@ sub direct : Private
         $c->model('SeriesOrderingType')->load(@entities);
     }
     elsif ($type eq 'event') {
+        $c->model('Event')->load_meta(@entities);
         $c->model('Event')->load_related_info(@entities);
         $c->model('Event')->load_areas(@entities);
     }

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -960,6 +960,7 @@ sub external_search
         {
             my @entities = map { $_->entity } @results;
             $self->c->model('Event')->load_ids(@entities);
+            $self->c->model('Event')->load_meta(@entities);
             $self->c->model('Event')->load_related_info(@entities);
             $self->c->model('Event')->load_areas(@entities);
         }

--- a/root/components/list/EventList.js
+++ b/root/components/list/EventList.js
@@ -56,6 +56,7 @@ component EventList(
       const nameColumn = defineNameColumn<EventT>({
         descriptive: false, // since dates have their own column
         order: order,
+        showArtworkPresence: true,
         sortable: sortable,
         title: l('Event'),
       });

--- a/root/components/list/ReleaseGroupList.js
+++ b/root/components/list/ReleaseGroupList.js
@@ -65,7 +65,7 @@ export component ReleaseGroupListTable(
       const nameColumn = defineNameColumn<ReleaseGroupT>({
         descriptive: false, // since ACs are in the next column
         order: order,
-        showCaaPresence: true,
+        showArtworkPresence: true,
         sortable: sortable,
         title: l('Title'),
       });

--- a/root/components/list/ReleaseList.js
+++ b/root/components/list/ReleaseList.js
@@ -60,7 +60,7 @@ component ReleaseList(
       const nameColumn = defineNameColumn<ReleaseT>({
         descriptive: false, // since ACs are in the next column
         order: order,
-        showCaaPresence: true,
+        showArtworkPresence: true,
         sortable: sortable,
         title: l('Release'),
       });

--- a/root/release_group/ReleaseGroupIndex.js
+++ b/root/release_group/ReleaseGroupIndex.js
@@ -64,7 +64,7 @@ function buildReleaseStatusTable(
               </td>
             ) : null}
           <td>
-            <EntityLink entity={release} showCaaPresence />
+            <EntityLink entity={release} showArtworkPresence />
           </td>
           {/* The class being added is for usage with userscripts */}
           <td className={

--- a/root/search/components/EventResults.js
+++ b/root/search/components/EventResults.js
@@ -33,7 +33,12 @@ function buildResult(result: SearchResultT<EventT>, index: number) {
   return (
     <tr className={loopParity(index)} data-score={score} key={event.id}>
       <td>
-        <EntityLink entity={event} showDisambiguation showEventDate={false} />
+        <EntityLink
+          entity={event}
+          showArtworkPresence
+          showDisambiguation
+          showEventDate={false}
+        />
       </td>
       <td>{formatDatePeriod(event)}</td>
       <td>{event.time}</td>

--- a/root/search/components/ReleaseGroupResults.js
+++ b/root/search/components/ReleaseGroupResults.js
@@ -32,7 +32,7 @@ function buildResult(result: SearchResultT<ReleaseGroupT>, index: number) {
       key={releaseGroup.id}
     >
       <td>
-        <EntityLink entity={releaseGroup} showCaaPresence />
+        <EntityLink entity={releaseGroup} showArtworkPresence />
       </td>
       <td>
         <ArtistCreditLink artistCredit={releaseGroup.artistCredit} />

--- a/root/search/components/ReleaseResults.js
+++ b/root/search/components/ReleaseResults.js
@@ -46,7 +46,7 @@ function buildResult(
   return (
     <tr className={loopParity(index)} data-score={score} key={release.id}>
       <td>
-        <EntityLink entity={release} showCaaPresence />
+        <EntityLink entity={release} showArtworkPresence />
       </td>
       <td>
         <ArtistCreditLink artistCredit={release.artistCredit} />

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -167,7 +167,7 @@ component EntityLink(
     | ReleaseEditorTrackT,
   hover as passedHover?: string,
   nameVariation as passedNameVariation?: boolean,
-  showCaaPresence: boolean = false,
+  showArtworkPresence: boolean = false,
   showDeleted: boolean = true,
   showDisambiguation as passedShowDisambiguation?: boolean | 'hover',
   showEditsPending: boolean = true,
@@ -332,14 +332,39 @@ component EntityLink(
     );
   }
 
-  if (showCaaPresence) {
+  if (showArtworkPresence) {
+    if (entity.entityType === 'event') {
+      if (entity.event_art_presence === 'present') {
+        content = (
+          <React.Fragment key="eaa">
+            <a href={'/event/' + entity.gid + '/event-art'}>
+              <span
+                className="artwork-icon"
+                title={l('This event has artwork in the Event Art Archive')}
+              />
+            </a>
+            {content}
+          </React.Fragment>
+        );
+      } else {
+        content = (
+          <React.Fragment key="caa">
+            <span
+              className="blank-icon"
+            />
+            {content}
+          </React.Fragment>
+        );
+      }
+    }
+
     if (entity.entityType === 'release') {
       if (entity.cover_art_presence === 'present') {
         content = (
           <React.Fragment key="caa">
             <a href={'/release/' + entity.gid + '/cover-art'}>
               <span
-                className="caa-icon"
+                className="artwork-icon"
                 title={l('This release has artwork in the Cover Art Archive')}
               />
             </a>
@@ -363,7 +388,7 @@ component EntityLink(
         content = (
           <React.Fragment key="caa">
             <span
-              className="caa-icon"
+              className="artwork-icon"
               title={l(
                 'This release group has artwork in the Cover Art Archive',
               )}

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -339,7 +339,7 @@ component EntityLink(
           <React.Fragment key="eaa">
             <a href={'/event/' + entity.gid + '/event-art'}>
               <span
-                className="artwork-icon"
+                className="artwork-icon eaa-icon"
                 title={l('This event has artwork in the Event Art Archive')}
               />
             </a>
@@ -364,7 +364,7 @@ component EntityLink(
           <React.Fragment key="caa">
             <a href={'/release/' + entity.gid + '/cover-art'}>
               <span
-                className="artwork-icon"
+                className="artwork-icon caa-icon"
                 title={l('This release has artwork in the Cover Art Archive')}
               />
             </a>
@@ -388,7 +388,7 @@ component EntityLink(
         content = (
           <React.Fragment key="caa">
             <span
-              className="artwork-icon"
+              className="artwork-icon caa-icon"
               title={l(
                 'This release group has artwork in the Cover Art Archive',
               )}

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -659,7 +659,14 @@ span.ac-mp {
     margin-left: -5px;
 }
 
-span.artwork-icon {
+/*
+ * .caa-icon was kept for userscript compatibility.
+ * .eaa-icon was added in case it's useful for scripts to distinguish
+ * between them.
+ */
+span.artwork-icon,
+span.caa-icon,
+span.eaa-icon {
     background-image: data-uri('../images/icons/picture.png');
     background-repeat: no-repeat;
     display: inline-block;

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -659,7 +659,7 @@ span.ac-mp {
     margin-left: -5px;
 }
 
-span.caa-icon {
+span.artwork-icon {
     background-image: data-uri('../images/icons/picture.png');
     background-repeat: no-repeat;
     display: inline-block;

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -415,7 +415,7 @@ export function defineNameColumn<T: NonUrlRelatableEntityT | CollectionT>(
   props: {
     ...OrderableProps,
     +descriptive?: boolean,
-    +showCaaPresence?: boolean,
+    +showArtworkPresence?: boolean,
     +title: string,
   },
 ): ColumnOptions<T, string> {
@@ -429,8 +429,8 @@ export function defineNameColumn<T: NonUrlRelatableEntityT | CollectionT>(
         : (
           <EntityLink
             entity={original}
+            showArtworkPresence={props.showArtworkPresence}
             // Event lists show date in its own column
-            showCaaPresence={props.showCaaPresence}
             showEventDate={false}
           />
         )


### PR DESCRIPTION
### Implement MBS-13600


# Description
This mirrors what we already do for releases and release groups, showing whether a particular event has event art in both event lists and event search results by displaying a small image icon by its name.

I made the variables and classes generic wherever it simplifies the code, since there's no reason to prefer CAA/EAA over artwork in cases like these.

# Testing
Tested locally with live data, with `/artist/b0109715-ff87-4546-b1e2-08a78c60329a/events`, `search?query=Fueu%21%09&type=event&limit=25&method=indexed` and `search?query=Fueu%21%09&type=event&limit=25&method=direct` 