### PR TITLE
MBS-13598, MBS-13604: Recent items menu fixes

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2/recentItems.js
+++ b/root/static/scripts/common/components/Autocomplete2/recentItems.js
@@ -263,6 +263,7 @@ export async function getOrFetchRecentItems<T: EntityItemT>(
         });
 
       _recentItemsRequests.set(key, fetchPromise);
+      return fetchPromise;
     }
   }
 

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -17,6 +17,7 @@ import {
 } from '../../common/components/Autocomplete2.js';
 import {
   default as autocompleteReducer,
+  generateItems as generateAutocompleteItems,
 } from '../../common/components/Autocomplete2/reducer.js';
 import type {
   ActionT as AutocompleteActionT,
@@ -330,7 +331,10 @@ export function reducer(
       stateCtx.get('singleArtistAutocomplete')
         .set('disabled', false)
         .set('selectedItem', firstNameAutocomplete.selectedItem)
-        .set('inputValue', firstNameAutocomplete.inputValue);
+        .set('inputValue', firstNameAutocomplete.inputValue)
+        .update((ctx) => {
+          ctx.set('items', generateAutocompleteItems(ctx.read()));
+        });
     } else {
       stateCtx.get('singleArtistAutocomplete')
         .set('disabled', true)

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -679,6 +679,7 @@ const seleniumTests = [
     sql: 'mbs-13015.sql',
   },
   {name: 'MBS-13392.json5', login: true},
+  {name: 'MBS-13604.json5', login: true},
   {name: 'Artist_Credit_Editor.json5', login: true},
   {name: 'Autocomplete2.json5'},
   {name: 'CAA.json5', login: true},

--- a/t/selenium/MBS-13604.json5
+++ b/t/selenium/MBS-13604.json5
@@ -1,0 +1,74 @@
+{
+  title: 'MBS-13604',
+  commands: [
+    {
+      command: 'open',
+      target: '/release/24d4159a-99d9-425d-a7b8-1b9ec0261a33/edit',
+      value: '',
+    },
+    // First set the first track AC to match the release AC.
+    {
+      command: 'pause',
+      target: '250',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#tracklist']",
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=ac-18674665-single-artist',
+      value: '5441c29d-3602-4898-b1a1-b77fa23b8e50',
+    },
+    {
+      command: 'pause',
+      target: '250',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#information']",
+      value: '',
+    },
+    // Clear the release AC.
+    {
+      command: 'type',
+      target: "id=ac-source-single-artist",
+      value: '',
+    },
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#tracklist']",
+      value: '',
+    },
+    // The track AC should now be empty.
+    {
+      command: 'assertEval',
+      target: 'window.document.getElementById("ac-18674665-single-artist").value',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: "id=ac-18674665-single-artist",
+      value: '',
+    },
+    // The recent items menu should be visible after focusing the track AC.
+    {
+      command: 'click',
+      target: "id=ac-18674665-single-artist-item-956-recent",
+      value: '',
+    },
+    {
+      command: 'open',
+      target: '/',
+      value: '',
+    },
+    {
+      command: 'handleAlert',
+      target: 'accept',
+      value: '',
+    },
+  ],
+}

--- a/t/selenium/Series_Relationship_Editor.json5
+++ b/t/selenium/Series_Relationship_Editor.json5
@@ -12,6 +12,12 @@
       target: 'document.getElementById("id-edit-series.type_id").value.trim() === ""',
       value: 'true',
     },
+    // Wait for the SeriesRelationshipEditor to initialize.
+    {
+        command: 'pause',
+        target: '500',
+        value: '',
+    },
     {
       command: 'select',
       target: 'id=id-edit-series.type_id',
@@ -215,6 +221,12 @@
       command: 'assertLocationMatches',
       target: '\\/series\\/create',
       value: '',
+    },
+    // Wait for the SeriesRelationshipEditor to initialize.
+    {
+        command: 'pause',
+        target: '500',
+        value: '',
     },
     {
       command: 'type',


### PR DESCRIPTION
# Problem

MBS-13598: Beta: recent items menu doesn't show sometimes
MBS-13604: Show recent track artists after clearing release AC

# Solution

See commits for details.

# Testing

I tested the changes manually on my local development server, and added a Selenium test for MBS-13604. I tried adding one for MBS-13598 too, but couldn't reproduce the issue in the Selenium test environment, so got frustrated and gave up.