### PR TITLE
MBS-13606: Drop search parameters in BetaOnlyEdit

### DIFF
--- a/root/edit/details/BetaOnlyEdit.js
+++ b/root/edit/details/BetaOnlyEdit.js
@@ -23,6 +23,7 @@ component BetaOnlyEdit(edit: EditT) {
     const betaUri = new URL($c.req.uri);
     betaUri.host = DBDefs.BETA_REDIRECT_HOSTNAME;
     betaUri.pathname = '/edit/' + encodeURIComponent(String(editId));
+    betaUri.search = '';
     return (
       <p>
         {exp.l(


### PR DESCRIPTION
### Fix MBS-13606

# Problem
The link to beta in `BetaOnlyEdit` includes any search parameters present on the page that shows it. Since this is intended a s a direct link to the edit in question, there would seem to be no benefit in including any search parameters in it. This is especially silly when getting to the edit from edit searches, since the link will currently contain the whole edit search query parameter group.

# Solution
Actively blank the search portion of the edit URL while creating it.

# Testing
Manually, with `/search/edits?auto_edit_filter=&order=desc&negation=0&combinator=and&conditions.0.field=id&conditions.0.operator=%3D&conditions.0.args.0=112144836&conditions.0.args.1=&unset_beta=1`