### PR TITLE
Fix warnings logged from artist search for autocompletion

### DIFF
--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -754,8 +754,10 @@ sub schema_fixup
                 primary_for_locale => $_->{primary},
             )
         } @{ $data->{aliases} };
-        my $best_alias = find_best_primary_alias(\@aliases, $user_lang);
-        $data->{primary_alias} = $best_alias->{name} if defined $best_alias;
+        if (defined $user_lang) {
+            my $best_alias = find_best_primary_alias(\@aliases, $user_lang);
+            $data->{primary_alias} = $best_alias->{name} if defined $best_alias;
+        }
 
         # Save the new objects so validation will pass, but note that the search
         # API doesn't include all attributes that are present in Entity::Alias,


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

In commit https://github.com/metabrainz/musicbrainz-server/commit/d981ba8c4517c88bb749119f12950cbac565dfe5 from the pull request https://github.com/metabrainz/musicbrainz-server/pull/3191 for MBS-7646 released in `v-2024-05-13-schema-change`, one of the two calls to the new subroutine `find_best_primary_alias` wasn’t checking if the second parameter was defined, causing the warnings below to be triggered (tens of thousands of times a day) in website logs:
    
    Use of uninitialized value $lang in substr at lib/MusicBrainz/Server/Data/Utils.pm line 779.
    Use of uninitialized value $lang in string eq at lib/MusicBrainz/Server/Data/Utils.pm line 785.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This patch fixes that to follow the other call. The behavior is to skip searching for any aliases when the user interface language is undefined.

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

Just tested that editing keeps working, but didn’t try to reproduce the bug either.

Better hiding whitespace changes when viewing the diff.