### PR TITLE
MBS-13174: Split relationships on different time

### DIFF
--- a/root/static/scripts/common/constants.js
+++ b/root/static/scripts/common/constants.js
@@ -315,6 +315,8 @@ export const RECORDING_OF_LINK_TYPE_GID: string =
 
 export const RT_MIRROR = 2;
 
+export const TIME_ATTRIBUTE = 'ebd303c3-7f57-452a-aa3b-d780ebad868d';
+
 export const SERIES_ORDERING_ATTRIBUTE =
   'a59c5830-5ec7-38fe-9a21-c7ea54f6650a';
 

--- a/root/static/scripts/relationship-editor/utility/compareRelationships.js
+++ b/root/static/scripts/relationship-editor/utility/compareRelationships.js
@@ -13,6 +13,7 @@ import {
   PART_OF_SERIES_LINK_TYPE_IDS,
   SERIES_ORDERING_ATTRIBUTE,
   SERIES_ORDERING_TYPE_AUTOMATIC,
+  TIME_ATTRIBUTE,
 } from '../../common/constants.js';
 import {compare} from '../../common/i18n.js';
 import linkedEntities from '../../common/linkedEntities.mjs';
@@ -169,6 +170,18 @@ const getPaddedSeriesNumber = memoizeWithDefault<
         }
       }
       return parts.join('');
+    }
+  }
+  return '';
+}, '');
+
+const getTimeIfPresent = memoizeWithDefault<
+  RelationshipStateT,
+  string,
+>((relationship: RelationshipStateT) => {
+  for (const attribute of tree.iterate(relationship.attributes)) {
+    if (attribute.type.gid === TIME_ATTRIBUTE) {
+      return attribute.text_value || '';
     }
   }
   return '';
@@ -350,6 +363,11 @@ export default function compareRelationships(
   const datePeriodCmp = compareDatePeriods(a, b);
   if (datePeriodCmp) {
     return datePeriodCmp;
+  }
+
+  const timeCmp = compareStrings(getTimeIfPresent(a), getTimeIfPresent(b));
+  if (timeCmp) {
+    return timeCmp;
   }
 
   const targetCreditA = backward

--- a/root/static/scripts/tests/relationship-editor/utility/compareRelationships.js
+++ b/root/static/scripts/tests/relationship-editor/utility/compareRelationships.js
@@ -164,7 +164,7 @@ test('compareRelationships: Basic comparisons', function (t) {
 test('compareRelationships: Series comparisons', function (t) {
   t.plan(4);
 
-  const recording = createArtistObject({
+  const recording = createRecordingObject({
     id: 1,
     name: 'Recording',
   });

--- a/root/static/scripts/tests/relationship-editor/utility/compareRelationships.js
+++ b/root/static/scripts/tests/relationship-editor/utility/compareRelationships.js
@@ -13,9 +13,11 @@ import * as tree from 'weight-balanced-tree';
 import {
   SERIES_ORDERING_ATTRIBUTE,
   SERIES_ORDERING_TYPE_AUTOMATIC,
+  TIME_ATTRIBUTE,
 } from '../../../common/constants.js';
 import {
   createArtistObject,
+  createEventObject,
   createRecordingObject,
   createSeriesObject,
 } from '../../../common/entity2.js';
@@ -158,6 +160,85 @@ test('compareRelationships: Basic comparisons', function (t) {
       true,
     ) === 0,
     'The exact same relationship is seen as equal with an entity credit',
+  );
+});
+
+test('compareRelationships: Time comparisons', function (t) {
+  t.plan(3);
+
+  const artist = createArtistObject({
+    id: 1,
+    name: 'Artist',
+  });
+
+  const event = createEventObject({
+    id: 1,
+    name: 'Event',
+  });
+
+  const attributesWithTime1 = tree.fromDistinctAscArray([{
+    text_value: '10:10',
+    type: {
+      gid: TIME_ATTRIBUTE,
+    },
+    typeID: 830,
+    typeName: 'time',
+  }]);
+
+  const attributesWithTime2 = tree.fromDistinctAscArray([{
+    text_value: '11:10',
+    type: {
+      gid: TIME_ATTRIBUTE,
+    },
+    typeID: 830,
+    typeName: 'time',
+  }]);
+
+  const artistEventRelTime1 = {
+    ...emptyRelationship,
+    attributes: attributesWithTime1,
+    entity0: artist,
+    entity1: event,
+    id: -1,
+    linkTypeID: 798, // Main performer
+  };
+
+  const artistEventRelTime2 = {
+    ...artistEventRelTime1,
+    attributes: attributesWithTime2,
+  };
+
+  const artistEventRelNoTime = {
+    ...artistEventRelTime1,
+    attributes: null,
+  };
+
+  t.ok(
+    compareRelationships(
+      artistEventRelTime1,
+      artistEventRelTime1,
+      false,
+    ) === 0,
+    'The same relationship with the same time is seen as equal',
+  );
+
+
+  t.ok(
+    compareRelationships(
+      artistEventRelTime1,
+      artistEventRelTime2,
+      false,
+    ) === -1,
+    'The same relationship with different times is not seen as equal, and earlier time sorts first',
+  );
+
+  t.ok(
+    compareRelationships(
+      artistEventRelTime1,
+      artistEventRelNoTime,
+      false,
+    ) === 1,
+    'The same relationship with and without time is not seen as equal, and time sorts last',
   );
 });
 


### PR DESCRIPTION
### Implement MBS-13174

# Problem
Relationships with different times should be by definition different, so we do not want them to be considered as duplicates of each other.
This is especially important in concerts where the same artist plays at least twice.

# Solution
This uses code similar to the one we use to check for series numbering and split rels based on it. Since I cannot think of any case where we would *not* want to accept multiple rels with different times, I apply this to all relationships, same as with dates.

# Testing
Added a few test cases to the `compareRelationships` test, plus did some basic manual testing.