### PR TITLE
MBS-13612: Clarify you can add several art types to a file

### DIFF
--- a/root/components/ArtFields.js
+++ b/root/components/ArtFields.js
@@ -61,7 +61,7 @@ component ArtFields(...{
       ) : null}
       <FormRow>
         <fieldset className={`${archiveName}-art-types row`}>
-          <legend>{addColonText(l('Type'))}</legend>
+          <legend>{addColonText(l('Types'))}</legend>
           <ul className={`${archiveName}-art-type-checkboxes`}>
             {typeIdOptions.map(option => (
               <li key={option.value}>

--- a/root/event/EventArtFields.js
+++ b/root/event/EventArtFields.js
@@ -20,8 +20,8 @@ const EventArtFields = ({
       archiveName="event"
       chooseMessage={l('Choose one or more event art types for this image')}
       documentationMessage={exp.l(
-        `Please see the {doc|Event Art Types} documentation
-         for a description of these types.`,
+        `Select all types that apply. See the {doc|Event Art Types}
+         documentation for their descriptions.`,
         {doc: {href: '/doc/Event_Art/Types', target: '_blank'}},
       )}
       form={form}

--- a/root/event/add_event_art.tt
+++ b/root/event/add_event_art.tt
@@ -51,7 +51,7 @@
             </div>
 
             <div class="event-art-types row" data-bind="visible: status() == 'waiting'">
-              <label>[%- l("Type:") -%]</label>
+              <label>[%- add_colon(l("Types")) -%]</label>
               <ul class="event-art-type-checkboxes" data-bind="foreach: types">
                 <li>
                   <label>
@@ -63,7 +63,7 @@
             </div>
             <div class="event-art-types-help row" data-bind="visible: status() == 'waiting'">
               <label>&nbsp;</label>
-              <p style="margin-left: 162px;">[%- l('Please see the {doc|Event Art Types} documentation for a description of these types.', { doc => { href => doc_link('Event_Art/Types'), target => '_blank' } }) -%]</p>
+              <p style="margin-left: 162px;">[%- l('Select all types that apply. See the {doc|Event Art Types} documentation for a description of these types.', { doc => { href => doc_link('Event_Art/Types'), target => '_blank' } }) -%]</p>
             </div>
             <div class="comment row" data-bind="visible: status() == 'waiting'">
               <label>[%- add_colon(l('Comment')) -%]</label>

--- a/root/release/CoverArtFields.js
+++ b/root/release/CoverArtFields.js
@@ -20,8 +20,8 @@ component CoverArtFields(...{
       archiveName="cover"
       chooseMessage={l('Choose one or more cover art types for this image')}
       documentationMessage={exp.l(
-        `Please see the {doc|Cover Art Types} documentation
-         for a description of these types.`,
+        `Select all types that apply. See the {doc|Cover Art Types}
+         documentation for their descriptions.`,
         {doc: {href: '/doc/Cover_Art/Types', target: '_blank'}},
       )}
       form={form}

--- a/root/release/add_cover_art.tt
+++ b/root/release/add_cover_art.tt
@@ -51,7 +51,7 @@
             </div>
 
             <div class="cover-art-types row" data-bind="visible: status() == 'waiting'">
-              <label>[%- l("Type:") -%]</label>
+              <label>[%- add_colon(l("Types")) -%]</label>
               <ul class="cover-art-type-checkboxes" data-bind="foreach: types">
                 <li>
                   <label>
@@ -63,7 +63,7 @@
             </div>
             <div class="cover-art-types-help row" data-bind="visible: status() == 'waiting'">
               <label>&nbsp;</label>
-              <p style="margin-left: 162px;">[%- l('Please see the {doc|Cover Art Types} documentation for a description of these types.', { doc => { href => doc_link('Cover_Art/Types'), target => '_blank' } }) -%]</p>
+              <p style="margin-left: 162px;">[%- l('Select all types that apply. See the {doc|Cover Art Types} documentation for a description of these types.', { doc => { href => doc_link('Cover_Art/Types'), target => '_blank' } }) -%]</p>
             </div>
             <div class="comment row" data-bind="visible: status() == 'waiting'">
               <label>[%- add_colon(l('Comment')) -%]</label>


### PR DESCRIPTION
### Implement MBS-13612

# Problem
Currently, only the error-related `chooseMessage` suggests that more than one type of artwork can be selected for the same file. It would seem checkboxes would make it obvious but it's not - many people still don't select, say, "spine" for files that show both the spine and another part of the art.

# Solution
The hope is that these changes, agreed with Aerozol, will make it more obvious that it's fine to select several types by changing "Type" to "Type**s**" and adding it explicitly to the doc line under the type selection.

# Testing
Checked manually that the new strings show fine.