### PR TITLE
Update IRC references to (live) chat

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -74,7 +74,7 @@ Once the image is built you can begin the deployment.
 ### Announce the deployment
 
 Because any deployment may cause issues for MusicBrainz users and MetaBrainz staff,
-each deployment should be announced through the IRC channel and the website’s banner.
+each deployment should be announced through the chat and the website’s banner.
 
 [Set the banner message](https://musicbrainz.org/admin/banner/edit) to
 

--- a/root/account/Register.js
+++ b/root/account/Register.js
@@ -78,11 +78,11 @@ component Register(
       <p>
         {exp.l(
           `Follow our {bl|blog} or {tw|twitter account}!
-           To talk to other users, try the {fo|forums} or {irc|IRC}.`,
+           To talk to other users, try the {fo|forums} or the {chat|chat}.`,
           {
             bl: 'http://blog.metabrainz.org/',
+            chat: '/doc/Communication/ChatBrainz',
             fo: 'https://community.metabrainz.org/',
-            irc: '/doc/Communication/IRC',
             tw: 'https://twitter.com/MusicBrainz',
           },
         )}

--- a/root/account/Register.js
+++ b/root/account/Register.js
@@ -77,13 +77,14 @@ component Register(
 
       <p>
         {exp.l(
-          `Follow our {bl|blog} or {tw|twitter account}!
-           To talk to other users, try the {fo|forums} or the {chat|chat}.`,
+          `Follow our {blog_link|blog} or {twitterx_link|twitter account}!
+           To talk to other users,
+           try the {forum_link|forums} or the {chat_link|chat}.`,
           {
-            bl: 'http://blog.metabrainz.org/',
-            chat: '/doc/Communication/ChatBrainz',
-            fo: 'https://community.metabrainz.org/',
-            tw: 'https://twitter.com/MusicBrainz',
+            blog_link: 'http://blog.metabrainz.org/',
+            chat_link: '/doc/Communication/ChatBrainz',
+            forum_link: 'https://community.metabrainz.org/',
+            twitterx_link: 'https://twitter.com/MusicBrainz',
           },
         )}
       </p>

--- a/root/layout.tt
+++ b/root/layout.tt
@@ -118,7 +118,7 @@
                 <a href="https://metabrainz.org/donate" class="internal">[% l('Donate') %]</a>
                 <a href="//wiki.musicbrainz.org/" class="internal">[% l('Wiki') %]</a>
                 <a href="https://community.metabrainz.org/" class="internal">[% l('Forums') %]</a>
-                <a href="/doc/Communication/IRC" class="internal">[% l('IRC') %]</a>
+                <a href="/doc/Communication/ChatBrainz" class="internal">[% l('Chat') %]</a>
                 <a href="https://tickets.metabrainz.org/" class="internal">[% l('Bug tracker') %]</a>
                 <a href="https://blog.metabrainz.org/" class="internal">[% l('Blog') %]</a>
                 <a href="https://twitter.com/MusicBrainz" class="internal">[% l('Twitter') %]</a>

--- a/root/layout/components/Footer.js
+++ b/root/layout/components/Footer.js
@@ -26,8 +26,8 @@ component Footer() {
         <a className="internal" href={DONATE_URL}>{l('Donate')}</a>
         <a className="internal" href="//wiki.musicbrainz.org/">{l('Wiki')}</a>
         <a className="internal" href="https://community.metabrainz.org/">{l('Forums')}</a>
-        <a className="internal" href="/doc/Communication/IRC">
-          {l('Chat (IRC)')}
+        <a className="internal" href="/doc/Communication/ChatBrainz">
+          {l('Chat')}
         </a>
         <a className="internal" href="http://tickets.metabrainz.org/">{l('Bug tracker')}</a>
         <a className="internal" href="https://blog.metabrainz.org/">{l('Blog')}</a>


### PR DESCRIPTION
We've moved to use Matrix as our main chat platform, so this changes references to IRC to point to our new generic page.