### PR TITLE
MBS-13618: Beta: Fix types display on release group "set cover art" page

### DIFF
--- a/root/release_group/set_cover_art.tt
+++ b/root/release_group/set_cover_art.tt
@@ -66,7 +66,7 @@
               <p>
                 [%- add_colon(lp('Cover art', 'singular')) -%]
                 <ul>
-                  <li>[%- l('Types:') %] [% comma_list(image.types) || '-' -%]</li>
+                  <li>[%- l('Types:') %] [% comma_list(image.l_type_names) || '-' -%]</li>
                   [%- IF image.comment -%]
                     <li>[%- add_colon(l('Comment')) %] [% image.comment | html -%]</li>
                   [%- END -%]


### PR DESCRIPTION
# Problem

MBS-13618

# Solution

This was broken by 3fb6b951e65071a8b87a4d4520d6a655c6f2bad9; though given that it previously used `image.types`, I don't think they were translated previously either, which they are now.

# Testing

Loaded the page in the ticket on my local dev server (via hendrix).