### PR TITLE
MBS-13629: Beta: ISE loading "Remove cover art" edit for removed release

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Role/RemoveArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/RemoveArt.pm
@@ -139,7 +139,7 @@ sub build_display_data {
 
     my $entity =
         $loaded->{ $art_archive_model->entity_model_name }{$entity_id} ||
-        $self->entity_model->_entity_class->new(
+        $art_archive_model->entity_model->_entity_class->new(
             id => $entity_id,
             name => $data->{entity}{name},
         );


### PR DESCRIPTION
# Problem

MBS-13629

# Solution

The code was trying to access `entity_model` on `$self`, which is the edit class, where it should be trying to access it on `$art_archive_model`.

This only affected edits where the release (or event, in the case of "Remove event art" edits) was removed.

# Testing

Tested loading http://localhost:5000/edit/112358221 via hendrix.