### PR TITLE
MBS-13626: Always link to correct edit note from timestamp 

### DIFF
--- a/lib/MusicBrainz/Server/Controller/EditNote.pm
+++ b/lib/MusicBrainz/Server/Controller/EditNote.pm
@@ -101,13 +101,13 @@ sub detach_if_cannot_change {
         $c->detach;
     }
 
-    my $all_edit_notes = $edit->{edit_notes};
+    my @all_edit_notes = $edit->all_edit_notes;
     my $note_index = first_index {
         $_->id == $edit_note->id,
-    } @$all_edit_notes;
+    } @all_edit_notes;
     my $has_reply = 0;
-    for (my $i = $note_index + 1; $i < @$all_edit_notes; $i++) {
-        my $reply_editor = $all_edit_notes->[$i]->editor_id;
+    for (my $i = $note_index + 1; $i < @all_edit_notes; $i++) {
+        my $reply_editor = $all_edit_notes[$i]->editor_id;
         if (($reply_editor != $edit_note->editor_id) &&
             ($reply_editor != $EDITOR_MODBOT)) {
             $has_reply = 1;

--- a/lib/MusicBrainz/Server/Controller/EditNote.pm
+++ b/lib/MusicBrainz/Server/Controller/EditNote.pm
@@ -36,6 +36,23 @@ sub _load
     return $edit_note;
 }
 
+sub show : PathPart('') Chained('load') {
+    my ($self, $c) = @_;
+
+    my $edit_note = $c->stash->{edit_note};
+    my $edit_id = $edit_note->edit_id;
+    my $edit = $c->model('Edit')->get_by_id($edit_id);
+    $c->model('EditNote')->load_for_edits($edit);
+    my @all_edit_notes = $edit->all_edit_notes;
+    my $note_index = (first_index {
+        $_->id == $edit_note->id,
+    } @all_edit_notes) + 1;
+
+    my $url = '/edit/' . $edit_id . '#note-' . $edit_id . '-' . $note_index;
+
+    $c->res->redirect($url);
+}
+
 sub detach_if_cannot_change {
     my ($self, $c, $edit_note, $edit) = @_;
 

--- a/root/edit/components/EditNote.js
+++ b/root/edit/components/EditNote.js
@@ -142,7 +142,7 @@ component EditNote(
         ) : null}
         <a
           className="date"
-          href={(isOnEditPage ? '' : `/edit/${edit.id}`) + `#${anchor}`}
+          href={isOnEditPage ? `#${anchor}` : `/edit-note/${editNote.id}`}
           rel={isOnEditPage ? null : 'noopener noreferrer'}
           target={isOnEditPage ? null : '_blank'}
         >

--- a/root/entity/NotFound.js
+++ b/root/entity/NotFound.js
@@ -69,6 +69,14 @@ const notFoundPages: {[namespace: string]: NotFoundPagesPropsT} = {
     args: {search_url: '/search/edits'},
     footer: null,
   },
+  'editnote': {
+    title: N_lp('Edit note not found', 'header'),
+    message: N_l(
+      'Sorry, we could not find an edit note with that ID.',
+    ),
+    args: {},
+    footer: null,
+  },
   'elections': {
     title: N_lp('Election not found', 'header'),
     message: N_l('Sorry, we could not find this election.'),

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -171,6 +171,7 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   'Controller::EditNote::edit_note_change',
   'Controller::EditNote::edit_note_history',
   'Controller::EditNote::modify',
+  'Controller::EditNote::show',
   'Controller::Event::alias',
   'Controller::Event::aliases',
   'Controller::Event::annotation_diff',


### PR DESCRIPTION
### Fix MBS-13626

# Problem
We are always using the index to create an anchor link when linking to a permalink for a specific edit note from the note's timestamp, but in many cases (such as when we are editing a note or loading just the one note for the edit in `notes-received`) we don't even know what the right index would be and were always passing `0`. This meant that the note linked was always the first for the edit in those cases, which often was not the right one.

# Solution
This creates a new `edit-note/id` endpoint that just redirects us to the right edit note anchor in the appropriate edit, and which we use instead of the anchor itself everywhere except when we are already on the edit page.

# Testing
Manually from an edit listing and from `notes-received`, making sure the link is correct and redirects to the appropriate edit note.