### PR TITLE
MBS-13630: Prioritize "Voting is closed" as no vote rights reason in AE elections

### DIFF
--- a/root/elections/ElectionVoting.js
+++ b/root/elections/ElectionVoting.js
@@ -27,7 +27,9 @@ component ElectionVoting(election: AutoEditorElectionT) {
   const user = $c.user;
 
   if (user) {
-    if (!isAutoEditor(user)) {
+    if (election.is_closed) {
+      message = l('Voting is closed.');
+    } else if (!isAutoEditor(user)) {
       message = l(
         `You cannot vote for this candidate,
          because you are not an auto-editor.`,
@@ -45,8 +47,6 @@ component ElectionVoting(election: AutoEditorElectionT) {
          that you cannot cast a "No" vote (or abstain)
          until two seconders have been found.`,
       );
-    } else if (election.is_closed) {
-      message = l('Voting is closed.');
     }
   }
 


### PR DESCRIPTION
### Implement MBS-13630

# Description
Nobody can vote on a closed election. As such, it makes sense to check for a closed election first, and always display "Voting is closed" when that's the case regardless of whether something else (like being a seconder) would also block voting for that editor.

# Testing
Checked manually that a more sensible reason is now shown for why I cannot participate in `/election/307`. This works for me - for other testers, you'll need to check elections where you are involved directly - or, as a non-autoeditor, see if "Voting is closed" is shown since I think earlier all you got was "You cannot vote for this candidate, because you are not an auto-editor"