### PR TITLE
MBS-13631: Keep trailing join phrase on release -> track AC change

### DIFF
--- a/root/static/scripts/edit/utility/getUpdatedTrackArtists.js
+++ b/root/static/scripts/edit/utility/getUpdatedTrackArtists.js
@@ -28,19 +28,22 @@ const sameEntities = (
 /*
  * Returns a copy of orig with its first numToReplace names changed to
  * replacement, preserving the original join phrase from the end of the
- * replaced names.
+ * replaced names unless the new join phrase is the end of the artist credit.
  */
 const replacePrefix = (
   orig: $ReadOnlyArray<ArtistCreditNameT>,
   numToReplace: number,
   replacement: $ReadOnlyArray<ArtistCreditNameT>,
 ): $ReadOnlyArray<ArtistCreditNameT> => {
-  const updated = cloneArrayDeep(replacement)
-    .concat(orig.slice(numToReplace));
-  updated[replacement.length - 1] = {
-    ...updated[replacement.length - 1],
-    joinPhrase: orig[numToReplace - 1].joinPhrase,
-  };
+  const extraOriginalArtists = orig.slice(numToReplace);
+  const updated = cloneArrayDeep(replacement).concat(extraOriginalArtists);
+  const isFullReplacement = extraOriginalArtists.length === 0;
+  if (!isFullReplacement) {
+    updated[replacement.length - 1] = {
+      ...updated[replacement.length - 1],
+      joinPhrase: orig[numToReplace - 1].joinPhrase,
+    };
+  }
   return updated;
 };
 

--- a/root/static/scripts/tests/edit/utility/getUpdatedTrackArtists.js
+++ b/root/static/scripts/tests/edit/utility/getUpdatedTrackArtists.js
@@ -229,6 +229,20 @@ test('getUpdatedTrackArtists', function (t) {
         name('D', '5'),
       ],
     },
+    {
+      desc: 'artist change with trailing join phrase, track matches old',
+      track: [name('Old', '1')],
+      oldRel: [name('Old', '1')],
+      newRel: [name('New', '2', ' & Friends')],
+      want: [name('New', '2', ' & Friends')],
+    },
+    {
+      desc: 'artist change with trailing join phrase, track matches old but has feat',
+      track: [name('Old', '1', ' feat. '), name('Aged', '3')],
+      oldRel: [name('Old', '1')],
+      newRel: [name('New', '2', ' & Friends')],
+      want: [name('New', '2', ' feat. '), name('Aged', '3')],
+    },
   ];
   /* eslint-enable sort-keys */
 


### PR DESCRIPTION
### Fix MBS-13631

# Problem
The changes to the artist credit copying mechanism that keeps ACs in sync between releases and tracks mean the system is always keeping the original join phrase at the end of the replaced AC section. This makes sense in most cases, but not when the whole AC is being replaced, in which case keeping any potential trailing phrases from the replacement AC makes a lot more sense.

# Solution
This checks whether the whole AC is being replaced, and in that case it skips the step setting the old join phrase back.

# Testing
Added a couple tests to `getUpdatedTrackArtists`.