### PR TITLE
MBS-13638: Remove duplicate schema on in_use query

### DIFF
--- a/lib/MusicBrainz/Server/Data/Role/ArtType.pm
+++ b/lib/MusicBrainz/Server/Data/Role/ArtType.pm
@@ -97,11 +97,10 @@ sub load_for {
 sub in_use {
     my ($self, $id) = @_;
 
-    my $schema = $self->art_schema;
     my $type_table = $self->art_type_table;
 
     return $self->sql->select_single_value(
-        "SELECT 1 FROM $schema.$type_table WHERE type_id = ? LIMIT 1",
+        "SELECT 1 FROM $type_table WHERE type_id = ? LIMIT 1",
         $id,
     );
 }


### PR DESCRIPTION
### Fix MBS-13638

# Problem
Cannot remove a cover art or event art type, because of an ISE in the `in_use` check because of a badly built query.

# Solution
This was failing because `$type_table` already contains the schema so the query ended up with a broken duplicate schema. So I just removed the unneeded `$schema` variable.

# Testing
Manually, to make sure the query resolves now and the deletion page loads.