### PR TITLE
MBS-13640: Add more event art stats

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Statistics.pm
+++ b/lib/MusicBrainz/Server/Controller/Statistics.pm
@@ -212,15 +212,20 @@ sub images : Local
 
     my $stats = try_fetch_latest_statistics($c);
 
+    my $cover_art_type_stats = [];
+    my $event_art_type_stats = [];
+    my $event_type_stats = [];
     my $release_type_stats = [];
     my $release_status_stats = [];
     my $release_format_stats = [];
-    my $type_stats = [];
 
     foreach my $stat_name
         (rev_nsort_by { $stats->statistic($_) } $stats->statistic_names) {
         if (my ($type) = $stat_name =~ /^count\.release\.type\.(.*)\.has_coverart$/) {
             push(@$release_type_stats, ({'stat_name' => $stat_name, 'type' => $type}));
+        }
+        if (my ($type) = $stat_name =~ /^count\.event\.type\.(.*)\.has_eventart$/) {
+            push(@$event_type_stats, ({'stat_name' => $stat_name, 'type' => $type}));
         }
         if (my ($status) = $stat_name =~ /^count\.release\.status\.(.*)\.has_coverart$/) {
             push(@$release_status_stats, ({'stat_name' => $stat_name, 'status' => $status}));
@@ -229,17 +234,22 @@ sub images : Local
             push(@$release_format_stats, ({'stat_name' => $stat_name, 'format' => $format}));
         }
         if (my ($type) = $stat_name =~ /^count\.coverart.type\.(.*)$/) {
-            push(@$type_stats, ({'stat_name' => $stat_name, 'type' => $type}));
+            push(@$cover_art_type_stats, ({'stat_name' => $stat_name, 'type' => $type}));
+        }
+        if (my ($type) = $stat_name =~ /^count\.eventart.type\.(.*)$/) {
+            push(@$event_art_type_stats, ({'stat_name' => $stat_name, 'type' => $type}));
         }
     }
 
     my %props = (
+        coverArtTypeStats => $cover_art_type_stats,
         dateCollected => $stats->{date_collected},
+        eventArtTypeStats => $event_art_type_stats,
+        eventTypeStats => $event_type_stats,
         releaseFormatStats => $release_format_stats,
         releaseStatusStats => $release_status_stats,
         releaseTypeStats => $release_type_stats,
         stats => $stats->{data},
-        typeStats => $type_stats,
     );
 
     $c->stash(

--- a/lib/MusicBrainz/Server/Data/Statistics.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics.pm
@@ -238,7 +238,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.area.type.'.$_ => $dist{$_}
+                    ("count.area.type.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -371,7 +371,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.event.country.'.$_ => $dist{$_}
+                    ("count.event.country.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -393,7 +393,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.event.type.'.$_ => $dist{$_}
+                    ("count.event.type.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -418,7 +418,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.event.type.'.$_. '.has_eventart' => $dist{$_}
+                    ("count.event.type.$_.has_eventart" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -463,7 +463,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.eventart.type.'.$_ => $dist{$_}
+                    ("count.eventart.type.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -497,7 +497,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.eventart.per_event.'.$_. 'images' => $dist{$_}
+                    ("count.eventart.per_event.${_}images" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -527,7 +527,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.instrument.type.'.$_ => $dist{$_}
+                    ("count.instrument.type.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -562,7 +562,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.place.country.'.$_ => $dist{$_}
+                    ("count.place.country.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -584,7 +584,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.place.type.'.$_ => $dist{$_}
+                    ("count.place.type.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -609,7 +609,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.series.type.'.$_ => $dist{$_}
+                    ("count.series.type.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -638,7 +638,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.coverart.type.'.$_ => $dist{$_}
+                    ("count.coverart.type.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -679,7 +679,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.release.status.'.$_. '.has_coverart' => $dist{$_}
+                    ("count.release.status.$_.has_coverart" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -706,7 +706,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.release.type.'.$_. '.has_coverart' => $dist{$_}
+                    ("count.release.type.$_.has_coverart" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -732,7 +732,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.release.format.'.$_. '.has_coverart' => $dist{$_}
+                    ("count.release.format.$_.has_coverart" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -766,7 +766,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.coverart.per_release.'.$_. 'images' => $dist{$_}
+                    ("count.coverart.per_release.${_}images" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -793,7 +793,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.label.type.'.$_ => $dist{$_}
+                    ("count.label.type.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -891,7 +891,7 @@ my %stats = (
                     return $row->{valid} && $row->{validated} && !(grep { $row->{$_} } @active_markers);
                 },
             };
-            my %ret = map { $_ => 0 } (keys %$stats, map { 'count.editor.valid.active.'.$_ } @active_markers);
+            my %ret = map { $_ => 0 } (keys %$stats, map { "count.editor.valid.active.$_" } @active_markers);
             for my $row (@$data) {
                 for my $stat (keys %$stats) {
                     if ($stats->{$stat}->($row)) {
@@ -965,7 +965,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.work.language.'.$_ => $dist{$_}
+                    ("count.work.language.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -987,7 +987,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.work.type.'.$_ => $dist{$_}
+                    ("count.work.type.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -1010,7 +1010,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.work.attribute.'.$_ => $dist{$_}
+                    ("count.work.attribute.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -1099,7 +1099,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.label.country.'.$_ => $dist{$_}
+                    ("count.label.country.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -1123,7 +1123,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.release.country.'.$_ => $dist{$_}
+                    ("count.release.country.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -1143,7 +1143,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.release.format.'.$_ => $dist{$_}
+                    ("count.release.format.$_" => $dist{$_})
                 } keys %dist,
             };
          },
@@ -1163,7 +1163,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.medium.format.'.$_ => $dist{$_}
+                    ("count.medium.format.$_" => $dist{$_})
                 } keys %dist,
             };
          },
@@ -1188,7 +1188,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.release.language.'.$_ => $dist{$_}
+                    ("count.release.language.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -1209,7 +1209,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.release.script.'.$_ => $dist{$_}
+                    ("count.release.script.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -1230,7 +1230,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.release.status.'.$_ => $dist{$_}
+                    ("count.release.status.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -1251,7 +1251,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.release.packaging.'.$_ => $dist{$_}
+                    ("count.release.packaging.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -1281,7 +1281,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.releasegroup.'.$_.'releases' => $dist{$_}
+                    ("count.releasegroup.${_}releases" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -1303,7 +1303,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.releasegroup.primary_type.'.$_ => $dist{$_}
+                    ("count.releasegroup.primary_type.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -1328,7 +1328,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.releasegroup.secondary_type.'.$_ => $dist{$_}
+                    ("count.releasegroup.secondary_type.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -1482,7 +1482,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.edit.type.'.$_ => $dist{$_}
+                    ("count.edit.type.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -1530,7 +1530,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.artist.country.'.$_ => $dist{$_}
+                    ("count.artist.country.$_" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -1885,7 +1885,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.release.'.$_.'discids' => $dist{$_}
+                    ("count.release.${_}discids" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -1924,7 +1924,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.medium.'.$_.'discids' => $dist{$_}
+                    ("count.medium.${_}discids" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -2003,7 +2003,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.recording.'.$_.'releases' => $dist{$_}
+                    ("count.recording.${_}releases" => $dist{$_})
                 } keys %dist,
             };
         },
@@ -2052,7 +2052,7 @@ my %stats = (
 
             +{
                 map {
-                    'count.ar.links.'.$_ => $dist{$_}
+                    ("count.ar.links.$_" => $dist{$_})
                 } keys %dist,
             };
         },

--- a/root/statistics/Images.js
+++ b/root/statistics/Images.js
@@ -30,7 +30,12 @@ type CoverArtReleaseTypeStatT = {
   +type: string,
 };
 
-type CoverArtTypeStatT = {
+type EventArtEventTypeStatT = {
+  +stat_name: string,
+  +type: string,
+};
+
+type ArtTypeStatT = {
   +stat_name: string,
   +type: string,
 };
@@ -44,12 +49,14 @@ const nameOrNull = (name: string, defaultName: string) => {
 };
 
 component Images(
+  coverArtTypeStats: $ReadOnlyArray<ArtTypeStatT>,
   dateCollected: string,
+  eventArtTypeStats: $ReadOnlyArray<ArtTypeStatT>,
+  eventTypeStats: $ReadOnlyArray<EventArtEventTypeStatT>,
   releaseFormatStats: $ReadOnlyArray<CoverArtReleaseFormatStatT>,
   releaseStatusStats: $ReadOnlyArray<CoverArtReleaseStatusStatT>,
   releaseTypeStats: $ReadOnlyArray<CoverArtReleaseTypeStatT>,
   stats: {[statName: string]: number},
-  typeStats: $ReadOnlyArray<CoverArtTypeStatT>,
 ) {
   const $c = React.useContext(CatalystContext);
   const noImageStatistics = (
@@ -326,7 +333,7 @@ component Images(
               </td>
               <td />
             </tr>
-            {typeStats.map((type, index) => (
+            {coverArtTypeStats.map((type, index) => (
               <tr key={'type' + index}>
                 <th />
                 <th>
@@ -412,6 +419,171 @@ component Images(
                   $c,
                   stats['count.coverart.per_release.30images'] /
                     stats['count.release.has_caa'],
+                  1,
+                )}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      )}
+
+      <h2>{l_statistics('Events')}</h2>
+      {eventTypeStats.length === 0 ? (
+        <p>
+          {l_statistics('No event art statistics available.')}
+        </p>
+      ) : (
+        <table className="database-statistics">
+          <tbody>
+            <tr className="thead">
+              <th colSpan="4">{l_statistics('By event type')}</th>
+            </tr>
+            <tr>
+              <th colSpan="2">
+                {addColonText(l_statistics('Events with event art'))}
+              </th>
+              <td>
+                {formatCount($c, stats['count.event.has_eaa'])}
+                {' '}
+                <TimelineLink statName="count.event.has_eaa" />
+              </td>
+              <td />
+            </tr>
+            {eventTypeStats.map((type, index) => (
+              <tr key={'type' + index}>
+                <th />
+                <th>
+                  {nameOrNull(
+                    lp_attributes(type.type, 'event_type'),
+                    l_statistics('No type'),
+                  )}
+                </th>
+                <td>
+                  {formatCount($c, stats[type.stat_name])}
+                  {' '}
+                  <TimelineLink statName={type.stat_name} />
+                </td>
+                <td>
+                  {formatPercentage(
+                    $c,
+                    stats[type.stat_name] / stats['count.event.has_eaa'],
+                    1,
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>)
+      }
+
+      <h2>{l_statistics('Pieces of event art')}</h2>
+      {stats['count.event.has_eaa'] < 1 ? (
+        <p>
+          {l_statistics('No event art statistics available.')}
+        </p>
+      ) : (
+        <table className="database-statistics">
+          <tbody>
+            <tr className="thead">
+              <th colSpan="4">{l_statistics('By event art type')}</th>
+            </tr>
+            <tr>
+              <th colSpan="2">
+                {addColonText(l_statistics('Pieces of event art'))}
+              </th>
+              <td>
+                {formatCount($c, stats['count.eventart'])}
+                {' '}
+                <TimelineLink statName="count.eventart" />
+              </td>
+              <td />
+            </tr>
+            {eventArtTypeStats.map((type, index) => (
+              <tr key={'type' + index}>
+                <th />
+                <th>
+                  {nameOrNull(
+                    lp_attributes(type.type, 'event_art_type'),
+                    l_statistics('No type'),
+                  )}
+                </th>
+                <td>
+                  {formatCount($c, stats[type.stat_name])}
+                  {' '}
+                  <TimelineLink statName={type.stat_name} />
+                </td>
+                <td>
+                  {formatPercentage(
+                    $c,
+                    stats[type.stat_name] / stats['count.eventart'],
+                    1,
+                  )}
+                </td>
+              </tr>
+            ))}
+            <tr className="thead">
+              <th colSpan="4">{l_statistics('Per event')}</th>
+            </tr>
+            <tr>
+              <th colSpan="2">{l_statistics('Events with event art:')}</th>
+              <td>
+                {formatCount($c, stats['count.event.has_eaa'])}
+                {' '}
+                <TimelineLink statName="count.event.has_eaa" />
+              </td>
+              <td />
+            </tr>
+            {mapRange(1, 14, (number) => (
+              <tr key={number}>
+                <th />
+                <th>
+                  {texp.ln_statistics(
+                    'with {num} piece of event art:',
+                    'with {num} pieces of event art:',
+                    number,
+                    {num: number},
+                  )}
+                </th>
+                <td>
+                  {formatCount(
+                    $c,
+                    stats['count.eventart.per_event.' + number + 'images'],
+                  )}
+                  {' '}
+                  <TimelineLink
+                    statName={
+                      'count.eventart.per_event.' + number + 'images'
+                    }
+                  />
+                </td>
+                <td>
+                  {formatPercentage(
+                    $c,
+                    stats['count.eventart.per_event.' + number + 'images'] /
+                      stats['count.event.has_eaa'],
+                    1,
+                  )}
+                </td>
+              </tr>
+            ))}
+            <tr>
+              <th />
+              <th>{l_statistics('with 15 or more pieces of event art:')}</th>
+              <td>
+                {formatCount(
+                  $c,
+                  stats['count.eventart.per_event.15images'],
+                )}
+                {' '}
+                <TimelineLink
+                  statName="count.eventart.per_event.15images"
+                />
+              </td>
+              <td>
+                {formatPercentage(
+                  $c,
+                  stats['count.eventart.per_event.15images'] /
+                    stats['count.event.has_eaa'],
                   1,
                 )}
               </td>

--- a/root/statistics/Index.js
+++ b/root/statistics/Index.js
@@ -925,6 +925,28 @@ component Index(
             <td>{fp('event.type.null', 'event')}</td>
           </tr>
         </tbody>
+        <tbody>
+          <tr className="thead">
+            <th colSpan="5">{l_statistics('Event art')}</th>
+          </tr>
+          <tr>
+            <th colSpan="3">{addColonText(l_statistics('Events'))}</th>
+            <td>{fc('event')}</td>
+            <td />
+          </tr>
+          <tr>
+            <th />
+            <th colSpan="2">{l_statistics('With EAA poster art:')}</th>
+            <td>{fc('event.has_eaa_poster')}</td>
+            <td>{fp('event.has_eaa_poster', 'event')}</td>
+          </tr>
+          <tr>
+            <th />
+            <th colSpan="2">{l_statistics('No poster art:')}</th>
+            <td>{fc('event.has_no_eaa_poster')}</td>
+            <td>{fp('event.has_no_eaa_poster', 'event')}</td>
+          </tr>
+        </tbody>
       </table>
 
       <h2>{l_statistics('Collections')}</h2>

--- a/root/statistics/stats.js
+++ b/root/statistics/stats.js
@@ -450,10 +450,22 @@ const stats = {
     color: '#22dd00',
     label: l_statistics('Events with an EAA poster'),
   },
+  'count.event.has_no_eaa_poster': {
+    category: 'event-art',
+    color: '#22dd00',
+    label: l_statistics('Events without an EAA poster'),
+  },
   'count.event.type.null': {
     category: 'event-types',
     color: '#ff0000',
     label: l_statistics('Events with no type set'),
+  },
+  'count.event.type.null.has_eventart': {
+    category: 'event-art',
+    color: '#ff0000',
+    label: l_statistics(
+      'Events with no type set that have event art',
+    ),
   },
   'count.genre': {
     category: 'core-entities',
@@ -1088,6 +1100,15 @@ export function buildTypeStats(typeData) {
       category: 'event-types',
       color: '#ff0000',
       label: texp.l_statistics('{type} events', {type: typeName}),
+    };
+
+    stats[`count.event.type.${encodeURI(type.name)}.has_eventart`] = {
+      category: 'event-art',
+      color: '#ff0000',
+      label: texp.l_statistics(
+        'Events of type “{type}” with event art',
+        {type: typeName},
+      ),
     };
   }
 


### PR DESCRIPTION
### Implement MBS-13640

# Description
This copies some of the CAA statistics for events:
* events with "front" for the main stats
* art pieces per event (max 15, I expect less per entity than CAA)
* art pieces by event type
* art pieces by event art type

Not adding the per-event-art-type stats to the `stats.js` file since it seems we already don't do that for cover art type stats; if we want to change that we can do both at once with another commit.

# Testing
Some basic manual testing that the pages load and the stats generate, but only based on 0 pieces of event art since I have no event art locally to test with. 