### PR TITLE
MBS-13645: Fix translations of edit type names

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -474,8 +474,8 @@ sub edit_types : Path('/doc/Edit_Types')
     for my $category (keys %by_category) {
         $by_category{$category} = [
             map {{
-                editName => $_->l_edit_name,
                 id => $_->edit_type,
+                l_edit_name => $_->l_edit_name,
             }}
             sort { $a->l_edit_name cmp $b->l_edit_name }
                 @{ $by_category{$category} },

--- a/lib/MusicBrainz/Server/Controller/Statistics.pm
+++ b/lib/MusicBrainz/Server/Controller/Statistics.pm
@@ -435,7 +435,7 @@ sub edits : Path('edits') {
     my %by_category;
     for my $class (EditRegistry->get_all_classes) {
         $by_category{$class->edit_category} ||= [];
-        push @{ $by_category{$class->edit_category} }, {edit_type => $class->edit_type, edit_name => $class->edit_name};
+        push @{ $by_category{$class->edit_category} }, {edit_type => $class->edit_type, l_edit_name => $class->l_edit_name};
     }
 
     for my $category (keys %by_category) {

--- a/lib/MusicBrainz/Server/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit.pm
@@ -17,14 +17,18 @@ use MusicBrainz::Server::Constants qw(
     $OPEN_EDIT_DURATION
     $REQUIRED_VOTES
 );
-use MusicBrainz::Server::Translation qw( l );
+use MusicBrainz::Server::Translation qw( l lp );
 use MusicBrainz::Server::Types
     DateTime => { -as => 'DateTimeType' }, 'EditStatus', 'Quality';
 
 sub edit_type { die 'Unimplemented' }
+sub edit_type_name_context { 'edit type' }
 sub edit_name { die 'Unimplemented' }
 sub edit_kind { die 'Unimplemented' }
-sub l_edit_name { l(shift->edit_name) }
+sub l_edit_name {
+    my $self = shift;
+    return lp($self->edit_name, $self->edit_type_name_context);
+}
 
 sub edit_template { die 'Unimplemented' }
 
@@ -310,6 +314,7 @@ sub TO_JSON {
         edit_name => $self->edit_name,
         edit_notes => to_json_array($self->edit_notes),
         edit_type => $self->edit_type + 0,
+        edit_type_name_context => $self->edit_type_name_context,
         editor_id => $self->editor_id + 0,
         expires_time => datetime_to_iso8601($self->expires_time),
         historic_type => $self->can('historic_type') ? $self->historic_type + 0 : undef,

--- a/lib/MusicBrainz/Server/Edit/Event/AddEventArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Event/AddEventArt.pm
@@ -13,6 +13,7 @@ with 'MusicBrainz::Server::Edit::Event',
      'MusicBrainz::Server::Edit::Role::AddArt';
 
 sub edit_name { N_lp('Add event art', 'singular, edit type') }
+sub edit_type_name_context { 'singular, edit type' }
 sub edit_template { 'AddEventArt' }
 sub edit_type { $EDIT_EVENT_ADD_EVENT_ART }
 

--- a/lib/MusicBrainz/Server/Edit/Event/EditEventArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Event/EditEventArt.pm
@@ -13,6 +13,7 @@ with 'MusicBrainz::Server::Edit::Event',
      'MusicBrainz::Server::Edit::Role::EditArt';
 
 sub edit_name { N_lp('Edit event art', 'singular, edit type') }
+sub edit_type_name_context { 'singular, edit type' }
 sub edit_template { 'EditEventArt' }
 sub edit_type { $EDIT_EVENT_EDIT_EVENT_ART }
 

--- a/lib/MusicBrainz/Server/Edit/Event/RemoveEventArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Event/RemoveEventArt.pm
@@ -13,6 +13,7 @@ with 'MusicBrainz::Server::Edit::Event',
      'MusicBrainz::Server::Edit::Role::RemoveArt';
 
 sub edit_name { N_lp('Remove event art', 'singular, edit type') }
+sub edit_type_name_context { 'singular, edit type' }
 sub edit_template { 'RemoveEventArt' }
 sub edit_type { $EDIT_EVENT_REMOVE_EVENT_ART }
 

--- a/lib/MusicBrainz/Server/Edit/Event/ReorderEventArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Event/ReorderEventArt.pm
@@ -13,6 +13,7 @@ with 'MusicBrainz::Server::Edit::Event',
      'MusicBrainz::Server::Edit::Role::ReorderArt';
 
 sub edit_name { N_lp('Reorder event art', 'plural, edit type') }
+sub edit_type_name_context { 'plural, edit type' }
 sub edit_template { 'ReorderEventArt' }
 sub edit_type { $EDIT_EVENT_REORDER_EVENT_ART }
 

--- a/lib/MusicBrainz/Server/Edit/Release/AddCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/AddCoverArt.pm
@@ -13,6 +13,7 @@ with 'MusicBrainz::Server::Edit::Release',
      'MusicBrainz::Server::Edit::Role::AddArt';
 
 sub edit_name { N_lp('Add cover art', 'singular, edit type') }
+sub edit_type_name_context { 'singular, edit type' }
 sub edit_template { 'AddCoverArt' }
 sub edit_type { $EDIT_RELEASE_ADD_COVER_ART }
 

--- a/lib/MusicBrainz/Server/Edit/Release/EditCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/EditCoverArt.pm
@@ -12,6 +12,7 @@ with 'MusicBrainz::Server::Edit::Release',
      'MusicBrainz::Server::Edit::Role::EditArt';
 
 sub edit_name { N_lp('Edit cover art', 'singular, edit type') }
+sub edit_type_name_context { 'singular, edit type' }
 sub edit_template { 'EditCoverArt' }
 sub edit_type { $EDIT_RELEASE_EDIT_COVER_ART }
 

--- a/lib/MusicBrainz/Server/Edit/Release/RemoveCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/RemoveCoverArt.pm
@@ -13,6 +13,7 @@ with 'MusicBrainz::Server::Edit::Release',
      'MusicBrainz::Server::Edit::Role::RemoveArt';
 
 sub edit_name { N_lp('Remove cover art', 'singular, edit type') }
+sub edit_type_name_context { 'singular, edit type' }
 sub edit_template { 'RemoveCoverArt' }
 sub edit_type { $EDIT_RELEASE_REMOVE_COVER_ART }
 

--- a/lib/MusicBrainz/Server/Edit/Release/ReorderCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/ReorderCoverArt.pm
@@ -12,6 +12,7 @@ with 'MusicBrainz::Server::Edit::Release',
      'MusicBrainz::Server::Edit::Role::ReorderArt';
 
 sub edit_name { N_lp('Reorder cover art', 'plural, edit type') }
+sub edit_type_name_context { 'plural, edit type' }
 sub edit_template { 'ReorderCoverArt' }
 sub edit_type { $EDIT_RELEASE_REORDER_COVER_ART }
 

--- a/lib/MusicBrainz/Server/Edit/ReleaseGroup/SetCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/ReleaseGroup/SetCoverArt.pm
@@ -18,6 +18,7 @@ with 'MusicBrainz::Server::Edit::ReleaseGroup',
      'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_lp('Set cover art', 'singular, edit type') }
+sub edit_type_name_context { 'singular, edit type' }
 sub edit_kind { 'other' }
 sub edit_type { $EDIT_RELEASEGROUP_SET_COVER_ART }
 sub release_group_ids { shift->data->{entity}->{id} }

--- a/root/doc/EditTypeList.js
+++ b/root/doc/EditTypeList.js
@@ -12,8 +12,8 @@ import {compare} from '../static/scripts/common/i18n.js';
 
 type EditTypesByCategoryT = {
   +[editCategory: string]: $ReadOnlyArray<{
-    +editName: string,
     +id: number,
+    +l_edit_name: string,
   }>,
 };
 
@@ -45,7 +45,7 @@ component EditTypeList(editTypesByCategory: EditTypesByCategoryT) {
                 {editTypes.map(editType => (
                   <li key={editType.id}>
                     <a href={`/doc/Edit_Types/${editType.id}`}>
-                      {editType.editName}
+                      {editType.l_edit_name}
                     </a>
                   </li>
                 ))}

--- a/root/edit/CancelEdit.js
+++ b/root/edit/CancelEdit.js
@@ -30,7 +30,7 @@ component CancelEdit(
       </p>
 
       <div className="edit-list">
-        <h2>{l(edit.edit_name)}</h2>
+        <h2>{lp(edit.edit_name, edit.edit_type_name_context)}</h2>
         <div className="edit-details">
           {edit.data
             ? detailsElement

--- a/root/edit/EditData.js
+++ b/root/edit/EditData.js
@@ -37,7 +37,7 @@ component EditData(
       <p>
         <strong>{('Type:')}</strong>
         {' '}
-        {l(edit.edit_name)}
+        {lp(edit.edit_name, edit.edit_type_name_context)}
         {' '}
         {bracketedText(edit.edit_type)}
       </p>

--- a/root/edit/components/EditHeader.js
+++ b/root/edit/components/EditHeader.js
@@ -44,7 +44,7 @@ component EditHeader(
   const mayVote = editorMayVote(user);
   const editTitle = texp.l(
     'Edit #{id} - {name}',
-    {id: edit.id, name: l(edit.edit_name)},
+    {id: edit.id, name: lp(edit.edit_name, edit.edit_type_name_context)},
   );
   const editEditor = linkedEntities.editor[edit.editor_id];
   const isEditEditor = user ? user.id === edit.editor_id : false;

--- a/root/edit/components/EditNoteListEntry.js
+++ b/root/edit/components/EditNoteListEntry.js
@@ -19,7 +19,7 @@ component EditNoteListEntry(
 ) {
   const editTitle = texp.l(
     'Edit #{id} - {name}',
-    {id: edit.id, name: l(edit.edit_name)},
+    {id: edit.id, name: lp(edit.edit_name, edit.edit_type_name_context)},
   );
 
   return (

--- a/root/statistics/Edits.js
+++ b/root/statistics/Edits.js
@@ -11,14 +11,13 @@ import * as React from 'react';
 
 import LinkSearchableEditType from '../components/LinkSearchableEditType.js';
 import {CatalystContext} from '../context.mjs';
-import {l as lMbServer} from '../static/scripts/common/i18n.js';
 
 import StatisticsLayout from './StatisticsLayout.js';
 import {formatCount, formatPercentage, TimelineLink} from './utilities.js';
 
 type EditCategoryT = {
-  +edit_name: string,
   +edit_type: string,
+  +l_edit_name: string,
 };
 
 component Edits(
@@ -62,7 +61,7 @@ component Edits(
                     {category.map((type) => (
                       <tr key={type.edit_type}>
                         <th />
-                        <th>{lMbServer(type.edit_name)}</th>
+                        <th>{type.l_edit_name}</th>
                         <td>
                           <LinkSearchableEditType
                             editTypeId={type.edit_type}

--- a/root/types/edit.js
+++ b/root/types/edit.js
@@ -71,6 +71,7 @@ declare type GenericEditT = {
   +edit_name: string,
   +edit_notes: $ReadOnlyArray<EditNoteT>,
   +edit_type: number,
+  +edit_type_name_context: string,
   +editor_id: number,
   +expires_time: string,
   +historic_type: number | null,


### PR DESCRIPTION
### Fix MBS-13645

# Problem
The translated names for edit types are not showing, even though the types are certainly translated in Spanish, French and Italian at least.

# Solution
We were not actually using the contexts we added when showing translations, so these were mostly just not working at all.

Since contexts vary per edit type, this sets a default context of `'edit type'` and allows overriding it for the few edits that change it (adding `'singular'` or `'plural'`).

In `statistics/Edits` I chose to pass `l_edit_name` rather than passing the context and translating on the JS side because the whole thing is a construct for display so we might as well simplify it. This is the same that is already done for `EditTypeList`.

# Testing
Manually, by visiting `/edit/open`, `/statistics/edits`, `/doc/Edit_Types` and `/edit/notes-received`