### PR TITLE
MBS-13623: Fix headers for CD stub possible mediums

### DIFF
--- a/root/cdtoc/lookup.tt
+++ b/root/cdtoc/lookup.tt
@@ -40,11 +40,13 @@
         <th>[% l('Release') %]</th>
         <th>[% l('Medium') %]</th>
         <th>[% l('Artist') %]</th>
-        <th>[% l('Date') %]</th>
-        <th>[% l('Country') %]</th>
+        <th>[% l('Country') _ lp('/', 'and') _ l('Date') %]</th>
         <th>[% l('Label') %]</th>
         <th>[% l('Catalog#') %]</th>
         <th>[% l('Barcode') %]</th>
+        [%- IF c.try_get_session('tport') -%]
+          <th>[% lp('Tagger', 'audio file metadata') %]</th>
+        [%- END -%]
       </thead>
       <tbody>
         [% FOR medium=possible_mediums %]


### PR DESCRIPTION
### Fix MBS-13623

# Description
The "Possible mediums" table when attaching a discID matching a CD stub has wrong (outdated?) headers. It has country and date headers separately, despite the table combining them in a single data column, meaning everything to the right of these is off by one. Additionally, an optional final Tagger header was missing, despite `release_info()` supporting it (see the image on the ticket for an example).

# Testing
With ro connector, see `/cdtoc/attach?toc=1%2010%20134955%20182%2014600%2026792%2042652%2058232%2074430%2083807%2097782%20108047%20118067`