### PR TITLE
Beta: Fix event art user stats search

### DIFF
--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -439,14 +439,16 @@ component UserEditsProperty(
   const encodedName = encodeURIComponent(user.name);
   const createEditTypes: string = entityType === 'cover_art'
     ? String(TYPES.EDIT_RELEASE_ADD_COVER_ART)
-    : entityType === 'release' ? (
-      // Also list historical edits
-      [
-        TYPES.EDIT_RELEASE_CREATE,
-        TYPES.EDIT_HISTORIC_ADD_RELEASE,
-      ].join(',')
-    // $FlowIgnore[invalid-computed-prop]
-    ) : String(TYPES[`EDIT_${entityType.toUpperCase()}_CREATE`]);
+    : entityType === 'event_art'
+      ? String(TYPES.EDIT_EVENT_ADD_EVENT_ART)
+      : entityType === 'release' ? (
+        // Also list historical edits
+        [
+          TYPES.EDIT_RELEASE_CREATE,
+          TYPES.EDIT_HISTORIC_ADD_RELEASE,
+        ].join(',')
+      // $FlowIgnore[invalid-computed-prop]
+      ) : String(TYPES[`EDIT_${entityType.toUpperCase()}_CREATE`]);
   const searchEditsURL = ((createEditTypes: string) => (
     '/search/edits' +
     '?auto_edit_filter=' +


### PR DESCRIPTION
I missed testing this last time since I tested while logged out, so I didn't notice there's an extra edit search link when logged in that was broken. Now tested properly.