### PR TITLE
MBS-13582: Add statistics for genre collections

### DIFF
--- a/lib/MusicBrainz/Server/Data/Statistics.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics.pm
@@ -2122,6 +2122,7 @@ my %stats = (
                 'count.collection.type.release_group' => $dist{13} || 0,
                 'count.collection.type.series' => $dist{14} || 0,
                 'count.collection.type.work' => $dist{15} || 0,
+                'count.collection.type.genre' => $dist{16} || 0,
             };
         },
     },

--- a/root/statistics/Index.js
+++ b/root/statistics/Index.js
@@ -1043,6 +1043,12 @@ component Index(
           </tr>
           <tr>
             <th />
+            <th colSpan="2">{addColonText(l_statistics('Of genres'))}</th>
+            <td>{fc('collection.type.genre')}</td>
+            <td>{fp('collection.type.genre', 'collection')}</td>
+          </tr>
+          <tr>
+            <th />
             <th colSpan="2">
               {addColonText(l_statistics('Of instruments'))}
             </th>

--- a/root/statistics/stats.js
+++ b/root/statistics/stats.js
@@ -214,6 +214,11 @@ const stats = {
     color: '#ff0000',
     label: l_statistics('Event collections (all types)'),
   },
+  'count.collection.type.genre': {
+    category: 'collection',
+    color: '#ff0000',
+    label: l_statistics('Genre collections'),
+  },
   'count.collection.type.instrument': {
     category: 'collection',
     color: '#ff0000',


### PR DESCRIPTION
### Implement MBS-13582

# Description
Yet another set of stats I missed entirely while writing a feature - wish there was a way to be reminded that some stats might be missing :sweat_smile: 

# Testing
Tested locally by adding a genre collection to the sample then running the stats.