### PR TITLE
Make admin/run log the (full) command it ran

### DIFF
--- a/admin/run
+++ b/admin/run
@@ -84,8 +84,10 @@ pre_command='carton exec --'
 echo "Running '$command_verbatim $*' and logging at '$log_file_path'..."
 if [[ -t 1 ]]
 then
+  echo "Running $command_verbatim $*" | TZ=Z ts %FT%.TZ | tee -a "$log_file_path"
   exec $pre_command "$command_full_path" "$@" 2>&1 | TZ=Z ts %FT%.TZ | tee -a "$log_file_path"
 else
+  echo "Running $command_verbatim $*" | TZ=Z ts %FT%.TZ >> "$log_file_path"
   exec $pre_command "$command_full_path" "$@" 2>&1 | TZ=Z ts %FT%.TZ >> "$log_file_path"
 fi
 

--- a/admin/run
+++ b/admin/run
@@ -81,12 +81,13 @@ log_timestamp=$(date --utc +%FT%TZ)
 log_file_path="$log_dir_path/$log_timestamp.log"
 
 pre_command='carton exec --'
-echo "Running '$command_verbatim $*' and logging at '$log_file_path'..."
+echo "Logging to $log_file_path"
 if [[ -t 1 ]]
 then
   echo "Running $command_verbatim $*" | TZ=Z ts %FT%.TZ | tee -a "$log_file_path"
   exec $pre_command "$command_full_path" "$@" 2>&1 | TZ=Z ts %FT%.TZ | tee -a "$log_file_path"
 else
+  echo "Quietly running $command_verbatim $*"
   echo "Running $command_verbatim $*" | TZ=Z ts %FT%.TZ >> "$log_file_path"
   exec $pre_command "$command_full_path" "$@" 2>&1 | TZ=Z ts %FT%.TZ >> "$log_file_path"
 fi


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Previously, the ran command was just printed on the standard output and not in the log file, which is fine for cron scripts but was quite embarrassing when occasionally running a specific command.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Log the command (with arguments) to run in the same file as its output.

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

Manually tested in the current cron container.