### PR TITLE
Fix missing lp_statistics translations

### DIFF
--- a/po/statistics.pot
+++ b/po/statistics.pot
@@ -1635,6 +1635,12 @@ msgstr ""
 msgid "Areas"
 msgstr ""
 
+#: ../root/statistics/Index.js:119 ../root/statistics/Index.js:848
+#: ../root/statistics/Index.js:856 ../root/statistics/stats.js:814
+msgctxt "plural"
+msgid "Series"
+msgstr ""
+
 #: ../root/statistics/Index.js:123 ../root/statistics/Index.js:872
 #: ../root/statistics/Index.js:879 ../root/statistics/stats.js:483
 msgid "Instruments"
@@ -1660,6 +1666,11 @@ msgstr ""
 
 #: ../root/statistics/Index.js:154
 msgid "CD stubs (all time / current):"
+msgstr ""
+
+#: ../root/statistics/Index.js:163
+msgctxt "folksonomy"
+msgid "Tags (raw / aggregated):"
 msgstr ""
 
 #: ../root/statistics/Index.js:169
@@ -1873,6 +1884,11 @@ msgstr ""
 msgid "Videos"
 msgstr ""
 
+#: ../root/statistics/Index.js:690
+msgctxt "recording"
+msgid "Standalone"
+msgstr ""
+
 #: ../root/statistics/Index.js:695
 msgid "With ISRCs"
 msgstr ""
@@ -2020,6 +2036,11 @@ msgstr ""
 msgid "who leave edit notes:"
 msgstr ""
 
+#: ../root/statistics/Index.js:1186
+msgctxt "folksonomy"
+msgid "who use tags:"
+msgstr ""
+
 #: ../root/statistics/Index.js:1194
 msgid "who use ratings:"
 msgstr ""
@@ -2072,6 +2093,11 @@ msgstr ""
 msgid "Failed (internal error):"
 msgstr ""
 
+#: ../root/statistics/Index.js:1295
+msgctxt "edit"
+msgid "Cancelled"
+msgstr ""
+
 #: ../root/statistics/Index.js:1307 ../root/statistics/Index.js:1363
 msgid "Last 7 days:"
 msgstr ""
@@ -2083,6 +2109,26 @@ msgstr ""
 #: ../root/statistics/Index.js:1321 ../root/statistics/Index.js:1324
 #: ../root/statistics/Index.js:1357 ../root/statistics/stats.js:895
 msgid "Votes"
+msgstr ""
+
+#: ../root/statistics/Index.js:1331
+msgctxt "vote"
+msgid "Approve"
+msgstr ""
+
+#: ../root/statistics/Index.js:1338
+msgctxt "vote"
+msgid "Yes"
+msgstr ""
+
+#: ../root/statistics/Index.js:1344
+msgctxt "vote"
+msgid "No"
+msgstr ""
+
+#: ../root/statistics/Index.js:1351
+msgctxt "vote"
+msgid "Abstain"
 msgstr ""
 
 #: ../root/statistics/LanguagesScripts.js:43
@@ -2145,6 +2191,16 @@ msgstr ""
 msgid "No relationship statistics available."
 msgstr ""
 
+#: ../root/statistics/Relationships.js:105
+msgctxt "relationships"
+msgid "This type only"
+msgstr ""
+
+#: ../root/statistics/Relationships.js:106
+msgctxt "relationships"
+msgid "Including subtypes"
+msgstr ""
+
 #: ../root/statistics/Relationships.js:128
 msgid "{type0}-{type1}"
 msgstr ""
@@ -2165,6 +2221,26 @@ msgstr ""
 msgid "Artist types and genders"
 msgstr ""
 
+#: ../root/statistics/stats.js:21
+msgctxt "plural"
+msgid "Cover art"
+msgstr ""
+
+#: ../root/statistics/stats.js:22
+msgctxt "plural"
+msgid "Event art"
+msgstr ""
+
+#: ../root/statistics/stats.js:24
+msgctxt "noun"
+msgid "Edit information"
+msgstr ""
+
+#: ../root/statistics/stats.js:25
+msgctxt "noun"
+msgid "Edit types"
+msgstr ""
+
 #: ../root/statistics/stats.js:26
 msgid "Event types"
 msgstr ""
@@ -2181,8 +2257,18 @@ msgstr ""
 msgid "Label types"
 msgstr ""
 
+#: ../root/statistics/stats.js:31
+msgctxt "stats category"
+msgid "Other"
+msgstr ""
+
 #: ../root/statistics/stats.js:32
 msgid "Place types"
+msgstr ""
+
+#: ../root/statistics/stats.js:33
+msgctxt "folksonomy"
+msgid "Ratings and tags"
 msgstr ""
 
 #: ../root/statistics/stats.js:35
@@ -2417,6 +2503,11 @@ msgstr ""
 msgid "Edits that have been voted down"
 msgstr ""
 
+#: ../root/statistics/stats.js:336
+msgctxt "noun"
+msgid "Open edits"
+msgstr ""
+
 #: ../root/statistics/stats.js:342
 msgid "Edits per day"
 msgstr ""
@@ -2471,6 +2562,11 @@ msgstr ""
 
 #: ../root/statistics/stats.js:411
 msgid "Editors who use subscriptions"
+msgstr ""
+
+#: ../root/statistics/stats.js:416
+msgctxt "folksonomy"
+msgid "Editors who have added tags"
 msgstr ""
 
 #: ../root/statistics/stats.js:421
@@ -2719,6 +2815,16 @@ msgstr ""
 
 #: ../root/statistics/stats.js:819
 msgid "Series with no type set"
+msgstr ""
+
+#: ../root/statistics/stats.js:824
+msgctxt "folksonomy"
+msgid "Unique tag names"
+msgstr ""
+
+#: ../root/statistics/stats.js:829
+msgctxt "folksonomy"
+msgid "Votes for/against tags"
 msgstr ""
 
 #: ../root/statistics/stats.js:834

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -22,6 +22,7 @@ import {
 import {
   l_statistics as lStatisticsActual,
   ln_statistics as lnStatisticsActual,
+  lp_statistics as lpStatisticsActual,
 } from '../i18n/statistics.js';
 
 import expand, {
@@ -455,3 +456,9 @@ export const lp = (
   context: string,
   args?: ?VarArgsObject<Input>,
 ): Output => expand2react(lpActual(key, context), args);
+
+export const lp_statistics = (
+  key: string,
+  context: string,
+  args?: ?VarArgsObject<Input>,
+): Output => expand2react(lpStatisticsActual(key, context), args);

--- a/root/static/scripts/common/i18n/expand2text.js
+++ b/root/static/scripts/common/i18n/expand2text.js
@@ -19,6 +19,7 @@ import {
 import {
   l_statistics as lStatisticsActual,
   ln_statistics as lnStatisticsActual,
+  lp_statistics as lpStatisticsActual,
 } from '../i18n/statistics.js';
 
 import expand, {
@@ -151,3 +152,9 @@ export const lp = (
   context: string,
   args: VarArgsObject<StrOrNum>,
 ): string => expand2text(lpActual(key, context), args);
+
+export const lp_statistics = (
+  key: string,
+  context: string,
+  args: VarArgsObject<StrOrNum>,
+): string => expand2text(lpStatisticsActual(key, context), args);

--- a/root/vars.js
+++ b/root/vars.js
@@ -125,6 +125,11 @@ declare var exp: {
     context: string,
     args?: ?{+[arg: string]: Expand2ReactInput},
   ) => Expand2ReactOutput,
+  +lp_statistics: (
+    key: string,
+    context: string,
+    args?: ?{+[arg: string]: Expand2ReactInput},
+  ) => Expand2ReactOutput,
 };
 
 declare var texp: {
@@ -159,6 +164,11 @@ declare var texp: {
     args: {+[arg: string]: StrOrNum, ...},
   ) => string,
   +lp: (
+    key: string,
+    context: string,
+    args: {+[arg: string]: StrOrNum, ...},
+  ) => string,
+  +lp_statistics: (
     key: string,
     context: string,
     args: {+[arg: string]: StrOrNum, ...},

--- a/script/xgettext.js
+++ b/script/xgettext.js
@@ -228,6 +228,7 @@ keywords = {
   ...keywords,
   l_statistics: keywords.l,
   ln_statistics: keywords.ln,
+  lp_statistics: keywords.lp,
 };
 
 const parser = new XGettext({

--- a/webpack/providePluginConfig.mjs
+++ b/webpack/providePluginConfig.mjs
@@ -69,9 +69,11 @@ const providePluginConfig = {
 
   'exp.l_statistics': [expandPath, 'l_statistics'],
   'exp.ln_statistics': [expandPath, 'ln_statistics'],
+  'exp.lp_statistics': [expandPath, 'lp_statistics'],
 
   'texp.l_statistics': [expandTextPath, 'l_statistics'],
   'texp.ln_statistics': [expandTextPath, 'ln_statistics'],
+  'texp.lp_statistics': [expandTextPath, 'lp_statistics'],
   /* eslint-enable sort-keys */
 };
 


### PR DESCRIPTION
At some point we missed `lp_statistics` in gettext / webpack, so our `.pot` files were missing all strings using `lp_statistics`.