### PR TITLE
MBS-13675: Split statistic events into history translation component

### DIFF
--- a/.eslintrc.unfixed.yaml
+++ b/.eslintrc.unfixed.yaml
@@ -12,6 +12,7 @@ rules:
                        "l_countries",
                        "ln_countries",
                        "lp_countries",
+                       "l_history",
                        "l_instrument_descriptions",
                        "ln_instrument_descriptions",
                        "lp_instrument_descriptions",

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -52,6 +52,7 @@ globals:
   l_countries: readonly
   ln_countries: readonly
   lp_countries: readonly
+  l_history: readonly
   l_instrument_descriptions: readonly
   ln_instrument_descriptions: readonly
   lp_instrument_descriptions: readonly

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -348,6 +348,7 @@ sub with_translations {
                 MusicBrainz::Server::Translation::Languages
                 MusicBrainz::Server::Translation::Attributes
                 MusicBrainz::Server::Translation::Relationships
+                MusicBrainz::Server::Translation::History
                 MusicBrainz::Server::Translation::Instruments
                 MusicBrainz::Server::Translation::InstrumentDescriptions );
 

--- a/lib/MusicBrainz/Server/Data/Statistics.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics.pm
@@ -17,7 +17,8 @@ use MusicBrainz::Server::Constants qw(
     entities_with
 );
 use MusicBrainz::Server::Data::Relationship;
-use MusicBrainz::Server::Translation::Statistics qw( l );
+use MusicBrainz::Server::Translation::History;
+use MusicBrainz::Server::Translation::Statistics;
 use MusicBrainz::Server::Replication qw( :replication_type );
 
 use DBDefs;
@@ -32,7 +33,11 @@ sub all_events {
     my ($self) = @_;
 
     return [
-        map { $_->{title} = l($_->{title}); $_->{description} = l($_->{description}); $_; }
+        map {
+            $_->{title} = MusicBrainz::Server::Translation::History::l($_->{title});
+            $_->{description} = MusicBrainz::Server::Translation::History::l($_->{description});
+            $_;
+        }
         @{$self->sql->select_list_of_hashes(
             'SELECT * FROM statistics.statistic_event ORDER BY date ASC',
         )},

--- a/lib/MusicBrainz/Server/Entity/EditNote.pm
+++ b/lib/MusicBrainz/Server/Entity/EditNote.pm
@@ -55,6 +55,7 @@ has 'latest_change' => (
 my %domain_classes = (
     'attributes' => 'Attributes',
     'countries' => 'Countries',
+    'history' => 'History',
     'instrument_descriptions' => 'InstrumentDescriptions',
     'instruments' => 'Instruments',
     'languages' => 'Languages',

--- a/lib/MusicBrainz/Server/Translation/History.pm
+++ b/lib/MusicBrainz/Server/Translation/History.pm
@@ -1,0 +1,10 @@
+package MusicBrainz::Server::Translation::History;
+use Moose;
+use namespace::autoclean;
+
+extends 'MusicBrainz::Server::Translation';
+with 'MusicBrainz::Server::Role::Translation' => { domain => 'history' };
+
+sub l { __PACKAGE__->instance->gettext(@_) }
+
+1;

--- a/po/Makefile
+++ b/po/Makefile
@@ -62,7 +62,7 @@ install: $(MOFILES)
 		install -m 0644 $$file ../lib/LocaleData/$$lang/LC_MESSAGES/$$catalog.mo; \
 	done
 
-pot: mb_server.pot statistics.pot countries.pot languages.pot languages_notrim.pot scripts.pot relationships.pot attributes.pot instruments.pot instrument_descriptions.pot
+pot: mb_server.pot statistics.pot countries.pot languages.pot languages_notrim.pot scripts.pot relationships.pot attributes.pot instruments.pot instrument_descriptions.pot history.pot
 
 mb_server.pot: $(POTFILES) $(JSFILES) $(TT) $(wildcard extract_pot_templates)
 	@echo "Rebuilding the mb_server.pot file";
@@ -124,6 +124,11 @@ instrument_descriptions.pot: $(wildcard extract_pot_db)
 	@echo "Rebuilding the instrument_descriptions.pot file";
 	@echo "- Update database .pot";
 	@./extract_pot_db instrument_descriptions | msguniq -w $(MSGWRAP) -s | ./format_extracted_comments > instrument_descriptions.pot
+
+history.pot: $(wildcard extract_pot_db)
+	@echo "Rebuilding the history.pot file";
+	@echo "- Update database .pot";
+	@./extract_pot_db history | msguniq -w $(MSGWRAP) -s | ./format_extracted_comments > history.pot
 
 clean:
 	rm -f $(MOFILES)

--- a/po/extract_pot_db
+++ b/po/extract_pot_db
@@ -43,8 +43,8 @@ my $domain = $domain[0];
 # where, which specifies a WHERE clause to add to the SQL query;
 # and ctx, which specifies a column to use for a msgctxt entry (unused at present).
 my @DBDEFS = (
-              {'domain' => 'statistics', 'table' => 'statistics.statistic_event', 'columns' => ['title'], 'id' => 'date'},
-              {'domain' => 'statistics', 'table' => 'statistics.statistic_event', 'columns' => ['description'], 'comment' => ['title'], 'id' => 'date'},
+              {'domain' => 'history', 'table' => 'statistics.statistic_event', 'columns' => ['title'], 'id' => 'date'},
+              {'domain' => 'history', 'table' => 'statistics.statistic_event', 'columns' => ['description'], 'comment' => ['title'], 'id' => 'date'},
               {'domain' => 'countries', 'table' => 'area JOIN iso_3166_1 iso ON iso.area = area.id', 'columns' => ['area.name'], 'comment' => ['iso.code']},
               {'domain' => 'languages', 'table' => 'language', 'columns' => ['name'], 'comment' => ['frequency', 'iso_code_3'], 'where' => 'iso_code_2t IS NOT NULL OR frequency > 0'},
               {'domain' => 'languages_notrim', 'table' => 'language', 'columns' => ['name'], 'comment' => ['frequency', 'iso_code_3']},

--- a/po/history.bg.po
+++ b/po/history.bg.po
@@ -1,0 +1,1100 @@
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: FULL NAME <email address hidden>\n"
+"Language-Team: Bulgarian (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/bg/)\n"
+"Language: bg\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.bn.po
+++ b/po/history.bn.po
@@ -1,0 +1,1100 @@
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: FULL NAME <email address hidden>\n"
+"Language-Team: Bengali (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/bn/)\n"
+"Language: bn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.ca.po
+++ b/po/history.ca.po
@@ -1,0 +1,1100 @@
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: FULL NAME <email address hidden>\n"
+"Language-Team: Catalan (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/ca/)\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.cs.po
+++ b/po/history.cs.po
@@ -1,0 +1,1102 @@
+#
+# Translators:
+# pabouk <email address hidden>, 2012
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: pabouk <pabouk@gmail.com>, 2012\n"
+"Language-Team: Czech (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/cs/)\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n "
+"<= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.cy.po
+++ b/po/history.cy.po
@@ -1,0 +1,1104 @@
+#
+# Translators:
+# adhawkins <email address hidden>, 2012
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: adhawkins <andy@gently.org.uk>, 2012\n"
+"Language-Team: Welsh (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/cy/)\n"
+"Language: cy\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != "
+"11) ? 2 : 3;\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+#, fuzzy
+#| msgid "Cover Art"
+msgid "Amazon cover art"
+msgstr "Celf Albwm"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.da.po
+++ b/po/history.da.po
@@ -1,0 +1,1100 @@
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: FULL NAME <email address hidden>\n"
+"Language-Team: Danish (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/da/)\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.de.po
+++ b/po/history.de.po
@@ -1,0 +1,1202 @@
+#
+# Translators:
+# nikki, 2014
+# Daniel Schury <email address hidden>, 2011
+# David Kellner <email address hidden>, 2019-2020
+# Ettore Atalan <email address hidden>, 2014
+# Frank Matthiae <email address hidden>, 2018
+# Frank Matthiae <email address hidden>, 2015
+# Ian McEwen <email address hidden>, 2012
+# happykraut, 2017
+# Mark Spike, 2019
+# Wieland Hoffmann <email address hidden>, 2011
+# Nikolai Prokoschenko <email address hidden>, 2011
+# Philipp Wolfer <email address hidden>, 2018,2020
+# S.Brandt <email address hidden>, 2014,2018
+# Shepard, 2011
+# Shepard, 2013-2014
+# TL, 2016
+# Tobias Quathamer <email address hidden>, 2007
+# Ulrich Klauer <email address hidden>, 2015-2016
+# Wieland Hoffmann <email address hidden>, 2013-2014
+# Philipp Wolfer <ph.wolfer@gmail.com>, 2023, 2024.
+# kellnerd <kellnerd@users.noreply.translations.metabrainz.org>, 2023, 2024.
+# Leonie2 <renkenjakob@gmail.com>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2024-04-08 14:28+0000\n"
+"Last-Translator: Leonie2 <renkenjakob@gmail.com>\n"
+"Language-Team: German <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/de/>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.4\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr "1200px Vorschaubilder"
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+"Ein neuer AJAX-Cover-Art-Uploader wird veröffentlicht, der es einfacher "
+"macht, Cover-Art zu Veröffentlichungen hinzuzufügen."
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+"Eine neue Bannerbenachrichtigung teilt Benutzern mit, wenn sie eine neue "
+"Bearbeitungsbemerkung erhalten haben."
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr "Ein Zerwürfnis in der MusicBrainz-Community führt zum Großen Streit."
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "Erweiterte Beziehungen"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+"Erweiterte Beziehungen, die es den Benutzern erlauben, die "
+"Hauptdatenbankobjekte miteinander zu verbinden, werden herausgebracht und "
+"unbenutzte TRMs aus der Datenbank entfernt. Inline-Bearbeitung wird "
+"standardmäßig deaktiviert, wodurch die Abstimmaktivität abnimmt."
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Albensprachen"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+"Albensprachen, Verbesserung für das Raten von Groß-/Kleinschreibung und "
+"umgestaltete Editierformulare herausgebracht."
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr "Amazon veröffentlicht SoundUnwound als Beta"
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr "Amazon Cover-Art"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr "Amazon Cover-Art-Unterstützung herausgebracht."
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+"Ein verbesserter Albeneditor und ein neues Seitendesign werden "
+"herausgebracht."
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr "Unterstützung für Anmerkungen herausgebracht."
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "Anmerkungen"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "Künstlerabonnements"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+"Künstlerabonnements öffentlich gemacht und verschiedene kleinere "
+"benutzerspezifische Verbesserungen herausgebracht."
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr "Künstlerabonnements."
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr "BBCs dynamische Künstlerseiten"
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+"BBC führt dynamische Künstlerseiten basierend auf MusicBrainz-Daten ein."
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr "Die BBC geht eine Partnerschaft mit MetaBrainz ein"
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr "CAA erstmals herausgebracht"
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr "CAA offiziell herausgebracht"
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr "Gemeinsame Sammlungen"
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr "Sammlung, Bewertungen, CD-Stubs"
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr "Sammlung, Bewertungen, CD-Stubs, LastUpdate herausgebracht."
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr "Cover-Art-Uploader"
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr "Dedizierter Datenbankserver"
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+"Verbesserungen der Bearbeitungsanzeige, RDF-Abbilder deaktiviert, neue "
+"Installationsskripte veröffentlicht."
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr "Benachrichtigungen zu Bearbeitungsbemerkungen"
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr "Bearbeitungssuche"
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+"Bearbeiter ojnkpjg lässt ein Script zum Setzen der Titellängen aus DiscID-"
+"Werten laufen. Dies verursacht einen großen Bearbeitungs-Ausschlag."
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr "E-Mail-Verifizierung"
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+"Ehemaliger GSoC Student Roman Tsukanov tritt Teilzeitstelle bei MetaBrainz "
+"an."
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+"FreeDB Auto-Import-Funktion deaktiviert und Autobearbeiter-Wahl "
+"veröffentlicht. Unbenutzte TRMs aus der Datenbank bereinigt."
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr "FreeDB aus/Autobearbeiter"
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr "Genre als neues Objekt hinzugefügt"
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+"Genres als neues Objekt hinzugefügt, obwohl sie weiterhin eng an Tags "
+"gebunden sind."
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr "Großer Streit"
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr "Katalog von CD Baby als CD-Stubs importiert"
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+"Die Metadaten des Katalogs von CD Baby wurden in unsere CD-Stubs-Sammlung "
+"importiert."
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr "Verbessertes Abstimmen"
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr "Verbesserte Suche"
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+"Der Zeitraum, für den Bearbeitungen offen bleiben, wird von 14 auf 7 Tage "
+"reduziert, um die Schlange mit offenen Bearbeitungen zu verkürzen und Nutzer "
+"weniger lang auf Änderungen warten zu lassen."
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+"Zur Vorbereitung auf die Veröffentlichung von NGS wird das Bearbeiten bis "
+"zur Veröffentlichung deaktiviert."
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+"Zur Vorbereitung auf die Veröffentlichung von NGS wird Bearbeitern "
+"empfohlen, nur unbedingt notwendige Bearbeitungen vorzunehmen."
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr "Indexierte Suche/XML-WS"
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+"Indexierte Suche und ein neuer XML-basierter Webservice wurden "
+"herausgebracht."
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr "Inline-Bearbeitungen"
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr "Inline-Bearbeitungen, neue Reporte, verbesserte Daten-Importskripte."
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr "Installationsskripte"
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+"Kuno Woudt nimmt seine Arbeit als Vollzeitentwickler für MusicBrainz auf."
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr "Kuno Woudt als Vollzeitentwickler eingestellt"
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr "Labels / Datenqualität"
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+"Last.fm wird MetaBrainz-Kunde und beginnt, MusicBrainz-Daten zu nutzen."
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+"Verlinken zu MusicBrainz Funktion, Veröffentlichungsereignisse und "
+"Bearbeitungsvorschläge veröffentlicht."
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr "Linkara Musica wird der erste kommerzielle Kunde von MetaBrainz."
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr "Verlinkung"
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr "MetaBrainz nimmt drei Studenten für Google Summer of Code auf."
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr "MetaBrainz stellt Oliver Charles ein"
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr "MetaBrainz gestartet"
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr "MetaBrainz schließt Vertrag mit erstem Kunden ab"
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr "Mehr Auto-Bearbeitungen"
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+"Mehr Bearbeitungstypen werden zu automatischen Bearbeitungen für jeden: "
+"„Beziehung hinzufügen“, „Veröffentlichung hinzufügen“ sowie "
+"„Veröffentlichungslabel hinzufügen“, „bearbeiten“ und „entfernen“. Außerdem "
+"stehen die deutsche, französische und niederländische Übersetzung auf dem "
+"Haupt-Server bereit."
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr "MusicBrainz-Bewegung"
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+"Der MusicBrainz-Server-Quellcode wurde von Subversion nach Git umgezogen."
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr "MusicBrainz bekommt seinen ersten dedizierten Datenbankserver."
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+"MusicBrainz selbst bekommt ein neues Design, um sich besser der restlichen "
+"*Brainz Familie anzupassen."
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr "MusicBrainz zieht zu Digital West Networks in San Luis Obispo um."
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+"MusicBrainz geht eine Partnerschaft mit MusicIP ein und beginnt MusicDNS' "
+"PUID akustische Fingerabdrücke zu nutzen. Picard wird der offizielle "
+"MusicBrainz-Tagger mit PUID-Unterstützung, wodurch sich die "
+"Bearbeitungsaktivitäten verringern."
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "MusicIP PUID"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr "Phase ohne Bearbeitungen wegen NGS"
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr "Phase reduzierter Bearbeitungen wegen NGS"
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr "NGS-Veröffentlichung"
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+"NGS, eine komplette Überarbeitung von MusicBrainz, wird veröffentlicht!"
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr "Neues MusicBrainz Design"
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr "Titel ohne Album"
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr "Titel ohne Album werden veröffentlicht."
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr "Oliver Charles wird Angestellter Nr. 1 der MetaBrainz-Foundation."
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr "Oliver Charles nimmt die Vollzeitarbeit für MusicBrainz auf."
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr "Oliver Charles arbeitet Vollzeit für MusicBrainz"
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+"Unser alter Suchserver erhält mit der Umstellung auf Solr ein bedeutendes "
+"Upgrade, darunter nahezu sofortige Index-Aktualisierungen."
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr "Beziehungs-Editor"
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr "Veröffentlichungsgruppen, ISRCs, CD-Stub-Suche"
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr "Albeneditor"
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr "Albeneditor und „Groß-/Kleinschreibung erraten“ werden veröffentlicht."
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+"Veröffentlichungsgruppen, ISRC Unterstützung, CD-Stub-Suche und verbesserte "
+"Suche freigegeben."
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr "Roman Tsukanov tritt dem MetaBrainz Team bei"
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr "SG5-Verbesserungen"
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr "Suchverbesserungen"
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr "Verschiedene neue Auto-Edit-Typen und Übersetzungen"
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr "SoC 2008"
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr "Solr‐basierter Suchserver bereitgestellt"
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+"Umgehungslösung für Stilrichtlinie 5 eingeführt und unbenutzte TRMs aus der "
+"Datenbank entfernt."
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr "Unterstützung für Label und Datenqualität wurden veröffentlicht."
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr "Das AcousticBrainz-Projekt geht auf Sendung"
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr "Das AcousticBrainz-Projekt wird eingestellt"
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+"Die BBC wird ein MetaBrainz-Kunde und beginnt, MusicBrainz-Daten zu nutzen."
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr "Das Cover-Art-Archiv wurde initial verfügbar gemacht."
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr "Das Cover-Art-Archiv wurde offiziell veröffentlicht."
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr "Das CritiqueBrainz-Projekt geht auf Sendung"
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr "Das ListenBrainz-Projekt geht auf Sendung"
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+"Die MetaBrainz-Stiftung, der Rechtsrahmen für MusicBrainz, wird der "
+"Öffentlichkeit bekannt gegeben."
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+"Die Alpha-Version von ListenBrainz, einer Open Source- und Open Data-"
+"Alternative zu Last.fm®, wird live geschaltet."
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr "Die Betaversion von CritiqueBrainz wird gestartet."
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr "Die neue MetaBrainz-Webseite geht online"
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+"Die neue MusicBrainz-Webseite mit einem völlig neuen Design und Online-"
+"Anmeldung für gewerbliche Nutzer ersetzt die im Jahr 2000 entworfene!"
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+"Der Beziehungs-Editor, zur Massenbearbeitung von Beziehungen einer "
+"Veröffentlichung, wurde für den Produktiveinsatz freigegeben."
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr "Die Suchfunktion und Web-Service-Verbesserungen wurden freigegeben."
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+"Der Abstimmungszeitraum für Bearbeitungen, die eine Nein-Stimme erhalten, "
+"wird verlängert, um Nutzern mehr Zeit zu geben, auf die Problematik zu "
+"reagieren."
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+"Navigation im Hauptmenü verbessert; Funktionen doppelte Künstler, alles an "
+"einem Album bearbeiten, Titellängen bearbeiten herausgebracht."
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr "Titellängen von Disc-ID`s gesetzt"
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr "Benutzerverbesserungen"
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+"Version 1 des Webservice (bereits seit 2011 veraltet) wird endlich endgültig "
+"abgeschaltet (mehr als ein Jahr nach der Ankündigung, dass dies in sechs "
+"Monaten geschehen würde!)."
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+"Abstimmlogik wurde verbessert, webbasierte Wahl der Autobearbeiter "
+"herausgebracht."
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr "Abstimmungszeitraum für angefochtene Bearbeitungen verlängert"
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr "Abstimmungszeitraum auf 7 Tage verkürzt"
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr "Abstimmvorschläge"
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr "Webservice Version 1 stillgelegt"
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr "Yvanzo schließt sich MusicBrainz als Entwickler an"
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+"Yvanzo tritt dem Entwicklungsteam als zweiter Entwickler für MusicBrainz bei."
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr "mb_server jetzt auf Git gehostet"
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.el.po
+++ b/po/history.el.po
@@ -1,0 +1,1127 @@
+#
+# Translators:
+# Dimitris <email address hidden>, 2013
+# Dimitris <email address hidden>, 2012
+# Panos Bouklis <email address hidden>, 2012
+# reosarevok <reosarevok@users.noreply.translations.metabrainz.org>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2024-01-04 11:06+0000\n"
+"Last-Translator: reosarevok <reosarevok@users.noreply.translations."
+"metabrainz.org>\n"
+"Language-Team: Greek <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/el/>\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.3\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+"Μία μικρή ρωγμή στην κοινότητα του MusicBrainz οδηγεί σε Μεγάλο Σχίσμα."
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "Προχωρημένες σχέσεις"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Γλώσσες άλμπουμ"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr "Amazon betas SoundUnwound"
+
+#: DB:statistics.statistic_event/title:2004-02-24
+#, fuzzy
+#| msgid "Amazon Coverart"
+msgid "Amazon cover art"
+msgstr "Εξώφυλλο από Amazon"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+#, fuzzy
+#| msgid "Amazon coverart support released."
+msgid "Amazon cover art support released."
+msgstr "Κυκλοφόρησε η υποστήριξη για εξώφυλλο Amazon."
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+"Κυκλοφόρησε ένας βελτιωμένος επεξεργαστής κυκλοφοριών και έγινε νέος "
+"σχεδιασμός της ιστοσελίδας."
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr "Κυκλοφόρησε η υποστήριξη σχολίων."
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "Σχόλια"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "Παρακακολουθήσεις καλλιτεχνών"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr "Παρακακολουθήσεις καλλιτεχνών."
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr "Δυναμικές σελίδες καλλιτεχνών BBC."
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+"Το BBC ξεκινά τη λειτουργία των δυναμικών σελίδων καλλιτεχνών βασισμένες στα "
+"δεδομένα του MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr "Συνεργασία MetaBrainz με BBC"
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr "Αποκλειστικός εξυπηρετητής βάσης δεδομένων"
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr "Αναζήτηση επεξεργασιών"
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr "Μέγα Σχίσμα"
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr "Βελτίωση ψηφοφοριών"
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr "Βελτίωση αναζήτησης"
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr "Σενάρια εγκατάστασης"
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+"Ο Kuno Woudt ξεκινά να δουλεύει για το MusicBrainz κανονικά απασχολούμενος."
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr "Ο Kuno Woudt προσλαμβάνεται ως μόνιμος προγραμματιστής"
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr "Δισκογραφικές εταιρείες/ποιότητα δεδομένων"
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+"Το Last.fm εγγράφεται στο MetaBrainz και χρησιμοποιεί τα δεδομένα του "
+"MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr "Το Linkara Musica γίνεται ο πρώτος εμπορικός πελάτης του MetaBrainz."
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr "Το MetaBrainz δέχεται τρεις μαθητές για το Google Summer of Code."
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr "Το MetaBrainz προσλαμβάνει τον Oliver Charles"
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr "MetaBrainz ξεκινά τη λειτουργία του"
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr "MetaBrainz υπογράφει με τον πρώτο πελάτη"
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr "MetaWeb εγγράφηκε"
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr "Μετακίνηση MusicBrainz"
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+"Ο πηγαίος κώδικας του εξυπηρετητή MusicBrainz μετακινείται από το Git στο "
+"Subversion."
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr "Το MusicBrainz αποκτά τον πρώτο αποκλειστικό εξυπηρετητή δεδομένων."
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+"Το MusicBrainz μετακομίζει στην Digital West Networks στο San Luis Obispo."
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "MusicIP PUID"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr "Κομμάτια εκτός άλμπουμ"
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr "Κυκλοφορούν τα κομμάτια εκτός άλμπουμ."
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+"Ο Oliver Charles γίνεται ο εργαζόμενος υπ' αριθμό #1 του Ιδρύματος "
+"MetaBrainz."
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr "Ο Oliver Charles ξεκινάει να δουλεύει μόνιμα για το MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr "Ο Oliver Charles συμμετέχει στο MusicBrainz σε μόνιμη βάση"
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr "Επεξεργαστής κυκλοφοριών"
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr "Βελτιώσεις αναζήτησης"
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr "SoC 2008"
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+"Κυκλοφορεί η υποστήριξη για δισκογραφικές εταιρείες και ποιότητα δεδομένων."
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+"Το BBC γίνεται πελάτης του MetaBrainz και ξεκινά να χρησιμοποιεί τα δεδομένα "
+"του MusicBrainz."
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+"Ανακοινώνεται δημόσια το ίδρυμα MetaBrainz, η νομική στέγη του MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr "Βελτιώσεις χρηστών"
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr "mb_server φιλοξενείται πλέον στο Git"
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.eo.po
+++ b/po/history.eo.po
@@ -1,0 +1,1118 @@
+#
+# Translators:
+# Alex Mauer <email address hidden>, 2016
+# FIRST AUTHOR <email address hidden>, 2009
+# Ian McEwen <email address hidden>, 2012-2013
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: Alex Mauer <hawke@hawkesnest.net>, 2016\n"
+"Language-Team: Esperanto (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/eo/)\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+"Nova AJAX kovrilarto alŝutilo estas eldoninta, faciliĝanta la aldono de "
+"kovrilarto al aldonoj."
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr "Disiĝo en la komunumo de MusicBrainz resultas Granda Malpaco."
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "Progresinta rilato"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+"Progresinta rilatoj ke ebligi uzantoj konekti baza datumentoj estas "
+"eldonita. Neuzitaj TRMj stucita de la datenaro. Enpaĝa redakto elŝaltita por "
+"defaŭlto, kaŭzanta defalo en balota agado."
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Albumo lingvoj"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+"Albuma lingvoj, plibonigoj al diveni-uskleca, kaj revisioj al "
+"redaktaformularoj eldonita"
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr "Amazon betas SoundUnwound"
+
+#: DB:statistics.statistic_event/title:2004-02-24
+#, fuzzy
+#| msgid "Amazon Coverart"
+msgid "Amazon cover art"
+msgstr "Amazono kovrilarto"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+#, fuzzy
+#| msgid "Amazon coverart support released."
+msgid "Amazon cover art support released."
+msgstr "Subteno por Amazon kuvrilarto eldonita"
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr "Plibonigita eldonredakilo kaj nova reteja projecto eldonis."
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr "Komentaria subteno eldonis"
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "Komentarioj"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "Artistaj abonoj"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+"Artista abonoj farita publika kaj diversa pli malgranda uzanto-centritaj "
+"plibonigoj eldonita"
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+"Redaktisto ojnkpjg rulas skripto, agordi trakdaŭro de DiscID valoroj, kaj "
+"estigi grandega spiko de redaktoj."
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr "Trakdaŭroj difini de DiscID"
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.es.po
+++ b/po/history.es.po
@@ -1,0 +1,1141 @@
+#
+# Translators:
+# Alexander Dupuy <email address hidden>, 2012
+# Alfredo Briones <email address hidden>, 2016
+# Antonio Perea, 2022
+# 3b2b9b2970dff2223d07f096c7a072f3, 2011
+# Héctor Arroyo <email address hidden>, 2012
+# Mario Herrera <email address hidden>, 2020
+# Marta PD <email address hidden>, 2014
+# Nicolás Tamargo <email address hidden>, 2011-2013,2018
+# Robert Schneider <email address hidden>, 2019
+# Roboron <email address hidden>, 2020
+# Stich Lilo <email address hidden>, 2020
+# Kevin López Brante <email address hidden>, 2012
+# Tobias Quathamer <email address hidden>, 2007
+# t0n3t <email address hidden>, 2012
+# reosarevok <reosarevok@users.noreply.translations.metabrainz.org>, 2023, 2024.
+# yvanzo <yvanzo@users.noreply.translations.metabrainz.org>, 2024.
+# Zetas70 <stevenguardiola41@gmail.com>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2024-05-31 18:42+0000\n"
+"Last-Translator: reosarevok <reosarevok@users.noreply.translations."
+"metabrainz.org>\n"
+"Language-Team: Spanish <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/es/>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n != 0 && n % 1000000 == "
+"0) ? 1 : 2);\n"
+"X-Generator: Weblate 5.5.4\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+#, fuzzy
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr "Español"
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+"Un nuevo cargador de imagen AJAX se ha publicado, facilitando añadir "
+"imágenes a los lanzamientos."
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+"Ahora un nuevo anuncio notifica a los usuarios cada vez que reciben una nota "
+"sobre la edición."
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr "Una brecha en la comunidad de MusicBrainz termina en una Gran Disputa."
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+"AcousticBrainz, que pretende ser una fuente colaborativa de información "
+"acústica sobre la música, es anunciado en cooperación con el Grupo de "
+"Tecnología Musical de la Universidad Pompeu Fabra."
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "Relaciones avanzadas"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Idiomas del álbum"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr "Imágenes de Amazon"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "Anotaciones"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "Suscripciones a artistas"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr "Suscripciones a artistas."
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr "Páginas dinámicas de artistas de la BBC"
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+"BBC lanza sus páginas dinámicas de artistas basadas en datos de MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr "La BBC se asocia a MetaBrainz"
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr "Colecciones colaborativas"
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr "Colección, Calificación, CDStubs"
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr "Colección, Calificación, CDStubs, Última actualización lanzada."
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr "Subir Imagen de Portada"
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr "Servidor dedicado de base de datos"
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr "Búsqueda de ediciones"
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+"El editor ojnkpjg ejecuta un script que usa la información de las IDs de "
+"disco para modificar las duraciones de las pistas, lo que causa un enorme "
+"pico en el número de ediciones."
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr "Verificación de la dirección de correo electrónico"
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr "Gran disputa"
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr "Ian McEwen abandona MetaBrainz"
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr "Ian McEwen abandona el proyecto por motivos personales."
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr "Catálogo de CD Baby importado como esbozos"
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+"Importamos los datos del catálogo de CD Baby en nuestra colección de esbozos "
+"de CD."
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr "Votación mejorada"
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr "Búsqueda mejorada"
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr "Búsqueda indexada/XML WS"
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr "Editar en linea"
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+"Ediciones en línea, nuevos informes, scripts de importación de datos "
+"mejoradas."
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr "Instalar Scripts"
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr "Kuno Woudt empieza a trabajar a tiempo completo para MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr "Kuno Woudt contratado como desarrollador a tiempo completo"
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr "Discográficas / calidad de datos"
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr "Enlace"
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr "MetaBrainz fue lanzado"
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr "MusicBrainz obtiene su primer servidor de base de datos dedicado."
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr "MusicBrainz se traslada a Digital West Networks en San Luis Obispo."
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr "Nuevo diseño de MusicBrainz"
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr "Sin pistas de álbum"
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+"Oliver Charles se convierte en el primer empleado de la MetaBrainz "
+"Foundation."
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr "Oliver Charles empieza a trabajar a tiempo completo para MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr "Oliver Charles se une a MusicBrainz a tiempo completo"
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr "Editor de relaciones"
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr "Mejoras de búsqueda"
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr "SoC 2008"
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr "El proyecto AcousticBrainz se pone en marcha"
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+"La BBC se convierte en cliente de MetaBrainz y empieza a usar datos de "
+"MusicBrainz."
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr "El proyecto CritiqueBrainz se pone en marcha"
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr "El proyecto ListenBrainz se pone en marcha"
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr "Se lanza el nuevo sitio web de MetaBrainz"
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr "Mejoras de usuario"
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+"Ahora los usuarios deben verificar su dirección de correo para poder editar."
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr "Período de votación acortado a 7 días"
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr "Sugerencias de voto"
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr "Atributos de obra"
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr "mb_server ahora alojado en Git"
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.es_419.po
+++ b/po/history.es_419.po
@@ -1,0 +1,1097 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es_419\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.et.po
+++ b/po/history.et.po
@@ -1,0 +1,1146 @@
+#
+# Translators:
+# Mihkel Tõnnov <email address hidden>, 2008-2009,2011-2012
+# Mihkel Tõnnov <email address hidden>, 2015,2018
+# reosarevok <reosarevok@users.noreply.translations.metabrainz.org>, 2023.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2023-12-19 21:28+0000\n"
+"Last-Translator: reosarevok <reosarevok@users.noreply.translations."
+"metabrainz.org>\n"
+"Language-Team: Estonian <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/et/>\n"
+"Language: et\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.3\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+"Lisati varasemast palju mugavam AJAXi-põhine kaanepiltide üleslaadimise "
+"võimalus."
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr "Kasutajatele hakati uute toimetusmärgete saamisel märguannet näitama."
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr "Lahkheli MusicBrainzi kogukonnas viis Suure Vaidluseni."
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "Täpsemad seosed"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+"Lisati täpsemad seosed, mille kaudu saab ühendada peamisi andmeelemente. "
+"Kasutamata TRM-id eemaldati andmebaasist. Leheküljesisene hääletamine "
+"lülitati vaikimisi välja, mis põhjustas hääletusaktiivsuse langemist."
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Albumi keeled"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+"Lisati albumi keele tugi, parandati suurtähestuse oletamist ja muudeti "
+"toimetamisvormi."
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr "Amazon alustas SoundUnwoundi beetatestimist"
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr "Amazoni kaanepildid"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr "Lisati Amazoni kaanepiltide tugi."
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr "Avalikustati senisest parem väljalasketoimeti ja uus lehekujundus."
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr "Lisati annotatsioonide võimalus."
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "Annotatsioonid"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "Jälgitavad artistid"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+"Avalikustati artistide jälgimise võimalus, lisaks muid väiksemaid parandusi "
+"kasutajaliideses."
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr "Lisati artistide jälgimise funktsioon."
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr "BBC dünaamilised artistilehed"
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+"BBC käivitas MusicBrainzi andmetel põhinevat dünaamiliste artistilehtede "
+"süsteemi."
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr "Algas BBC partnerlus MetaBrainziga"
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr "Eelavalikustati CAA"
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr "CAA kuulutati avalikult välja"
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr "Koostöökogud"
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr "Kogud, hinded, pooleldi sisestatud CD-d"
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+"Lisati kogude, hinnete, pooleldi lisatud CD-de ja viimase uuendusaja tugi."
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr "Kaanepiltide üleslaadimine"
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr "Eraldi andmebaasiserver"
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+"Parandati toimetuste kuvamist, lülitati välja RDF-andmetõmmised, "
+"avalikustati uued paigaldusskriptid."
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr "Märguanded toimetusmärgete kohta"
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr "Toimetuste otsing"
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+"Toimetaja ojnkpjg jooksutas skripti, mis määras plaadi-ID järgi lugude "
+"kestused, tekitades tohutult toimetusi."
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+"Varasem GSoC tudeng Roman Tsukanov alustas osakoormusega tööd MetaBrainzi "
+"heaks."
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+"FreeDB automaatimport lülitati välja ja lisati vanemtoimetajavalimised. "
+"Kasutamata TRM-id eemaldati andmebaasist."
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr "FreeDB välja; vanemtoimetajad"
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr "Suur Vaidlus"
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr "CD Baby kataloog imporditi pooleldi lisatud CD-dena"
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+"CD Baby kataloogi metaandmed imporditi meie pooleldi lisatud CD-de kogusse."
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr "Täiustati hääletamist"
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr "Täiustati otsingut"
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+"Püüdes vähendada lahtiste toimetuste järjekorda ja muudatuste rakendumise "
+"ootamist, lühendati toimetuste aegumisaeg 14 päevalt 7-le."
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr "NGS-i ettevalmistusena lülitati toimetamine välja."
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+"NGS-i ettevalmistusena soovitatakse toimetajatel andmete muutmist vältida, "
+"kui vähegi võimalik."
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr "Indekseeritud otsing, XML-veebiteenus"
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr "Lisati indekseeritud otsing ja uus XML-põhine veebiteenus."
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr "Leheküljesisene hääletamine"
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+"Lisati leheküljesisene hääletamine ja uusi aruandeid, parandati andmete "
+"impordiskripte."
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr "Paigaldusskriptid"
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr "Kuno Woudt alustas täiskohaga tööd MusicBrainzi heaks."
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr "Kuno Woudt täiskohaga arendajaks"
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr "Plaadifirmad, andmekvaliteet"
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+"Last.fm-ist sai MetaBrainzi klient, hakkas kasutama MusicBrainzi andmeid."
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+"Lisati MusicBrainziga linkimise funktsioon, väljalaskesündmused ja "
+"toimetamissoovitused."
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr "Linkara Musicast sai MetaBrainzi esimene kommertsklient."
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr "Linkimine"
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr "Menüüd, kliendipoolne skriptimine"
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr "MetaBrainz võttis Google Summer of Code’i raames vastu kolm õpilast"
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr "MetaBrainz võttis tööle Oliver Charlesi"
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr "MetaBrainz alustas tööd"
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr "MetaBrainzi leping esimese kliendiga"
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr "Leping MetaWebiga"
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr "Rohkem kohetoimetusi"
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr "MusicBrainzi kolimine"
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr "MusicBrainzi serveri lähtekood koliti Subversionist Git-i. "
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr "MusicBrainz sai oma esimese eraldiseisva andmebaasiserveri."
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr "MusicBrainz kolis Digital West Networks’i (San Luis Obispo’s)."
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+"MusicBrainz alustas partnerlust MusicIP-ga ja hakkas kasutama MusicDNS-i "
+"„akustilisi sõrmejälgi” (PUID). Picardist sai ametlik MusicBrainzi "
+"sildistusprogramm koos PUID toega, põhjustades toimetusaktiivsuse langemist."
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "MusicIP PUID"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr "NGS: toimetamiseta faas"
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr "NGS: vähese toimetamise faas"
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr "NGS: väljalase"
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+"Avalikustati NGS (Next Generation Schema), MusicBrainzi suur ümberkorraldus!"
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr "MusicBrainzi uus kujundus"
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr "Albumivälised lood"
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr "Lisati albumiväliste lugude võimalus."
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr "Oliver Charles sai MetaBrainz Foundationi töötajaks #1."
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr "Oliver Charles alustas täiskohaga MusicBrainzi heaks töötamist."
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr "Oliver Charles täiskohaga MusicBrainzis"
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr "Seosetoimeti"
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr "Väljalaskerühmad, ISRC-d, pooleldi sisestatud CD-de otsing"
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr "Väljalasketoimeti"
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr "Lisati väljalasketoimeti ja suurtähestuse oletamise nupp."
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+"Lisati väljalaskerühmad ja ISRC-de tugi, lubati otsida pooleldi lisatud CD-"
+"sid, parandati otsingusüsteemi."
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr "Roman Tsukanov liitus MetaBrainzi meeskonnaga"
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr "SG5 parandused"
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr "Otsingutäiustused"
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr "Mitu uut kohetoimetusetüüpi ja tõlget"
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr "SoC 2008"
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+"Avaldati osaline lahendus stiilijuhis nr 5 jaoks. Kasutamata TRM-id "
+"eemaldati andmebaasist."
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr "Lisati plaadifirmade ja andmekvaliteedi tugi."
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr "AcousticBrainzi projekt sai avalikuks"
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr "BBC-st sai MetaBrainzi klient, hakkas kasutama MusicBrainzi andmeid."
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr "Kaanepildiarhiiv tehti varajastele huvilistele kättesaadavaks."
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr "Kaanepildiarhiiv kuulutati ametlikult avatuks."
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr "CritiqueBrainzi projekt sai avalikuks"
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr "ListenBrainzi projekt sai avalikuks"
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr "Avalikustati MetaBrainz Foundation, MusicBrainzi juriidiline kodu."
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr "MetaBrainzi uus veebisait sai avalikuks"
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr "Avalikustati seosetoimeti väljalaske seoste hulgitoimetamiseks."
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr "Avalikustati otsingufunktsioonid ja veebiteenuse täiendused."
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+"Parandati põhimenüüd, avalikustati duplikaatartistide, kogu albumi "
+"toimetamise ja lugude kestuse toimetamise funktsioonid."
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr "Loopikkused plaadi-ID-dest"
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr "Kasutajaliidese parandused"
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+"Parandati hääletusloogikat, lisati veebipõhised vanemtoimetajavalimised."
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr "Hääletusaega lühendati 7 päevale"
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr "Hääletamissoovitused"
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr "mb_serveri projekt kolis Git-i"
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.fa.po
+++ b/po/history.fa.po
@@ -1,0 +1,1097 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fa\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.fi.po
+++ b/po/history.fi.po
@@ -1,0 +1,1147 @@
+#
+# Translators:
+# Jaakko Perttilä <email address hidden>, 2014,2018
+# Tukea <email address hidden>, 2016
+# jozo, 2014
+# Juhana Uuttu <email address hidden>, 2023
+# 68c019e72ca2ecf7f5428dd4599050d2_f003645, 2014
+# 68c019e72ca2ecf7f5428dd4599050d2_f003645, 2014
+# phonebox, 2014
+# phonebox, 2014
+# Timo Martikainen <email address hidden>, 2012-2014
+# Tukea <email address hidden>, 2016
+# reosarevok <reosarevok@users.noreply.translations.metabrainz.org>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2024-01-04 11:06+0000\n"
+"Last-Translator: reosarevok <reosarevok@users.noreply.translations."
+"metabrainz.org>\n"
+"Language-Team: Finnish <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/fi/>\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.3\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+"Uusi AJAX-pohjainen kansitaiteen lähetysohjelma on julkaistu. Se helpottaa "
+"kuvien liittämistä julkaisuihin."
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr "Uusi banneriviesti kertoo käyttäjille uusista muokkausmerkinnöistä."
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr "Välirikko MusicBrainz-yhteisössä johtaa Suureen väittelyyn."
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+"AcousticBrainz, joka pyrkii joukkoistamaan äänitunnistamisen musiikista, "
+"julkaistaan yhdessä Pompeu Fabran yliopiston musiikkiteknologiaryhmän kanssa."
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "Edistyneet yhteydet"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Julkaisujen kielet"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+#, fuzzy
+#| msgid "Amazon Coverart"
+msgid "Amazon cover art"
+msgstr "Amazonin kansikuvat"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+#, fuzzy
+#| msgid "Amazon coverart support released."
+msgid "Amazon cover art support released."
+msgstr "Tuki Amazon kansikuville julkaistiin."
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr "Parannettu julkaisumuokkain ja uusi sivuston ulkoasu julkaistu. "
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr "Tuki lisätietokentälle julkaistiin."
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "Lisätietokentät"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "Artisti-tilaukset"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+"Artisti-tilaukset tehtiin julkisiksi ja useat pienemmät käyttäjäkohtaiset "
+"parannukset julkaistiin. "
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr "Artisti-tilaukset."
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr "BBC:n dynaamiset artistisivut"
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr "BBC julkaisee MusicBrainzin dataan pohjautuvat dynaamiset artistisivut"
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr "BBC:n kumppanuus MetaBrainzin kanssa."
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr "alustava CAA-julkaisu"
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr "virallinen CAA-julkaisu"
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr "Kokoelmat, arvostelut, CD-tyngät"
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+"Kokoelmat, arvostelut, CD-tyngät ja viimeisin päivitys-ominaisuus "
+"julkaistiin. "
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr "Kansikuvalataaja"
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr "Tietokanta omalle palvelimelleen. "
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+"Muokkausten näyttämistä parannettiin, RDF-muotoisen tiedon jakaminen "
+"lopetettiin, uudet asennusskriptit julkaistiin."
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr "Muokkausmerkintöjen ilmoitukset."
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr "Muokkausten haku"
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+"Käyttäjä ojnkpjg ajaa komentojonon, joka asettaa kappaleiden pituudet DiscID-"
+"arvoista, mikä aiheuttaa valtavan nousun muokkausten määrässä."
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr "Suuri väittely"
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr "Äänestystä parannettiin"
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr "Parannettu haku"
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+"NGS-järjestelmään valmistaudutaan, kytkemällä muokkaaminen pois päältä ennen "
+"julkaisua."
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+"NGS-järjestelmään valmistautuessa editoreja kehotetaan välttämään "
+"muokkaamista ja vain välttämättömimmät muokkaukset sallitaan ennen julkaisua."
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr "Asennusskriptit"
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr "Kuno Woudt aloittaa täyspäiväisen työskentelynsä MusicBrainzille."
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr "Kuno Woudt palkattiin täyspäiväiseksi kehittäjäksi"
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr "Levymerkki/tiedon laatu"
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+"Last.fm:stä tulee MetaBrainzin asiakas ja se alkaa käyttää MusicBrainzin "
+"dataa."
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+"Linkittäminen MusicBrainz-ominaisuudeksi, julkaisutapahtumat ja "
+"muokkausehdotukset julkaistiin."
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr "Linkara Musicsta tulee ensimmäinen kaupallinen Metabrainzin asiakas."
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr "Linkittäminen"
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+"MetaBrainz hyväksyy kolme opiskelijaa Googlen Summer of Code-ohjelmaan."
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr "MetaBrainz palkkaa Oliver Charlesin"
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr "MetaBrainz perustettiin"
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr "MetaBrainzin ensimmäinen asiakas"
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr "MusicBrainzin muutto."
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+"MusicBrainzin palvelimen lähdekoodi muutti Subversionista Git-järjestelmään."
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+"MusicBrainz muutti Digital West Networksiin, joka sijaitsee San Luis "
+"Obispossa. "
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "MusicIP PUID"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr "NGS-järjestelmän ei muokkaamista-vaihe."
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr "NGS-järjestelmän rajoitettu muokkaaminen-vaihe."
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr "NGS julkaisu"
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr "NGS, MusicBrainzin suuri uudelleensuunnittelu julkaistaan!"
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr "Uusi MusicBrainzin ulkoasu"
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr "Julkaisuihin kuulumattomat kappaleet"
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr "Julkaisuihin kuulumattomat kappaleet ovat tuettu."
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+"Oliver Charlesista tulee MetaBrainz Foundationin ensimmäinen työntekijä."
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr "Oliver Charles alkaa työskennellä täyspäiväisesti MusicBrainzille."
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr "Oliver Charles palkattu täyspäiväiseksi MusicBrainziin."
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr "Yhteyksien muokkain"
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr "Julkaisuryhmät, ISRC-koodit, CD-tynkä-haku"
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr "Julkaisumuokkain"
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr "Julkaisumuokkain ja kirjoitusasun tunnistus julkaistu."
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr "SG5 korjaukset"
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr "Parannuksia hakuun"
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr "SoC 2008"
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+"BBC:stä tulee MetaBrainzin asiakas ja se alkaa käyttää MusicBrainzin dataa."
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+#, fuzzy
+#| msgid "CAA official release"
+msgid "The Cover Art Archive is officially released."
+msgstr "virallinen CAA-julkaisu"
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+"Äänestyslogiikkaa parannettiin, verkkopohjainen autoeditorien "
+"valintaäänestys julkaistiin."
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr "Äänestysaika lyhennettiin 7 päivään"
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.fr.po
+++ b/po/history.fr.po
@@ -1,0 +1,1387 @@
+#
+# Translators:
+# AO <email address hidden>, 2013
+# Benjamin Sonntag <email address hidden>, 2011-2012
+# Benjamin Sonntag <email address hidden>, 2011
+# Dibou <email address hidden>, 2012
+# AO <email address hidden>, 2013,2015
+# Laurent Monin <email address hidden>, 2014
+# Lotheric <email address hidden>, 2011
+# murdos <email address hidden>, 2011-2012
+# AO <email address hidden>, 2015
+# AO <email address hidden>, 2013-2015
+# yvanz, 2016,2019-2021,2023
+# yvanz, 2016
+# yvanzo <yvanzo@users.noreply.translations.metabrainz.org>, 2023, 2024.
+# reosarevok <reosarevok@users.noreply.translations.metabrainz.org>, 2023.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2024-05-31 18:42+0000\n"
+"Last-Translator: yvanzo <yvanzo@users.noreply.translations.metabrainz.org>\n"
+"Language-Team: French <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/fr/>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : ((n != 0 && n % "
+"1000000 == 0) ? 1 : 2);\n"
+"X-Generator: Weblate 5.5.4\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr "La recommendation « ne pas agglomérer » est abandonnée"
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr "La standardisation des « feat. » est abandonnée"
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr "Vignettes de 1200 px"
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+"Des vignettes de 1200 px sont ajoutées à la Cover Art Archive, fournissant "
+"aux utilisateurs une image très grande image d’une taille uniforme et sans "
+"avoir à récupérer l’image originale directement."
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+"Une plateforme de forum Discourse est ajoutée pour remplacer à la fois les "
+"forums de la vieille école et les listes de diffusion (maintenant inactives) "
+"et unifier la communication communautaire en un seul endroit."
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+"Un changement est introduit qui permet de voter pour ou contre les tags "
+"folksonomiques existants, plutôt que d’ajouter simplement les vôtres."
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+"Une mise à jour majeure pour le marqueur Picard est publiée, avec une énorme "
+"quantité de corrections de bugs et d'améliorations."
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+"Une nouvelle page « Suggestions de vote » est ajoutée, contenant des "
+"recherches de modifications prédéfinies pour aider les éditeurs à trouver "
+"des modifications intéressantes et/ou importantes à réviser et à voter."
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+"Un nouveau téléverseur d’illustrations AJAX est sorti, facilitant l’ajout "
+"d’illustrations aux parutions."
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+"Un nouveau message de bannière alerte les utilisateurs lorsqu’ils reçoivent "
+"une nouvelle note de modification."
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr "Une nouvelle mécanique de recherche, bien plus rapide, est ajoutée."
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+"Un clivage dans la communauté MusicBrainz mène vers une grande dispute."
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+"Un changement de schéma très conséquent ajoute un nouveau type d'entité "
+"(régions), la prise en charge des codes ISNI pour les artistes et les "
+"labels, et la possibilité d'avoir plus d'un événement de sortie pour une "
+"seule parution."
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+"Un moyen de rechercher des modifications en fonction de plusieurs critères "
+"différents est ajouté."
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+"AcousticBrainz, qui vise à créer de façon participative de l’information "
+"acoustique sur la musique, est annoncé en coopération avec le Music "
+"Technology Group de l’Université Pompeu Fabra."
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "Relations approfondies"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+"Relations approfondies qui permettent aux utilisateurs de connecter des "
+"entités simples de données, et les TRM inutilisés sont enlevés de la base de "
+"données. L’édition en ligne est désactivée par défaut, ce qui cause une "
+"baisse de l’activité de vote."
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+"Après de nombreux drames en coulisses, MetaBrainz remporte une bataille "
+"juridique contre un troll du droit d’auteur qui a tenté de poursuivre en "
+"justice en raison de l'utilisation d'images Wikimédia Commons. Les images "
+"Commons sont néanmoins retirées des sites MusicBrainz pour éviter d'autres "
+"problèmes jusqu'à ce que Wikimédia apporte des modifications rendant la "
+"réutilisation des images plus sûre."
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+"Après de nombreux débats, les données relationnelles commencent à être "
+"affichées sur les pages des parutions, ce qui les rend beaucoup plus "
+"visibles."
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+"Après un Summer of Code couvert de succès, Ian McEwen rejoint l’équipe "
+"MusicBrainz."
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+"Après de nombreuses années chez Digital West en Californie, le projet "
+"MetaBrainz transfère tous les serveurs vers un fournisseur dédié beaucoup "
+"plus grand en Allemagne, Hetzner."
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+"Après plusieurs années en tant que projet uniquement communautaire, "
+"BookBrainz est adopté comme projet officiel et se voit attribuer un "
+"véritable poste de développeur avec l'embauche de Monkey."
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+"Après un bouleversement inattendu chez Freenode, MetaBrainz déplace tous les "
+"canaux officiels vers Libera.Chat."
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Langues des albums"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+"Amélioration de la découverte des langues des albums et de la casse ainsi "
+"que des formulaires de modification revampés."
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+"Les alias sont ajoutés aux trois types d'entités qui en manquaient encore : "
+"enregistrements, parutions et groupes de parution. Cela permet de stocker "
+"des alias pour, par exemple, les noms anglais des groupes de parution "
+"asiatiques."
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+"Alias pour les enregistrements, les parutions et les groupes de parution"
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+"Amazon publie en bêta <a href=\"http://web.archive.org/web/20210123164029/"
+"https://www.wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> utilisant "
+"les données de MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr "SoundUnwound bêta d’Amazon"
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr "Illustrations provenant d’Amazon"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr "Prise en charge des illustrations provenant d’Amazon."
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+"Éditeur de parution amélioré ainsi qu’une nouvelle conception pour le site."
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+"Une mise à jour est publiée qui permet de spécifier un crédit pour les "
+"artistes dans les relations, si différent du nom de l'artiste."
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr "Prise en charge des annotations."
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "Annotations"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr "Régions, codes ISNI et multiples événements de parution par parution"
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "Abonnements à des artistes"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+"Les abonnements aux artistes sont rendus publics, et petites améliorations "
+"pour les utilisateurs."
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr "Abonnements aux artistes."
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+"Dans un mouvement de long terme vers plus grande fidélité aux données "
+"originales, nous arrêtons de standardiser l’orthographe de « featuring » et "
+"de ses variantes en « feat. », et demandons aux éditeurs de simplement "
+"utiliser ce qui est imprimé."
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr "Pages dynamiques des artistes provenant de la BBC"
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+"La BBC lance les pages dynamiques des artistes basées sur les données de "
+"MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr "Partenariat entre la BBC et MusicBrainz"
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr "BookBrainz devient officiellement un projet MetaBrainz"
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr "Parution initiale CAA"
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr "Parution officielle CAA"
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr "CatQuest devient « Instrument Inserter »"
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+"CatQuest succède officiellement à reosarevok en tant que personne principale "
+"chargée de l'ajout de nouveaux instruments à MusicBrainz, avec le poste de "
+"« Instrument Inserter » nouvellement créé."
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr "Collection collaboratives"
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+"Les propriétaires de collection ont maintenant la possibilité de permettre "
+"aux autres éditeurs d’ajouter et de supprimer des entités de leurs "
+"collections."
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr "Collections, évaluations, ébauches de CD"
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr "Collections, évaluations, ébauches de CD, dernières mise à jour."
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+"Les collections peuvent maintenant être fusionnées par leur propriétaire. De "
+"plus, il est maintenant possible de créer des séries d’artistes, et "
+"d’évaluer des lieux. (C’était les seuls à pouvoir être évalués sur "
+"CritiqueBrainz mais pas sur MusicBrainz.)"
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr "Téléverseur d’illustrations"
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr "Serveur de base de données dédié"
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr "Discourse unifie la communication communautaire"
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr "L’ajout des notes de modification est facilité"
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+"Améliorations de l’affichage des modifications, arrêt des vidages « RDF », "
+"nouveaux scripts d’installation."
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr "L’historique des modifications est visible sans se connecter"
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr "Alertes de note de modification"
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+"Des notes de modification peuvent désormais être ajoutées lors de la "
+"création d'une modification, ce qui permet aux éditeurs d'expliquer beaucoup "
+"plus facilement leurs modifications."
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr "Rechercher de modification"
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+"L’éditeur ojnkpjg fait tourner un script ajustant les durées de piste à "
+"partir des valeurs d’ID de disque créant un énorme pic dans les "
+"modifications."
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+"Les modifications faites par les éditeurs aux parutions qu’ils ont eux-mêmes "
+"ajouté moins d’1 heure avant sont maintenant automatiques, comme par exemple "
+"celles du type « Ajouter un enregistrement » et « Enlever un alias »."
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr "Vérification de l’adresse courriel"
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+"Les labels, les groupes de parution et les œuvres sont désormais "
+"automatiquement supprimés si toujours vides après 24 heures d’inutilisation, "
+"de la même manière que les artistes l’étaient déjà auparavant."
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+"Les labels, les groupes de parution et les œuvres vides commencent à être "
+"supprimés automatiquement"
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+"La prise en charge des événements est ajoutée à MusicBrainz, permettant de "
+"stocker des informations sur les concerts et les festivals. Ce changement de "
+"schéma comprend également une manière appropriée d’indiquer le contenu des "
+"pistes de données dans les listes de pistes d’une parution, ainsi que "
+"l'extension des tags folksonomiques aux instruments, régions et séries."
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr "Prise en charge des événements, pistes de données"
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+"Le taguage folksonomique et les abonnements d’éditeur sont arrivés. De plus, "
+"il est maintenant possible d’ajouter des relations par lot à de multiples "
+"pistes pour une parution."
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+"L’ancien étudiant du GSoC Roman Tsukanov commence à travailler à temps "
+"partiel pour MetaBrainz."
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+"Frederik « Freso » S. Olesen devient animateur de la communauté MetaBrainz"
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+"Fonction d’auto-importation de FreeDB est désactivée et élections des auto-"
+"éditeurs. Les TRM inutilisés sont enlevés de la base de données."
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr "FreeDB désactivée/auto-éditeurs"
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+"Freso devient le premier animateur de la communauté MetaBrainz, en charge "
+"d’aider à résoudre les conflits internes à la communauté et de garder une "
+"oreille attentive à ses besoins."
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr "Le genre a été ajouté comme nouvelle entité"
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+"Les genres ont été ajoutés comme une nouvelle entité, tout en restant liés "
+"aux étiquettes folksonomiques."
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr "Grande dispute"
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr "Boutons pour deviner les artistes invités"
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr "Canaux IRC déplacés vers Libera.Chat"
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr "Ian McEwen embauché"
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr "Ian McEwen quitte MetaBrainz"
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr "Ian McEwen quitte le projet pour des raisons personnelles."
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr "Catalogue CD baby importé comme ébauches de CD"
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+"Métadonnées du catalogue de CD Baby importées dans notre collection "
+"d’ébauches de CD."
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr "Amélioration du vote"
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr "Amélioration de la recherche"
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+"Afin de réduire la taille de la file d’attente des modifications ouvertes et "
+"forcer une attente moindre pour les changements, la durée d’ouverture des "
+"modifications avant expiration est réduite de 14 à 7 jours."
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+"Pour faciliter la correction des nombreux cas où les artistes invités sont "
+"indiqués dans les titres de parutions ou de leurs pistes au lieu de l’être "
+"dans les crédits d’artistes, des boutons pour deviner les artistes invités "
+"ont été ajoutés."
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+"En préparation de NGS, les modifications sont désactivées jusqu’à la sortie."
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+"En préparation de NGS, les éditeurs sont encouragés à éviter de modifier "
+"jusqu’à la sortie sauf si vraiment nécessaire."
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr "Recherche indexée/XML WS"
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr "Recherche indexée et nouveau service Web basé sur XML."
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr "Modifications en ligne"
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+"Modifications en ligne, nouveau rapports, scripts améliorés d’importation de "
+"données."
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr "Scripts d’installation"
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr "Images d’instrument, première date de parution des enregistrements"
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr "Instruments et séries"
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+"Traduction italienne publiée, l’IPI et l’ISNI deviennent des modifications "
+"automatiquement approuvées"
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr "Kartik Ohri rejoint l’équipe MetaBrainz"
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+"Kartik Ohri rejoint l’équipe MetaBrainz pour travailler sur ListenBrainz, "
+"AcousticBrainz et CritiqueBrainz, plus l’application Android, qu’il a déjà "
+"réécrite de façon significative comme bénévole."
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr "Kuno Woudt commence à travailler pour MusicBrainz à plein temps."
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr "Kuno Woudt engagé en temps que développeur à plein temps"
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr "Labels/qualité des données"
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+"Last.fm signe avec MusicBrainz et commence a utiliser les données de "
+"MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr "Laurent « Zas » Monin devient sysadmin"
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+"Laurent Monin, mieux connu comme Zas, rejoint l’équipe en tant que "
+"administrateur système dédié, pour s’assurer que les serveurs tournent "
+"correctement et aider à la transition vers un nouveau système de discussion "
+"communautaire."
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+"Fonction de lien vers MusicBrainz, événements de parution et suggestions de "
+"modification."
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr "Linkara Musica devient le premier client commercial de MetaBrainz."
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr "Liaison"
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+"MBBE_Bot est créé pour apporter des correctifs qui prennent trop de temps à "
+"réaliser manuellement, mais qui devraient quand même laisser une trace dans "
+"l'historique des modifications. Cela implique généralement la suppression "
+"des URL des domaines problématiques, le marquage des URL des domaines qui "
+"ont été fermés comme terminés et d'autres tâches d'édition par lots "
+"similaires."
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr "MBBE_Bot commence à fonctionner"
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr "Menus/scripts client"
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr "Collections fusionnables, séries d’artistes et lieux évaluables"
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr "MetaBrainz accepte trois étudiants pour le « Google Summer of Code »."
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr "MetaBrainz engage Oliver Charles"
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr "Lancement de MetaBrainz"
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+"Les projets MetaBrainz terminent leur migration vers les serveurs européens"
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr "MetaBrainz signe avec son premier client"
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+"MetaBrainz gagne une bataille contre un troll du droit d’auteur, les images "
+"Wikimédia sont retirées"
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr "MetaWeb devient un utilisateur des données MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr "Signature avec MetaWeb"
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr "Davantage de modifications automatiques"
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+"Plus de types de modification sont automatiques pour tout le monde : "
+"« Ajouter une relation » et « Ajouter une parution » ; ainsi que "
+"« Ajouter », « Modifier » et « Enlever un label à la parution ». Par "
+"ailleurs, les traductions allemandes, françaises et néerlandaises sont "
+"disponibles sur le serveur principal."
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr "Déménagement de MusicBrainz"
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+"Le code source du serveur MusicBrainz est déplacé de Subversion vers Git."
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr "MusicBrainz ajoute le support d’AcoustID"
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr "MusicBrainz obtient son premier serveur de base de données dédié."
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+"MusicBrainz s’est doté d’un nouvel habillage graphique qui correspond "
+"davantage au reste de la famille *Brainz."
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr "MusicBrainz est déménagé vers Digital West Networks à San Luis Obispo."
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+"MusicBrainz devient partenaire avec MusicIP et commence à utiliser les "
+"empreintes acoustiques PUID de MusicDNS. Picard devient le baliseur officiel "
+"de MusicBrainz avec prise en charge des PUID, ce qui entraîne une naisse de "
+"l’activité de modification."
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "PUID MusicIP"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr "Phase de non modification NGS"
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr "Phase de réduction des modifications NGS"
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr "Sortie de NGS"
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr "NGS, une réécriture majeure de MusicBrainz !"
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr "Nouvel habillage graphique de MusicBrainz"
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+"Période d'édition automatique de toute nouvelle entité étendue à 24 heures"
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+"Nicolás Tamargo (reosarevok) devient le leader de style MusicBrainz et un "
+"nouveau processus de style, plus officiel, utilisant Jira est établi."
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr "Pistes hors album"
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr "Pistes hors album."
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr "Oliver Charles devient le premier employé de la Fondation MusicBrainz."
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr "Oliver Charles commence a travailler pour MusicBrainz à plein temps."
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr "Oliver Charles rejoint MusicBrainz à plein temps"
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+"Notre vieux serveur de recherche a été grandement amélioré en passant à "
+"Solr, notamment capable de mettre à jour les index quasi-instantanément."
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr "Le support de PUID est supprimé"
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr "Pagination ajoutée pour les relations et les tags folksonomiques"
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+"La pagination a été ajoutée pour deux listes très longues et qui parofis ne "
+"pouvaient être chargées complètement : les tags folksonomiques et les "
+"relations."
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr "Picard 1.0 est sorti"
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr "Picard 2.0 est sorti"
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+"Plutôt que d’avoir à remarquer des erreurs pendant une période assez brève "
+"d’une heure, les éditeurs disposent désormais de 24 heures pour corriger les "
+"erreurs dans les données qu'ils ont ajoutées sans avoir besoin de vote."
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr "Éditeur de relations"
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr "Les crédits de relation sont arrivés"
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr "Relations affichées sur les pages de parution"
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+"Ébauches de parution, période de vote minimum pour les modifications "
+"destructives"
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr "Groupes des parution, ISRC, recherche d’ébauches de CD"
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr "Éditeur de parution"
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr "Éditeur de parution et devineur de casse."
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+"Groupes de parution, prise en charge des ISRC, recherche d’ébauches de CD et "
+"correctifs de recherche."
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+"Les parutions peuvent désormais être ajoutées sans aucun support, dans les "
+"cas où la seule information disponible est, par exemple, le titre + la date "
+"+ le label + le numéro, disponibles dans un catalogue. De plus, toutes les "
+"modifications destructrices telles que les fusions et les suppressions "
+"d'entités ne se ferment plus immédiatement une fois qu’elles obtiennent 3 "
+"votes Oui, mais elles restent ouvertes pendant au moins 48 heures pour "
+"garantir que les personnes qui s’y opposent ont le temps de les voir."
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+"Roman Tsukanov décide de ne pas renouveler son contrat. Sambhav Kothari et "
+"Param Singh sont embauchés pour le remplacer sur le moteur de recherche et "
+"Picard pour le premier, et ListenBrainz pour le second."
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr "Roman Tsukanov rejoint l’équipe MetaBrainz"
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr "Correctifs SG5"
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr "Sambhav Kothari et Param Singh remplacent Roman Tsukanov"
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+"Sambhav Kothari quitte MetaBrainz après beaucoup de travail acharné pour "
+"préparer le serveur Solr. Nicolás Tamargo (reosarevok) rejoint MusicBrainz "
+"en tant que programmeur à temps partiel en plus de ses postes de style et de "
+"support."
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr "Sambhav Kothari part, Nicolás Tamargo rejoint comme programmeur"
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr "Améliorations de la recherche"
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+"Plusieurs nouveaux types de modification automatique et nouvelles traductions"
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+"Étant donné que le projet de machine virtuelle avait tendance à être en "
+"retard par rapport aux données actuelles en raison du temps nécessaire à "
+"chaque fois pour publier de nouvelles versions, il est abandonné et il est "
+"suggéré aux utilisateurs d'exécuter simplement leur propre installation "
+"Docker pour MusicBrainz (ce que la machine virtuelle faisait déjà en "
+"coulisses)."
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr "Soc 2008"
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr "Déploiement du serveur de recherche basé sur Solr"
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+"Certaines pages d’instruments commencent à afficher des illustrations "
+"d’instruments par IROM. De plus, une première date de parution commence à "
+"être calculée et affichée pour les enregistrements en fonction des parutions "
+"sur lesquelles ils apparaissent."
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+"Implantation des directives de style 5, et les TRM inutilisés sont enlevés "
+"de la base de données."
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+"Processus de style à nouveau mis à jour, reosarevok « promu » BDFL Style"
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr "Prise en charge des labels et de la qualité des données."
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr "Vote positif/négatif des tags"
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr "Tags, abonnements aux éditeurs, ajout par lot de relations"
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr "Le projet AcousticBrainz prend vie"
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr "Le projet AcousticBrainz est abandonné"
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr "L’application Android est mise en ligne"
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+"La BBC devient un client de MusicBrainz et commence a utiliser les données "
+"de MusicBrainz."
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+"L’archive des illustrations « Cover Art Archive » est proposée pour la "
+"première fois."
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+"L’archive des illustrations « Cover Art Archive » est officiellement lancée."
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr "Le projet CritiqueBrainz prend vie"
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+"La traduction italienne, principalement réalisée par salo.rock, est "
+"officiellement publiée. L’ajout du premier code IPI et/ou ISNI pour une "
+"entité devient une modification automatique, sauf si le même code est déjà "
+"utilisé pour une autre."
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr "Le projet ListenBrainz prend vie"
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+"La Fondation MusicBrainz, le siège social de MusicBrainz, est annoncée au "
+"public."
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr "La machine virtuelle MusicBrainz est remplacée par MusicBrainz Docker"
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+"La version alpha de ListenBrainz, une alternative open source et open data à "
+"Last.fm®, prend vie."
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr "La version bêta de CritiqueBrainz est lancée."
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+"La qualité décroissante du service d'empreintes digitales PUID et la "
+"disponibilité continue d'une alternative open source dans AcoustID "
+"conduisent à la décision d’abandonner les PUID de MusicBrainz et de ne "
+"prendre en charge que AcoustID."
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+"L’historique des modifications des entités est rendu visible même lorsque "
+"vous êtes déconnecté, pour rendre plus facile de comprendre comment chaque "
+"entité a changé. (Les notes de modification sont masquées pour préserver une "
+"certaine confidentialité)."
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+"La première version complète du marqueur Picard sort, avec de nombreux "
+"changements et améliorations."
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+"La première version de l’application Android MusicBrainz, un projet Google "
+"Summer of Code de Jamie McDonald, est officiellement disponible."
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+"La recommandation de plus en plus controversée « Ne pas agglomérer », qui "
+"interdisait les grappes de relations telles que lier tous les frères Jackson "
+"les uns aux autres, est abandonnée. Éviter les données dupliquées devient la "
+"tâche des architectes des types de relation, pas celle des utilisateurs "
+"entrant des données."
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr "Le nouveau site Web de MetaBrainz prend vie"
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+"Le nouveau site Web de MetaBrainz, incluant une refonte complète et une "
+"inscription en ligne pour les utilisateurs commerciaux, est lancé, "
+"remplaçant celui conçu en l’an 2000 !"
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+"La solution open source d’empreintes digitales AcoustID (développée par un "
+"ami de MusicBrainz Lukáš Lalinský) commence à être utilisée parallèlement au "
+"PUID sur les pages d'empreintes digitales de MusicBrainz."
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+"L’éditeur de relations permettant les modifications par lot des relations "
+"pour une parution est mise en production."
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr "Fonctions de recherche et améliorations du service Web."
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+"Le processus de style est à nouveau mis à jour. Plutôt que d’exiger un débat "
+"communautaire long et souvent énervé jusqu’à ce que quelque chose soit "
+"adopté par consensus communautaire sans veto, les décisions sont prises par "
+"un BDFL qui consulte la communauté en cas de besoin. Nicolás Tamargo "
+"(reosarevok) est « promu » de leader du Style à BDFL Style."
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+"La période de vote pour les modifications qui ont reçues un vote « Non » est "
+"étendue pour donner le temps aux utilisateurs de régler les problèmes."
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+"Amélioration de la navigation du menu d’en haut, recherche d’artistes en "
+"double, tout modifier dans l’album, modification de la durée de pistes."
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr "Durée des pistes indiquée à partir des ID de disque"
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+"Deux nouveaux types d’entités sont ajoutés à MusicBrainz : les instruments "
+"et les séries. Les séries d’enregistrements, les parutions, les groupes de "
+"parution et les œuvres sont pris en charge."
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr "Améliorations pour l’utilisateur"
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+"Les utilisateurs doivent maintenant vérifier leurs adresses de courriel pour "
+"pouvoir modifier la base de données."
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+"La version 1 du service web (voué à disparaître depuis 2011 déjà) a "
+"finalement été fermée pour de bon (plus d’un an après l’annonce de sa "
+"fermeture dans six mois !)"
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+"Amélioration de la logique de vote, élections des auto-éditeurs basées sur "
+"le Web."
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr "La période de vote des modifications contestées est étendue"
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr "Période de vote réduite à 7 jours"
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr "Suggestions de vote"
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr "La version 1 du service web est fermée"
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+"Le projet AcousticBrainz étant jugé n’ayant pas rempli ses objectifs "
+"initiaux, la fondation MetaBrainz décide d’arrêter de s‘y consacrer, en vue "
+"d‘une fermeture du site en 2023."
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr "Attributs de l’œuvre"
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+"Les œuvres obtiennent leurs premiers attributs (tels que des clés) nous "
+"permettant de stocker des données qui n’ont pas de sens en tant que "
+"relations mais méritent plus qu’une entrée d’annotation."
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr "Yvanzo rejoint MusicBrainz comme développeur"
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+"Yvanzo rejoint l’équipe de développement comme second développeur se "
+"consacrant à MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr "Le serveur MusicBrainz est maintenant hébergé sur Git"
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr "reosarevok devient leader du Style de MusicBrainz"

--- a/po/history.gl.po
+++ b/po/history.gl.po
@@ -1,0 +1,1100 @@
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: FULL NAME <email address hidden>\n"
+"Language-Team: Galician (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/gl/)\n"
+"Language: gl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.he.po
+++ b/po/history.he.po
@@ -1,0 +1,1154 @@
+#
+# Translators:
+# Avi Markovitz <email address hidden>, 2018-2021
+# reosarevok <reosarevok@users.noreply.translations.metabrainz.org>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2024-01-04 11:06+0000\n"
+"Last-Translator: reosarevok <reosarevok@users.noreply.translations."
+"metabrainz.org>\n"
+"Language-Team: Hebrew <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/he/>\n"
+"Language: he\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n == 1) ? 0 : ((n == 2) ? 1 : ((n > 10 && "
+"n % 10 == 0) ? 2 : 3));\n"
+"X-Generator: Weblate 5.3\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr "תמונות ממוזערות 1200 פיקסל"
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr "טוען תמונות עטיפה AJAX חדש שוחרר, מה שמקל להוסיף תמונות עטיפה להוצאה."
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr "הודעת כרזה חדשה מודיעה למשתמשים בכל פעם שהם מקבלים הודעת עריכה חדשה."
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr "קרע בקהילת מוזיקבריינז מוביל לסכסוך גדול."
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+"אקוסטיקבריינז, שמטרתה לצבור מידע אקוסטי מקורי למוזיקה, הוכרזה כמשתפת פעולה "
+"עם קבוצת טכנולוגיות המוזיקה באוניברסיטת פומפאו פברה."
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "קשרי־גומלין מתקדמים"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+"קשרי־גומלין מתקדמים המאפשרים למשתמשים לחבר ישויות נתונים בסיסיות הם הוצאות "
+"ו־TRMs שאינם בשימוש שנגזרו ממסד הנתונים. עריכה מקוונת מושבתת כברירת מחדל, מה "
+"שגורם לירידה בפעילות ההצבעה."
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "שפות אלבום"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr "שפות אלבום, שיפורים בנחוש אותיות רישיות ושיפוץ עריכת טפסים ששוחררו."
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr "גרסאות אמזון בטא סאונד-אנוונד "
+
+#: DB:statistics.statistic_event/title:2004-02-24
+#, fuzzy
+#| msgid "Amazon Coverart"
+msgid "Amazon cover art"
+msgstr "תמונת עטיפה אמזון"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+#, fuzzy
+#| msgid "Amazon coverart support released."
+msgid "Amazon cover art support released."
+msgstr "שוחררה תמיכת בתמונות עטיפה של אמאזון."
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr "עורך הוצאה משופר ואתר בעיצוב חדש שוחררו."
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr "שוחררה תמיכת באורים."
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "ביאורים"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "מינויים לאמנים"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr "מינוי לאמנים הפך לציבורי ושיפורים קטנים ממוקדי משתמש, שוחררו."
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr "מינויים לאמנים."
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr "עמודי אמן דינמיים של ביביסי"
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr "ביביסי משגר את דפי האמן הדינמיים בהתבסס על נתוני מוזיקבריינז."
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr "שותפות BBC עם מטהברינינז"
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr "גרסת CAA ראשונית"
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr "גרסת CAA רשמית"
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr "אוספים משותפים"
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr "אוספים, דירוגים, ספחי תקליטור"
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr "אוספים, דירוגים, ספחי תקליטור, עדכון אחרון שוחררו."
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr "העלאת תמונת עטיפה"
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr "שרת מסד נתונים ייעודי"
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr "שיפורי תצוגת עריכה, כיבוי השלכות RDF, פרסום תסריטי התקנה חדשים."
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr "עריכת התראות הערה"
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr "עריכת חפוש"
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+"העורך ojnkpjg מריץ תסריט להגדרת זמני רצועה מערכי DiscID, ויוצר פקק עצום "
+"בעריכות."
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+"עריכות שבוצעו על־ידי עורכים, להוצאות שהם הוסיפו בעצמם, בתוך שעה לאחר שנוספו, "
+"יהיו כעת עריכות אוטומטיות, כמו גם עריכות \"הוספת הקלטה\" ו־\"הסרת כינוי\"."
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr "אימות דוא\"ל"
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr "סטודנט GSoC לשעבר, רומן צוקנוב, מתחיל לעבוד במטהבריינז במשרה חלקית."
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+"תכונת הייבוא האוטומטי FreeDB כובתה ובחירות עורכים אוטומטיים שוחררו. TRM שלא "
+"בשימוש נוקו ממסד הנתונים."
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr "פרידיבי מופסק/עורכים אוטומטיים"
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr "הסוגה נוספה כישות חדשה"
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+"סוגות מתווספות כישות חדשה, אם כי הן עדיין קשורים בהידוק לתגיות פולקסונומיות."
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr "מחלוקת גדולה"
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr "יבוא קטלוג סי.די בייבי כתלושי התקליטור."
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr "יבוא נתוני־על מתוך קטלוג סידי בייבי לתוך אוסף ספחי התקליטור שלנו."
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr "שיפור הצבעה"
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr "חיפוש משופר"
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+"במאמץ לצמצם את גודל תור העריכות הפתוחות ולצמצם את משך ההמתנה לשינויים, משך "
+"זמן העריכות יישאר פתוח לפני הקטנת התפוגה מ -14 ל -7 ימים."
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr "בהכנות ל־NGS, עריכה נוטרלה עד לשחרור."
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+"בהכנות ל־ NGS, עורכים מתבקשים להימנע מעריכה עד לשחרור אלה אם נדרש לחלוטין."
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr "חיפוש ממופתח/XML WS"
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr "חיפוש מפתוחים ושרות רשת חדש מבוסס XML שוחררו."
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr "עריכות שורה"
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr "עריכות שורה, דוחות חדשים, תסריטים משופרים לייבוא נתונים."
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr "תַּסְרִיטי התקנה"
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr "כלי נגינה וסדרות"
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr "קונו וודט יתחיל לעבוד בוזיקבריינז במשרה מלאה."
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr "קונו וודט גוייס כמפתח במשרה מלאה"
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr "חברות תקליטים/איכות נתונים"
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr "Last.fm מתקשרת עם מטהבריינז ומתחילה להשתמש בנתוני מוזיקבריינז."
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr "קישור לתכונת מוזיקבריינז,ארועי הוצאה ועריכת הוצאות מוצעות."
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr "לינקארה מוזיקה הופכת ללקוחה המסחרית הראשונה של מטהבריינז."
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr "קישור"
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr "MBBE_Bot החל לפעול"
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr "תפריטים/תסריטי לקוח"
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr "מטהבריינז מקבלת שלושה סטודנטים לקיץ קוד גוגל."
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr "מוזיקברינז מעסיקה את אוליבר צ'רלס"
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr "השקת מטהבריינז"
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr "מוזיקברינז חותמת עם הלקוח הראשון"
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr "מטהווב חותמת"
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr "עריכות אוטומטיות נוספות"
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+"סוגי עריכה נוספים נעשים בעריכה אוטומטיות לכולם: \"הוספת קשר־גומלין\" "
+"ו־\"הוספת הוצאה\"; ו־\"הוספה\",\"עריכה\" ו־\"הסרת חברת תקליטים הוצאה\". "
+"בנוסף, התרגומים לגרמנית, צרפתית והולנדית זמינים בשרת הראשי."
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr "העברת מוזיקבריינז"
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr "קוד המקור של שרתי מוזיקבריינז עוברים מסאבוורזיון לגיט."
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr "מוזיקבריינז מקבלת את שרת, מסד הנתונים היעודי, הראשון שלה."
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+"מוזיקבריינז בעצמה מקבלת עצוב חדש כדי שתתאים טוב יותר לשאר חברי משפחת *בריינז."
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr "מוזיקבריינז עוברת דיג'יטל וושט נטוורקס בסאן לואיס אוביספו."
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+"מוזיקבריינז משתפת פעולה עם MusicIP ומתחילה להשתמש בטביעות האצבעות האקוסטיות "
+"PUID של MusicDNS. פיקארד הופך למתייג הרשמי של מוזיקבריינז עם תמיכה ב־ PUID, "
+"מה שמביא לצמצום פעילות העריכה."
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "MusicIP PUID"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr "NGS שלב אין-עריכה"
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr "NGS שלב עריכה מצומצמת"
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr "שחרור NGS"
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr "NGS, שוחררה כתיבה מחדש של מוזיקבריינז!"
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr "עיצוב מיוזיקבריינז חדש"
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr "רצועות ללא אלבום"
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr "שוחררו רצועות ללא אלבום."
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr "אוליבר צ'רלס הוא עבוד מספר 1 של קרן מטהבריינז."
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr "אוליבר צ'רלס מתחיל לעבוד במוזיקבריינז במשרה מלאה"
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr "אוליבר צ'רלס מצטרף למוזיקבריינז במשרה מלאה"
+
+#: DB:statistics.statistic_event/description:2018-06-30
+#, fuzzy
+#| msgid ""
+#| "Our old search server gets a significant upgrade with its move to SOLR, "
+#| "including almost-instant index updates."
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+"שרת החיפוש הישן שלנו מקבל שדרוג משמעותי עם המעבר שלו ל־ SOLR, כולל עדכוני "
+"מפתח כמעט מיידיים."
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr "פיקרד 1.0 שוחרר"
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr "פיקרד 2.0 שוחרר"
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr "עורך קשר־גומלין"
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr "קבוצת הוצאה, חיפוש ספח, ISRCs"
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr "עורך הוצאה"
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr "עורך הוצאה ונחוש גודל אותיות שוחררו."
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr " קבוצות הוצאה, תמיכת ISRC, חיפוש ספח תקליטור ותיקוני חיפוש ששוחררו."
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr "רומן צ'וקנוב הצטרף לצוות מטהבריינז"
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr "תיקוני SG5"
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr "חיפוש שיפורים"
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr "כמה סוגי עריכה־אוטומטית ותרגומים חדשים"
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr "SoC 2008"
+
+#: DB:statistics.statistic_event/title:2018-06-30
+#, fuzzy
+#| msgid "SOLR-based search server deployed"
+msgid "Solr-based search server deployed"
+msgstr "נפרס שרת חיפוש מבוסס SOLR "
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+"דרך לעקיפת הבעית הנחית סגנון 5 הונהגה ו־TRM ללא שימוש נוקו ממסד הנתונים."
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr "תמיכה בחרבות תקליטים ואיכות נתונים משוחררים."
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr "תיוג הצבעה בעד/נגד"
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr "מיזם אקוסטיקבריינז  עולה לאוויר"
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr "BBC הופך ללקוח של מטהבריינז ומתחיל להשתמש בנתוני מוזיקבריינז."
+
+#: DB:statistics.statistic_event/description:2012-04-30
+#, fuzzy
+#| msgid "The Cover Art Archive becomes initially available"
+msgid "The Cover Art Archive becomes initially available."
+msgstr "ארכיב תמונות עטיפה הפך זמין לראשונה"
+
+#: DB:statistics.statistic_event/description:2012-10-10
+#, fuzzy
+#| msgid "The Cover Art Archive is officially released"
+msgid "The Cover Art Archive is officially released."
+msgstr "ארכיב תמונות עטיפה שוחרר באופן רשמי"
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr "מיזם קריטיקבריינז  עולה לאוויר"
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr "מיזם ליסנבריינז  עולה לאוויר"
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr "קרן מטהבריינז, הבית המשפטי של מוזיקבריינז מוכרזת לציבור."
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+"גרסת האלפא של ליסטנבריינז, קוד פתוח וחלופת מאגר נתונים פתוחים ל־ Last.fm®, "
+"עולה לאוויר."
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr "גרסת בטא של קריטיקבריינז הושקה."
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr "אתר מוזיקבריינז החדש עולה לאוויר"
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+"האתר החדש של מטהבריינז, עם עיצוב חדש ואפשרות הרשמה מקוונת למשתמשים מסחריים, "
+"מושק ומחליף את זה שתוכנן בשנת 2000!"
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr "עורך קשר־גומלין, לעריכת ריבוי קשרי־גומלין להוצאה, שוחרר לגרסת הפקה."
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr "שיפורים בתכונות החיפוש ושירותי הרשת שוחררו."
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+"תקופת ההצבעה לעריכות שמקבלות הצבעת 'לא' מתארכת כדי לאפשר למשתמשים יותר זמן "
+"להגיב."
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+"תפריט ניווט ראשי משופר, אמנים כפולים, עריכת  הכל לאלבום, מעקב אחר מועד עריכת "
+"תכונות שפורסמו."
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr "פרטי רצוע נקבעו ממזהי דיסק"
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr "שיפורי משתמש"
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+"גרסה 1 של שירות המרשתת (שהוצא משימוש כבר ב־2011) מוסרת סופית ולתמיד (יותר "
+"משנה לאחר ההודעה שזה יקרה בעוד חצי שנה!)."
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr "לוגיקת ההצבעה שופרה, בחירות עורך אוטומטי מבוססות רשת פורסמו."
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr "הוארכה תקופת ההצבעה לתחרות העריכות"
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr "תקופת הצבעה קוצרה ל־7 ימים"
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr "הצעות הצבעה"
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr "שרות מרשתת גרסה 1 הוסר"
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr "יבנזו מצטרף למוזיקבריינז כמפתח"
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr "יבנזו מצטרף לצוות הפתוח כמפתח היעודי השני."
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr "mb_server מתארח כעת ב־ Git"
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.hr.po
+++ b/po/history.hr.po
@@ -1,0 +1,1105 @@
+#
+# Translators:
+# Chris_Kay_083, 2014
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2023-08-18 14:07+0000\n"
+"Last-Translator: yvanzo <yvanzo@users.noreply.translations.metabrainz.org>\n"
+"Language-Team: Croatian <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/hr/>\n"
+"Language: hr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Weblate 4.18.2\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Jezici albuma"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+#, fuzzy
+#| msgid "Cover Art"
+msgid "Amazon cover art"
+msgstr "Umjetnost na omotu"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr "Povezivanje"
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.hu.po
+++ b/po/history.hu.po
@@ -1,0 +1,1100 @@
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: FULL NAME <email address hidden>\n"
+"Language-Team: Hungarian (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/hu/)\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.id.po
+++ b/po/history.id.po
@@ -1,0 +1,1100 @@
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: FULL NAME <email address hidden>\n"
+"Language-Team: Indonesian (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/id/)\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.it.po
+++ b/po/history.it.po
@@ -1,0 +1,1377 @@
+#
+# Translators:
+# Gioele <email address hidden>, 2012
+# leofiore <email address hidden>, 2012
+# salo.rock, 2012,2016,2019-2022
+# salo.rock, 2020
+# salo.rock, 2013-2015
+# salo.rock, 2012
+# salo.rock, 2021,2023
+# "salo.rock" <salo.rock+musicbrainz@gmail.com>, 2023.
+# "salo.rock" <salo.rock@users.noreply.translations.metabrainz.org>, 2023, 2024.
+# yvanzo <yvanzo@users.noreply.translations.metabrainz.org>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2024-05-24 16:42+0000\n"
+"Last-Translator: \"salo.rock\" <salo.rock@users.noreply.translations."
+"metabrainz.org>\n"
+"Language-Team: Italian <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/it/>\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n != 0 && n % 1000000 == "
+"0) ? 1 : 2);\n"
+"X-Generator: Weblate 5.5.4\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr "Abbandono della linea guida \"Non creare raggruppamenti di relazioni\""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr "Abbandono della standardizzazione dei \"feat.\""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr "Miniature 1200px"
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+"Le miniature da 1200px sono aggiunte al Cover Art Archive, fornendo agli "
+"utenti immagini molto grandi a dimensione costante e permettendo loro di non "
+"dover utilizzare direttamente i caricamenti originali."
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+"Viene aggiunta una piattaforma di forum Discourse per sostituire sia i "
+"vecchi forum che le mailing list (ormai defunte), unificando le "
+"comunicazioni nella comunità in un posto solo."
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+"Viene introdotto un cambiamento che permette di votare a favore o contro tag "
+"di folksonomia esistenti, anziché poter solo aggiungere i propri."
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+"È rilasciato un importante aggiornamento per il tagger Picard, che include "
+"un'enorme quantità di correzioni e miglioramenti."
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+"Viene rilasciata una nuova pagina di \"Suggerimenti di voto\", che contiene "
+"ricerche predefinite di modifiche per aiutare gli editor a trovare modifiche "
+"interessanti e/o importanti da controllare e su cui votare."
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+"Rilascio di un nuovo uploader di copertine in AJAX, che rende più facile "
+"aggiungere copertine alle pubblicazioni."
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+"Un nuovo banner di avviso notifica gli utenti ogni volta che ricevono una "
+"nota di modifica."
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr "Viene aggiunto un nuovo meccanismo di ricerca molto più veloce."
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+"Una frattura nella comunità di MusicBrainz porta a una Grande Discussione."
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+"Una versione con cambiamenti allo schema molto sostanziosa aggiunge un nuovo "
+"tipo di entità (le aree), il supporto per i codici ISNI per artisti ed "
+"etichette, e la possibilità di avere più di un evento di pubblicazione su "
+"una pubblicazione."
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+"Viene rilasciato un nuovo modo per cercare modifiche in base a molti criteri "
+"diversi."
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+"AcousticBrainz, che mira al crowdsourcing di informazioni acustiche sulla "
+"musica, è annunciato in cooperazione con il Music Technology Group "
+"dell'Universitat Pompeu Fabra."
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "Relazioni avanzate"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+"Rilascio delle relazioni avanzate, che permettono agli utenti di collegare "
+"entità di dati di base, ed eliminazione dal database dei TRM inutilizzati. "
+"Disattivazione di default delle modifiche in linea, che porta a una "
+"diminuzione dell'attività di voto."
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+"Dopo molte crisi dietro le quinte, MetaBrainz vince la battaglia legale "
+"contro un troll del copyright che ha cercato di farle causa per l'utilizzo "
+"di immagini da Wikimedia Commons. MusicBrainz abbandona comunque le immagini "
+"da Wikimedia Commons per evitare ulteriori problemi fino a quando Wikimedia "
+"non avrà apportato cambiamenti che rendano più sicuro il riutilizzo delle "
+"immagini."
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+"Dopo molte discussioni, i dati delle relazioni iniziano a essere "
+"visualizzati sulle pagine delle pubblicazioni, rendendoli molto più visibili."
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+"Dopo una Summer of Code ben riuscita, Ian McEwen si unisce al team di "
+"MusicBrainz."
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+"Dopo molti anni presso Digital West in California, il progetto MetaBrainz "
+"trasferisce tutti i suoi server presso un fornitore dedicato molto più "
+"grande in Germania, Hetzner."
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+"Dopo diversi anni come un progetto guidato esclusivamente dalla comunità, "
+"BookBrainz viene adottato come progetto ufficiale e gli viene assegnata una "
+"posizione di sviluppatore con l'assunzione di Monkey."
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+"A seguito di inattesi scompigli su Freenode, MetaBrainz sposta tutti i "
+"canali ufficiali su Libera.Chat."
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Lingue album"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+"Rilascio delle lingue album, miglioramenti alla funzione \"Ritocca titoli\" "
+"e rinnovamento dei form per le modifiche."
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+"Vengono aggiunti gli alias per tre tipi di entità che ancora non li avevano: "
+"registrazioni, pubblicazioni e gruppi di pubblicazioni. Ciò permette, per "
+"esempio, di memorizzare i nomi inglesi di gruppi di pubblicazioni asiatici."
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr "Alias per registrazioni, pubblicazioni e gruppi di pubblicazioni"
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+"Amazon rilascia in beta <a href=\"http://web.archive.org/web/20210123164029/"
+"https://www.wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> con dati "
+"da MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr "Amazon lancia la beta di SoundUnwound"
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr "Copertine di Amazon"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr "Rilascio del supporto per le copertine di Amazon."
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+"Rilascio di un editor di pubblicazioni migliorato e di un nuovo design del "
+"sito."
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+"Viene rilasciato un aggiornamento che permette di specificare un "
+"accreditamento per gli artisti all'interno di una relazione, qualora esso "
+"non corrisponda al nome dell'artista."
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr "Rilascio del supporto per le annotazioni."
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "Annotazioni"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr "Aree, codici ISNI e più eventi di pubblicazione per ogni pubblicazione"
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "Iscrizioni ad artisti"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+"Lancio pubblico delle iscrizioni ad artisti e rilascio di vari miglioramenti "
+"per l'utenza."
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr "Iscrizioni ad artisti."
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+"All'interno di una transizione di lungo termine verso una maggior fedeltà ai "
+"dati originali, smettiamo di standardizzare i \"featuring\" e tutte le "
+"varianti in \"feat.\", e chiediamo agli utenti di utilizzare ciò che si "
+"trova stampato sulla pubblicazione."
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr "Pagine artista dinamiche della BBC"
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+"La BBC lancia le pagine artista dinamiche basate su dati di MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr "La BBC si associa a MetaBrainz"
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr "BookBrainz diventa un progetto ufficiale di MetaBrainz"
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr "Rilascio iniziale CAA"
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr "Rilascio ufficiale CAA"
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr "CatQuest diventa l'inseritore di strumenti"
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+"CatQuest subentra ufficialmente a reosarevok come incaricato principale per "
+"aggiungere nuovi strumenti a MusicBrainz, con la nuova posizione di "
+"inseritore di strumenti."
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr "Collezioni collaborative"
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+"I possessori di collezioni possono ora permettere ad altri editor di "
+"aggiungere/rimuovere entità da qualsiasi loro collezione."
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr "Collezioni, valutazioni, bozze CD"
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr "Rilascio di collezioni, valutazioni, bozze CD, ultima modifica."
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+"È ora possibile unire le collezioni, nel caso in cui un editor voglia "
+"accorpare più collezioni di cui dispone in una sola. In aggiunta, è "
+"possibile creare serie di artisti, nonché valutare i luoghi (la sola entità "
+"che poteva essere recensita su CritiqueBrainz ma non valutata su "
+"MusicBrainz)."
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr "Uploader copertine"
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr "Server dedicato per il database"
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr "Discourse unifica le comunicazioni nella comunità"
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr "Semplificata l'aggiunta di note di modifica"
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+"Rilascio di miglioramenti alla visualizzazione delle modifiche, "
+"disattivazione dei dump RDF, nuovi script di installazione."
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr "Cronologia modifiche visibile senza aver effettuato l'accesso"
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr "Notifiche delle note di modifica"
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+"Le note di modifica possono essere aggiunte durante la creazione di una "
+"modifica, rendendo molto più semplice per gli editor spiegare i cambiamenti."
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr "Cerca modifiche"
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+"L'editor ojnkpjg esegue uno script che imposta la durata delle tracce a "
+"partire dai valori degli ID disco, creando un enorme picco di modifiche."
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+"Le modifiche fatte dagli editor alle pubblicazioni aggiunte da loro stessi "
+"sono ora auto-modifiche fino a 1 ora dall'aggiunta della pubblicazione, così "
+"come le modifiche \"Aggiungi registrazione\" e \"Rimuovi alias\"."
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr "Verifica email"
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+"Le etichette, i gruppi di pubblicazioni e le opere vuote sono rimosse "
+"automaticamente dopo essere inutilizzate per 24 ore, similmente a quanto già "
+"succedeva per gli artisti."
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+"Etichette, gruppi di pubblicazioni e opere vuote iniziano ad essere rimosse "
+"automaticamente"
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+"Il supporto per gli eventi è aggiunto a MusicBrainz, permettendo di "
+"memorizzare informazioni su concerti e festival. Nella stessa versione con "
+"cambiamenti dello schema vengono introdotti un modo corretto per indicare il "
+"contenuto di tracce dati negli elenchi tracce delle pubblicazioni, e la "
+"possibilità di aggiungere tag ad aree, strumenti e serie."
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr "Supporto per eventi, tracce dati"
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+"Sono rilasciati i tag di folksonomia e le iscrizioni agli editor. In più, è "
+"ora possibile aggiungere relazioni in blocco a più tracce di una "
+"pubblicazione."
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+"L'ex studente GSoC Roman Tsukanov inizia a lavorare part time per MetaBrainz."
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+"Frederik \"Freso\" S. Olesen diventa il community manager di MetaBrainz"
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+"Disattivazione della funzione di importazione automatica da FreeDB e "
+"rilascio delle elezioni per auto-editor. Eliminazione dal database dei TRM "
+"inutilizzati."
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr "FreeDB disattivato/Autoeditor"
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+"Freso diventa il primo community manager di MetaBrainz, con l'incarico di "
+"aiutare a risolvere i conflitti nella comunità e tenerne d'occhio i bisogni."
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr "Genere aggiunto come nuova entità"
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+"I generi sono aggiunti come nuova entità, seppur ancora fermamente legati ai "
+"tag di folksonomia."
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr "Grande Discussione"
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr "Pulsanti Ritocca artisti feat."
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr "I canali IRC si spostano su Libera.Chat"
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr "Ian McEwen assunto"
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr "Ian McEwen lascia MetaBrainz"
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr "Ian McEwen lascia il progetto per motivi personali."
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr "Importato il catalogo di CD Baby come bozze CD"
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+"Importazione dei metadati dal catalogo di CD Baby nella nostra collezione di "
+"bozze CD."
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr "Miglioramenti alle votazioni"
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr "Miglioramenti alla ricerca"
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+"Nel tentativo di ridurre la dimensione della coda di modifiche in corso e "
+"costringere a un'attesa minore per l'applicazione dei cambiamenti, il "
+"periodo di tempo in cui le modifiche restano aperte al voto prima della "
+"scadenza è ridotto da 14 a 7 giorni."
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+"Per semplificare la correzione dei molti casi in cui gli artisti feat. sono "
+"ancora presenti nel titolo di tracce e pubblicazioni anziché nel campo "
+"artista, vengono aggiunti i pulsanti Ritocca artisti feat., rendendo il "
+"processo molto più semplice."
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr "In preparazione a NGS, le modifiche sono disattivate fino al rilascio."
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+"In preparazione a NGS, si incoraggiano gli editor a evitare le modifiche non "
+"strettamente necessarie fino al rilascio."
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr "Ricerca indicizzata/WS XML"
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+"Rilascio della ricerca indicizzata e di un nuovo Web Service basato su XML."
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr "Modifiche in linea"
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+"Modifiche in linea, nuovi report, miglioramenti agli script di importazione "
+"dati."
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr "Script di installazione"
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+"Immagini degli strumenti, prima data di pubblicazione per le registrazioni"
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr "Strumenti e serie"
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr "Traduzione italiana pubblicata, IPI e ISNI diventano auto-modifiche"
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr "Kartik Ohri si unisce al team di MetaBrainz"
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+"Kartik Ohri si unisce al team di MetaBrainz per lavorare a ListenBrainz, "
+"AcousticBrainz e CritiqueBrainz, più l'app Android, che aveva già ampiamente "
+"riscritto da volontario."
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr "Kuno Woudt inizia a lavorare a tempo pieno per MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr "Kuno Woudt assunto come sviluppatore a tempo pieno"
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr "Etichette/Qualità dei dati"
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+"Last.fm firma con MetaBrainz e inizia a utilizzare i dati di MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr "Laurent \"zas\" Monin diventa sistemista"
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+"Laurent Monin, più conosciuto come Zas, si unisce al team come "
+"amministratore di sistema, per assicurarsi che i server funzionino "
+"correttamente e per supportare la transizione a un nuovo sistema di "
+"discussione per la comunità."
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+"Rilascio della funzione di collegamento a MusicBrainz, degli eventi di "
+"pubblicazione e dei suggerimenti per le modifiche."
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr "Linkara Musica diventa il primo cliente commerciale di MetaBrainz."
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr "Collegamenti"
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+"Viene creato MBBE_Bot al fine di apportare modifiche che richiedono troppo "
+"tempo per essere create manualmente, ma di cui deve comunque restare traccia "
+"nella cronologia modifiche. Alcuni esempi includono la rimozione di URL di "
+"domini problematici, impostare come conclusi gli URL di domini che sono "
+"stati chiusi e altri compiti simili di modifica in blocco."
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr "MBBE_Bot inizia a operare"
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr "Menu/Script lato client"
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+"Serie di artisti, possibilità di unire collezioni, possibilità di valutare "
+"luoghi"
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr "MetaBrainz accetta tre studenti per la Google Summer of Code."
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr "MetaBrainz assume Oliver Charles"
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr "Lancio di MetaBrainz"
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr "I progetti di MetaBrainz completano il trasferimento su server europei"
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr "MetaBrainz firma con il primo cliente"
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+"MetaBrainz vince la battaglia contro un troll del copyright; abbandonate le "
+"immagini da Wikimedia"
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr "MetaWeb diventa un utente di dati di MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr "MetaWeb firma"
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr "Più auto-modifiche"
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+"Più tipi di modifiche diventano auto-modifiche per tutti: \"Aggiungi "
+"relazione\" e \"Aggiungi pubblicazione\"; e \"Aggiungi\", \"Modifica\" e "
+"\"Rimuovi etichetta dalla pubblicazione\". In più, le traduzioni tedesca, "
+"francese e olandese sono rese disponibili sul server principale."
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr "Trasloco di MusicBrainz"
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+"Trasferimento del codice sorgente del server di MusicBrainz da Subversion a "
+"Git."
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr "Supporto per AcoustID aggiunto a MusicBrainz"
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr "MusicBrainz ottiene il suo primo server dedicato per il database."
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+"MusicBrainz riceve un nuovo design più vicino al resto della famiglia "
+"*Brainz."
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+"MusicBrainz si trasferisce presso la Digital West Networks di San Luis "
+"Obispo."
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+"MusicBrainz si associa a MusicIP e inizia a utilizzare le impronte digitali "
+"acustiche PUID di MusicDNS. Picard diventa il tagger ufficiale di "
+"MusicBrainz con supporto ai PUID, il che comporta una diminuzione "
+"dell'attività di modifica."
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "PUID MusicIP"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr "Fase senza modifiche pre-NGS"
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr "Fase di modifica ridotta pre-NGS"
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr "Rilascio NGS"
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr "Rilascio di NGS, una revisione principale di MusicBrainz!"
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr "Nuovo design di MusicBrainz"
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr "Periodo di auto-modifica per nuove entità esteso a 24 ore"
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+"Nicolás Tamargo (reosarevok) diventa il leader di stile di MusicBrainz e "
+"viene creato un nuovo processo di stile più ufficiale utilizzando Jira."
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr "Tracce senza album"
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr "Rilascio delle tracce senza album."
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr "Oliver Charles diventa il primo impiegato della MetaBrainz Foundation."
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr "Oliver Charles inizia a lavorare a tempo pieno per MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr "Oliver Charles si unisce a MusicBrainz a tempo pieno"
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+"Il nostro vecchio server di ricerca riceve un upgrade significativo con il "
+"passaggio a Solr, che porta tra le altre cose aggiornamenti dell'indice "
+"quasi istantanei."
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr "Supporto per PUID rimosso"
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr "Aggiunta divisione in pagine per le relazioni e i tag degli utenti"
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+"Viene aggiunta la divisione in pagine per due elenchi molto lunghi che "
+"talvolta non era possibile caricare per intero a causa di timeout: i tag "
+"degli utenti e le relazioni delle entità."
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr "Rilasciato Picard 1.0"
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr "Rilasciato Picard 2.0"
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+"Anziché avere a disposizione un breve periodo di una sola ora per correggere "
+"eventuali errori, ora gli editor dispongono di 24 ore per apportare "
+"correzioni ai dati che hanno aggiunto senza necessitare di voti."
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr "Editor di relazioni"
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr "Accreditamenti relazione resi disponibili"
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr "Relazioni visualizzate sulle pagine delle pubblicazioni"
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+"\"Bozze\" di pubblicazioni, periodo di voto minimo per modifiche distruttive"
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr "Gruppi di pubblicazioni, ISRC, ricerca di bozze CD"
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr "Editor di pubblicazioni"
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+"Rilascio dell'editor di pubblicazioni e della funzione \"Ritocca titoli\"."
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+"Rilascio del supporto per gruppi di pubblicazioni, ISRC, ricerca di bozze CD "
+"e correzioni alla ricerca."
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+"Le pubblicazioni possono ora essere aggiunte senza supporti, per i casi in "
+"cui le sole informazioni disponibili sono, per esempio, titolo + data + "
+"etichetta + numero di catalogo. In aggiunta, tutte le modifiche distruttive "
+"come unioni e rimozioni di entità non possono più chiudersi immediatamente "
+"appena ricevono 3 voti a favore, ma devono rimanere aperte per almeno 48 ore "
+"affinché chi è contro abbia tempo a sufficienza per vederle."
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+"Roman Tsukanov decide di non rinnovare il suo contratto. Sambhav Kothari e "
+"Param Singh sono assunti per sostituirlo e lavorare rispettivamente alla "
+"ricerca e Picard il primo e a ListenBrainz il secondo."
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr "Roman Tsukanov si unisce al team di MetaBrainz"
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr "Correzioni a LGS5"
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr "Sambhav Kothari e Param Singh sostituiscono Roman Tsukanov"
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+"Sambhav Kothari lascia MetaBrainz dopo tanto duro lavoro per preparare il "
+"server SOLR. Nicolás Tamargo (reosarevok) si unisce come programmatore part "
+"time, in aggiunta ai suoi incarichi di stile e supporto, per lavorare a "
+"MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr "Sambhav Kothari lascia, Nicolás Tamargo si unisce come programmatore"
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr "Miglioramenti alla ricerca"
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr "Diversi nuovi tipi di auto-modifiche e traduzioni"
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+"Siccome il progetto Virtual Machine tendeva a restare molto indietro "
+"rispetto ai dati aggiornati a causa del tempo necessario per rilasciare "
+"nuove versioni, questo viene abbandonato e agli utenti viene suggerito di "
+"utilizzare la loro installazione di Docker per MusicBrainz (cosa che la "
+"Virtual Machine già faceva dietro le quinte)."
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr "SoC 2008"
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr "Server di ricerca basato su Solr messo in funzione"
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+"Alcune pagine degli strmenti iniziano a visualizare illustrazioni degli "
+"strumenti realizzate da IROM. In aggiunta, la prima data di pubblicazione "
+"inizia a essere calcolata e visualizzata per le registrazioni sulla base "
+"delle pubblicazioni su cui esse compaiono."
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+"Introduzione della soluzione di ripiego alla Linea Guida di Stile 5 ed "
+"eliminazione dal database dei TRM inutilizzati."
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+"Processo di stile nuovamente aggiornato, reosarevok \"promosso\" a Benevolo "
+"Dittatore a Vita di stile"
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr "Rilascio del supporto per le etichette e per la qualità dei dati."
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr "Voti a favore/contro i tag"
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr "Tag, iscrizioni agli editor, aggiunta in blocco di relazioni"
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr "Lancio del progetto AcousticBrainz"
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr "Il progetto AcousticBrainz viene chiuso"
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr "L'app Android viene lanciata"
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+"La BBC diventa un cliente di MetaBrainz e inizia a utilizzare i dati di "
+"MusicBrainz."
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr "Il Cover Art Archive è disponibile in anteprima."
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr "Il Cover Art Archive viene rilasciato ufficialmente."
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr "Lancio del progetto CritiqueBrainz"
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+"La traduzione italiana, realizzata perlopiù da salo.rock, è rilasciata "
+"ufficialmente. Aggiungere il primo codice IPI e/o ISNI a un'entità diventa "
+"un'auto-modifica, a meno che lo stesso codice non sia già utilizzato da "
+"un'altra entità."
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr "Lancio del progetto ListenBrainz"
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+"La MetaBrainz Foundation, \"domicilio\" legale di MusicBrainz, viene "
+"annunciata al pubblico."
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+"La Virtual Machine di MusicBrainz è sostituita dal Docker di MusicBrainz"
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+"Lancio della versione alpha di ListenBrainz, un'alternativa open source e "
+"open data a Last.fm®."
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr "Lancio della versione beta di CritiqueBrainz."
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+"La qualità in calo del servizio di impronte digitali audio PUID e la "
+"disponibilità ininterrotta di un'alternativa open source, AcoustID, porta "
+"alla decisione di abbandonare i PUID su MusicBrainz e supportare solo gli "
+"AcoustID."
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+"La cronologia delle modifiche alle entità è resa visibile anche senza aver "
+"effettuato l'accesso, per rendere più semplice capire come è cambiata ogni "
+"entità (le note di modifica restano nascoste per salvaguardare la privacy)."
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+"La prima pubblicazione a numero di versione intero del tagger Picard, che "
+"include molti cambiamenti e miglioramenti, è rilasciata."
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+"La prima versione dell'app Android di MusicBrainz, un progetto Google Summer "
+"of Code di Jamie McDonald, viene resa ufficialmente disponibile."
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+"La linea guida \"Non creare raggruppamenti\", sempre più discussa e che "
+"proibiva di creare raggruppamenti di relazioni, come per es. collegare ogni "
+"fratello Jackson a tutti gli altri, viene abbandonata. Evitare la "
+"duplicazione di dati diventa un compito per chi progetta le relazioni "
+"anziché per gli utenti che inseriscono dati."
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr "Lancio del nuovo sito web di MetaBrainz"
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+"Il nuovo sito web di MetaBrainz, caratterizzato da un nuovo design e "
+"dall'iscrizione online per gli utenti commerciali, viene lanciato, "
+"sostituendo quello progettato nell'anno 2000!"
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+"La soluzione di impronte digitali audio open source AcoustID (sviluppata da "
+"un amico di MusicBrainz, Lukáš Lalinský) comincia a essere usata a fianco "
+"dei PUID sulle pagine di impronte digitali di MusicBrainz."
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+"L'editor di relazioni, per modificare in massa le relazioni di una "
+"pubblicazione, viene rilasciato ufficialmente."
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr "Rilascio della funzione di ricerca e miglioramenti al web service."
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+"Il processo di stile è aggiornato di nuovo. Anziché richiedere lunghe e "
+"spesso infiammate discussioni nella comunità finché qualcosa non viene "
+"approvato per consenso senza veti, le decisioni vengono prese da un Benevolo "
+"Dittatore a Vita che consulta la comunità quando necessario. Nicolás Tamargo "
+"(reosarevok) è \"promosso\" da leader di stile a Benevolo Dittatore a Vita "
+"di stile."
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+"Il periodo di votazione per le modifiche che ricevono un voto \"No\" è "
+"esteso in modo da dare agli utenti più tempo per reagire ai problemi."
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+"Miglioramenti alla navigazione nel menù superiore, rilascio del supporto "
+"agli artisti omonimi, alle modifiche per tutte le tracce di un album, alle "
+"modifiche alla durata delle tracce."
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr "Durata tracce impostata dagli ID disco"
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+"Due nuovi tipi di entità sono aggiunti a MusicBrainz: gli strumenti e le "
+"serie. Sono supportate le serie di registrazioni, pubblicazioni, gruppi di "
+"pubblicazioni e opere."
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr "Miglioramenti per l'utente"
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+"Agli utenti viene richiesto di verificare il loro indirizzo email prima di "
+"poter effettuare modifiche."
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+"La versione 1 del web service (già obsoleta dal 2011) è infine messa offline "
+"(più di un anno dopo l'annuncio che sarebbe stata messa offline sei mesi "
+"dopo!)."
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+"Miglioramento della logica di voto, rilascio delle elezioni per auto-editor "
+"su base web."
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr "Periodo di votazione per modifiche contestate esteso"
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr "Periodo di votazione ridotto a 7 giorni"
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr "Suggerimenti di voto"
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr "Web service versione 1 messo offline"
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+"Giudicando che il progetto AcousticBrainz non ha realizzato i suoi obiettivi "
+"originari, la MetaBrainz Foundation decide di interrompere il lavoro su di "
+"esso, con l'intenzione di chiudere il sito nel 2023."
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr "Attributi delle opere"
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+"Le opere ricevono i loro primi attributi (come le tonalità), permettendoci "
+"di memorizzare dati che non richiedono relazioni, ma che meritano di essere "
+"più di una voce di annotazione."
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr "Yvanzo si unisce a MusicBrainz come sviluppatore"
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+"Yvanzo si unisce al team di sviluppo come secondo sviluppatore dedicato di "
+"MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr "mb_server è ospitato su Git"
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr "reosarevok diventa il leader di stile di MusicBrainz"

--- a/po/history.ja.po
+++ b/po/history.ja.po
@@ -1,0 +1,1125 @@
+#
+# Translators:
+# nikki, 2014
+# john doe, 2016
+# mai inoue, 2015
+# Masuda Sunatomo <email address hidden>, 2021
+# Nozomu KURASAWA <email address hidden>, 2013
+# ffff23 <email address hidden>, 2021
+# Shunsuke Shimizu <email address hidden>, 2017,2019
+# th1rtyf0ur, 2013
+# yyb987 <tyui54-a93@yahoo.com>, 2023.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2023-12-29 21:28+0000\n"
+"Last-Translator: yyb987 <tyui54-a93@yahoo.com>\n"
+"Language-Team: Japanese <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/ja/>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.3\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+"AJAXによる新しいカバーアートアップローダによって、リリースへカバーアートを追"
+"加しやすくなりました。"
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+"新しい通知メッセージは、新たな編集ノートを受け取ったことをすぐにユーザーに知"
+"らせます。"
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr "MusicBrainzコミュニティの亀裂は、大きな抗争につながります。"
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+"音楽の音響情報をクラウドソーシングすることを目的としたAcousticBrainzは、ポン"
+"ペウファブラ大学の音楽技術グループと協力して発表されました。"
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "高度な関係"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+"ユーザーが基本的なデータエンティティに接続できるようにする高度な関係は、デー"
+"タベースから削除された未使用のTRMです。 インライン編集はデフォルトでオフに"
+"なっているため、投票アクティビティが低下します。"
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "アルバムの言語"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr "アルバム言語・大文字小文字の推測を改善・編集フォームの改良をリリース"
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+#, fuzzy
+#| msgid "Amazon Coverart"
+msgid "Amazon cover art"
+msgstr "Amazonのカバーアート"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "注釈"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "購読中のアーティスト"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr "アーティストの購読"
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr "BBCとMetaBrainzが提携"
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr "CAAが公式リリース"
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr "共同コレクション"
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr "コレクション・評価・CDスタブ"
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr "カバーアートアップローダ"
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr "編集ノート通知"
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr "編集を検索"
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr "投票の改善"
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr "検索の改善"
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr "インデックス検索/XML WS"
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr "インライン編集"
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr "Kuno Woudtをフルタイム開発者として雇用"
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr "レーベル/データ品質"
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "MusicIP PUID"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr "NGSリリース"
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr "新しいMusicBrainzのデザイン"
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr "関係編集者"
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr "リリースグループ・ISRC・CDスタブ検索"
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr "リリースグループ・ISRCサポート・CDスタブ検索・検索の修正をリリース"
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr "SG5の修正"
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr "検索の改善"
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr "SoC 2008"
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+#, fuzzy
+#| msgid "The Cover Art Archive is officially released"
+msgid "The Cover Art Archive becomes initially available."
+msgstr "Cover Art Archiveが正式リリース"
+
+#: DB:statistics.statistic_event/description:2012-10-10
+#, fuzzy
+#| msgid "The Cover Art Archive is officially released"
+msgid "The Cover Art Archive is officially released."
+msgstr "Cover Art Archiveが正式リリース"
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr "投票の提案"
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr "YvanzoがMusicBrainzに開発者として参加"
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.ko.po
+++ b/po/history.ko.po
@@ -1,0 +1,1104 @@
+#
+# Translators:
+# hashflu <minwuekim@gmail.com>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2024-01-26 13:28+0000\n"
+"Last-Translator: hashflu <minwuekim@gmail.com>\n"
+"Language-Team: Korean <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/ko/>\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.3\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+#, fuzzy
+#| msgid "Cover Art"
+msgid "Amazon cover art"
+msgstr "커버 아트"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "MusicIP PUID"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.lt.po
+++ b/po/history.lt.po
@@ -1,0 +1,1175 @@
+#
+# Translators:
+# "Vac31." <gateway_31@protonmail.com>, 2023, 2024.
+# Vaclovas Intas <gateway_31@protonmail.com>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2024-06-14 17:42+0000\n"
+"Last-Translator: Vaclovas Intas <gateway_31@protonmail.com>\n"
+"Language-Team: Lithuanian <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/lt/>\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n % 10 == 1 && (n % 100 > 19 || n % 100 < "
+"11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? "
+"1 : n % 1 != 0 ? 2: 3);\n"
+"X-Generator: Weblate 5.5.5\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr "„Nesudaryti klasterių“ gairės atsisakyta"
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr "„feat. (su)“ standartizavimo atsisakyta"
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr "1200 tšk. miniatiūros"
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+"1200 tšk. miniatiūros yra pridėtos į Cover Art Archive, suteikiant "
+"naudotojams labai didelį ir pastovaus dydžio vaizdą, kad nereikėtų "
+"tiesiogiai naudoti originalių įkėlimų."
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+"Discourse forumo platforma pridėta vietoj senųjų forumų ir (dabar jau "
+"neegzistuojančių) elektroninio pašto sąrašų ir suvienija bendruomenės "
+"bendravimą vienoje vietoje."
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+"Įvestas pakeitimas, leidžiantis balsuoti už ir prieš esamas folksonomijos "
+"žymes, o ne tik pridėti savo."
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+"Išleistas didelis Picard žymeklio naujinimas, kuriame ištaisyta daugybė "
+"klaidų ir patobulinimų."
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+"Išleistas naujas puslapis „Balsavimo pasiūlymai“, kuriame pateikiamos iš "
+"anksto nustatytos redagavimo paieškos, padedančios redaktoriams rasti įdomių "
+"ir (arba) svarbių redagavimų, kuriuos reikia peržiūrėti ir balsuoti už tuos."
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+"Išleistas naujas AJAX viršelio apipavidalinimų įkėlėjas, kuris palengvina "
+"leidinių viršelių pridėjimą."
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+"Nauja reklamjuostės pranešimas dabar informuoja naudotojus, kai jie gauna "
+"naują redagavimo pastabą."
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr "Pridėtas naujas, daug greitesnis paieškos mechanizmas."
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr "Dėl nesutarimų MusicBrainz bendruomenėje kilo Didysis Ginčas."
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+"Labai svarbus schemos pakeitimo leidimas pridėta naujo subjekto tipą "
+"(teritorijas), palaikomi atlikėjų ir leidyklų ISNI kodai, taip pat "
+"suteikiama galimybė viename leidinyje turėti daugiau nei vieną išleidimo "
+"įvykį."
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+"Išleista galimybė ieškoti redagavimų pagal kelis skirtingus kriterijus."
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+"AcousticBrainz, kurios tikslas – sutelktinai kaupti akustinę informaciją "
+"apie muziką, paskelbta bendradarbiaujant su Muzikos technologijų grupe "
+"Pompeu Fabra universitete."
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "Išplėstiniai santykiai"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+"Išplėstiniai santykiai, leidžiantys naudotojams prijungti pagrindines "
+"duomenų subjektus, yra išleisti, o nenaudojami TRM pašalinami iš duomenų "
+"bazės. Pagal numatytuosius nustatymus išjungiamas vidinis redagavimas, dėl "
+"to sumažėja balsavimo aktyvumas."
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+"Po daugybės užkulisinių dramų MetaBrainz laimi teisinį mūšį prieš autorių "
+"teisių trolius, kurie bandė pateikti ieškinį dėl Vikitekos vaizdų naudojimo. "
+"Vaizdai vis dar atsisakomi MetaBrainz svetainėse, kad būtų išvengta tolesnių "
+"problemų, kol Vikiteka padarys pakeitimus, kurie padidins pakartotinio "
+"vaizdų naudojimo saugumą."
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+"Po ilgų diskusijų santykių duomenys pradedami rodyti leidinio puslapiuose, "
+"todėl jie tampa daug labiau matomi."
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+"Po sėkmingos Summer of Code prie MusicBrainz komandos prisijungė Ian McEwen."
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+"Po daugelio metų, praleistų Digital West Kalifornijoje, MetaBrainz projektas "
+"perkelia visus serverius į daug didesnį specializuotą paslaugų teikėją "
+"Vokietijoje – Hetzner."
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+"Po kelerių metų, kai BookBrainz buvo tik bendruomenės inicijuotas projektas, "
+"jis priimamas kaip oficialus projektas ir jam suteikiama reali programuotojo "
+"pozicija, įdarbinant Monkey."
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+"Po netikėtų sukrėtimų Freenode, MetaBrainz perkelia visus oficialius kanalus "
+"į Libera.Chat."
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Albumo kalbos"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+"Išleistos albumo kalbos, patobulinta atspėti raidžių lygį ir pakeistos "
+"redagavimo formos."
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+"Slapyvardžiai yra pridėti į tris subjektų tipus, kuriuose jų vis dar nebuvo: "
+"įrašus, leidinius ir leidinių grupes. Tai leidžia saugoti slapyvardžius, "
+"pavyzdžiui, angliškus Azijos leidinių grupių pavadinimus."
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr "Įrašų, leidinių ir leidinių grupių slapyvardžiai"
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+"Amazon pristato <a href=\"http://web.archive.org/web/20210123164029/https://"
+"www.wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> betą su "
+"MusicBrainz duomenimis."
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr "Amazon pristato SoundUnwound betą"
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr "Amazon viršelio apipavidalinimas"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr "Išleistas Amazon viršelio apipavidalinimo palaikymas."
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr "BookBrainz tampa oficialiu MetaBrainz projektu"
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr "Viršelio įkėlėjas"
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr "Discourse suvienija bendruomenės bendravimą"
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr "Redaguoti paiešką"
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr "El. pašto tikrinimas"
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+"Tuščios leidyklos, leidinių grupės ir kūriniai dabar automatiškai pašalinami "
+"po 24 valandų nenaudojimo, kaip ir anksčiau buvo pašalinami atlikėjai."
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr "Žanras pridėtas kaip naujas subjektas"
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr "Indeksuota paieška / XML WS"
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr "Išleistas vertimas į italų kalbą, IPI ir ISNI tampa autoredagavimais"
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr "Leidyklos / duomenų kokybė"
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+"Last.fm prisijungia prie MetaBrainz ir pradeda naudoti MusicBrainz duomenis."
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr "Daugiau autoredagavimų"
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+#, fuzzy
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr "Išleistas NGS, pagrindinis MusicBrainz perrašymas!"
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr "Naujas MusicBrainz dizainas"
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr "Ne albumo takeliai"
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr "Išleista Picard 1.0"
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr "Išleista Picard 2.0"
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+"Redaktoriai, užuot pastebėję klaidas per gana trumpą 1 valandos laikotarpį, "
+"dabar turi 24 valandas, per kurias gali ištaisyti klaidas savo pridėtuose "
+"duomenyse, nereikalaudami balsavimo."
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr "Santykių redaktorius"
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr "Paieškos patobulinimai"
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr "Keletas naujų autoredagavimo tipų ir vertimų"
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+"Kadangi Virtuali mašina buvo linkęs atsilikti nuo dabartinių duomenų dėl "
+"laiko, reikalingo naujoms versijoms nuolat stumti, jo atsisakyta ir "
+"naudotojams siūloma tiesiog paleisti savo MusicBrainz Docker sąranką (ką "
+"Virtuali mašina jau darė užkulisiuose)."
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr "SoC 2008"
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+"Atvirojo kodo pirštų atspaudų nustatymo sprendimas AcoustID (kurį sukūrė "
+"MusicBrainz draugas Lukasas Lalinskis (Lukáš Lalinský)) pradedamas naudoti "
+"kartu su PUID MusicBrainz atspaudų puslapiuose."
+
+#: DB:statistics.statistic_event/description:2012-10-15
+#, fuzzy
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+"Santykių redaktorius, skirtas masiniam leidinio santykių redagavimui, "
+"išleidžiamas į gamybą."
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr "Naudotojo patobulinimai"
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr "Kūrinio požymiai"
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.mr.po
+++ b/po/history.mr.po
@@ -1,0 +1,1100 @@
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: FULL NAME <email address hidden>\n"
+"Language-Team: Marathi (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/mr/)\n"
+"Language: mr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.nb.po
+++ b/po/history.nb.po
@@ -1,0 +1,1119 @@
+#
+# Translators:
+# Allan Nordhøy <email address hidden>, 2017
+# Andreas Dreyer Hysing, 2016
+# CatQuest, The Endeavouring Cat, 2015
+# Ian McEwen <email address hidden>, 2012
+# CatQuest, The Endeavouring Cat, 2012
+# "ApeKattQuest, MonkeyPython" <ApeKattQuestMonkeyPython@users.noreply.translations.metabrainz.org>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2024-06-04 22:42+0000\n"
+"Last-Translator: \"ApeKattQuest, MonkeyPython\" "
+"<ApeKattQuestMonkeyPython@users.noreply.translations.metabrainz.org>\n"
+"Language-Team: Norwegian Bokmål <https://translations.metabrainz.org/"
+"projects/musicbrainz/statistics/nb_NO/>\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.5.4\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+"Den nye AJAX omslagsbildeopplasteren slippes. Dette gjør det lettere å legge "
+"til omslagsbilder på utgivelser."
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr "MuiscBrainz får en ny, mye raskere søkemekanisme."
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "Avanserte relasjoner"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+"Etter mange år ved Digital West i California, flytter MetaBrainz alle "
+"serverne til Hetzner i Tyskland."
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Albumspråk"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr "Aliaser for innspillinger, utgivelser og utgivelsesgrupper"
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+"Amazon bruker data fra MusicBrainz for å betakjøre <a href=\"http://web."
+"archive.org/web/20210123164029/https://www.wired.com/2008/09/amazon-takes-on/"
+"\">SoundUnwound</a>."
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr "Amazon beta-er SoundUnwound"
+
+#: DB:statistics.statistic_event/title:2004-02-24
+#, fuzzy
+#| msgid "Amazon Coverart"
+msgid "Amazon cover art"
+msgstr "Amazon omslagskunst"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+#, fuzzy
+#| msgid "Amazon coverart support released."
+msgid "Amazon cover art support released."
+msgstr "Amazon omslagskunst-støtte sluppet."
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr "Forbedret utgivelsestekstbehandler og ny sidedesign sluppet."
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "Artistabonnementer"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr "BookBrainz blir ett offisielt MetaBrainzprosjekt"
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr "Epostverifisering"
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr "IRCkanaler flyttes til libera.chat"
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr "Ian McEwen hyres"
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr "Instrumenter og serier"
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr "Kuno Woudt ansatt som fulltidsutvikler"
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr "Laurent \"zas\" Monin blir sysadmin"
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr "MBBE_Bot begynner å kjøre"
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr "Sammenslåbare samlinger, artistserier og vurderbare steder"
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr "MetaBrainz hyrer Oliver Charles"
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr "MetaBrainz lanseres"
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr "MusicBrainz flytter"
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr "MusicBrainzserverens kildekode flyttes fra Subversion til Git."
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr "MusicBrainz flyttes til Digital West Networks i San Luis Obispo."
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "MusicIP PUID"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr "Nytt MusicBrainz design"
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr "Oliver Charles blir første ansatte ved MetaBrainz Foundation."
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr "Oliver Charles begynner å arbeide fulltid for MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr "PUID support fjernes"
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr "Sambhav Kothari og Param Singh erstatter Roman Tsukanov"
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr "Søkeforbedringer"
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr "Brukerforbedringer"
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.nl.po
+++ b/po/history.nl.po
@@ -1,0 +1,1372 @@
+#
+# Translators:
+# reneweesp <email address hidden>, 2018
+# Ian McEwen <email address hidden>, 2012
+# Maurits Meulenbelt, 2012
+# Maurits Meulenbelt, 2013-2022
+# Nikolai Prokoschenko <email address hidden>, 2011
+# Remko de Keijzer <email address hidden>, 2021
+# kellnerd <kellnerd@users.noreply.translations.metabrainz.org>, 2023.
+# mfmeulenbelt <mfmeulenbelt@users.noreply.translations.metabrainz.org>, 2023, 2024.
+# reosarevok <reosarevok@users.noreply.translations.metabrainz.org>, 2023.
+# yvanzo <yvanzo@users.noreply.translations.metabrainz.org>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2024-01-17 10:00+0000\n"
+"Last-Translator: yvanzo <yvanzo@users.noreply.translations.metabrainz.org>\n"
+"Language-Team: Dutch <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/nl/>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.3\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr "De richtlijn “Niet clusteren” afgeschaft"
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr "Standaardisering van “feat.” afgeschaft"
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr "Miniaturen van 1200 px"
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+"Aan het Cover Art Archive werden miniaturen van 1200 px toegevoegd, zodat "
+"gebruikers grote afbeeldingen met gestandaardiseerde afmetingen kunnen "
+"gebruiken, zonder dat ze de oorspronkelijk geüploade afbeeldingen moeten "
+"gebruiken."
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+"Er werd een Discourse-forum toegevoegd om het ouderwetse forum en de (nu ter "
+"ziele gegane) e-maillijsten te vervangen, zodat de communicatie op één plek "
+"werd samengebracht."
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+"Het werd mogelijk om voor en tegen bestaande folksonomietags te stemmen, in "
+"plaats van dat je alleen je eigen tags kon toevoegen."
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+"Er werd een nieuwe versie van de Picard-tagger uitgebracht, waarin heel veel "
+"fouten werden opgelost en verbeteringen werden doorgevoerd."
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+"Er werd een nieuw pagina met suggesties voor het stemmen uitgebracht. Hierop "
+"kan je kant-en-klare zoekopdrachten vinden waarmee je interessante en/of "
+"belangrijke bewerkingen kan vinden om op te stemmen."
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+"Een nieuwe op AJAX gebaseerde uploader wordt uitgebracht, waardoor het "
+"makkelijker wordt om afbeeldingen toe te voegen."
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+"Gebruikers zien nu een melding als ze een nieuwe bewerkingsnotitie krijgen."
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr "Er werd een nieuw, veel sneller zoekmechanisme toegevoegd."
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+"Een breuk in de gemeenschap van MusicBrainz leidt tot het Grote Schisma."
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+"In een uitgave met grote schemawijzigingen werden een nieuw soort object "
+"(gebieden), ondersteuning voor ISNI-codes voor artiesten en "
+"platenmaatschappijen en de mogelijkheid om aan één uitgave meerdere "
+"uitgavegebeurtenissen toe te voegen geïntroduceerd."
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+"Er werd een nieuwe manier om op basis van meerdere criteria naar bewerkingen "
+"te zoeken geïntroduceerd."
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+"AcousticBrainz, een project dat als doel heeft om akoestische informatie "
+"over muziek te crowdsourcen, wordt in samenwerking met de Music Technology "
+"Group van de Universitat Pompeu Fabra in Barcelona aangekondigd."
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "Relaties"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+"Relaties waarmee gebruikers objecten kunnen verbinden, zijn uitgebracht en "
+"ongebruikte TRM’s zijn uit de database verwijderd. Bewerken op dezelfde "
+"pagina is standaard uitgeschakeld, waardoor er minder wordt gestemd."
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+"Na veel drama achter de schermen won MetaBrainz een juridische strijd tegen "
+"een auteursrechtentrol die MetaBrainz aanklaagde vanwege het gebruik van "
+"afbeeldingen van Wikimedia Commons. Afbeeldingen van Commons blijven "
+"uitgeschakeld tot Wikimedia veranderingen doorvoert om hergebruik veiliger "
+"te maken."
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+"Na veel discussie werd begonnen met het tonen van relatiegegevens op "
+"uitgavepagina’s, waardoor deze gegevens veel zichtbaarder werden."
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+"Na een succesvolle Summer of Code werd Ian McEwen lid van het MusicBrainz-"
+"team."
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+"Na vele jaren bij Digital West in Californië verhuist het MetaBrainz-project "
+"al zijn servers naar een veel grotere aanbieder in Duitsland, Hetzner."
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+"Na vele jaren als puur gemeenschapsproject werd BookBrainz een officieel "
+"MetaBrainz-project en kwam met Monkey een ontwikkelaar voor BookBrainz in "
+"dienst."
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+"Na onverwachte opschudding bij Freenode verplaatst MetaBrainz alle officiële "
+"kanalen naar Libera.Chat."
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Albumtalen"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+"Talen van uitgaven, verbeteringen in het gokken van hoofdlettergebruik en "
+"vernieuwde bewerkingsformulieren worden uitgebracht."
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+"Er worden aliassen toegevoegd aan de drie objecten die ze nog niet hadden: "
+"opnames, uitgaven en uitgavegroepen. Zo kunnen bijvoorbeeld voor Aziatische "
+"uitgavegroepen Engelse namen worden toegevoegd."
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr "Aliassen voor opnames, uitgaven en uitgavegroepen"
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+"Amazon brengt een bèta van <a href=\"http://web.archive.org/"
+"web/20210123164029/https://www.wired.com/2008/09/amazon-takes-on/"
+"\">SoundUnwound</a> met data van MusicBrainz uit."
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr "Amazon begint met een bèta van SoundUnwound"
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr "Afbeeldingen van Amazon"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr "Ondersteuning voor afbeeldingen van Amazon uitgebracht."
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+"Een verbeterde uitgavebewerker en een nieuw siteontwerp worden uitgebracht."
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+"Het werd mogelijk om vermeldingen van artiesten die afwijken van de "
+"(standaard) artiestennaam in een relatie vast te leggen."
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr "Ondersteuning voor aantekeningen uitgebracht."
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "Aantekeningen"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr "Gebieden, ISNI-codes en meerdere uitgavegebeurtenissen per uitgave"
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "Abonnementen op artiesten"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+"Abonnementen op artiesten openbaar gemaakt en verschillende kleinere "
+"verbeteringen voor gebruikers zijn uitgebracht."
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr "Abonnementen op artiesten."
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+"In het kader van een streven om dichter bij de oorspronkelijke data te "
+"blijven, zijn we opgehouden met het standaardiseren van “featuring” en alle "
+"varianten daarvan naar “feat.” en vragen we redacteurs nu om te gebruiken "
+"wat er op de uitgave is afgedrukt."
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr "Dynamische artiestenpagina’s van de BBC"
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+"De BBC lanceert dynamische artiestenpagina’s gebaseerd op gegevens van "
+"MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr "BBC wordt een partner van MetaBrainz"
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr "BookBrainz wordt een officieel MetaBrainz-project"
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr "Eerste versie van het CAA"
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr "Officiële begin van het CAA"
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr "CatQuest wordt Instrumentinvoeger"
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+"CatQuest neemt de taak om nieuwe instrumenten aan MusicBrainz toe te voegen "
+"officieel over, in de nieuwe functie van Instrumentinvoeger."
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr "Gezamenlijke collecties"
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+"Eigenaren van collecties kunnen nu andere redacteurs toestaan om objecten in "
+"hun collecties toe te voegen of te verwijderen."
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr "Collecties, waarderingen, cd-beginnetjes"
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+"Collecties, waarderingen, cd-beginnetjes en LastUpdate worden uitgebracht."
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+"Redacteurs kunnen nu hun collecties samenvoegen. Bovendien kunnen nu series "
+"van artiesten worden gemaakt en plaatsen worden gewaardeerd (het enige "
+"object dat op CritiqueBrainz kon worden gerecenseerd maar niet op "
+"MusicBrainz kon worden beoordeeld)."
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr "Cover Art Uploader"
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr "Toegewijde databaseserver"
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr "Communicatie wordt in Discourse-forum samengebracht"
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr "Toevoegen van bewerkingsnotities wordt makkelijker"
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+"Verbeteringen in het weergeven van bewerkingen, RDF-dumps uitgeschakeld en "
+"nieuwe installatiescripts uitgebracht."
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr "Bewerkingsgeschiedenis zichtbaar zonder aanmelding"
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr "Meldingen voor bewerkingsnotities"
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+"Bewerkingsnotities kunnen nu worden toegevoegd bij het maken van de "
+"bewerking, zodat redacteurs hun wijzigingen veel makkelijker kunnen "
+"uitleggen."
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr "Zoeken naar bewerkingen"
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+"Redacteur ojnkpjg voert een script uit dat de duur van nummers instelt aan "
+"de hand van disc-ID’s, wat tot een enorme piek aan bewerkingen leidt."
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+"Als een redacteur een uitgave binnen een uur na het toevoegen van deze "
+"uitgave bewerkt, zijn die bewerkingen nu automatisch. Ook het toevoegen van "
+"een opname en het verwijderen van een alias zijn nu automatische bewerkingen."
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr "E-mailverificatie"
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+"Lege platenmaatschappijen, uitgavegroepen en composities worden nu "
+"verwijderd na 24 uur niet te zijn gebruikt, net als al met artiesten "
+"gebeurde."
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+"Lege platenmaatschappijen, uitgavegroepen en composities worden automatisch "
+"verwijderd"
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+"Aan MusicBrainz werd ondersteuning voor evenementen toegevoegd. Nu kan "
+"informatie over concerten en festivals worden toegevoegd. Nieuw in deze "
+"schemawijziging is ook een betere manier om de inhoud van datanummers in "
+"nummerlijsten weer te geven en het uitbreiden van taggen naar gebieden, "
+"instrumenten en series."
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr "Ondersteuning voor evenementen en datanummers"
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+"Folksonomietags en abonnementen op redacteurs werden uitgebracht. Ook is het "
+"nu mogelijk om meerdere relaties in één keer aan meerdere nummers op een "
+"uitgave toe te voegen."
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+"Voormalig GSoC-student Roman Tsukanov begint in deeltijd voor MetaBrainz te "
+"werken."
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr "Frederik “Freso” S. Olesen wordt MetaBrainz-gemeenschapsmanager"
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+"De automatische import vanuit FreeDB wordt uitgeschakeld en de verkiezing "
+"van autoredacteurs toegevoegd. Niet-gebruikte TRM’s worden verwijderd."
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr "FreeDB uit / Autoredacteurs"
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+"Freso werd de eerste MetaBrainz-gemeenschapsmanager, met als taak om "
+"conflicten binnen de gemeenschap te helpen oplossen en een oogje op de "
+"behoeften van gebruikers te houden."
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr "Genres worden toegevoegd als nieuw object"
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+"Genres worden in de vorm van een nieuw object toegevoegd, maar blijven nauw "
+"verbonden met folksonomietags."
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr "Het Grote Schisma"
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr "Knoppen om gastartiesten te gokken"
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr "IRC-kanalen naar Libera.Chat verhuisd"
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr "Ian McEwen aangenomen"
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr "Ian McEwen verlaat MetaBrainz"
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr "Ian McEwen verlaat het project om persoonlijke redenen."
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr "Catalogus van CD Baby geïmporteerd als cd-beginnetjes"
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+"Metagegevens van de catalogus van CD Baby geïmporteerd in onze verzameling "
+"cd-beginnetjes."
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr "Verbeterd stemmen"
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr "Verbeterde zoekfunctie"
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+"In een poging om de lengte van de wachtrij voor bewerkingen en de wachttijd "
+"voor veranderingen te verminderen, is de tijd waarin bewerkingen open "
+"blijven staan verminderd van veertien naar zeven dagen."
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+"Er zijn knoppen toegevoegd waarmee artiesten die nog in de titel van een "
+"nummer of uitgave worden vermeld in plaats van in de artiestvermeldingen, "
+"makkelijker naar de artiestvermeldingen kunnen worden verplaatst."
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+"In aanloop naar NGS zijn bewerkingen uitgeschakeld tot het uitbrengen van "
+"NGS."
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+"In aanloop naar NGS worden redacteurs aangespoord om bewerkingen te "
+"vermijden tenzij het strikt noodzakelijk is."
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr "Geïndexeerd zoeken / XML-webdienst"
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+"Geïndexeerde zoekfunctie en een nieuwe op XML gebaseerde webdienst worden "
+"uitgebracht."
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr "Ingebedde bewerkingen"
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+"Ingebedde bewerkingen, nieuwe rapporten en verbeterde scripts voor "
+"gegevensimport."
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr "Installatiescripts"
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr "Afbeeldingen voor instrumenten, eerste uitgavedatum voor opnames"
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr "Instrumenten en series"
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+"Italiaanse vertaling uitgebracht, IPI- en ISNI-bewerkingen worden "
+"automatische bewerkingen"
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr "Kartik Ohri wordt lid van het MetaBrainz-team"
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+"Kartik Ohri wordt lid van het MetaBrainz-team om te werken aan ListenBrainz, "
+"AcousticBrainz, CritiqueBrainz en de Android-app, die hij als vrijwilliger "
+"al grotendeels had herschreven."
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr "Kuno Woudt begint voltijds te werken bij MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr "Kuno Woudt aangenomen als voltijds ontwikkelaar"
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr "Platenmaatschappijen / gegevenskwaliteit"
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+"Last.fm tekent een contract met MetaBrainz en begint gegevens van "
+"MusicBrainz te gebruiken."
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr "Laurent “zas” Monin wordt systeembeheerder"
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+"Laurent Monin, beter bekend als Zas, wordt lid van het team als "
+"systeembeheerder. Zijn taak wordt om te zorgen dat de servers goed werken en "
+"om te helpen bij de overstap op een nieuw discussiesysteem voor de "
+"gemeenschap."
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+"Mogelijkheden voor links naar MusicBrainz, uitgavegebeurtenissen en "
+"suggesties voor bewerkingen uitgebracht."
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr "Linkara Musica wordt de eerste commerciële klant van MetaBrainz."
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr "Links"
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+"MBBE_Bot wordt gemaakt om dingen te verbeteren die met de hand te veel tijd "
+"zouden kosten, maar wel in de bewerkingsgeschiedenis moeten worden "
+"opgenomen. Het gaat hierbij meestal om het verwijderen van URL’s van "
+"problematische domeinen, het markeren van URL’s van domeinen die zijn "
+"beëindigd en meer van dat soort massawerk."
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr "MBBE_Bot wordt gestart"
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr "Scripting voor menu’s en programma’s"
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr "Collecties samenvoegen, artiestenseries en waarderingen voor plaatsen"
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr "MetaBrainz accepteert drie studenten voor de Google Summer of Code."
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr "MetaBrainz neemt Oliver Charles aan"
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr "MetaBrainz gelanceerd"
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr "MetaBrainz-projecten naar Europese servers verhuisd"
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr "MetaBrainz tekent zijn eerste klant"
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+"MetaBrainz wint gevecht met auteursrechtentrol, Wikimedia-afbeeldingen "
+"verwijderd"
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr "MetaWeb gaat de data van MusicBrainz gebruiken."
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr "MetaWeb getekend"
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr "Meer automatische bewerkingen"
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+"Meer soorten bewerkingen worden voor iedereen automatisch: het toevoegen van "
+"uitgaven en het toevoegen, bewerken of verwijderen van platenmaatschappijen "
+"van uitgaven. Bovendien worden de Duitse, Franse en Nederlandse vertalingen "
+"op de hoofdserver beschikbaar."
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr "Verhuizing van MusicBrainz"
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+"De broncode voor de server van MusicBrainz verhuist van Subversion naar Git."
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr "MusicBrainz gaat AcoustID ondersteunen"
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr "MusicBrainz krijgt zijn eerste toegewijde databaseserver."
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+"Ook MusicBrainz krijgt een nieuw ontwerp om beter aan te sluiten op de rest "
+"van de *Brainz-familie."
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr "MusicBrainz verhuist naar Digital West Networks in San Luis Obispo."
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+"MusicBrainz begint een partnerschap met MusicIP en begint de PUID "
+"akoestische vingerafdrukken van MusicDNS te gebruiken. Picard wordt de "
+"officiële tagger van MusicBrainz met ondersteuning voor PUID’s, waardoor er "
+"minder bewerkingen worden gedaan."
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "MusicIP-PUID"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr "Bewerkingsloze fase voor NGS"
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr "Bewerkingsarme fase voor NGS"
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr "NGS uitgebracht"
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr "NGS, een grote verbouwing van MusicBrainz, is uitgebracht!"
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr "Nieuw ontwerp voor MusicBrainz"
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+"Periode voor automatische bewerkingen van nieuwe objecten verlengd naar 24 "
+"uur"
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+"Nicolás Tamargo (reosarevok) wordt de stijlleider van MusicBrainz, en voor "
+"het ontwikkelen van de stijlgids wordt een nieuw, formeler proces via Jira "
+"ingesteld."
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr "Nummers zonder album"
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr "Nummers zonder album uitgebracht."
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr "Oliver Charles wordt de eerste werknemer van de MetaBrainz Foundation."
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr "Oliver Charles begint voltijds voor MusicBrainz te werken."
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr "Oliver Charles wordt voltijdwerknemer van MusicBrainz"
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+"Met de overstap op SOLR krijgt onze oude zoekserver een flinke upgrade. Het "
+"wordt onder andere mogelijk om indices bijna direct bij te werken."
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr "PUID-ondersteuning beëindigd"
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr "Paginering voor relaties en gebruikersetiketten toegevoegd"
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+"Voor twee erg lange lijsten die soms niet volledig konden worden geladen "
+"omdat dat te lang duurde is paginering toegevoegd: gebruikersetiketten en "
+"relaties van objecten."
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr "Picard 1.0 uitgebracht"
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr "Picard 2.0 uitgebracht"
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+"In plaats van dat redacteurs maar een uur hebben om fouten in je bewerkingen "
+"te corrigeren zonder dat erover gestemd hoeft te worden, hebben redacteurs "
+"nu 24 uur."
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr "Relatiebewerker"
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr "Relatievermeldingen komen beschikbaar"
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr "Relaties worden op uitgavepagina’s weergegeven"
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+"‘Beginnetjes’ voor uitgaven, minimale stemmingsperiode voor destructieve "
+"bewerkingen"
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr "Uitgavegroepen, ISRC’s, zoeken naar cd-beginnetjes"
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr "Uitgavebewerker"
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+"De uitgavebewerker en het gokken van hoofdlettergebruik worden uitgebracht."
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+"Uitgavegroepen, ondersteuning voor ISRC’s, zoeken in cd-beginnetjes en "
+"verbeteringen aan de zoekfunctie uitgebracht."
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+"Uitgaven kunnen nu zonder een medium worden toegevoegd. Dat is handig als "
+"die informatie niet bekend is, maar de titel, datum, platenmaatschappij of "
+"het catalogusnummer wel. Ook blijven destructieve bewerkingen, zoals "
+"samenvoegingen, vanaf dit moment ook bij drie stemmen voor minimaal 48 uur "
+"open, zodat andere redacteurs die het er mogelijk niet mee eens zijn de "
+"bewerking ook te zien krijgen."
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+"Roman Tsukanov besluit om zijn contract niet te verlengen. Sambhav Kothari "
+"en Param Singh worden aangenomen als zijn vervanger en gaan werken aan "
+"respectievelijk Picard en ListenBrainz."
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr "Roman Tsukanov wordt lid van het MetaBrainz-team"
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr "SG5-verbeteringen"
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr "Sambhav Kothari en Param Singh vervangen Roman Tsukanov"
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+"Na veel werk te hebben verzet om de SOLR-server klaar te krijgen, verlaat "
+"Sambhav Kothari MetaBrainz. Nicolás Tamargo (reosarevok) wordt aangenomen "
+"als programmeur in deeltijd om naast zijn werk voor de stijlgids en "
+"ondersteuning aan MusicBrainz te gaan werken."
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+"Vertrek van Sambhav Kothari, Nicolás Tamargo treedt in dienst als programmeur"
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr "Zoekverbeteringen"
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr "Nieuwe soorten automatische bewerkingen en nieuwe vertalingen"
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+"Omdat de virtuele machine toch vaak achterliep bij de actuele data en het "
+"uitgeven van nieuwe versies veel tijd kostte, is het VM-project stopgezet en "
+"worden gebruikers aangeraden om MusicBrainz zelf via Docker te draaien (iets "
+"wat de virtuele machine achter de schermen al deed)."
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr "SoC 2008"
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr "Op SOLR gebaseerde zoekserver geïmplementeerd"
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+"Op sommige instrumentenpagina’s worden illustraties van IROM weergegeven. "
+"Bovendien wordt voor opnames op basis van de uitgaven waarop ze staan de "
+"eerste uitgavedatum berekend."
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+"Er wordt een oplossing voor fouten in Stijlgids 5 geïntroduceerd en "
+"ongebruikte TRM’s worden verwijderd."
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+"Stijlproces weer aangepast, reosarevok ‘gepromoveerd’ tot welwillende "
+"stijldictator"
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+"Ondersteuning voor platenmaatschappijen en gegevenskwaliteit worden "
+"uitgebracht."
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr "Stemmen op etiketten"
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr "Etiketten, abonnementen op redacteurs, relaties in bulk toevoegen"
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr "Het AcousticBrainz-project wordt gelanceerd"
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr "Het AcousticBrainz-project wordt stopgezet"
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr "De Android-app wordt gelanceerd"
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+"De BBC wordt een klant van MetaBrainz en begint gegevens van MusicBrainz te "
+"gebruiken."
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr "Het Cover Art Archive wordt voor het eerst beschikbaar."
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr "Het Cover Art Archive wordt officieel uitgebracht."
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr "Het CritiqueBrainz-project wordt gelanceerd"
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+"De Italiaanse vertaling, die grotendeels door salo.rock is gemaakt, wordt "
+"officieel uitgebracht. Het toevoegen van een eerste IPI en/of ISNI voor een "
+"object wordt een automatische bewerking, tenzij dezelfde code al ergens is "
+"toegevoegd."
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr "Het ListenBrainz-project wordt gelanceerd"
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+"De MetaBrainz Foundation, het juridische thuis van MusicBrainz, wordt aan "
+"het publiek gepresenteerd."
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+"De virtuele machine van MusicBrainz wordt vervangen door MusicBrainz Docker"
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+"De alfaversie van ListenBrainz, een openbron- en opendata-alternatief voor "
+"Last.fm®, wordt gelanceerd."
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr "De bètaversie van CritiqueBrainz wordt gelanceerd."
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+"Omdat de dienst achter de PUID-vingerafdrukken steeds minder werd en er met "
+"AcoustID een openbron-alternatief beschikbaar was, werd besloten om PUID-"
+"ondersteuning te beëindigen en voortaan alleen AcoustID te ondersteunen."
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+"De bewerkingsgeschiedenis van een object is nu ook zichtbaar voor gebruikers "
+"die niet zijn aangemeld, waardoor het makkelijker is om te begrijpen hoe elk "
+"object in de loop van de tijd is veranderd. Bewerkingsnotities blijven "
+"onzichtbaar vanwege de privacy."
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+"De eerste volledige uitgave van de Picard-tagger wordt uitgebracht met een "
+"hoop veranderingen en verbeteringen."
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+"De eerste versie van de Android-app voor MusicBrainz, een Google Summer of "
+"Code-project van Jamie McDonald, komt officieel beschikbaar."
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+"De impopulaire richtlijn ‘niet clusteren’, die relatieclusters (zoals het "
+"aan elkaar koppelen van alle leden van de Jacksons) verbiedt, wordt "
+"afgeschaft. Het voorkomen van dubbele gegevens wordt een taak van de "
+"bedenkers van relaties in plaats van gebruikers die gegevens toevoegen."
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr "De nieuwe MetaBrainz-website wordt gelanceerd"
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+"MetaBrainz krijgt een nieuwe website, met een compleet nieuw ontwerp en een "
+"mogelijkheid voor commerciële gebruikers om zich online aan te melden. De "
+"oude website kwam uit het jaar 2000!"
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+"De openbronoplossing voor audiovingerafdrukken AcoustID (ontwikkeld door "
+"vriend van MusicBrainz Lukáš Lalinský) wordt vanaf nu naast PUID gebruikt op "
+"MusicBrainz."
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+"De relatiebewerker voor massabewerkingen aan relaties van uitgaven, is "
+"uitgebracht."
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr "Verbeteringen aan de zoekfunctie en de webdienst worden uitgebracht."
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+"Het stijlproces wordt weer eens vernieuwd. In plaats van een lange, vaak "
+"slechtgehumeurde discussie binnen de gemeenschap totdat er eindelijk "
+"consensus is, worden beslissingen voortaan genomen door een welwillende "
+"dictator die als het nodig is advies vraagt aan de gemeenschap. Nicolás "
+"Tamargo (reosarevok) krijgt ‘promotie’ van stijlleider tot welwillende "
+"stijldictator."
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+"De stemmingsperiode voor bewerkingen waarop tegen wordt gestemd, wordt "
+"verlengd, zodat gebruikers langer de tijd hebben om op bedenkingen te "
+"reageren."
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+"Verbeterde menunavigatie, dubbele artiesten, bewerkingen voor hele uitgaven "
+"en de lengte van nummers uitgebracht."
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr "Nummerlengtes die met disc-ID’s zijn ingesteld"
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+"Er worden twee nieuwe objecten aan MusicBrainz toegevoegd: instrumenten en "
+"series. Series van opnames, uitgaven, uitgavegroepen en composities worden "
+"ondersteund."
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr "Verbeteringen voor gebruikers"
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+"Gebruikers moeten nu voordat ze bewerkingen kunnen doorvoeren hun e-"
+"mailadres bevestigen."
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+"Versie 1 van de webdienst (die al sinds 2011 verouderd was) wordt eindelijk "
+"voorgoed uit de lucht gehaald (meer dan een jaar nadat werd aangekondigd dat "
+"dit over zes maanden zou gebeuren!)"
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+"Logica voor stemmen verbeterd en verkiezingen voor autoredacteurs "
+"uitgebracht."
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr "Stemmingsperiode voor omstreden bewerkingen verlengd"
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr "Stemmingsperiode tot zeven dagen ingekort"
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr "Suggesties voor het stemmen"
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr "Versie 1 van de webdienst uit de lucht gehaald"
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+"Omdat de doelen van het AcousticBrainz-project niet zijn gehaald, heeft de "
+"MetaBrainz Foundation besloten om het project stop te zetten; de website "
+"wordt waarschijnlijk in 2023 uit de lucht gehaald."
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr "Compositie-eigenschappen"
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+"Composities krijgen hun eerste eigenschappen (zoals toonsoort), zodat we "
+"informatie op kunnen slaan die niet past binnen het idee van relaties maar "
+"meer aandacht vereist dan een vermelding in de aantekening."
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr "Yvanzo wordt ontwikkelaar bij MusicBrainz"
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+"Yvanzo wordt lid van het ontwikkelteam en wordt de tweede ontwikkelaar die "
+"zich alleen met MusicBrainz bezighoudt."
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr "mb_server wordt nu gehost op Git"
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr "reosarevok wordt de stijlleider van MusicBrainz"

--- a/po/history.oc.po
+++ b/po/history.oc.po
@@ -1,0 +1,1171 @@
+#
+# Translators:
+# Cédric Valmary <email address hidden>, 2015
+# Cédric Valmary <email address hidden>, 2015
+# Joan Luci Labòrda <email address hidden>, 2018
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: Joan Luci Labòrda <joanluci@gmail.com>, 2018\n"
+"Language-Team: Occitan (post 1500) (http://app.transifex.com/musicbrainz/"
+"musicbrainz/language/oc/)\n"
+"Language: oc\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+"Un novèl mandador d'illustracions AJAX es sortit, facilita l'apondon "
+"d'illustracions a las parucions."
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+"Adara un messatge nau notifica los utilizadors quan receben una nava nota "
+"escriuta."
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+"Un clivatge dins la comunautat MusicBrainz mena cap a una granda garrolha."
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "Relacions aprigondidas"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+"Sortidas : relacions aprigondidas que permeton als utilizaires de connectar "
+"d'entitats simplas de donadas, e los TRM inutilizats son levats de la banca "
+"de donadas. L'edicion en linha es desactivada per defaut, aquò prepausa una "
+"baissa de l'activitat de vòte."
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Lengas dels albums"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+"Sortida : melhorament de la descoberta de las lengas dels albums e de la "
+"cassa e tanben dels formularis de modificacion revampats."
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr "SoundUnwound bèta d'Amazon"
+
+#: DB:statistics.statistic_event/title:2004-02-24
+#, fuzzy
+#| msgid "Amazon Coverart"
+msgid "Amazon cover art"
+msgstr "Illustracions que provenon d'Amazon"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+#, fuzzy
+#| msgid "Amazon coverart support released."
+msgid "Amazon cover art support released."
+msgstr "Sortida : presa en carga de las illustracion que provenon d'Amazon"
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+"Sortida : editor de parucion melhorat e tanben una novèla concepcion pel "
+"site."
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr "Sortida : presa en carga de las anotacions"
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "Anotacions"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "Abonaments als artistas"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+"Sortida : los abonaments als artistas son renduts publics, e pichons "
+"melhoraments pels utilizaires."
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr "Abonaments als artistas."
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr "Paginas dinamicas dels artistas que provenon de la BBC"
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+"La BBC àvia las paginas dinamicas dels artistas basadas sus las donadas de "
+"MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr "Partenariat entre la BBC e MusicBrainz"
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr "Parucion iniciala CAA"
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr "Parucion oficiala CAA"
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr "Colleccions, avaloracions copons de CD"
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+"Sortida : colleccions, avaloracions copons de CD, darrièras mesa a jorn."
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr "Mandador d'illustracions"
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr "Servidor de banca de donadas dedicat"
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+"Sortida : melhoraments de l'afichatge de las modificacions, arrèst dels "
+"voidatges « RDF », novèls escripts d'installacion."
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr "Recèrca de las modificacions"
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+"L'editor ojnkpjg fa virar un escript qu'ajusta las duradas de pista a partir "
+"de las valors d'ID de disc e crèa un enòrme pic dins las modificacions."
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+"Sortida : foncion d'autoïmportacion de FreeDB es desactivada e eleccions "
+"dels autoeditors. Los TRM inutilizats son levats de la banca de donadas."
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr "FreeDB desactivada/autoeditors"
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr "Granda garrolha"
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr "Catalòg CD baby importat coma copons de CD"
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+"Metadonadas del catalòg de CD Baby importat dins nòstra colleccion de copons "
+"de CD"
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr "Melhorament del vòte"
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr "Melhorament de la recèrca"
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+"Per fin de redusir la talha de la fila d'espèra de las modificacions "
+"dobèrtas e forçar una espèra mendre pels cambiaments, la durada de dobertura "
+"de las modificacions abans expiracion es redusida de 14 a 7 jorns."
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+"En preparacion per NGS, las modificacions son desactivadas fins a la sortida."
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+"En preparacion per NGS, los editors son encoratjats a evitar de modificar "
+"fins a la sortida levat se vertadièrament necessari."
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr "Recèrca indexada/XML WS"
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr "Sortida : recèrca indexada e novèl servici Web basat sus XML."
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr "Modificacions en linha"
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+"Sortida : modificacions en linha, novèl rapòrts, escripts melhorats "
+"d'importacion de donadas. "
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr "Escripts d'installacion"
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr "Kuno Woudt comença de trabalhar per MusicBrainz a temps complet."
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr "Kuno Woudt engatjat en tant que desvelopaire a temps complet"
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr "Labèls/qualitat de las donadas"
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+"Last.fm signa amb MusicBrainz e comença d'utilizar las donadas de "
+"MusicBrainz."
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+"Sortida : foncion de ligam cap a MusicBrainz, eveniments de parucion e "
+"suggestions de modificacion. "
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr "Linkara Musica ven lo primièr client comercial de MetaBrainz."
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr "Ligason"
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr "Menús/escripts client"
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr "MetaBrainz accèpta tres estudiants pel « Google Summer of Code »."
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr "MetaBrainz engatja Oliver Charles."
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr "Aviada de MetaBrainz"
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr "MetaBrainz signa amb son primièr client"
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr "Signatura amb MetaWeb "
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr "Mudason de MusicBrainz"
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+"Lo còde font del servidor MusicBrainz es desplaçat de Subversion cap a Git."
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr "MusicBrainz obten son primièr servidor de banca de donadas dedicat."
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr "MusicBrainz es mudat cap a Digital West Networks a San Luis Obispo."
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+"MusicBrainz ven partenari amb MusicIP e comença d'utilizar las emprentas "
+"acosticas PUID de MusicDNS. Picard ven lo balisador oficial de MusicBrainz "
+"amb presa en carga dels PUID, aquò entraïna una baissa de l'activitat de "
+"modificacion."
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "PUID MusicIP"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr "Fasa de non modificacion NGS"
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr "Fasa de reduccion de las modificacions NGS"
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr "Sortida de NGS"
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr "Sortida : NGS, una reescritura màger de MusicBrainz!"
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr "Pistas fòra album"
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr "Sortida : pistas fòra album."
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr "Oliver Charles ven lo primièr emplegat de la Fondation MusicBrainz."
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr "Oliver Charles comença de trabalhar per MusicBrainz a temps complet."
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr "Oliver Charles rejonh MusicBrainz a temps complet"
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr "Editor de relacions"
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr "Gropes de las parucion, ISRC, recèrca dels copons de CD"
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr "Editor de parucion"
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr "Sortida : editor de parucion e endevinar la cassa."
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+"Sortida : gropes de parucion, presa en carga dels ISRC, recèrca dels copons "
+"de CD e correctius de recèrca."
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr "Correctius SG5"
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr "Melhoraments de la recèrca"
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr "Soc 2008"
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+"Implantacion de las directivas d'estil 5, e los TRM inutilizats son levats "
+"de la banca de donadas"
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr "Sortida : presa en carga dels labèls e qualitat de las donadas."
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+"La BBC ven un client de MusicBrainz e comença d'utilizar las donadas de "
+"MusicBrainz."
+
+#: DB:statistics.statistic_event/description:2012-04-30
+#, fuzzy
+#| msgid "The Cover Art Archive becomes initially available"
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+"L'archiu de las illustracions « Cover Art Archive » es prepausada pel "
+"primièr còp."
+
+#: DB:statistics.statistic_event/description:2012-10-10
+#, fuzzy
+#| msgid "The Cover Art Archive is officially released"
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+"L'archiu de las illustracions « Cover Art Archive » es oficialament aviat"
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+"La Fondacion MusicBrainz, lo sèti social de MusicBrainz, es anonciat al "
+"public."
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+"L'editor de relacions que permet las modificacions per lòt de las relacions "
+"per una parucion es mesa en produccion."
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr "Sortida : foncions de recèrca e melhoraments del servici Web."
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+"Sortidas : melhorament de la navigation del menú d'amont, recèrca d'artistas "
+"en doble, tot modificar dins l'album, modificacion de la durada de pistas."
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr "Durada de las pistas indicada a partir dels ID de disc"
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr "Melhoraments per l'utilizaire"
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+"Sortida : melhorament de la logica de vòte, eleccions dels autoeditors "
+"basadas sul Web."
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr "Periòde de vòte redusit a 7 jorns"
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr "Lo servidor MusicBrainz es ara albergat sus Git"
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.pa.po
+++ b/po/history.pa.po
@@ -1,0 +1,1100 @@
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: FULL NAME <email address hidden>\n"
+"Language-Team: Panjabi (Punjabi) (http://app.transifex.com/musicbrainz/"
+"musicbrainz/language/pa/)\n"
+"Language: pa\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.pl.po
+++ b/po/history.pl.po
@@ -1,0 +1,1117 @@
+#
+# Translators:
+# czaja <email address hidden>, 2011
+# Eryk Michalak <email address hidden>, 2023
+# Debeat <email address hidden>, 2015
+# Marcin Rataj <email address hidden>, 2011, 2012
+# Nikolai Prokoschenko <email address hidden>, 2011
+# nikki, 2012
+# Piotr Myśliński <email address hidden>, 2013
+# Tobias Toedter <email address hidden>, 2007
+# reosarevok <reosarevok@users.noreply.translations.metabrainz.org>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2024-01-04 11:06+0000\n"
+"Last-Translator: reosarevok <reosarevok@users.noreply.translations."
+"metabrainz.org>\n"
+"Language-Team: Polish <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/pl/>\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && "
+"(n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && "
+"n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"X-Generator: Weblate 5.3\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "Zaawansowane relacje"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Języki albumu"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+#, fuzzy
+#| msgid "Cover Art"
+msgid "Amazon cover art"
+msgstr "Okładka"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "Adnotacje"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr "Dynamiczne strony artysty BBC"
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr "Początkowe wydanie CAA"
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr "Oficjalne wydanie CAA"
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr "Osoba przesyłąjąca okładkę"
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr "Edytuj wyszukiwanie"
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr "Weryfikacja e-mail"
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr "Redaktor relacji"
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+#, fuzzy
+#| msgid "CAA official release"
+msgid "The Cover Art Archive is officially released."
+msgstr "Oficjalne wydanie CAA"
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.pot
+++ b/po/history.pot
@@ -1,0 +1,1204 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#. title:1200px thumbnails
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#. title:Discourse unifies community communication
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#. title:Tag up/downvoting
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#. title:Picard 2.0 released
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#. title:Voting suggestions
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#. title:Cover Art Uploader
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#. title:Edit note notifications
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#. title:Improved search
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#. title:Great Dispute
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#. title:Areas, ISNI codes and multiple release events per release
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#. title:Edit search
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#. title:The AcousticBrainz project goes live
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#. title:Advanced relationships
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#. title:MetaBrainz wins copyright troll battle, Wikimedia images dropped
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#. title:Relationships displayed on release pages
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#. title:Ian McEwen hired
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#. title:MetaBrainz projects complete move to European servers
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#. title:BookBrainz becomes official MetaBrainz project
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#. title:IRC channels move to Libera.Chat
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#. title:Album languages
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#. title:Aliases for recordings, releases and release groups
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#. title:Amazon betas SoundUnwound
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#. title:Amazon cover art
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#. title:Release editor
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#. title:Relationship credits become available
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#. title:Annotations
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#. title:User improvements
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#. title:Artist subscriptions
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#. title:"feat." standardization dropped
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#. title:BBC dynamic artist pages
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#. title:CatQuest becomes Instrument Inserter
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#. title:Collaborative collections
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#. title:Collection, Ratings, CDStubs
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#. title:Mergeable collections, artist series and ratable places
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#. title:Install scripts
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#. title:Easier edit note adding
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#. title:Track times set from DiscIDs
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#. title:More auto-edits
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#. title:Empty labels, release groups and works start being auto-removed
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#. title:Event support, data tracks
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#. title:Tags, editor subscriptions, relationship batch-adding
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#. title:Roman Tsukanov joins the MetaBrainz team
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#. title:FreeDB off/Autoeditors
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#. title:Frederik "Freso" S. Olesen becomes MetaBrainz Community Manager
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#. title:Genre added as a new entity
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#. title:Ian McEwen leaves MetaBrainz
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#. title:Imported CD Baby catalog as CD Stubs
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#. title:Voting period shortened to 7 days
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#. title:Guess feat. buttons
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#. title:NGS No-Editing Phase
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#. title:NGS Reduced Editing Phase
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#. title:Indexed search/XML WS
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#. title:Inline edits
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#. title:Kartik Ohri joins the MetaBrainz team
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#. title:Kuno Woudt hired as full-time developer
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr ""
+
+#. title:Last.fm
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#. title:Laurent "zas" Monin becomes sysadmin
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#. title:Linking
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#. title:MetaBrainz signs first customer
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#. title:MBBE_Bot starts running
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#. title:SoC 2008
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#. title:MetaWeb signed
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#. title:Several new auto-edit types and translations
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#. title:mb_server now hosted on Git
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#. title:Dedicated database server
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#. title:New MusicBrainz design
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#. title:MusicBrainz Move
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#. title:MusicIP PUID
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#. title:NGS Release
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#. title:reosarevok becomes the MusicBrainz style leader
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#. title:Non album tracks
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#. title:MetaBrainz hires Oliver Charles
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#. title:Oliver Charles joins MusicBrainz full-time
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#. title:Solr-based search server deployed
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#. title:Pagination added for relationships, user tags
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#. title:New entity auto-editing period extended to 24 hours
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#. title:Release editor
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#. title:Release Groups, ISRCs, CDStub searching
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#. title:Release "stubs", minimum voting period for destructive edits
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#. title:Sambhav Kothari and Param Singh replace Roman Tsukanov
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#. title:Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#. title:The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#. title:Instrument images, recordings' first release date
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#. title:SG5 Fixes
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#. title:Labels/data quality
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#. title:BBC partners with MetaBrainz
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#. title:CAA initial release
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#. title:CAA official release
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#. title:Italian translation released, IPI and ISNI become autoedits
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#. title:MetaBrainz launched
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#. title:The ListenBrainz project goes live
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#. title:The CritiqueBrainz project goes live
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#. title:PUID support is removed
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#. title:Edit history visible without logging in
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#. title:Picard 1.0 released
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#. title:The Android app goes live
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#. title:"Do Not Cluster" guideline dropped
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#. title:The new MetaBrainz website goes live
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#. title:MusicBrainz adds AcoustID support
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#. title:Relationship Editor
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#. title:Search improvements
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#. title:Style process updated again, reosarevok "promoted" to Style BDFL
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#. title:Voting period for contested edits extended
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#. title:Menus/Client scripting
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#. title:Instruments and series
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#. title:Email verification
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#. title:Web service version 1 taken down
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#. title:Improve voting
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#. title:The AcousticBrainz project is discontinued
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+msgid "Work attributes"
+msgstr ""
+
+#. title:Work attributes
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#. title:Yvanzo joins MusicBrainz as a developer
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.pt.po
+++ b/po/history.pt.po
@@ -1,0 +1,1105 @@
+#
+# Translators:
+# Felipe Silva <musicbrainz@felipeqq2.rocks>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2024-06-02 17:42+0000\n"
+"Last-Translator: Felipe Silva <musicbrainz@felipeqq2.rocks>\n"
+"Language-Team: Portuguese <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/pt/>\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : ((n != 0 && n % "
+"1000000 == 0) ? 1 : 2);\n"
+"X-Generator: Weblate 5.5.4\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+#, fuzzy
+#| msgid "Cover Art"
+msgid "Amazon cover art"
+msgstr "Capa"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "PUID MusicIP"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.ro.po
+++ b/po/history.ro.po
@@ -1,0 +1,1102 @@
+#
+# Translators:
+# viper666 <email address hidden>, 2013
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: viper666 <bruceradu@gmail.com>, 2013\n"
+"Language-Team: Romanian (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/ro/)\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
+"2:1));\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "Relații avansate"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "Adnotari"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "MusicIP PUID"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr "Lansarea NGS"
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr "Piese fără album"
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.ru.po
+++ b/po/history.ru.po
@@ -1,0 +1,1140 @@
+#
+# Translators:
+# Dmitr Y, 2017
+# Ekaterina <email address hidden>, 2020
+# greycat <email address hidden>, 2012
+# Ilya <email address hidden>, 2023
+# karlov m, 2022
+# Little Loli, 2016
+# Nikolai Prokoschenko <email address hidden>, 2011
+# dubwai <email address hidden>, 2012
+# odinvolk <email address hidden>, 2018
+# arsinclair <email address hidden>, 2017
+# Александр Жибарь <email address hidden>, 2016
+# Дмитрий <email address hidden>, 2014
+# Лёва, 2015
+# wileyfoxyx <wileyfoxyx@users.noreply.translations.metabrainz.org>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2024-06-15 22:42+0000\n"
+"Last-Translator: wileyfoxyx <wileyfoxyx@users.noreply.translations."
+"metabrainz.org>\n"
+"Language-Team: Russian <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/ru/>\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
+"(n%100>=11 && n%100<=14)? 2 : 3);\n"
+"X-Generator: Weblate 5.5.5\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr "Руководство \"Не группировать\" отброшено"
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr "Прекращение стандартизации \"feat.\""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr "Обложки в 1200 пикселей"
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+"Создан новый AJAX-загрузчик обложек, облегчающий их добавление в релизы."
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+"Теперь новое всплывающее сообщение уведомляет пользователей, когда они "
+"получают заметку о редактировании."
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+"Расширенные отношения, которые позволяют пользователям подключать базовые "
+"объекты данных, - это освобожденные и неиспользуемые TRM, отрезанные из базы "
+"данных. Встроенное редактирование отключено по умолчанию, что приводит к "
+"снижению активности голосования."
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+"После множества закулисных драматических событий MetaBrainz выиграла "
+"судебный процесс против тролля, пытавшегося предъявить иск из-за "
+"использования изображений Викисклада. Изображения оттуда по-прежнему не "
+"используются на сайтах MusicBrainz, чтобы избежать дальнейших проблем, пока "
+"фонд Викимедиа не внесет изменения, которые сделают повторное использование "
+"изображений более безопасным."
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+"После долгих дебатов данные о взаимоотношениях стали отображаться на "
+"страницах изданий, что сделало их гораздо более заметными."
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+"После успешного проведения Summer of Code, Иэн Макьюэн присоединяется к "
+"команде MusicBrainz."
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Языки альбома"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr "Обложка Amazon"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr "Добавлена поддержка обложек Amazon."
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr "Добавлен улучшенный редактор и новый дизайн сайта."
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr "Добавлена поддержка аннотаций."
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "Аннотации"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "Подписки на исполнителей"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr "Подписки на исполнителей."
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr "Первоначальный релиз CCA"
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr "Официальный релиз CAA"
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr "Общие коллекции"
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr "Разместил Обложку"
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr "Выделенный сервер базы данных"
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr "Редактировать уведомления о заметках"
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr "Поиск по правкам"
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+"Правки, сделанные редакторами к добавленным ими релизами в течение часа "
+"после их добавления (например, правки типов \"Добавление записи\" и "
+"\"Удаление псевдонима\"), теперь являются автоправками."
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+"Пустые лейблы, группы релизов и работы теперь удаляются спустя 24 часа их "
+"неиспользования, так же, как и у исполнителей."
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr "Автоудаление пустых лейблов, групп релизов и работ"
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr "Жанр добавлен в качестве нового объекта"
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr "Улучшить голосование"
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr "Улучшенный поиск"
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr "Встроенные правки"
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr "Установка скриптов"
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr "Лейблы/качество данных"
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr "Связывание"
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr "MetaBrainz запущен"
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "MusicIP PUID"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr "Треки вне альбома"
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr "Опубликованные треки вне альбома."
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr "Редактор связей"
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr "Редактор публикаций"
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr "Улучшения поиска"
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr "Несколько новых типов авторедактирования и переводов"
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr "Официально запущен Cover Art Archive."
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr "Официально запущен Cover Art Archive."
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr "Период голосования сокращён до 7 дней"
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr "Предложения по голосованию"
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr "Атрибуты работы"
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.sk.po
+++ b/po/history.sk.po
@@ -1,0 +1,1104 @@
+#
+# Translators:
+# Lukáš Lalinský <email address hidden>, 2012
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: Lukáš Lalinský <lalinsky@gmail.com>, 2012\n"
+"Language-Team: Slovak (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/sk/)\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n == 1 ? 0 : n % 1 == 0 && n "
+">= 2 && n <= 4 ? 1 : n % 1 != 0 ? 2: 3);\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+#, fuzzy
+#| msgid "Cover Art"
+msgid "Amazon cover art"
+msgstr "Obrázok Albumu"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "MusicIP PUID"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.sl.po
+++ b/po/history.sl.po
@@ -1,0 +1,1101 @@
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: FULL NAME <email address hidden>\n"
+"Language-Team: Slovenian (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/sl/)\n"
+"Language: sl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3);\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.sq.po
+++ b/po/history.sq.po
@@ -1,0 +1,1102 @@
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: FULL NAME <email address hidden>\n"
+"Language-Team: Albanian (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/sq/)\n"
+"Language: sq\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+#, fuzzy
+#| msgid "Cover Art"
+msgid "Amazon cover art"
+msgstr "Kopertinë"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr "Koleksione me bashkëpunim"
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr "Përpunues Marrëdhënieje"
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.sr.po
+++ b/po/history.sr.po
@@ -1,0 +1,1101 @@
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: FULL NAME <email address hidden>\n"
+"Language-Team: Serbian (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/sr/)\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.sv.po
+++ b/po/history.sv.po
@@ -1,0 +1,1118 @@
+#
+# Translators:
+# A. Regnander <email address hidden>, 2017
+# Jonatan Nyberg, 2016-2017,2021
+# efef6ec5b435a041fce803c7f8af77d2_2341d43, 2018,2020-2021
+# Staffan Vilcans, 2015
+# Staffan Vilcans, 2017,2019
+# Tom Sawyer, 2022
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: Tom Sawyer, 2022\n"
+"Language-Team: Swedish (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/sv/)\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "Avancerade relationer"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Albumspråk"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+#, fuzzy
+#| msgid "Amazon Coverart"
+msgid "Amazon cover art"
+msgstr "Amazon omslag"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "Anteckningar"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "Artist abonnemang"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+"Offentliga artistprenumerationer och diverse mindre användarcentrerade "
+"förbättringar ges ut."
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr "Artist abonneringar."
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr "Omslagsuppladdning"
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr "Dedikerad databasservrar"
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+"Redigerade visningsförbättringar, inaktiverade RDF-dumpar, nya "
+"installationsskript släpptes."
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr "Redigera anteckningsaviseringar"
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr "Redigera sökning"
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+"Genrer läggs till som en ny enhet, även om de fortfarande är nära knutna "
+"till folksonomitaggar."
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr "Förbättrad sökning"
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr "Installera skript"
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr "Förhållanderedigerare"
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr "Sökförbättringar"
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+#, fuzzy
+#| msgid "The Cover Art Archive becomes initially available"
+msgid "The Cover Art Archive becomes initially available."
+msgstr "Omslagsarkivet blir tillgängligt"
+
+#: DB:statistics.statistic_event/description:2012-10-10
+#, fuzzy
+#| msgid "The Cover Art Archive is officially released"
+msgid "The Cover Art Archive is officially released."
+msgstr "Omslagsarkivet har officiellt släppts"
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr "Användarförbättringar"
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.th.po
+++ b/po/history.th.po
@@ -1,0 +1,1097 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: th\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.tr.po
+++ b/po/history.tr.po
@@ -1,0 +1,1135 @@
+#
+# Translators:
+# ym syserror <email address hidden>, 2012
+# Nikolai Prokoschenko <email address hidden>, 2011
+# portik <email address hidden>, 2013
+# brtc <boratici@gmail.com>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2024-03-18 23:28+0000\n"
+"Last-Translator: brtc <boratici@gmail.com>\n"
+"Language-Team: Turkish <https://translations.metabrainz.org/projects/"
+"musicbrainz/statistics/tr/>\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Weblate 5.4\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr "Yeni, çok daha hızlı bir arama tekniği eklendi."
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr "Düzenlemeleri birkaç farklı kritere göre aramanın bir yolu yayınlandı."
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "Gelişmiş ilişkiler"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+"Pek çok tartışmanın ardından ilişki verileri sürüm sayfalarında "
+"görüntülenmeye başlıyor ve bu da onu çok daha görünür hale getiriyor."
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+"Başarılı bir Summer of Code'un ardından Ian McEwen, MusicBrainz ekibine "
+"katıldı."
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+"Kaliforniya'daki Digital West'te uzun yıllar geçirdikten sonra MetaBrainz "
+"projesi, tüm sunucuları Almanya'daki çok daha büyük bir özel sağlayıcı olan "
+"Hetzner'e taşıyor."
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+"Freenode'daki beklenmedik karışıklığın ardından tüm MetaBrainz resmi "
+"kanalları Libera.Chat'e taşıdı."
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "Albüm dilleri"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr "Amazon SoundUnwound'un betasını yapıyor"
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr "Bilgi notu desteği yayınlandı."
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "Bilgi notları"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "Sanatçı abonelikleri"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+"Sanatçı abonelikleri herkese açık hale getirildi ve kullanıcı odaklı çeşitli "
+"küçük iyileştirmeler yayınlandı."
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr "Sanatçı abonelikleri."
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr "BBC dinamik sanatçı sayfaları"
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+"BBC, MusicBrainz verilerini temel alan dinamik sanatçı sayfalarını kullanıma "
+"sunuyor."
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr "BBC, MetaBrainz ile ortak oldu"
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr "BookBrainz resmi MetaBrainz projesi oldu"
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr "CAA'nın ilk sürümü"
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr "CAA resmi sürümü"
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr "Özel veri tabanı sunucusu"
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr "E-posta doğrulama"
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+"Eski GSoC öğrencisi Roman Tsukanov, MetaBrainz için yarı zamanlı çalışmaya "
+"başladı."
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr "Frederik \"Freso\" S. Olesen, MetaBrainz Topluluk Yöneticisi oldu"
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+"FreeDB otomatik içe aktarma özelliği kapatıldı ve otomatik düzenleyici "
+"seçimleri yayınlandı. Kullanılmayan TRM'ler veri tabanından çıkarıldı."
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr "Ian McEwen işe alındı"
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr "Ian McEwen MetaBrainz'den ayrıldı"
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr "Ian McEwen kişisel nedenlerden dolayı projeden ayrılıyor."
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr "Oylamayı iyileştirin"
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr "Geliştirilmiş arama"
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr "Komut dosyalarını yükleyin"
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr "İtalyanca çeviri yayınlandı, IPI ve ISNI otomatik düzenlemeye dönüştü"
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr "Kartik Ohri MetaBrainz ekibine katıldı"
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+"Kartik Ohri, ListenBrainz, AcousticBrainz ve CritiqueBrainz'in yanı sıra "
+"gönüllü olarak önemli ölçüde yeniden yazdığı Android uygulaması üzerinde "
+"çalışmak üzere MetaBrainz ekibine katılıyor."
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr "Kuno Woudt, MusicBrainz için tam zamanlı çalışmaya başladı."
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr "Kuno Woudt tam zamanlı geliştirici olarak işe alındı"
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+"Last.fm, MetaBrainz'le anlaşarak MusicBrainz datasını kullanmaya başladı."
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr "Laurent \"zas\" Monin sistem yöneticisi oluyor"
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+"Daha çok Zas olarak bilinen Laurent Monin, sunucuların düzgün çalıştığından "
+"emin olmak ve yeni bir topluluk tartışma sistemine geçişe yardımcı olmak "
+"için ekibe özel sistem yöneticisi olarak katılıyor."
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr "Linkara Musica, MetaBrainz'in ilk ticari müşterisi oldu."
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+"MBBE_Bot, elle yapılması çok zaman alan ancak yine de düzenleme geçmişinde "
+"iz bırakması gereken düzeltmeleri yapmak için yaratılmıştır. Bu genellikle "
+"sorunlu alanlardaki URL'lerin kaldırılmasını, kapatılan alanlardaki "
+"URL'lerin sona erdi olarak işaretlenmesini ve diğer benzer toplu düzenleme "
+"işlerini içerir."
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr "MBBE_Bot çalışmaya başlıyor"
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr "MetaBrainz Oliver Charles'ı işe aldı"
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr "MetaBrainz başlatıldı"
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr "MetaBrainz projeleri Avrupa sunucularına taşınmayı tamamladı"
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr "MetaBrainz ilk müşterisiyle sözleşme imzaladı"
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+"MetaBrainz telif hakkı trol savaşını kazandı, Wikimedia görselleri düştü"
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr "MetaWeb imzalandı"
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr "MusicBrainz AcoustID desteği ekliyor"
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr "MusicBrainz ilk özel veri tabanı sunucusuna kavuştu."
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr "MusicBrainz, San Luis Obispo'daki Digital West Networks'e taşındı."
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr "Oliver Charles, MetaBrainz Vakfı'nın 1 numaralı çalışanı oldu."
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr "Oliver Charles, MusicBrainz'de tam zamanlı çalışmaya başladı."
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr "Oliver Charles, MusicBrainz'e tam zamanlı katıldı"
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.vi.po
+++ b/po/history.vi.po
@@ -1,0 +1,1100 @@
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2012-05-24 18:54+0000\n"
+"Last-Translator: FULL NAME <email address hidden>\n"
+"Language-Team: Vietnamese (http://app.transifex.com/musicbrainz/musicbrainz/"
+"language/vi/)\n"
+"Language: vi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.zh.po
+++ b/po/history.zh.po
@@ -1,0 +1,1128 @@
+#
+# Translators:
+# Dian Li <email address hidden>, 2009-2019
+# Gary Liu, 2022
+# suming <331874545@qq.com>, 2023.
+# claybiockiller <clay0305@hotmail.com>, 2023.
+# darlingz <yagamidai@gmail.com>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2024-05-04 09:42+0000\n"
+"Last-Translator: darlingz <yagamidai@gmail.com>\n"
+"Language-Team: Chinese (Simplified) <https://translations.metabrainz.org/"
+"projects/musicbrainz/statistics/zh_Hans/>\n"
+"Language: zh\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.5.3\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr "已放弃\"Do Not Cluster\"基准"
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr "已放弃\"feat.\"标准化"
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr "1200像素预览图"
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+"1200像素预览图已加入Cover Art Archive，向用户提供尺寸恒定的超大图，无需直接上"
+"传。"
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+"加入了一个基于Discourse 的新论坛，以替代老式论坛和(现已不活跃)邮件列表，将社"
+"区交流集中于一处。"
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr "允许投票支持和反对已有的folksonomy标签，而不仅是自己建立。"
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr "发布了Picard标签系统的主要更新，含大量漏洞修复和功能改进。"
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+"发布了新的\"投票建议\"页面，包含可用于辅助编辑者发现感兴趣和/或重要的编辑并投"
+"票的编辑搜索预设。"
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr "发布了一个新的基于AJAX的封面上传器，为发行版添加封面更容易了。"
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr "现在当用户收到了新的编辑注释时会有一个新的横幅消息通知。"
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr "添加了一个新的、更快的搜索机制。"
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr "MusicBrainz社区的意见分歧导致了一场大争论。"
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+"一个非常重要的架构改动版本，引入了新的实体类型（区域），支持艺术家和唱片公司"
+"的 ISNI 代码，并允许一个发行拥有多个发行事件/活动。"
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr "发布了一个基于多种不同条件的编辑搜索方式。"
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+"庞培法布拉大学大学的音乐技术小组共同宣布成立 AcousticBrainz，其目的是在庞杂资"
+"源中获取音乐的声学信息。"
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr "高级关系"
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr "专辑语言"
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr "发布了专辑语言和改良的编辑表格，优化了Guess Case。"
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr "亚马逊推出了SoundUnwound的测试版。"
+
+#: DB:statistics.statistic_event/title:2004-02-24
+#, fuzzy
+#| msgid "Amazon Coverart"
+msgid "Amazon cover art"
+msgstr "来自亚马逊的封面"
+
+#: DB:statistics.statistic_event/description:2004-02-24
+#, fuzzy
+#| msgid "Amazon coverart support released."
+msgid "Amazon cover art support released."
+msgstr "发布了亚马逊封面支持。"
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr "发布了一个改进了的发行版编辑器和新的站点设计。"
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr "发布了一个允许通过关联中的艺术家(如果与艺术家名称不同)确定名单的更新。"
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr "发布了注释支持。"
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr "注释"
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr "订阅艺术家"
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr "艺术家关注公开化和多种较小用户体验改进发布。"
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr "合作编辑收藏"
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr "发布了收藏，评分，CDStubs和LastUpdate功能。"
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr "专用数据库服务器"
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr "优化了编辑显示，关闭了RDF转储，发布了新的安装脚本。"
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr "编辑记录在未登录时可见"
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr "编辑备注通知"
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr "编辑搜索"
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+"编辑器 ojnkpjg 运行脚本时，根据 DiscID 值设置音轨时长，从而在编辑中产生巨大的"
+"峰值。"
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr "电子邮件验证"
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+"发布了Folksonomy标签和编辑器订阅功能。此外，现在可以批量添加同一专辑中多个不"
+"同音轨的关联。"
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+"关闭了FreeDB自动导入功能，发布了自动编辑推选功能。未使用的TRM已从数据库中精"
+"简。"
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr "大冲突"
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr "改善投票"
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr "改善搜索"
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr "发布了索引搜索以及新的基于XML的网页端服务。"
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr "安装脚本"
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr "发布了意大利文翻译，IPI和ISNI为自动编辑。"
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr "发布了链接到MusicBrainz功能，专辑事件以及编辑提示。"
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr "链接"
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+"MusicBrainz 与 MusicIP 合作，并开始使用 MusicDNS 的 PUID 声学指纹。 Picard 成"
+"为有着 PUID 支持的官方 MusicBrainz 跟踪器，这可以减少编辑活动。"
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr "MusicIP PUID"
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr "发布了NGS，MusicBrainz的大规模重构！"
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr "非专辑曲目"
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr "发布了非专辑曲目。"
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr "发布了Picard 1.0"
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr "发布了Picard 2.0"
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr "关联编辑器"
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr "关联名单可用"
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr "发布了编辑器"
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr "发布了专辑编辑器以及Guess Case。"
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr "AcousticBrainz 项目上线"
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr "顶部菜单检索得到改善，复制艺术家、编辑专辑全部，曲目时间编辑功能发布。"
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr "从 DiscIDs 设置音轨时长"
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr "投票建议"
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr "作品属性"
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/po/history.zh_Hant.po
+++ b/po/history.zh_Hant.po
@@ -1,0 +1,1097 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh_Hant\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: DB:statistics.statistic_event/title:2015-09-08
+msgid "\"Do Not Cluster\" guideline dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-04-11
+msgid "\"feat.\" standardization dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-19
+msgid "1200px thumbnails"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-19
+msgid ""
+"1200px thumbnails are added to the Cover Art Archive, providing users with a "
+"very large image with a consistent size that avoids having to use the "
+"original uploads directly."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-03-01
+msgid ""
+"A Discourse forum platform is added to replace both the old-school forums "
+"and the (by now dead) mailing lists and unify community communication in one "
+"place."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-29
+msgid ""
+"A change is introduced that allows voting for and against existing "
+"folksonomy tags, rather than only adding your own."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-07-19
+msgid ""
+"A major update for the Picard tagger is released, with a huge amount of "
+"bugfixes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-11-12
+msgid ""
+"A new \"Voting suggestions\" page is released, containing predefined edit "
+"searches to help editors find interesting and/or important edits to review "
+"and vote on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-08-05
+msgid ""
+"A new AJAX coverart uploader is released, making it easier to add cover art "
+"to releases."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-12-28
+msgid ""
+"A new banner message now notifies users whenever they receive a new edit "
+"note."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-04-05
+msgid "A new, much faster search mechanism is added."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-08-15
+msgid "A rift in the MusicBrainz community leads to a Great Dispute."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-05-15
+msgid ""
+"A very substantial schema change release adds a new entity type (areas), "
+"support for ISNI codes for artists and labels, and the possibility to have "
+"more than one release event on one release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-11-10
+msgid ""
+"A way to search for edits based on several different criteria is released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-11-19
+msgid ""
+"AcousticBrainz, which aims to crowd source acoustic information for music, "
+"is announced in cooperation with the Music Technology Group at Universitat "
+"Pompeu Fabra."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-10
+msgid "Advanced relationships"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-10
+msgid ""
+"Advanced relationships that allow users to connect basic data entities is "
+"relased and unused TRMs pruned from the database. Inline editing is turned "
+"off by default, causing a drop in voting activity."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-06-25
+msgid ""
+"After a lot of behind-the-scenes drama, MetaBrainz wins a legal battle "
+"against a copyright troll who tried to sue because of the use of Wikimedia "
+"Commons images. Commons images are still dropped from MusicBrainz sites to "
+"avoid further issues until Wikimedia makes changes that make image reuse "
+"more safe."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-11-23
+msgid ""
+"After a lot of debate, relationship data starts being displayed on release "
+"pages, making it a lot more visible."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-09-01
+msgid ""
+"After a successful Summer of Code, Ian McEwen joins the MusicBrainz team."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-11-08
+msgid ""
+"After many years at Digital West in California, the MetaBrainz project moves "
+"all servers to a much larger dedicated provider in Germany, Hetzner."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-10
+msgid ""
+"After several years as a community-driven only project, BookBrainz is "
+"adopted as an official project and given an actual developer position with "
+"the hiring of Monkey."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-26
+msgid ""
+"After unexpected upheaval on Freenode, MetaBrainz moves all official "
+"channels to Libera.Chat instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-05-22
+msgid "Album languages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-05-22
+msgid ""
+"Album languages, guess case improvements and revamps edit forms released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-19
+msgid ""
+"Aliases are added to the three entity types that were still missing them: "
+"recordings, releases and release groups. This allows storing aliases for, "
+"for example, English names of Asian release groups."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-19
+msgid "Aliases for recordings, releases and release groups"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-01
+msgid ""
+"Amazon betas <a href=\"http://web.archive.org/web/20210123164029/https://www."
+"wired.com/2008/09/amazon-takes-on/\">SoundUnwound</a> with data from "
+"MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-01
+msgid "Amazon betas SoundUnwound"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-02-24
+msgid "Amazon cover art"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-02-24
+msgid "Amazon cover art support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-07-12
+msgid "An improved release editor and a new site design are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-06-02
+msgid ""
+"An update is released that allows specifying a credit for artists in a "
+"relationship, if not the same as the artist name."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-11-14
+msgid "Annotation support released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-11-14
+msgid "Annotations"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-05-15
+msgid "Areas, ISNI codes and multiple release events per release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-22
+msgid "Artist subscriptions"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-02-13
+msgid ""
+"Artist subscriptions made public and various smaller user centric "
+"improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-22
+msgid "Artist subscriptions."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-04-11
+msgid ""
+"As part of a long term move towards more fidelity to the original data, we "
+"stop standardizing \"featuring\" and all its variants to \"feat.\", and ask "
+"editors to use whatever is printed instead."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-07-30
+msgid "BBC dynamic artist pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-07-30
+msgid "BBC launches the dynamic artist pages based on MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-06-28
+msgid "BBC partners with MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-10
+msgid "BookBrainz becomes official MetaBrainz project"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-04-30
+msgid "CAA initial release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-10
+msgid "CAA official release"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-06-20
+msgid "CatQuest becomes Instrument Inserter"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-06-20
+msgid ""
+"CatQuest officially takes over from reosarevok as the main person for adding "
+"new instruments to MusicBrainz, with the newly created Instrument Inserter "
+"position."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-08-08
+msgid "Collaborative collections"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-08-08
+msgid ""
+"Collection owners are now able to allow other editors to also add/remove "
+"entities from any of their collections."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-11-24
+msgid "Collection, Ratings, CDStubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-11-24
+msgid "Collection, Ratings, CDStubs, LastUpdate released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-05-18
+msgid ""
+"Collections can now be merged, in case an editor wants to consolidate "
+"several of their collections into one. Additionally, it is now possible to "
+"create series of artists, and to rate places (the only entity that could be "
+"reviewed on CritiqueBrainz but not rated on MusicBrainz)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-08-05
+msgid "Cover Art Uploader"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-03-29
+msgid "Dedicated database server"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-03-01
+msgid "Discourse unifies community communication"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-07-25
+msgid "Easier edit note adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-05-09
+msgid ""
+"Edit display improvements, turned off RDF dumps, new install scripts "
+"released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-02-18
+msgid "Edit history visible without logging in"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-12-28
+msgid "Edit note notifications"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-07-25
+msgid ""
+"Edit notes can now be added when creating an edit, making it much easier for "
+"editors to explain their changes."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-11-10
+msgid "Edit search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-12-07
+msgid ""
+"Editor ojnkpjg runs a script setting track times from DiscID values, "
+"creating a huge spike in edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-30
+msgid ""
+"Edits made by editors to their own release additions within 1 hour of adding "
+"them are now auto-edits, as are \"Add recording\" and \"Remove alias\" edits."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-06-07
+msgid "Email verification"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-25
+msgid ""
+"Empty labels, release groups and works are now auto-removed after 24 hours "
+"of being unused, in the same way artists already were before."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-25
+msgid "Empty labels, release groups and works start being auto-removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-09-17
+msgid ""
+"Event support is added to MusicBrainz, allowing storing information about "
+"concerts and festivals. Also part of this schema change release is a proper "
+"way to indicate the content of data tracks in release tracklists, and the "
+"extension of tagging to areas, instruments and series."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-09-17
+msgid "Event support, data tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-10-17
+msgid ""
+"Folksonomy tagging and editor subscriptions are released. Additionally, it's "
+"now possible to batch-add relationships to multiple tracks on a release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-04
+msgid ""
+"Former GSoC student Roman Tsukanov begins working for MetaBrainz part-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-08-06
+msgid "Frederik \"Freso\" S. Olesen becomes MetaBrainz Community Manager"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-10-10
+msgid ""
+"FreeDB auto import feature turned off and autoeditor elections released. "
+"Unused TRMs pruned from the database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-10-10
+msgid "FreeDB off/Autoeditors"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-08-06
+msgid ""
+"Freso becomes the first MetaBrainz Community Manager, tasked with helping "
+"resolve conflicts in the community and keeping an eye on their needs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-11-02
+msgid "Genre added as a new entity"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-11-02
+msgid ""
+"Genres are added as a new entity, although still tightly tied to folksonomy "
+"tags."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-08-15
+msgid "Great Dispute"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-27
+msgid "Guess feat. buttons"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-26
+msgid "IRC channels move to Libera.Chat"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-09-01
+msgid "Ian McEwen hired"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-07-17
+msgid "Ian McEwen leaves MetaBrainz"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-07-17
+msgid "Ian McEwen leaves the project for personal reasons."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-06-17
+msgid "Imported CD Baby catalog as CD Stubs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-06-17
+msgid ""
+"Imported the metadata from the CD Baby catalog into our CD Stubs collection."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-07-24
+msgid "Improve voting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-04-05
+msgid "Improved search"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-02-11
+msgid ""
+"In an effort to reduce the size of the open edit queue and force less "
+"waiting for changes, the length of time edits stay open before expiration is "
+"reduced from 14 to 7 days."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-27
+msgid ""
+"In order to make it easier to fix a lot of cases where featured artists are "
+"still part of the track / release titles rather than the artists, guess "
+"feat. buttons are added that greatly simplify the process."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-12
+msgid "In preparation for NGS, editing is turned off until release."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-02
+msgid ""
+"In preparation for NGS, editors are encouraged to avoid editing until "
+"release unless entirely necessary."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-05
+msgid "Indexed search/XML WS"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-05
+msgid "Indexes search and a new XML based Web Service are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-01-17
+msgid "Inline edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-01-17
+msgid "Inline edits, new reports, improved data import scripts."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2004-05-09
+msgid "Install scripts"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-12-31
+msgid "Instrument images, recordings' first release date"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-14
+msgid "Instruments and series"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-01
+msgid "Italian translation released, IPI and ISNI become autoedits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-02-23
+msgid "Kartik Ohri joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-23
+msgid ""
+"Kartik Ohri joins the MetaBrainz team to work on ListenBrainz, "
+"AcousticBrainz and CritiqueBrainz, plus the Android app, which he had "
+"already significantly rewritten as a volunteer."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-12-14
+msgid "Kuno Woudt begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-12-14
+msgid "Kuno Woudt hired as full-time developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-04-01
+msgid "Labels/data quality"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-11-07
+msgid "Last.fm"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-11-07
+msgid "Last.fm signs up with MetaBrainz and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-28
+msgid "Laurent \"zas\" Monin becomes sysadmin"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-28
+msgid ""
+"Laurent Monin, better known as Zas, joins the team as a dedicated systems "
+"administrator, to make sure the servers run properly and help transition to "
+"a new community discussion system."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-12-28
+msgid ""
+"Link to MusicBrainz feature, release events and edit suggestions released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-01-20
+msgid "Linkara Musica becomes first commercial customer of MetaBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-12-28
+msgid "Linking"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-10-07
+msgid ""
+"MBBE_Bot is created to make fixes that are too time-consuming to do by hand, "
+"but should still leave a trace in edit history. This usually involves "
+"removing URLs from problematic domains, marking URLs from domains that have "
+"been closed as ended, and other similar batch-editing jobs."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-10-07
+msgid "MBBE_Bot starts running"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-10-23
+msgid "Menus/Client scripting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-05-18
+msgid "Mergeable collections, artist series and ratable places"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-21
+msgid "MetaBrainz accepts three students for Google Summer of Code."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-09-23
+msgid "MetaBrainz hires Oliver Charles"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-04-19
+msgid "MetaBrainz launched"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-11-08
+msgid "MetaBrainz projects complete move to European servers"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-01-20
+msgid "MetaBrainz signs first customer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-06-25
+msgid "MetaBrainz wins copyright troll battle, Wikimedia images dropped"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-04-01
+msgid "MetaWeb becomes a MusicBrainz data user."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-01
+msgid "MetaWeb signed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-30
+msgid "More auto-edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-11-16
+msgid ""
+"More edit types are made auto-edits for everyone: \"Add relationship\" and "
+"\"Add release\"; and \"Add\", \"Edit\" and \"Remove release label\". "
+"Additionally, the German, French and Dutch translations are available on the "
+"main server."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-02-27
+msgid "MusicBrainz Move"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-02-08
+msgid "MusicBrainz Server source code moved to Git from Subversion."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-01-12
+msgid "MusicBrainz adds AcoustID support"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-03-29
+msgid "MusicBrainz gets its first dedicated database server."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2016-02-22
+msgid ""
+"MusicBrainz itself gets a new design to better match the rest of the *Brainz "
+"family."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-02-27
+msgid "MusicBrainz moved to Digital West Networks in San Luis Obispo."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-03-12
+msgid ""
+"MusicBrainz partners with MusicIP and starts using MusicDNS's PUID acoustic "
+"fingerprints. Picard becomes the official MusicBrainz tagger with PUID "
+"support, which causes edit activity to decrease."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-03-12
+msgid "MusicIP PUID"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-12
+msgid "NGS No-Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-02
+msgid "NGS Reduced Editing Phase"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-05-18
+msgid "NGS Release"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-05-18
+msgid "NGS, a MusicBrainz major rewrite, is released!"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2016-02-22
+msgid "New MusicBrainz design"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-10-31
+msgid "New entity auto-editing period extended to 24 hours"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-02-17
+msgid ""
+"Nicolás Tamargo (reosarevok) becomes the MusicBrainz style leader, and a "
+"new, more official style process using Jira is established."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2003-10-13
+msgid "Non album tracks"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-13
+msgid "Non album tracks are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2008-09-23
+msgid "Oliver Charles becomes employee #1 of MetaBrainz Foundation."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2010-06-18
+msgid "Oliver Charles begins working for MusicBrainz full-time."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-06-18
+msgid "Oliver Charles joins MusicBrainz full-time"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-06-30
+msgid ""
+"Our old search server gets a significant upgrade with its move to Solr, "
+"including almost-instant index updates."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-10-14
+msgid "PUID support is removed"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2021-04-05
+msgid "Pagination added for relationships, user tags"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-04-05
+msgid ""
+"Pagination was added for two very long lists that sometimes couldn't be "
+"loaded in full because of timeouts: user tags and entity relationships."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-06-02
+msgid "Picard 1.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-07-19
+msgid "Picard 2.0 released"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-10-31
+msgid ""
+"Rather than having to notice any errors during a fairly brief 1 hour period, "
+"editors now have 24 hours to correct errors in the data they have added "
+"without needing a vote."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-10-15
+msgid "Relationship Editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-02
+msgid "Relationship credits become available"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-11-23
+msgid "Relationships displayed on release pages"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-04-06
+msgid "Release \"stubs\", minimum voting period for destructive edits"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2009-05-24
+msgid "Release Groups, ISRCs, CDStub searching"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-07-12
+#: DB:statistics.statistic_event/title:2003-10-19
+msgid "Release editor"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-10-19
+msgid "Release editor and Guess Case released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2009-05-24
+msgid ""
+"Release groups, ISRC support, CDStub searching and search fixes released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-04-06
+msgid ""
+"Releases can now be added without any mediums, for cases where the only "
+"information available is, for example, a title + date + label + catalog "
+"number entry in a catalog. Additionally, any destructive edits such as "
+"entity merges and removals no longer close immediately once they get 3 Yes "
+"votes, but they remain open for at least 48 hours to ensure people who "
+"oppose them have time to see them."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-09-06
+msgid ""
+"Roman Tsukanov decides not to renew his contract. Sambhav Kothari and Param "
+"Singh are hired as replacements to work on search and Picard and on "
+"ListenBrainz, respectively."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-04
+msgid "Roman Tsukanov joins the MetaBrainz team"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-01-08
+msgid "SG5 Fixes"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-09-06
+msgid "Sambhav Kothari and Param Singh replace Roman Tsukanov"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2018-09-09
+msgid ""
+"Sambhav Kothari leaves MetaBrainz after a lot of hard work getting the SOLR "
+"server ready. Nicolás Tamargo (reosarevok) joins as a programmer part-time "
+"in addition to his style and support positions, to work on MusicBrainz."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-09-09
+msgid "Sambhav Kothari leaves, Nicolás Tamargo joins as a programmer"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2006-12-17
+msgid "Search improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-11-16
+msgid "Several new auto-edit types and translations"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-05-16
+msgid ""
+"Since the Virtual Machine project tended to just lag way behind current data "
+"because of the time required to always push new versions, it is dropped and "
+"users are suggested to just run their own Docker setup for MusicBrainz "
+"(which the Virtual Machine already did behind the scenes)."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2008-04-21
+msgid "SoC 2008"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2018-06-30
+msgid "Solr-based search server deployed"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-12-31
+msgid ""
+"Some instrument pages start displaying instrument illustrations by IROM. "
+"Additionally, a first release date starts being calculated and displayed for "
+"recordings based on the releases they appear on."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-01-08
+msgid ""
+"Style Guideline 5 workaround introduced and unused TRMs pruned from the "
+"database."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-10-17
+msgid "Style process updated again, reosarevok \"promoted\" to Style BDFL"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-04-01
+msgid "Support for Labels and data quality are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-06-29
+msgid "Tag up/downvoting"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-10-17
+msgid "Tags, editor subscriptions, relationship batch-adding"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-11-19
+msgid "The AcousticBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2022-02-16
+msgid "The AcousticBrainz project is discontinued"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2011-08-03
+msgid "The Android app goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2007-06-28
+msgid ""
+"The BBC becomes a MetaBrainz customer and starts using MusicBrainz data."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-04-30
+msgid "The Cover Art Archive becomes initially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-10
+msgid "The Cover Art Archive is officially released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-05-19
+msgid "The CritiqueBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2021-02-01
+msgid ""
+"The Italian translation, mostly worked on by salo.rock, is officially "
+"released. Adding the first IPI and/or ISNI code for an entity becomes an "
+"autoedit, unless the same code is already in use for another."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-09-17
+msgid "The ListenBrainz project goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-04-19
+msgid ""
+"The MetaBrainz Foundation, the legal home for MusicBrainz is announced to "
+"the public."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2020-05-16
+msgid "The MusicBrainz Virtual Machine is replaced by MusicBrainz Docker"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-17
+msgid ""
+"The alpha version of ListenBrainz, an open source and open data alternative "
+"to Last.fm®, goes live."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-19
+msgid "The beta version of CritiqueBrainz is launched."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-10-14
+msgid ""
+"The diminishing quality of the PUID fingerprinting service and the continued "
+"availability of an open source alternative in AcoustID leads to the decision "
+"of dropping PUIDs from MusicBrainz and supporting only AcoustID."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2020-02-18
+msgid ""
+"The edit history for entities is made visible even when logged out, to make "
+"it easier to understand how each entity has changed (edit notes are kept "
+"hidden to preserve some privacy)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-06-02
+msgid ""
+"The first full-version release of the Picard tagger comes out, with a lot of "
+"changes and improvements."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2011-08-03
+msgid ""
+"The first version of the MusicBrainz Android app, a Google Summer of Code "
+"project by Jamie McDonald, is made officially available."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-09-08
+msgid ""
+"The increasingly controversial \"Do Not Cluster\" guideline, which forbid "
+"relationship clusters such as linking every Jackson sibling to each other, "
+"is dropped - avoiding duplicate data becomes a task for relationship "
+"designers, not users entering the data."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2015-05-18
+msgid "The new MetaBrainz website goes live"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2015-05-18
+msgid ""
+"The new MetaBrainz website, featuring an all-new design and online sign-up "
+"for commercial users, is launched, replacing the one designed in the year "
+"2000!"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-01-12
+msgid ""
+"The open source fingerprinting solution AcoustID (developed by friend of "
+"MusicBrainz Lukáš Lalinský) starts being used alongside PUID on MusicBrainz "
+"fingerprint pages."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2012-10-15
+msgid ""
+"The relationship editor, for bulk-editing relationships for a release, is "
+"released to production."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2006-12-17
+msgid "The search features and web service improvements are released."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-10-17
+msgid ""
+"The style process is updated again. Rather than requiring long, often angry "
+"community debate until something is passed by community consensus without a "
+"veto, decisions are taken by a BDFL who consults the community when needed. "
+"Nicolás Tamargo (reosarevok) is \"promoted\" from style leader to style BDFL."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2013-06-24
+msgid ""
+"The voting period for edits that get a No vote is extended to give users "
+"more time to react to the issues."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2005-10-23
+msgid ""
+"Top menu navigation improved, duplicate artists, album edit all, track time "
+"editing features released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2007-12-07
+msgid "Track times set from DiscIDs"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-05-14
+msgid ""
+"Two new entity types are added to MusicBrainz: instruments and series. "
+"Series of recordings, releases, release groups and works are supported."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2005-02-13
+msgid "User improvements"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2003-06-07
+msgid "Users now have to verify their email address for editing."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2019-04-26
+msgid ""
+"Version 1 of the web service (already deprecated since 2011) is finally "
+"taken down for good (more than a year after announcing it would happen in "
+"six months!)."
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2004-07-24
+msgid "Voting logic was improved, web based autoeditor elections released."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-06-24
+msgid "Voting period for contested edits extended"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2013-02-11
+msgid "Voting period shortened to 7 days"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-11-12
+msgid "Voting suggestions"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2019-04-26
+msgid "Web service version 1 taken down"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2022-02-16
+msgid ""
+"With the AcousticBrainz project deemed to not have fulfilled its original "
+"goals, the MetaBrainz Foundation decides to stop work on it, with a view to "
+"shut down the site in 2023."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2014-03-17
+#: ../root/statistics/stats.js:43
+msgid "Work attributes"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2014-03-17
+msgid ""
+"Works get their first attributes (such as keys) allowing us to store data "
+"that doesn't make sense as relationships but deserves more than an "
+"annotation entry."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2017-03-13
+msgid "Yvanzo joins MusicBrainz as a developer"
+msgstr ""
+
+#: DB:statistics.statistic_event/description:2017-03-13
+msgid ""
+"Yvanzo joins the development team as a second dedicated MusicBrainz "
+"developer."
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2010-02-08
+msgid "mb_server now hosted on Git"
+msgstr ""
+
+#: DB:statistics.statistic_event/title:2012-02-17
+msgid "reosarevok becomes the MusicBrainz style leader"
+msgstr ""

--- a/root/static/scripts/common/i18n/history.js
+++ b/root/static/scripts/common/i18n/history.js
@@ -1,0 +1,13 @@
+/*
+ * @flow strict
+ * Copyright (C) 2024 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as wrapGettext from './wrapGettext.js';
+
+export const l_history: (string) => string =
+  wrapGettext.dgettext('history');

--- a/root/static/scripts/common/i18n/wrapGettext.js
+++ b/root/static/scripts/common/i18n/wrapGettext.js
@@ -46,6 +46,7 @@ function tryLoadDomain(domain: GettextDomainT) {
 type GettextDomainT =
   | 'attributes'
   | 'countries'
+  | 'history'
   | 'instrument_descriptions'
   | 'instruments'
   | 'languages'

--- a/root/static/scripts/jed-data.mjs
+++ b/root/static/scripts/jed-data.mjs
@@ -33,6 +33,13 @@ const jedData: JedData = {
           plural_forms: 'nplurals=2; plural=(n != 1);',
         },
       },
+      history: {
+        '': {
+          domain: 'history',
+          lang: 'en',
+          plural_forms: 'nplurals=2; plural=(n != 1);',
+        },
+      },
       instrument_descriptions: {
         '': {
           domain: 'instrument_descriptions',

--- a/root/vars.js
+++ b/root/vars.js
@@ -62,6 +62,8 @@ declare var l_countries: typeof l;
 declare var ln_countries: typeof ln;
 declare var lp_countries: typeof lp;
 
+declare var l_history: typeof l;
+
 declare var l_instrument_descriptions: typeof l;
 declare var ln_instrument_descriptions: typeof ln;
 declare var lp_instrument_descriptions: typeof lp;

--- a/script/.check_eslint_rule_config.yaml
+++ b/script/.check_eslint_rule_config.yaml
@@ -48,6 +48,7 @@ globals:
   l_countries: readonly
   ln_countries: readonly
   lp_countries: readonly
+  l_history: readonly
   l_instrument_descriptions: readonly
   ln_instrument_descriptions: readonly
   lp_instrument_descriptions: readonly

--- a/webpack/constants.mjs
+++ b/webpack/constants.mjs
@@ -32,6 +32,7 @@ export {WEBPACK_MODE};
 export const GETTEXT_DOMAINS = [
   'attributes',
   'countries',
+  'history',
   'instrument_descriptions',
   'instruments',
   'languages',


### PR DESCRIPTION
### Implement MBS-13675

# Description
History events (used in the history page and the timeline) are completely different from most statistics, and it seems sensible to translate them separately. In many cases, they probably are even less important than the rest of the statistics strings.

# Testing
Tested manually that both history and timeline pages load and show the right translations. I had to `make install` the translations to generate the `.mo` files in order for them to work on the timeline page.

# Notes
I copied the events into the history `.po` files with:

```
#!/bin/bash
for filename in statistics.*.po; do
    output=${filename/statistics/history}
    msggrep $filename -N DB:statistics.statistic_event/* -o $output
done

```

# Further action

1. Update translations and source messages (as in [releasing beta](https://github.com/metabrainz/musicbrainz-server/blob/01710ae7a494f7ba95e107dbdacfc3e937a792dc/RELEASING.md#release-beta))
2. Merge this pull request introducing the translation domain `history`
3. Update translations and source messages (as in [releasing beta](https://github.com/metabrainz/musicbrainz-server/blob/01710ae7a494f7ba95e107dbdacfc3e937a792dc/RELEASING.md#release-beta)) again
4. Create and set up the translation component History in Weblate
5. Test it
6. Check that there is still [no comment to the strings to be removed](https://translations.metabrainz.org/projects/musicbrainz/statistics/?q=has:comment%20%20location:statistic_event#search)
7. Merge a second pull request cleaning up the translation domain `statistics`
8. Release beta completely
