### PR TITLE
MBS-13676: Remove alignment spacing when there is no cover art indicator

### DIFF
--- a/root/components/list/EventList.js
+++ b/root/components/list/EventList.js
@@ -56,7 +56,7 @@ component EventList(
       const nameColumn = defineNameColumn<EventT>({
         descriptive: false, // since dates have their own column
         order: order,
-        showArtworkPresence: true,
+        showArtworkPresence: events.some((event) => event.event_art_presence === 'present'),
         sortable: sortable,
         title: l('Event'),
       });

--- a/root/components/list/EventList.js
+++ b/root/components/list/EventList.js
@@ -56,7 +56,8 @@ component EventList(
       const nameColumn = defineNameColumn<EventT>({
         descriptive: false, // since dates have their own column
         order: order,
-        showArtworkPresence: events.some((event) => event.event_art_presence === 'present'),
+        showArtworkPresence: events
+          .some((event) => event.event_art_presence === 'present'),
         sortable: sortable,
         title: l('Event'),
       });

--- a/root/components/list/ReleaseGroupList.js
+++ b/root/components/list/ReleaseGroupList.js
@@ -65,7 +65,7 @@ export component ReleaseGroupListTable(
       const nameColumn = defineNameColumn<ReleaseGroupT>({
         descriptive: false, // since ACs are in the next column
         order: order,
-        showArtworkPresence: true,
+        showArtworkPresence: releaseGroups.some((group) => group.hasCoverArt),
         sortable: sortable,
         title: l('Title'),
       });

--- a/root/components/list/ReleaseList.js
+++ b/root/components/list/ReleaseList.js
@@ -60,7 +60,8 @@ component ReleaseList(
       const nameColumn = defineNameColumn<ReleaseT>({
         descriptive: false, // since ACs are in the next column
         order: order,
-        showArtworkPresence: releases.some((release) => release.cover_art_presence === 'present'),
+        showArtworkPresence: releases
+          .some((release) => release.cover_art_presence === 'present'),
         sortable: sortable,
         title: l('Release'),
       });

--- a/root/components/list/ReleaseList.js
+++ b/root/components/list/ReleaseList.js
@@ -60,7 +60,7 @@ component ReleaseList(
       const nameColumn = defineNameColumn<ReleaseT>({
         descriptive: false, // since ACs are in the next column
         order: order,
-        showArtworkPresence: true,
+        showArtworkPresence: releases.some((release) => release.cover_art_presence === 'present'),
         sortable: sortable,
         title: l('Release'),
       });

--- a/root/release_group/ReleaseGroupIndex.js
+++ b/root/release_group/ReleaseGroupIndex.js
@@ -35,85 +35,82 @@ import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import ReleaseGroupLayout from './ReleaseGroupLayout.js';
 
-function getReleaseStatusTableBuilder(showArtworkPresence: boolean) {
-  function buildReleaseStatusTable(
-    $c: CatalystContextT,
-    releaseStatusGroup: $ReadOnlyArray<ReleaseT>,
-    releaseGroupCreditId: number | void,
-  ) {
-    const status = releaseStatusGroup[0].status;
-    return (
-      <React.Fragment key={status ? status.name : 'no-status'}>
-        <tr className="subh">
-          {$c.user ? <th /> : null}
-          <th colSpan={$c.session?.tport == null ? 8 : 9}>
-            {status?.name
-              ? lp_attributes(status.name, 'release_status')
-              : lp('(unknown)', 'release status')}
-          </th>
-        </tr>
-        {releaseStatusGroup.map((release, index) => (
-          <tr className={loopParity(index)} key={release.id}>
-            {$c.user
-              ? (
-                <td>
-                  <input
-                    name="add-to-merge"
-                    type="checkbox"
-                    value={release.id}
-                  />
-                </td>
-              ) : null}
-            <td>
-              <EntityLink
-                entity={release}
-                showArtworkPresence={showArtworkPresence}
-              />
-            </td>
-            {/* The class being added is for usage with userscripts */}
-            <td className={
-              releaseGroupCreditId === release.artistCredit.id
-                ? null
-                : 'artist-credit-variation'}
-            >
-              <ArtistCreditLink artistCredit={release.artistCredit} />
-            </td>
-            <td>
-              {nonEmpty(release.combined_format_name)
-                ? release.combined_format_name
-                : l('[missing media]')}
-            </td>
-            <td>
-              {nonEmpty(release.combined_track_count)
-                ? release.combined_track_count
-                : lp('-', 'missing data')}
-            </td>
-            <td>
-              <ReleaseEvents events={release.events} />
-              {manifest.js(
-                'common/components/ReleaseEvents',
-                {async: 'async'},
-              )}
-            </td>
-            <td>
-              <ReleaseLabelList labels={release.labels} />
-            </td>
-            <td>
-              <ReleaseCatnoList labels={release.labels} />
-            </td>
-            <td className="barcode-cell">{formatBarcode(release.barcode)}</td>
-            {$c.session?.tport == null ? null : (
+function buildReleaseStatusTable(
+  $c: CatalystContextT,
+  releaseStatusGroup: $ReadOnlyArray<ReleaseT>,
+  releaseGroupCreditId: number | void,
+  showArtworkPresence: boolean,
+) {
+  const status = releaseStatusGroup[0].status;
+  return (
+    <React.Fragment key={status ? status.name : 'no-status'}>
+      <tr className="subh">
+        {$c.user ? <th /> : null}
+        <th colSpan={$c.session?.tport == null ? 8 : 9}>
+          {status?.name
+            ? lp_attributes(status.name, 'release_status')
+            : lp('(unknown)', 'release status')}
+        </th>
+      </tr>
+      {releaseStatusGroup.map((release, index) => (
+        <tr className={loopParity(index)} key={release.id}>
+          {$c.user
+            ? (
               <td>
-                <TaggerIcon entityType="release" gid={release.gid} />
+                <input
+                  name="add-to-merge"
+                  type="checkbox"
+                  value={release.id}
+                />
               </td>
+            ) : null}
+          <td>
+            <EntityLink
+              entity={release}
+              showArtworkPresence={showArtworkPresence}
+            />
+          </td>
+          {/* The class being added is for usage with userscripts */}
+          <td className={
+            releaseGroupCreditId === release.artistCredit.id
+              ? null
+              : 'artist-credit-variation'}
+          >
+            <ArtistCreditLink artistCredit={release.artistCredit} />
+          </td>
+          <td>
+            {nonEmpty(release.combined_format_name)
+              ? release.combined_format_name
+              : l('[missing media]')}
+          </td>
+          <td>
+            {nonEmpty(release.combined_track_count)
+              ? release.combined_track_count
+              : lp('-', 'missing data')}
+          </td>
+          <td>
+            <ReleaseEvents events={release.events} />
+            {manifest.js(
+              'common/components/ReleaseEvents',
+              {async: 'async'},
             )}
-          </tr>
-        ))}
-      </React.Fragment>
-    );
-  }
-
-  return buildReleaseStatusTable;
+          </td>
+          <td>
+            <ReleaseLabelList labels={release.labels} />
+          </td>
+          <td>
+            <ReleaseCatnoList labels={release.labels} />
+          </td>
+          <td className="barcode-cell">{formatBarcode(release.barcode)}</td>
+          {$c.session?.tport == null ? null : (
+            <td>
+              <TaggerIcon entityType="release" gid={release.gid} />
+            </td>
+          )}
+        </tr>
+      ))}
+    </React.Fragment>
+  );
 }
 
 component ReleaseGroupIndex(
@@ -121,20 +118,19 @@ component ReleaseGroupIndex(
   numberOfRevisions: number,
   pager: PagerT,
   releaseGroup: ReleaseGroupT,
-  releases: $ReadOnlyArray<$ReadOnlyArray<ReleaseT>>,
+  releases: $ReadOnlyArray< $ReadOnlyArray< ReleaseT >>,
   wikipediaExtract: WikipediaExtractT | null,
 ) {
   const $c = React.useContext(CatalystContext);
   const firstReleaseGid = releases.length
     ? releases[0][0].gid
     : null;
-  const buildReleaseStatusTable = getReleaseStatusTableBuilder(
-    releases.some(
+  const
+    showArtworkPresence = releases.some(
       (sub) => sub.some(
         (res) => res.cover_art_presence === 'present',
       ),
-    ),
-  );
+    );
 
   return (
     <ReleaseGroupLayout
@@ -189,6 +185,7 @@ component ReleaseGroupIndex(
                     $c,
                     releaseStatusGroup,
                     releaseGroup.artistCredit.id,
+                    showArtworkPresence,
                   ))}
                 </tbody>
               </table>

--- a/root/release_group/ReleaseGroupIndex.js
+++ b/root/release_group/ReleaseGroupIndex.js
@@ -35,78 +35,82 @@ import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import ReleaseGroupLayout from './ReleaseGroupLayout.js';
 
-function buildReleaseStatusTable(
-  $c: CatalystContextT,
-  releaseStatusGroup: $ReadOnlyArray<ReleaseT>,
-  releaseGroupCreditId: number | void,
-) {
-  const status = releaseStatusGroup[0].status;
-  return (
-    <React.Fragment key={status ? status.name : 'no-status'}>
-      <tr className="subh">
-        {$c.user ? <th /> : null}
-        <th colSpan={$c.session?.tport == null ? 8 : 9}>
-          {status?.name
-            ? lp_attributes(status.name, 'release_status')
-            : lp('(unknown)', 'release status')}
-        </th>
-      </tr>
-      {releaseStatusGroup.map((release, index) => (
-        <tr className={loopParity(index)} key={release.id}>
-          {$c.user
-            ? (
-              <td>
-                <input
-                  name="add-to-merge"
-                  type="checkbox"
-                  value={release.id}
-                />
-              </td>
-            ) : null}
-          <td>
-            <EntityLink entity={release} showArtworkPresence />
-          </td>
-          {/* The class being added is for usage with userscripts */}
-          <td className={
-            releaseGroupCreditId === release.artistCredit.id
-              ? null
-              : 'artist-credit-variation'}
-          >
-            <ArtistCreditLink artistCredit={release.artistCredit} />
-          </td>
-          <td>
-            {nonEmpty(release.combined_format_name)
-              ? release.combined_format_name
-              : l('[missing media]')}
-          </td>
-          <td>
-            {nonEmpty(release.combined_track_count)
-              ? release.combined_track_count
-              : lp('-', 'missing data')}
-          </td>
-          <td>
-            <ReleaseEvents events={release.events} />
-            {manifest.js(
-              'common/components/ReleaseEvents',
-              {async: 'async'},
-            )}
-          </td>
-          <td>
-            <ReleaseLabelList labels={release.labels} />
-          </td>
-          <td>
-            <ReleaseCatnoList labels={release.labels} />
-          </td>
-          <td className="barcode-cell">{formatBarcode(release.barcode)}</td>
-          {$c.session?.tport == null ? null : (
-            <td>
-              <TaggerIcon entityType="release" gid={release.gid} />
-            </td>
-          )}
+function getReleaseStatusTableBuilder (showArtworkPresence: boolean) {
+  function buildReleaseStatusTable(
+    $c: CatalystContextT,
+    releaseStatusGroup: $ReadOnlyArray<ReleaseT>,
+    releaseGroupCreditId: number | void,
+  ) {
+    const status = releaseStatusGroup[0].status;
+    return (
+      <React.Fragment key={status ? status.name : 'no-status'}>
+        <tr className="subh">
+          {$c.user ? <th /> : null}
+          <th colSpan={$c.session?.tport == null ? 8 : 9}>
+            {status?.name
+              ? lp_attributes(status.name, 'release_status')
+              : lp('(unknown)', 'release status')}
+          </th>
         </tr>
-      ))}
-    </React.Fragment>
-  );
+        {releaseStatusGroup.map((release, index) => (
+          <tr className={loopParity(index)} key={release.id}>
+            {$c.user
+              ? (
+                <td>
+                  <input
+                    name="add-to-merge"
+                    type="checkbox"
+                    value={release.id}
+                  />
+                </td>
+              ) : null}
+            <td>
+              <EntityLink entity={release} showArtworkPresence={showArtworkPresence} />
+            </td>
+            {/* The class being added is for usage with userscripts */}
+            <td className={
+              releaseGroupCreditId === release.artistCredit.id
+                ? null
+                : 'artist-credit-variation'}
+            >
+              <ArtistCreditLink artistCredit={release.artistCredit} />
+            </td>
+            <td>
+              {nonEmpty(release.combined_format_name)
+                ? release.combined_format_name
+                : l('[missing media]')}
+            </td>
+            <td>
+              {nonEmpty(release.combined_track_count)
+                ? release.combined_track_count
+                : lp('-', 'missing data')}
+            </td>
+            <td>
+              <ReleaseEvents events={release.events} />
+              {manifest.js(
+                'common/components/ReleaseEvents',
+                {async: 'async'},
+              )}
+            </td>
+            <td>
+              <ReleaseLabelList labels={release.labels} />
+            </td>
+            <td>
+              <ReleaseCatnoList labels={release.labels} />
+            </td>
+            <td className="barcode-cell">{formatBarcode(release.barcode)}</td>
+            {$c.session?.tport == null ? null : (
+              <td>
+                <TaggerIcon entityType="release" gid={release.gid} />
+              </td>
+            )}
+          </tr>
+        ))}
+      </React.Fragment>
+    );
+  }
+
+  return buildReleaseStatusTable
 }
 
 component ReleaseGroupIndex(
@@ -119,6 +123,7 @@ component ReleaseGroupIndex(
 ) {
   const $c = React.useContext(CatalystContext);
   const firstReleaseGid = releases.length ? releases[0][0].gid : null;
+  let buildReleaseStatusTable = getReleaseStatusTableBuilder(releases.some((sub) => sub.some((res) => res.cover_art_presence === 'present')));
 
   return (
     <ReleaseGroupLayout

--- a/root/release_group/ReleaseGroupIndex.js
+++ b/root/release_group/ReleaseGroupIndex.js
@@ -35,7 +35,7 @@ import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import ReleaseGroupLayout from './ReleaseGroupLayout.js';
 
-function getReleaseStatusTableBuilder (showArtworkPresence: boolean) {
+function getReleaseStatusTableBuilder(showArtworkPresence: boolean) {
   function buildReleaseStatusTable(
     $c: CatalystContextT,
     releaseStatusGroup: $ReadOnlyArray<ReleaseT>,
@@ -65,7 +65,10 @@ function getReleaseStatusTableBuilder (showArtworkPresence: boolean) {
                 </td>
               ) : null}
             <td>
-              <EntityLink entity={release} showArtworkPresence={showArtworkPresence} />
+              <EntityLink
+                entity={release}
+                showArtworkPresence={showArtworkPresence}
+              />
             </td>
             {/* The class being added is for usage with userscripts */}
             <td className={
@@ -110,7 +113,7 @@ function getReleaseStatusTableBuilder (showArtworkPresence: boolean) {
     );
   }
 
-  return buildReleaseStatusTable
+  return buildReleaseStatusTable;
 }
 
 component ReleaseGroupIndex(
@@ -122,8 +125,16 @@ component ReleaseGroupIndex(
   wikipediaExtract: WikipediaExtractT | null,
 ) {
   const $c = React.useContext(CatalystContext);
-  const firstReleaseGid = releases.length ? releases[0][0].gid : null;
-  let buildReleaseStatusTable = getReleaseStatusTableBuilder(releases.some((sub) => sub.some((res) => res.cover_art_presence === 'present')));
+  const firstReleaseGid = releases.length
+    ? releases[0][0].gid
+    : null;
+  const buildReleaseStatusTable = getReleaseStatusTableBuilder(
+    releases.some(
+      (sub) => sub.some(
+        (res) => res.cover_art_presence === 'present',
+      ),
+    ),
+  );
 
   return (
     <ReleaseGroupLayout

--- a/root/search/components/EventResults.js
+++ b/root/search/components/EventResults.js
@@ -26,8 +26,8 @@ import type {ResultsPropsT, SearchResultT} from '../types.js';
 import PaginatedSearchResults from './PaginatedSearchResults.js';
 import ResultsLayout from './ResultsLayout.js';
 
-function getResultBuilder (showArtworkPresence: boolean) {
-  function buildResult (result: SearchResultT<EventT>, index: number) {
+function getResultBuilder(showArtworkPresence: boolean) {
+  function buildResult(result: SearchResultT<EventT>, index: number) {
     const event = result.entity;
     const score = result.score;
 
@@ -52,7 +52,7 @@ function getResultBuilder (showArtworkPresence: boolean) {
           <ArtistRoles relations={event.performers} />
           {manifest.js(
             'common/components/ArtistRoles',
-            { async: 'async' },
+            {async: 'async'},
           )}
         </td>
         <td>
@@ -62,7 +62,7 @@ function getResultBuilder (showArtworkPresence: boolean) {
     );
   }
 
-  return buildResult
+  return buildResult;
 }
 
 component EventResults(...{
@@ -71,9 +71,10 @@ component EventResults(...{
   pager,
   query,
   results,
-}: ResultsPropsT < EventT >) {
+}: ResultsPropsT<EventT>) {
   const $c = React.useContext(CatalystContext);
-  let buildResult = getResultBuilder(results.some((res) => res.entity.event_art_presence === 'present'))
+  const buildResult = getResultBuilder(results
+    .some((res) => res.entity.event_art_presence === 'present'));
 
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>

--- a/root/search/components/EventResults.js
+++ b/root/search/components/EventResults.js
@@ -26,39 +26,43 @@ import type {ResultsPropsT, SearchResultT} from '../types.js';
 import PaginatedSearchResults from './PaginatedSearchResults.js';
 import ResultsLayout from './ResultsLayout.js';
 
-function buildResult(result: SearchResultT<EventT>, index: number) {
-  const event = result.entity;
-  const score = result.score;
+function getResultBuilder (showArtworkPresence: boolean) {
+  function buildResult (result: SearchResultT<EventT>, index: number) {
+    const event = result.entity;
+    const score = result.score;
 
-  return (
-    <tr className={loopParity(index)} data-score={score} key={event.id}>
-      <td>
-        <EntityLink
-          entity={event}
-          showArtworkPresence
-          showDisambiguation
-          showEventDate={false}
-        />
-      </td>
-      <td>{formatDatePeriod(event)}</td>
-      <td>{event.time}</td>
-      <td>
-        {nonEmpty(event.typeName)
-          ? lp_attributes(event.typeName, 'event_type')
-          : null}
-      </td>
-      <td>
-        <ArtistRoles relations={event.performers} />
-        {manifest.js(
-          'common/components/ArtistRoles',
-          {async: 'async'},
-        )}
-      </td>
-      <td>
-        <EventLocations event={event} />
-      </td>
-    </tr>
-  );
+    return (
+      <tr className={loopParity(index)} data-score={score} key={event.id}>
+        <td>
+          <EntityLink
+            entity={event}
+            showArtworkPresence={showArtworkPresence}
+            showDisambiguation
+            showEventDate={false}
+          />
+        </td>
+        <td>{formatDatePeriod(event)}</td>
+        <td>{event.time}</td>
+        <td>
+          {nonEmpty(event.typeName)
+            ? lp_attributes(event.typeName, 'event_type')
+            : null}
+        </td>
+        <td>
+          <ArtistRoles relations={event.performers} />
+          {manifest.js(
+            'common/components/ArtistRoles',
+            { async: 'async' },
+          )}
+        </td>
+        <td>
+          <EventLocations event={event} />
+        </td>
+      </tr>
+    );
+  }
+
+  return buildResult
 }
 
 component EventResults(...{
@@ -67,8 +71,10 @@ component EventResults(...{
   pager,
   query,
   results,
-}: ResultsPropsT<EventT>) {
+}: ResultsPropsT < EventT >) {
   const $c = React.useContext(CatalystContext);
+  let buildResult = getResultBuilder(results.some((res) => res.entity.event_art_presence === 'present'))
+
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>
       <PaginatedSearchResults

--- a/root/search/components/ReleaseGroupResults.js
+++ b/root/search/components/ReleaseGroupResults.js
@@ -21,8 +21,8 @@ import type {ResultsPropsT, SearchResultT} from '../types.js';
 import PaginatedSearchResults from './PaginatedSearchResults.js';
 import ResultsLayout from './ResultsLayout.js';
 
-function getResultBuilder (showArtworkPresence: boolean) {
-  function buildResult (result: SearchResultT<ReleaseGroupT>, index: number) {
+function getResultBuilder(showArtworkPresence: boolean) {
+  function buildResult(result: SearchResultT<ReleaseGroupT>, index: number) {
     const releaseGroup = result.entity;
     const score = result.score;
 
@@ -33,21 +33,26 @@ function getResultBuilder (showArtworkPresence: boolean) {
         key={releaseGroup.id}
       >
         <td>
-          <EntityLink entity={releaseGroup} showArtworkPresence={showArtworkPresence} />
+          <EntityLink
+            entity={releaseGroup}
+            showArtworkPresence={showArtworkPresence}
+          />
         </td>
         <td>
           <ArtistCreditLink artistCredit={releaseGroup.artistCredit} />
         </td>
         <td>
           {nonEmpty(releaseGroup.typeName)
-            ? lp_attributes(releaseGroup.typeName, 'release_group_primary_type')
+            ? lp_attributes(
+              releaseGroup.typeName, 'release_group_primary_type',
+            )
             : null}
         </td>
       </tr>
     );
   }
 
-  return buildResult
+  return buildResult;
 }
 
 component ReleaseGroupResults(...{
@@ -56,9 +61,11 @@ component ReleaseGroupResults(...{
   pager,
   query,
   results,
-}: ResultsPropsT < ReleaseGroupT >) {
+}: ResultsPropsT< ReleaseGroupT >) {
   const $c = React.useContext(CatalystContext);
-  let buildResult = getResultBuilder(results.some((res) => res.entity.hasCoverArt))
+  const buildResult = getResultBuilder(
+    results.some((res) => res.entity.hasCoverArt),
+  );
 
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>

--- a/root/search/components/ReleaseGroupResults.js
+++ b/root/search/components/ReleaseGroupResults.js
@@ -21,29 +21,33 @@ import type {ResultsPropsT, SearchResultT} from '../types.js';
 import PaginatedSearchResults from './PaginatedSearchResults.js';
 import ResultsLayout from './ResultsLayout.js';
 
-function buildResult(result: SearchResultT<ReleaseGroupT>, index: number) {
-  const releaseGroup = result.entity;
-  const score = result.score;
+function getResultBuilder (showArtworkPresence: boolean) {
+  function buildResult (result: SearchResultT<ReleaseGroupT>, index: number) {
+    const releaseGroup = result.entity;
+    const score = result.score;
 
-  return (
-    <tr
-      className={loopParity(index)}
-      data-score={score}
-      key={releaseGroup.id}
-    >
-      <td>
-        <EntityLink entity={releaseGroup} showArtworkPresence />
-      </td>
-      <td>
-        <ArtistCreditLink artistCredit={releaseGroup.artistCredit} />
-      </td>
-      <td>
-        {nonEmpty(releaseGroup.typeName)
-          ? lp_attributes(releaseGroup.typeName, 'release_group_primary_type')
-          : null}
-      </td>
-    </tr>
-  );
+    return (
+      <tr
+        className={loopParity(index)}
+        data-score={score}
+        key={releaseGroup.id}
+      >
+        <td>
+          <EntityLink entity={releaseGroup} showArtworkPresence={showArtworkPresence} />
+        </td>
+        <td>
+          <ArtistCreditLink artistCredit={releaseGroup.artistCredit} />
+        </td>
+        <td>
+          {nonEmpty(releaseGroup.typeName)
+            ? lp_attributes(releaseGroup.typeName, 'release_group_primary_type')
+            : null}
+        </td>
+      </tr>
+    );
+  }
+
+  return buildResult
 }
 
 component ReleaseGroupResults(...{
@@ -52,8 +56,10 @@ component ReleaseGroupResults(...{
   pager,
   query,
   results,
-}: ResultsPropsT<ReleaseGroupT>) {
+}: ResultsPropsT < ReleaseGroupT >) {
   const $c = React.useContext(CatalystContext);
+  let buildResult = getResultBuilder(results.some((res) => res.entity.hasCoverArt))
+
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>
       <PaginatedSearchResults

--- a/root/search/components/ReleaseResults.js
+++ b/root/search/components/ReleaseResults.js
@@ -34,66 +34,70 @@ import type {
 import PaginatedSearchResults from './PaginatedSearchResults.js';
 import ResultsLayout from './ResultsLayout.js';
 
-function buildResult(
-  $c: CatalystContextT,
-  result: SearchResultT<ReleaseT>,
-  index: number,
-) {
-  const release = result.entity;
-  const score = result.score;
-  const typeName = release.releaseGroup?.typeName;
+function getResultBuilder (showArtworkPresence: boolean) {
+  function buildResult(
+    $c: CatalystContextT,
+    result: SearchResultT<ReleaseT>,
+    index: number,
+  ) {
+    const release = result.entity;
+    const score = result.score;
+    const typeName = release.releaseGroup?.typeName;
 
-  return (
-    <tr className={loopParity(index)} data-score={score} key={release.id}>
-      <td>
-        <EntityLink entity={release} showArtworkPresence />
-      </td>
-      <td>
-        <ArtistCreditLink artistCredit={release.artistCredit} />
-      </td>
-      <td>
-        {nonEmpty(release.combined_format_name)
-          ? release.combined_format_name
-          : l('[missing media]')}
-      </td>
-      <td>
-        {nonEmpty(release.combined_track_count)
-          ? release.combined_track_count
-          : lp('-', 'missing data')}
-      </td>
-      <td>
-        <ReleaseEvents events={release.events} />
-        {manifest.js(
-          'common/components/ReleaseEvents',
-          {async: 'async'},
-        )}
-      </td>
-      <td>
-        <ReleaseLabelList labels={release.labels} />
-      </td>
-      <td>
-        <ReleaseCatnoList labels={release.labels} />
-      </td>
-      <td className="barcode-cell">{formatBarcode(release.barcode)}</td>
-      <td>
-        <ReleaseLanguageScript release={release} />
-      </td>
-      <td>
-        {nonEmpty(typeName)
-          ? lp_attributes(typeName, 'release_group_primary_type')
-          : null}
-      </td>
-      <td>
-        {release.status
-          ? lp_attributes(release.status.name, 'release_status') : null}
-      </td>
-      {$c.session?.tport == null ? null : (
+    return (
+      <tr className={loopParity(index)} data-score={score} key={release.id}>
         <td>
-          <TaggerIcon entityType="release" gid={release.gid} />
+          <EntityLink entity={release} showArtworkPresence={showArtworkPresence} />
         </td>
-      )}
-    </tr>
-  );
+        <td>
+          <ArtistCreditLink artistCredit={release.artistCredit} />
+        </td>
+        <td>
+          {nonEmpty(release.combined_format_name)
+            ? release.combined_format_name
+            : l('[missing media]')}
+        </td>
+        <td>
+          {nonEmpty(release.combined_track_count)
+            ? release.combined_track_count
+            : lp('-', 'missing data')}
+        </td>
+        <td>
+          <ReleaseEvents events={release.events} />
+          {manifest.js(
+            'common/components/ReleaseEvents',
+            {async: 'async'},
+          )}
+        </td>
+        <td>
+          <ReleaseLabelList labels={release.labels} />
+        </td>
+        <td>
+          <ReleaseCatnoList labels={release.labels} />
+        </td>
+        <td className="barcode-cell">{formatBarcode(release.barcode)}</td>
+        <td>
+          <ReleaseLanguageScript release={release} />
+        </td>
+        <td>
+          {nonEmpty(typeName)
+            ? lp_attributes(typeName, 'release_group_primary_type')
+            : null}
+        </td>
+        <td>
+          {release.status
+            ? lp_attributes(release.status.name, 'release_status') : null}
+        </td>
+        {$c.session?.tport == null ? null : (
+          <td>
+            <TaggerIcon entityType="release" gid={release.gid} />
+          </td>
+        )}
+      </tr>
+    );
+  }
+
+  return buildResult
 }
 
 export component ReleaseResultsInline(...{
@@ -102,6 +106,7 @@ export component ReleaseResultsInline(...{
   results,
 }: InlineResultsPropsT<ReleaseT>) {
   const $c = React.useContext(CatalystContext);
+  let buildResult = getResultBuilder(results.some((res) => res.entity.cover_art_presence === 'present'))
 
   return (
     <PaginatedSearchResults

--- a/root/search/components/ReleaseResults.js
+++ b/root/search/components/ReleaseResults.js
@@ -34,7 +34,7 @@ import type {
 import PaginatedSearchResults from './PaginatedSearchResults.js';
 import ResultsLayout from './ResultsLayout.js';
 
-function getResultBuilder (showArtworkPresence: boolean) {
+function getResultBuilder(showArtworkPresence: boolean) {
   function buildResult(
     $c: CatalystContextT,
     result: SearchResultT<ReleaseT>,
@@ -47,7 +47,10 @@ function getResultBuilder (showArtworkPresence: boolean) {
     return (
       <tr className={loopParity(index)} data-score={score} key={release.id}>
         <td>
-          <EntityLink entity={release} showArtworkPresence={showArtworkPresence} />
+          <EntityLink
+            entity={release}
+            showArtworkPresence={showArtworkPresence}
+          />
         </td>
         <td>
           <ArtistCreditLink artistCredit={release.artistCredit} />
@@ -97,7 +100,7 @@ function getResultBuilder (showArtworkPresence: boolean) {
     );
   }
 
-  return buildResult
+  return buildResult;
 }
 
 export component ReleaseResultsInline(...{
@@ -106,7 +109,11 @@ export component ReleaseResultsInline(...{
   results,
 }: InlineResultsPropsT<ReleaseT>) {
   const $c = React.useContext(CatalystContext);
-  let buildResult = getResultBuilder(results.some((res) => res.entity.cover_art_presence === 'present'))
+  const buildResult = getResultBuilder(
+    results.some(
+      (res) => res.entity.cover_art_presence === 'present',
+    ),
+  );
 
   return (
     <PaginatedSearchResults


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
[MBS-13676](https://tickets.metabrainz.org/browse/MBS-13676): #3256 added a blank icon to the left of titles of releases that don't have cover art to fix the alignment issue described in [MBS-13263](https://tickets.metabrainz.org/browse/MBS-13263).

However, the extra spacing looks strange when none of the releases in a list have cover art.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

in `EventList.js`, `ReleaseGroupList.js` and `ReleaseList.js`, do not show cover art indicators, and therefore spacers, if none of the listed entities have cover art.

In `ReleaseGroupIndex.js`, `EventResults.js`, `ReleaseGroupResults.js` and `ReleaseResults.js`, do the same, but curry `buildResult` to pass the data down.

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

Tested on the following URLs on a sample database:
- http://127.0.0.1:5000/artist/109958eb-a335-4c5e-907e-597ff4c6af46
- http://127.0.0.1:5000/artist/cacbff60-5547-4982-aed3-1f4810896738/events
- http://127.0.0.1:5000/release-group/d4311638-e684-4ed5-b5b8-62fcbaa81883
- http://127.0.0.1:5000/release-group/910d3893-626a-3bad-b28a-486b4d1daa7e
- http://127.0.0.1:5000/search?query=%22Scratch+to+Reveal%22&type=release&limit=25&method=indexed
- http://127.0.0.1:5000/search?query=a&type=release_group&limit=25&method=indexed
- http://127.0.0.1:5000/search?query=a&type=event&limit=25&method=indexed

# Further action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

- Is the currying I've done in the second commit the best way to pass that state? It's the simplest I could figure out, not being very familiar with React. 
- Do I need to squash this?
