### PR TITLE
MBS-13677: Show cover art presence in indexed searches

### DIFF
--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -985,7 +985,7 @@ sub external_search
         {
             my @entities = map { $_->entity } @results;
             $self->c->model('ReleaseGroup')->load_ids(@entities);
-            $self->c->model('CoverArt')->load_for_release_groups(@entities);
+            $self->c->model('ReleaseGroup')->load_has_cover_art(@entities);
         }
 
         my $pager = Data::Page->new;


### PR DESCRIPTION
### Fix MBS-13677

# Problem
Cover art presence is not actually displayed for release group indexed searches (all release groups show as not having cover art).

# Solution
This was loading the artwork (which we don't actually need) but not actually updating the `has_cover_art` flag we actually care about for displaying the icon.

I probably broke this when I introduced `load_has_cover_art` and forgot to use it here? In any case, that's what we need here. Should also make searches slightly faster, I expect.

# Testing
Manually, with `/search?query=arvo+part&type=release_group&limit=25&method=indexed&page=3` with live data