### PR TITLE
MBS-13528 / MBS-13696: Calculate invalid edit notes in more places and with more invisible characters

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -741,9 +741,8 @@ sub submit_edits {
             $c->forward('/ws/js/detach_with_error', ['editNote required']);
         }
 
-        if ($edit_type == $EDIT_RELEASE_CREATE &&
-            !is_valid_edit_note($data->{editNote})) {
-            $c->forward('/ws/js/detach_with_error', ['editNote invalid']);
+        if ($data->{editNote} && !is_valid_edit_note($data->{editNote})) {
+            $c->forward('/ws/js/detach_with_error', [l('Your edit note seems to have no actual content. Please provide a note that will be helpful to your fellow editors!')]);
         }
 
         unless (contains_number($ALLOWED_EDIT_TYPES, $edit_type)) {

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -447,7 +447,7 @@ sub remove_lineformatting_characters {
     # - zwsp
     # - shy
     # - Other, control (including TAB \x09, LF \x0A, and CR \x0D)
-    =~ s/[\N{ZERO WIDTH SPACE}\N{SOFT HYPHEN}\p{Cc}]//gr;
+    =~ s/[\N{ZERO WIDTH SPACE}\N{SOFT HYPHEN}\N{HANGUL FILLER}\N{HALFWIDTH HANGUL FILLER}\N{HANGUL JUNGSEONG FILLER}\N{HANGUL CHOSEONG FILLER}\p{Cc}]//gr;
 }
 
 sub type_to_model

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -441,6 +441,7 @@ sub remove_invalid_characters {
 }
 
 Readonly my @invisible_characters => (
+    '\N{BRAILLE PATTERN BLANK}',
     '\N{HANGUL FILLER}',
     '\N{HALFWIDTH HANGUL FILLER}',
     '\N{HANGUL JUNGSEONG FILLER}',

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -71,7 +71,7 @@ our @EXPORT_OK = qw(
     placeholders
     ref_to_type
     remove_equal
-    remove_lineformatting_characters
+    remove_invisible_characters
     sanitize
     take_while
     trim
@@ -440,14 +440,33 @@ sub remove_invalid_characters {
     =~ s/[\N{ZERO WIDTH NO-BREAK SPACE}\x{F0000}-\x{FFFFF}\x{100000}-\x{10FFFF}${noncharacter_pattern}]//gr;
 }
 
+Readonly my @invisible_characters => (
+    '\N{HANGUL FILLER}',
+    '\N{HALFWIDTH HANGUL FILLER}',
+    '\N{HANGUL JUNGSEONG FILLER}',
+    '\N{HANGUL CHOSEONG FILLER}',
+);
+Readonly my $invisible_characters => join '', @invisible_characters;
+Readonly my $invisible_characters_class => qr/[$invisible_characters]/;
+
 # Keep in sync with invalidEditNote in static/scripts/release-editor/init.js
+sub remove_invisible_characters {
+    my $string = shift;
+
+    $string = remove_lineformatting_characters($string);
+
+    $string =~ s/$invisible_characters_class//g;
+
+    return $string;
+}
+
 sub remove_lineformatting_characters {
     shift
     # trim lasting line-formatting characters:
     # - zwsp
     # - shy
     # - Other, control (including TAB \x09, LF \x0A, and CR \x0D)
-    =~ s/[\N{ZERO WIDTH SPACE}\N{SOFT HYPHEN}\N{HANGUL FILLER}\N{HALFWIDTH HANGUL FILLER}\N{HANGUL JUNGSEONG FILLER}\N{HANGUL CHOSEONG FILLER}\p{Cc}]//gr;
+    =~ s/[\N{ZERO WIDTH SPACE}\N{SOFT HYPHEN}\p{Cc}]//gr;
 }
 
 sub type_to_model

--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -60,7 +60,7 @@ use MusicBrainz::Server::Constants qw(
 );
 use MusicBrainz::Server::Data::Utils qw(
     contains_number
-    remove_lineformatting_characters
+    remove_invisible_characters
 );
 use utf8;
 
@@ -356,7 +356,7 @@ sub is_valid_edit_note
     return 0 unless $edit_note;
 
     # We don't want line format chars to stop an edit note from being "empty"
-    $edit_note = remove_lineformatting_characters($edit_note);
+    $edit_note = remove_invisible_characters($edit_note);
     # Additional format chars that can cause unwanted negatives
     $edit_note =~ s/[\p{Cf}\p{Mn}]//g;
 

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -292,16 +292,19 @@ releaseEditor.init = function (options) {
       return false;
     }
 
-    // We don't want line format chars to stop an edit note from being "empty"
-    const editNoteNoLineFormat = editNote.replace(
+    /*
+     * We don't want line format characters and other invisible characters
+     * to stop an edit note from being "empty"
+     */
+    const editNoteNoInvisibleChars = editNote.replace(
       /[\u200b\u00AD\u3164\uFFA0\u115F\u1160\p{Cc}\p{Cf}\p{Mn}]/ug,
       '',
     );
     return self.action === 'add' && (
-      // If it's empty now but not earlier, it was all format characters
-      empty(editNoteNoLineFormat) ||
-      /^[\p{White_Space}\p{Punctuation}]+$/u.test(editNoteNoLineFormat) ||
-      /^\p{ASCII}$/u.test(editNoteNoLineFormat)
+      // If it's empty now but not earlier, it was all invisible characters
+      empty(editNoteNoInvisibleChars) ||
+      /^[\p{White_Space}\p{Punctuation}]+$/u.test(editNoteNoInvisibleChars) ||
+      /^\p{ASCII}$/u.test(editNoteNoInvisibleChars)
     );
   };
 

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -299,7 +299,7 @@ releaseEditor.init = function (options) {
     );
     return self.action === 'add' && (
       // If it's empty now but not earlier, it was all format characters
-      empty(editNote) ||
+      empty(editNoteNoLineFormat) ||
       /^[\p{White_Space}\p{Punctuation}]+$/u.test(editNoteNoLineFormat) ||
       /^\p{ASCII}$/u.test(editNoteNoLineFormat)
     );

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -297,7 +297,7 @@ releaseEditor.init = function (options) {
      * to stop an edit note from being "empty"
      */
     const editNoteNoInvisibleChars = editNote.replace(
-      /[\u200b\u00AD\u3164\uFFA0\u115F\u1160\p{Cc}\p{Cf}\p{Mn}]/ug,
+      /[\u200b\u00AD\u3164\uFFA0\u115F\u1160\u2800\p{Cc}\p{Cf}\p{Mn}]/ug,
       '',
     );
     return self.action === 'add' && (

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -294,7 +294,7 @@ releaseEditor.init = function (options) {
 
     // We don't want line format chars to stop an edit note from being "empty"
     const editNoteNoLineFormat = editNote.replace(
-      /[\u200b\u00AD\p{Cc}\p{Cf}\p{Mn}]/ug,
+      /[\u200b\u00AD\u3164\uFFA0\u115F\u1160\p{Cc}\p{Cf}\p{Mn}]/ug,
       '',
     );
     return self.action === 'add' && (

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -300,7 +300,7 @@ releaseEditor.init = function (options) {
       /[\u200b\u00AD\u3164\uFFA0\u115F\u1160\u2800\p{Cc}\p{Cf}\p{Mn}]/ug,
       '',
     );
-    return self.action === 'add' && (
+    return (
       // If it's empty now but not earlier, it was all invisible characters
       empty(editNoteNoInvisibleChars) ||
       /^[\p{White_Space}\p{Punctuation}]+$/u.test(editNoteNoInvisibleChars) ||

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -169,7 +169,7 @@ test 'previewing/creating/editing a release group and release' => sub {
 
     $response = from_json($mech->content);
 
-    is($response->{error}, 'editNote invalid', 'ws response says editNote invalid');
+    is($response->{error}, 'Your edit note seems to have no actual content. Please provide a note that will be helpful to your fellow editors!', 'ws response says the note is invalid');
 
 
     @edits = capture_edits {

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -320,6 +320,14 @@ test 'Test is_valid_edit_note' => sub {
         is_valid_edit_note("\N{ZERO WIDTH JOINER}\N{COMBINING GRAPHEME JOINER}abc\N{ZERO WIDTH JOINER}\N{COMBINING GRAPHEME JOINER}"),
         'Note made of format and join characters plus text is valid',
     );
+    ok(
+        !is_valid_edit_note("\N{HANGUL FILLER}\N{HALFWIDTH HANGUL FILLER}\N{HANGUL CHOSEONG FILLER}\N{HANGUL JUNGSEONG FILLER}"),
+        'Note made of Hangul fillers is invalid',
+    );
+    ok(
+        is_valid_edit_note("\N{HANGUL FILLER}\N{HALFWIDTH HANGUL FILLER}\N{HANGUL CHOSEONG FILLER}abc\N{HANGUL JUNGSEONG FILLER}"),
+        'Note made of Hangul fillers plus text is valid',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -321,12 +321,12 @@ test 'Test is_valid_edit_note' => sub {
         'Note made of format and join characters plus text is valid',
     );
     ok(
-        !is_valid_edit_note("\N{HANGUL FILLER}\N{HALFWIDTH HANGUL FILLER}\N{HANGUL CHOSEONG FILLER}\N{HANGUL JUNGSEONG FILLER}"),
-        'Note made of Hangul fillers is invalid',
+        !is_valid_edit_note("\N{HANGUL FILLER}\N{HALFWIDTH HANGUL FILLER}\N{BRAILLE PATTERN BLANK}\N{HANGUL CHOSEONG FILLER}\N{HANGUL JUNGSEONG FILLER}"),
+        'Note made of invisible characters is invalid',
     );
     ok(
-        is_valid_edit_note("\N{HANGUL FILLER}\N{HALFWIDTH HANGUL FILLER}\N{HANGUL CHOSEONG FILLER}abc\N{HANGUL JUNGSEONG FILLER}"),
-        'Note made of Hangul fillers plus text is valid',
+        is_valid_edit_note("\N{HANGUL FILLER}\N{HALFWIDTH HANGUL FILLER}\N{BRAILLE PATTERN BLANK}\N{HANGUL CHOSEONG FILLER}abc\N{HANGUL JUNGSEONG FILLER}"),
+        'Note made of invisible characters plus text is valid',
     );
 };
 


### PR DESCRIPTION
### Implement MBS-13528 and MBS-13696

# Problem
People are using Hangul fillers to circumvent the edit note requirement. Also, while 63898c73fe4482688bee7c57e937035ad5c76b0a wanted to check all edit notes, we forgot that some places that go through `ws/js` are not affected by it.  

# Solution
HANGUL FILLER is a character often used to have "empty usernames" and similar things since it's an empty space but not considered a space char. This considers it, together with other similar Hangul fillers, insufficient for a valid note.

While testing in the release editor I noticed something was weird since Hangul-filler only edit notes were not getting rejected. The second commit here fixes that bug (we were not checking the right variable).

The third commit makes it so that invisible characters are not actually stripped by `sanitize`, since they can have value when they are used as part of text, just not as the only content of an edit note.

The fourth commit also adds `BRAILLE PATTERN BLANK` to the list of invisible characters, since it similarly doesn't actually have any use other than being invisible when used outside a Braille context.

The last commit here also makes it so that the relationship editor and editing in the release editor also check for invalid notes.

# Testing
Tested manually both for artist and release edits (since release edits use the JS version of this). Added tests for them to the perl `Validation` tests. Also tested the last commit manually separately by entering `⠀ᅟ` as the edit note when editing a release and when in the relationship editor.