### PR TITLE
MBS-13679: RYM cleanup improvements

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4893,7 +4893,7 @@ const CLEANUPS: CleanupEntries = {
     )],
     restrict: [LINK_TYPES.otherdatabases],
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?rateyourmusic\.com\//, 'https://rateyourmusic.com/');
+      return url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?rateyourmusic\.com\/([^#?]+).*$/, 'https://rateyourmusic.com/$1');
     },
     validate: function (url, id) {
       const m = /^https:\/\/rateyourmusic\.com\/(\w+)\/(?:(\w+)\/)?/.exec(url);

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4888,12 +4888,12 @@ const CLEANUPS: CleanupEntries = {
   },
   'rateyourmusic': {
     match: [new RegExp(
-      '^(https?://)?(www\\.)?rateyourmusic\\.com/(?!feature)',
+      '^(https?://)?([^/]+\\.)?rateyourmusic\\.com/(?!feature)',
       'i',
     )],
     restrict: [LINK_TYPES.otherdatabases],
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?(?:www\.)?rateyourmusic\.com\//, 'https://rateyourmusic.com/');
+      return url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?rateyourmusic\.com\//, 'https://rateyourmusic.com/');
     },
     validate: function (url, id) {
       const m = /^https:\/\/rateyourmusic\.com\/(\w+)\/(?:(\w+)\/)?/.exec(url);

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4698,7 +4698,7 @@ limited_link_type_combinations: [
         only_valid_entity_types: ['genre'],
   },
   {
-                     input_url: 'https://rateyourmusic.com/label/tzadik/',
+                     input_url: 'https://ru.rateyourmusic.com/label/tzadik/',
              input_entity_type: 'label',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://rateyourmusic.com/label/tzadik/',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4677,7 +4677,7 @@ limited_link_type_combinations: [
   },
   // RateYourMusic
   {
-                     input_url: 'http://www.rateyourmusic.com/artist/johanna_beyer',
+                     input_url: 'http://www.rateyourmusic.com/artist/johanna_beyer?__cf_chl_f_tk=d9ucwvyvsyPN6wYqKhaxZAloHggP6RNt.iEnchyh1qc-1720128733-0.0.1.1-4862',
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://rateyourmusic.com/artist/johanna_beyer',
@@ -4740,7 +4740,7 @@ limited_link_type_combinations: [
         only_valid_entity_types: ['series'],
   },
   {
-                     input_url: 'https://rateyourmusic.com/work/funktion_violett/',
+                     input_url: 'https://rateyourmusic.com/work/funktion_violett/#Compilation',
              input_entity_type: 'work',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://rateyourmusic.com/work/funktion_violett/',


### PR DESCRIPTION
### Implement MBS-13679

# Description
The first commit cleans up (new?) country subdomains for RYM, which seem to make no real changes and be safe to just remove.

The second commit drops query parameters (such as the ones left by Cloudflare protection) and anchors (such as the ones to select specific sections of a work page) from RYM URLs. I checked for any current uses in the DB, I found none for anchors, and 18 for query parameters - all of them either Cloudflare-related or incorrectly linked backend pages, such as https://rateyourmusic.com/artist/profile_details?id=848742 - I fixed those by hand.

# Testing
Amended RYM handling tests to cover the relevant changes.