### PR TITLE
MBS-13667: Return rating as number in JSON rating API

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Rating.pm
+++ b/lib/MusicBrainz/Server/Controller/Rating.pm
@@ -51,7 +51,7 @@ sub rate : Local RequireAuth DenyWhenReadonly
 
     if ($c->request->params->{json}) {
         my $body = $c->json_utf8->encode({
-            rating         => $rating,
+            rating         => $rating + 0,
             rating_average => $count > 0 ? ($sum / $count) : 0,
             rating_count   => $count,
         });


### PR DESCRIPTION
### Fix MBS-13667

# Problem
An existing rating can be removed from the sidebar. But a rating added in the same page load cannot, unless the page is reloaded.

# Solution
The jQuery used to update ratings was expecting rating to be sent as a number by the API, but for some reason we were sending it as a string. This caused the comparison in the jQuery to fail, meaning the rating could no longer be removed without a refresh. This just makes sure the API returns a number as expected.

# Testing
Manually, by adding and removing the same rating multiple times.