### PR TITLE
MBS-13644: Reduce sidebar artwork layout shift

### DIFF
--- a/root/layout/components/sidebar/ReleaseGroupSidebar.js
+++ b/root/layout/components/sidebar/ReleaseGroupSidebar.js
@@ -35,7 +35,7 @@ component ReleaseGroupSidebar(
   return (
     <div id="sidebar">
       {releaseGroup.cover_art ? (
-        <div className="cover-art">
+        <div className="cover-art present">
           <Artwork artwork={releaseGroup.cover_art} />
         </div>
       ) : null}

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -75,11 +75,13 @@ component ReleaseSidebar(release: ReleaseT) {
     ? null
     : linkedEntities.script[scriptId];
   const isEmpty = release.has_no_tracks;
+  const isPresent = release.cover_art_presence === 'present';
+  const isDarkened = release.cover_art_presence === 'darkened';
 
   return (
     <div id="sidebar">
-      <div className="cover-art">
-        {release.cover_art_presence === 'present' && releaseArtwork ? (
+      <div className={'cover-art' + (isPresent ? ' present' : '')}>
+        {isPresent && releaseArtwork ? (
           <Artwork
             artwork={releaseArtwork}
             message={ReactDOMServer.renderToStaticMarkup(exp.l(
@@ -88,12 +90,12 @@ component ReleaseSidebar(release: ReleaseT) {
               {all: entityHref(release, 'cover-art')},
             ))}
           />
-        ) : release.cover_art_presence === 'darkened' ? (
+        ) : isDarkened ? (
           l(`Images for this item have been hidden
              by the Internet Archive because of a takedown request.`)
         ) : (
           <p className="cover-art-note" style={{textAlign: 'left'}}>
-            {release.cover_art_presence === 'present' ? (
+            {isPresent ? (
               <>
                 {l('No front cover image available.')}
                 <br />

--- a/root/static/scripts/common/coverart.js
+++ b/root/static/scripts/common/coverart.js
@@ -20,8 +20,9 @@ $(function () {
         if ($e.data('fallback') && $e.attr('src') === thumbnailUrl) {
           $e.attr('src', $e.data('fallback'));
         } else {
-          $e.closest('a')
-            .replaceWith('<em>' + $e.data('message') + '</em>');
+          $e.closest('a').replaceWith(
+            '<em class="cover-art-error">' + $e.data('message') + '</em>',
+          );
         }
       })
       .attr({

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -499,8 +499,9 @@ div.warning img.warning {
     img {
         vertical-align: top; /* avoid inline space below image */
     }
-    &:not(:has(img)) {
-        border: 1px solid @light-border; /* border around error messages */
+    &:has(.cover-art-error),
+    &:has(.cover-art-note) {
+        border: 1px solid @light-border; /* border around text messages */
     }
     & ~ .listenbrainz-button {
         margin-top: 16px; /* matches #sidebar's padding-left */

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -491,6 +491,22 @@ div.warning img.warning {
     max-height: 16px;
 }
 
+#sidebar .cover-art.present {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    min-height: 218px; /* matches img's max-width */
+    img {
+        vertical-align: top; /* avoid inline space below image */
+    }
+    &:not(:has(img)) {
+        border: 1px solid @light-border; /* border around error messages */
+    }
+    & ~ .listenbrainz-button {
+        margin-top: 16px; /* matches #sidebar's padding-left */
+    }
+}
+
 #sidebar .cover-art img,
 #sidebar .event-art img,
 #sidebar .picture img {


### PR DESCRIPTION
# MBS-13644

Set a min-height for the div used to display cover artwork in the release and release group sidebars to avoid a big layout shift when the image is eventually loaded.

# Problem

The release and release group sidebars don't reserve any space for cover artwork, so their content shifts down when the artwork is eventually loaded. The shift usually happens a second or two after layout, so I find that it frequently causes me to click in the wrong place when I'm trying to e.g. subscribe, merge, or add to a collection. (I attached an animated GIF to MBS-13644 showing the shift.)

# Solution

Make `ReleaseSidebar` and `ReleaseGroupSidebar` set a new `present` class on `<div class="cover-art">`, and add a CSS ruleset that sets `min-height: 218px` (which I think is the height that a square image will end up with). There can still be a shift if the image has a non-square aspect ratio, but I don't think there's any way to predict the final height.

I'm using `display: flex` to center the content so the message won't look funny if the cover art can't be loaded for some reason:

![unavailable](https://github.com/metabrainz/musicbrainz-server/assets/40385/fa9d1484-00ce-4e93-ab84-7629b6a07b0d)

I noticed that there was also a (presumably unintentional) bit of vertical spacing below the image, apparently due to it being displayed in an inline context (see e.g. <https://stackoverflow.com/q/7642883>). I'm setting `vertical-align: top` on the image to prevent this, but please let me know if it's desirable. Here's the before and after:

![old](https://github.com/metabrainz/musicbrainz-server/assets/40385/4f51ff70-1ebb-48be-8047-5063eebec39a)

![new](https://github.com/metabrainz/musicbrainz-server/assets/40385/99759607-cc4f-4bb8-ba01-c94e6f56b294)

# Testing

I tried to test this on `/release/mbid` pages, but my ability was somewhat limited due to cover images not working in my dev environment. I've manually applied the CSS ruleset to the live site via DevTools and it seems to work as intended, but I'd appreciate it if you could also test manually with release and RG pages with and without cover images if cover art is available in your environment.