### PR TITLE
MBS-8217: Show preview on hover over guess case

### DIFF
--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -251,7 +251,7 @@
       [% React.embed(c, 'static/scripts/edit/components/GuessCaseIcon') %]
     [% END %]
     <div style="float: right; margin: 10px;" class="buttons">
-      <button id="guess-case-button" type="button" data-bind="click: guessCase">[% lp('Guess case', 'interactive') %]</button>
+      <button id="guess-case-button" type="button" data-bind="click: guessCase, event: { mouseenter: guessCase, mouseleave: guessCase }">[% lp('Guess case', 'interactive') %]</button>
     </div>
     <p class="guesscase-options">
       <select data-bind="value: modeName">

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -209,9 +209,8 @@
       <input class="pos" type="text" data-bind="value: number" />
     </td>
 
-    <td class="title" data-bind="css: { 'preview-differs': previewNameDiffers() }">
-      <input type="text" class="track-name" data-bind="value: name, valueUpdate: 'input', visible: !previewNameDiffers()" />
-      <input type="text" class="preview" readonly data-bind="value: previewName, visible: previewNameDiffers()" />
+    <td class="title">
+      <input type="text" class="track-name" data-bind="value: inputName, valueUpdate: 'input', css: { preview: previewNameDiffers() }" />
     </td>
 
     <td class="artist autocomplete" data-bind="artistCreditEditor: $data">
@@ -317,8 +316,7 @@
           (<a href="[% c.uri_for('/doc/Release/Format') %]" target="_blank">[% l('help') %]</a>)
           <!-- ko if: release.mediums().length > 1 || name() -->
             <label data-bind="attr: { for: 'medium-title-' + uniqueID }">[% l('Medium title:') %]</label>
-            <input type="text" data-bind="value: name, attr: { id: 'medium-title-' + uniqueID }, visible: !previewNameDiffers()" />
-            <input type="text" class="preview" readonly data-bind="value: previewName, visible: previewNameDiffers()" />
+            <input type="text" data-bind="attr: { id: 'medium-title-' + uniqueID }, value: inputName, valueUpdate: 'input', css: { preview: previewNameDiffers() }" />
             <button type="button" class="icon guesscase-title" title="[% l('Guess case medium title') %]" data-bind="click: $root.guessCaseMediumName, event: { mouseenter: $root.guessCaseMediumName, mouseleave: $root.guessCaseMediumName }"></button>
           <!-- /ko -->
           <p class="error field-error" style="padding-left: 1em" data-bind="showErrorWhenTabIsSwitched: needsFormat">

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -209,8 +209,9 @@
       <input class="pos" type="text" data-bind="value: number" />
     </td>
 
-    <td class="title">
-      <input type="text" class="track-name" data-bind="value: name, valueUpdate: 'input'" />
+    <td class="title" data-bind="css: { 'preview-differs': previewNameDiffers() }">
+      <input type="text" class="track-name" data-bind="value: name, valueUpdate: 'input', visible: !previewNameDiffers()" />
+      <input type="text" class="preview" readonly data-bind="value: previewName, visible: previewNameDiffers()" />
     </td>
 
     <td class="artist autocomplete" data-bind="artistCreditEditor: $data">
@@ -221,7 +222,7 @@
     </td>
 
     <td class="icon">
-      <button type="button" class="icon guesscase-title" title="[% l('Guess case track') %]" data-click="guessCaseTrackName"></button>
+      <button type="button" class="icon guesscase-title" title="[% l('Guess case track') %]" data-bind="click: $root.guessCaseTrackName, event: { mouseenter: $root.guessCaseTrackName, mouseleave: $root.guessCaseTrackName }"></button>
       <button type="button" class="icon guessfeat" title="[% l('Guess feat. artists') %]" data-click="guessTrackFeatArtists"></button>
       <!-- ko ifnot: (medium.hasToc() && !isDataTrack()) -->
       <button type="button" class="icon remove-item remove-track" title="[% l('Remove track') %]" data-click="removeTrack"></button>
@@ -316,8 +317,9 @@
           (<a href="[% c.uri_for('/doc/Release/Format') %]" target="_blank">[% l('help') %]</a>)
           <!-- ko if: release.mediums().length > 1 || name() -->
             <label data-bind="attr: { for: 'medium-title-' + uniqueID }">[% l('Medium title:') %]</label>
-            <input type="text" data-bind="value: name, attr: { id: 'medium-title-' + uniqueID }" />
-            <button type="button" class="icon guesscase-title" title="[% l('Guess case medium title') %]" data-click="guessCaseMediumName"></button>
+            <input type="text" data-bind="value: name, attr: { id: 'medium-title-' + uniqueID }, visible: !previewNameDiffers()" />
+            <input type="text" class="preview" readonly data-bind="value: previewName, visible: previewNameDiffers()" />
+            <button type="button" class="icon guesscase-title" title="[% l('Guess case medium title') %]" data-bind="click: $root.guessCaseMediumName, event: { mouseenter: $root.guessCaseMediumName, mouseleave: $root.guessCaseMediumName }"></button>
           <!-- /ko -->
           <p class="error field-error" style="padding-left: 1em" data-bind="showErrorWhenTabIsSwitched: needsFormat">
             [%~ l('A format is required. If you don’t know it, tick the “I don’t know” checkbox next to the format dropdown.') %]
@@ -524,7 +526,7 @@
           <button type="button" class="open-track-parser" data-click="openTrackParser">[% l('Track parser') %]</button>
           <button type="button" class="reset-track-numbers" data-click="resetTrackNumbers">[%- l('Reset track numbers') -%]</button>
           <button type="button" data-click="swapTitlesWithArtists">[%- l('Swap track titles with artist credits') -%]</button>
-          <button type="button" data-click="guessMediumCase">[%- l('Guess case') -%]</button>
+          <button type="button" data-bind="click: $root.guessMediumCase, event: { mouseenter: $root.guessMediumCase, mouseleave: $root.guessMediumCase }">[%- l('Guess case') -%]</button>
           <button type="button" data-click="guessMediumFeatArtists">[%- l('Guess feat. artists from track titles') -%]</button>
         </div>
 

--- a/root/static/scripts/alias/AliasEditForm.js
+++ b/root/static/scripts/alias/AliasEditForm.js
@@ -304,7 +304,8 @@ const AliasEditForm = ({
               disabled={state.isTypeSearchHint}
               dispatch={sortNameDispatch}
               entity={entity}
-              field={state.form.field.sort_name}
+              nameField={state.form.field.name}
+              sortNameField={state.form.field.sort_name}
             />
             <FormRowSelect
               allowEmpty

--- a/root/static/scripts/edit/components/FormRowNameWithGuessCase.js
+++ b/root/static/scripts/edit/components/FormRowNameWithGuessCase.js
@@ -99,8 +99,7 @@ component FormRowNameWithGuessCase(
   label: React$Node = addColonText(l('Name')),
 ) {
   const inputRef = React.useRef<HTMLInputElement | null>(null);
-  const [nameBeforePreview, setNameBeforePreview] =
-    React.useState<string | null>(null);
+  const [preview, setPreview] = React.useState<string | null>(null);
 
   function handleNameChange(event: SyntheticKeyboardEvent<HTMLInputElement>) {
     dispatch({
@@ -111,12 +110,8 @@ component FormRowNameWithGuessCase(
 
   function handleGuessCase() {
     flushSync(() => {
-      // Restore the original value if we're displaying a preview.
-      if (nameBeforePreview !== null) {
-        dispatch({name: nameBeforePreview, type: 'set-name'});
-        setNameBeforePreview(null);
-      }
       dispatch({entity, type: 'guess-case'});
+      setPreview(null);
     });
 
     if (inputRef.current) {
@@ -125,18 +120,13 @@ component FormRowNameWithGuessCase(
   }
 
   function showGuessCasePreview() {
-    setNameBeforePreview(field.value);
-    const name = GuessCase.entities[entity.entityType].guess(
-      field.value ?? '',
+    setPreview(
+      GuessCase.entities[entity.entityType].guess(field.value ?? ''),
     );
-    dispatch({name, type: 'set-name'});
   }
 
-  function hideGuessCasePreview() {
-    if (nameBeforePreview !== null) {
-      dispatch({name: nameBeforePreview, type: 'set-name'});
-      setNameBeforePreview(null);
-    }
+  function hidePreview() {
+    setPreview(null);
   }
 
   const toggleGuessCaseOptions = React.useCallback((
@@ -156,8 +146,7 @@ component FormRowNameWithGuessCase(
     [dispatch],
   );
 
-  const previewDiffers =
-    nameBeforePreview !== null && nameBeforePreview !== field.value;
+  const previewDiffers = preview !== null && preview !== field.value;
   const className =
     'with-guesscase' + (guessFeat ? '-guessfeat' : '') +
     (previewDiffers ? ' preview' : '');
@@ -169,13 +158,14 @@ component FormRowNameWithGuessCase(
       inputRef={inputRef}
       label={label}
       onChange={handleNameChange}
+      preview={preview}
       required
     >
       <button
         className="guesscase-title icon"
         onClick={handleGuessCase}
         onMouseEnter={showGuessCasePreview}
-        onMouseLeave={hideGuessCasePreview}
+        onMouseLeave={hidePreview}
         title={l('Guess case')}
         type="button"
       />

--- a/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
+++ b/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
@@ -68,8 +68,7 @@ component FormRowSortNameWithGuessCase(
   label: React$Node = addColonText(l('Sort name')),
   required: boolean = false,
 ) {
-  const [sortNameBeforePreview, setSortNameBeforePreview] =
-    React.useState<string | null>(null);
+  const [preview, setPreview] = React.useState<string | null>(null);
 
   const handleSortNameChange = React.useCallback((
     event: SyntheticKeyboardEvent<HTMLInputElement>,
@@ -81,34 +80,28 @@ component FormRowSortNameWithGuessCase(
   }, [dispatch]);
 
   function handleGuessCase() {
-    // Restore the original value if we're displaying a preview.
-    if (sortNameBeforePreview !== null) {
-      dispatch({sortName: sortNameBeforePreview, type: 'set-sortname'});
-      setSortNameBeforePreview(null);
-    }
     dispatch({entity, type: 'guess-case-sortname'});
+    setPreview(null);
   }
 
   function showGuessCasePreview() {
-    setSortNameBeforePreview(sortNameField.value);
-    const sortName = guessSortName(nameField.value ?? '', entity);
-    dispatch({sortName, type: 'set-sortname'});
-  }
-
-  function hideGuessCasePreview() {
-    if (sortNameBeforePreview !== null) {
-      dispatch({sortName: sortNameBeforePreview, type: 'set-sortname'});
-      setSortNameBeforePreview(null);
-    }
+    setPreview(guessSortName(nameField.value ?? '', entity));
   }
 
   function handleSortNameCopy() {
     dispatch({type: 'copy-sortname'});
+    setPreview(null);
   }
 
-  const previewDiffers =
-    sortNameBeforePreview !== null &&
-    sortNameBeforePreview !== sortNameField.value;
+  function showSortNameCopyPreview() {
+    setPreview(nameField.value ?? '');
+  }
+
+  function hidePreview() {
+    setPreview(null);
+  }
+
+  const previewDiffers = preview !== null && preview !== sortNameField.value;
 
   return (
     <FormRowText
@@ -117,6 +110,7 @@ component FormRowSortNameWithGuessCase(
       field={sortNameField}
       label={label}
       onChange={handleSortNameChange}
+      preview={preview}
       required={required}
     >
       <button
@@ -124,7 +118,7 @@ component FormRowSortNameWithGuessCase(
         disabled={disabled}
         onClick={handleGuessCase}
         onMouseEnter={showGuessCasePreview}
-        onMouseLeave={hideGuessCasePreview}
+        onMouseLeave={hidePreview}
         title={l('Guess sort name')}
         type="button"
       />
@@ -132,6 +126,8 @@ component FormRowSortNameWithGuessCase(
         className="sortname-copy icon"
         disabled={disabled}
         onClick={handleSortNameCopy}
+        onMouseEnter={showSortNameCopyPreview}
+        onMouseLeave={hidePreview}
         title={l('Copy name')}
         type="button"
       />

--- a/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
+++ b/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
@@ -43,15 +43,9 @@ export function runReducer(
       break;
     }
     case 'guess-case-sortname': {
-      const {entityType, typeID} = action.entity;
-      const isPerson =
-        entityType === 'artist' && typeID === ARTIST_TYPE_PERSON;
       newState.set(
         'sortNameField', 'value',
-        GuessCase.entities[entityType].sortname(
-          newState.read().nameField.value ?? '',
-          isPerson,
-        ),
+        guessSortName(newState.read().nameField.value ?? '', action.entity),
       );
       break;
     }
@@ -69,10 +63,14 @@ component FormRowSortNameWithGuessCase(
   disabled: boolean = false,
   dispatch: (ActionT) => void,
   entity: SortNamedEntityT,
-  field: FieldT<string | null>,
+  sortNameField: FieldT<string | null>,
+  nameField: FieldT<string | null>,
   label: React$Node = addColonText(l('Sort name')),
   required: boolean = false,
 ) {
+  const [sortNameBeforePreview, setSortNameBeforePreview] =
+    React.useState<string | null>(null);
+
   const handleSortNameChange = React.useCallback((
     event: SyntheticKeyboardEvent<HTMLInputElement>,
   ) => {
@@ -83,18 +81,40 @@ component FormRowSortNameWithGuessCase(
   }, [dispatch]);
 
   function handleGuessCase() {
+    // Restore the original value if we're displaying a preview.
+    if (sortNameBeforePreview !== null) {
+      dispatch({sortName: sortNameBeforePreview, type: 'set-sortname'});
+      setSortNameBeforePreview(null);
+    }
     dispatch({entity, type: 'guess-case-sortname'});
+  }
+
+  function showGuessCasePreview() {
+    setSortNameBeforePreview(sortNameField.value);
+    const sortName = guessSortName(nameField.value ?? '', entity);
+    dispatch({sortName, type: 'set-sortname'});
+  }
+
+  function hideGuessCasePreview() {
+    if (sortNameBeforePreview !== null) {
+      dispatch({sortName: sortNameBeforePreview, type: 'set-sortname'});
+      setSortNameBeforePreview(null);
+    }
   }
 
   function handleSortNameCopy() {
     dispatch({type: 'copy-sortname'});
   }
 
+  const previewDiffers =
+    sortNameBeforePreview !== null &&
+    sortNameBeforePreview !== sortNameField.value;
+
   return (
     <FormRowText
-      className="with-guesscase"
+      className={'with-guesscase' + (previewDiffers ? ' preview' : '')}
       disabled={disabled}
-      field={field}
+      field={sortNameField}
       label={label}
       onChange={handleSortNameChange}
       required={required}
@@ -103,6 +123,8 @@ component FormRowSortNameWithGuessCase(
         className="guesscase-sortname icon"
         disabled={disabled}
         onClick={handleGuessCase}
+        onMouseEnter={showGuessCasePreview}
+        onMouseLeave={hideGuessCasePreview}
         title={l('Guess sort name')}
         type="button"
       />
@@ -118,3 +140,9 @@ component FormRowSortNameWithGuessCase(
 }
 
 export default FormRowSortNameWithGuessCase;
+
+function guessSortName(name: string, entity: SortNamedEntityT): string {
+  const isPerson =
+    entity.entityType === 'artist' && entity.typeID === ARTIST_TYPE_PERSON;
+  return GuessCase.entities[entity.entityType].sortname(name, isPerson);
+}

--- a/root/static/scripts/edit/components/FormRowText.js
+++ b/root/static/scripts/edit/components/FormRowText.js
@@ -40,6 +40,7 @@ component FormRowText(
   field: FieldT<?string>,
   inputRef?: {-current: HTMLInputElement | null},
   label: React$Node,
+  preview?: string | null = null,
   required: boolean = false,
   size?: number,
   type: string = 'text',
@@ -57,7 +58,7 @@ component FormRowText(
     type: type,
   };
 
-  const inputValue = field.value ?? '';
+  const inputValue = preview ?? field.value ?? '';
 
   if (controlledProps.uncontrolled /*:: === true */) {
     inputProps.defaultValue = inputValue;

--- a/root/static/scripts/guess-case/MB/Control/GuessCase.js
+++ b/root/static/scripts/guess-case/MB/Control/GuessCase.js
@@ -30,13 +30,31 @@ MB.Control.initializeGuessCase = function (type, formPrefix) {
 
   function setVal($input, value) {
     $input.val(value).trigger('change');
+    $input.removeData('orig-value');
+    $input.removeClass('preview');
+  }
+  function showPreview($input, value) {
+    const orig = $input.val();
+    if (value !== orig) {
+      $input.val(value);
+      $input.data('orig-value', orig);
+      $input.addClass('preview');
+    }
+  }
+  function hidePreview($input) {
+    const orig = $input.data('orig-value');
+    if (orig !== undefined) {
+      $input.val(orig);
+      $input.removeData('orig-value');
+      $input.removeClass('preview');
+    }
   }
 
   $name.parent()
     .find('button.guesscase-title')
-    .on('click', function () {
-      setVal($name, guess.guess($name.val()));
-    })
+    .on('click', () => setVal($name, guess.guess($name.val())))
+    .on('mouseenter', () => showPreview($name, guess.guess($name.val())))
+    .on('mouseleave', () => hidePreview($name))
     .end()
     .find('button.guesscase-options')
     .on('click', function () {
@@ -46,16 +64,19 @@ MB.Control.initializeGuessCase = function (type, formPrefix) {
   var $sortname = $('#' + formPrefix + 'sort_name');
   var $artistType = $('#id-edit-artist\\.type_id');
 
+  function guessSortName() {
+    var args = [$name.val()];
+    if (type === 'artist') {
+      args.push($artistType.val() != 2 /* person */);
+    }
+    return guess.sortname.apply(guess, args);
+  }
+
   $sortname.parent()
-    .find('button.guesscase-sortname').on('click', function () {
-      var args = [$name.val()];
-
-      if (type === 'artist') {
-        args.push($artistType.val() != 2 /* person */);
-      }
-
-      setVal($sortname, guess.sortname.apply(guess, args));
-    })
+    .find('button.guesscase-sortname')
+    .on('click', () => setVal($sortname, guessSortName()))
+    .on('mouseenter', () => showPreview($sortname, guessSortName()))
+    .on('mouseleave', () => hidePreview($sortname))
     .end()
     .find('button.sortname-copy')
     .on('click', function () {

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -127,20 +127,38 @@ const actions = {
     }
   },
 
-  guessCaseAllMedia: function () {
+  guessCaseAllMedia: function (data, event) {
     for (const medium of this.mediums.peek()) {
-      releaseEditor.guessCaseMediumName(medium);
+      releaseEditor.guessCaseMediumName(medium, event);
       if (!medium.collapsed.peek()) {
-        releaseEditor.guessCaseTrackNames(medium);
+        releaseEditor.guessCaseTrackNames(medium, event);
       }
     }
   },
 
-  guessCaseMediumName: function (medium) {
-    var name = medium.name.peek();
+  /*
+   * Shows or hides a preview if event.type is 'mouseenter' or 'mouseleave'.
+   * Otherwise, updates the current name.
+   */
+  guessCaseMediumName: function (medium, event) {
+    const name = medium.name.peek();
+    if (!name) {
+      return;
+    }
 
-    if (name) {
-      medium.name(GuessCase.entities.release.guess(name));
+    switch (event.type) {
+      case 'mouseenter':
+        medium.previewName(GuessCase.entities.release.guess(name));
+        break;
+      case 'mouseleave':
+        medium.previewName(null);
+        break;
+      default:
+        medium.name(
+          medium.previewName() ??
+            GuessCase.entities.release.guess(name),
+        );
+        medium.previewName(null);
     }
   },
 
@@ -241,13 +259,30 @@ const actions = {
     medium.toc(null);
   },
 
-  guessCaseTrackName: function (track) {
-    track.name(GuessCase.entities.track.guess(track.name.peek()));
+  /*
+   * Shows or hides a preview if event.type is 'mouseenter' or 'mouseleave'.
+   * Otherwise, updates the current name.
+   */
+  guessCaseTrackName: function (track, event) {
+    switch (event.type) {
+      case 'mouseenter':
+        track.previewName(GuessCase.entities.track.guess(track.name.peek()));
+        break;
+      case 'mouseleave':
+        track.previewName(null);
+        break;
+      default:
+        track.name(
+          track.previewName() ??
+            GuessCase.entities.track.guess(track.name.peek()),
+        );
+        track.previewName(null);
+    }
   },
 
-  guessCaseTrackNames: function (medium) {
+  guessCaseTrackNames: function (medium, event) {
     for (const track of medium.tracks.peek()) {
-      releaseEditor.guessCaseTrackName(track);
+      releaseEditor.guessCaseTrackName(track, event);
     }
   },
 
@@ -309,9 +344,9 @@ const actions = {
     guessFeat(track);
   },
 
-  guessMediumCase: function (medium) {
-    releaseEditor.guessCaseMediumName(medium);
-    releaseEditor.guessCaseTrackNames(medium);
+  guessMediumCase: function (medium, event) {
+    releaseEditor.guessCaseMediumName(medium, event);
+    releaseEditor.guessCaseTrackNames(medium, event);
   },
 
   guessMediumFeatArtists: function (medium) {

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -57,6 +57,12 @@ class Track {
     this.name.original = data.name;
     this.name.subscribe(this.nameChanged, this);
 
+    this.previewName = ko.observable(null);
+    this.previewNameDiffers = ko.computed(() => {
+      const preview = this.previewName();
+      return preview !== null && preview !== this.name();
+    });
+
     this.length = ko.observable(data.length);
     this.length.original = data.length;
 
@@ -348,6 +354,11 @@ class Medium {
     this.release = release;
     this.name = ko.observable(data.name);
     this.originalName = data.name;
+    this.previewName = ko.observable(null);
+    this.previewNameDiffers = ko.computed(() => {
+      const preview = this.previewName();
+      return preview !== null && preview !== this.name();
+    });
     this.position = ko.observable(data.position || 1);
     this.formatID = ko.observable(data.format_id);
     this.originalFormatID = data.format_id

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -63,6 +63,12 @@ class Track {
       return preview !== null && preview !== this.name();
     });
 
+    this.inputName = ko.computed({
+      read: ko.computed(() => this.previewName() ?? this.name()),
+      write: this.name,
+      owner: this,
+    });
+
     this.length = ko.observable(data.length);
     this.length.original = data.length;
 
@@ -358,6 +364,11 @@ class Medium {
     this.previewNameDiffers = ko.computed(() => {
       const preview = this.previewName();
       return preview !== null && preview !== this.name();
+    });
+    this.inputName = ko.computed({
+      read: ko.computed(() => this.previewName() ?? this.name()),
+      write: this.name,
+      owner: this,
     });
     this.position = ko.observable(data.position || 1);
     this.formatID = ko.observable(data.format_id);

--- a/root/static/styles/colors.less
+++ b/root/static/styles/colors.less
@@ -85,3 +85,5 @@
 @edit-remove-bg: @negative-bg;                       // remove edit header
 @edit-merge-bg: #DDA0DD;                             // merge edit header
 @edit-other-bg: #ADD8E6;                             // other edit header
+
+@input-preview-bg: #FFF59D;                          // background color for <input> previews, e.g. for "guess case"

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -317,6 +317,10 @@ button.guessfeat {
     background-size: @form-icon-size @form-icon-size;
 }
 
+input[type=text].preview {
+    background-color: @input-preview-bg;
+}
+
 /* __________________________________
 
           MB.Control.Autocomplete

--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -111,16 +111,18 @@ fieldset.advanced-medium {
     tr.track td {
         background: @text-white;
         border: 1px dotted @very-light-border;
-        padding: 0 5px;
+        padding: 0;
         vertical-align: inherit !important;
 
-        &.position { width: 2em; }
+        &.position { width: 3em; }
         &.position input { text-align: right; }
 
-        &.reorder { width: 38px; }
+        &.reorder {
+            padding: 0 5px;
+            width: 38px;
+        }
 
         &.artist {
-            padding: 0;
             width: 45%;
             div.artist-credit-editor.autocomplete2 {
                 width: 100%;
@@ -132,22 +134,24 @@ fieldset.advanced-medium {
         }
 
         &.length {
-            width: 5em;
+            width: 6em;
             input { text-align: right; }
         }
 
-        &.icon { width: (@form-icon-size + 4) * 3; text-align: right; }
+        &.icon {
+            padding: 0 5px;
+            text-align: right;
+            width: (@form-icon-size + 4) * 3;
+        }
 
         &.guesscase a { color: @light-grey; font-weight: bolder; }
-
-        &.preview-differs { background-color: @input-preview-bg; }
 
         input[type=text] {
             width: 100%;
             height: 2em;
             border: 0;
-            /* Override grey background for input[readonly]. */
-            &.preview { background-color: transparent; }
+            padding: 0 5px;
+            &.preview { background-color: @input-preview-bg; }
         }
     }
 }

--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -140,10 +140,14 @@ fieldset.advanced-medium {
 
         &.guesscase a { color: @light-grey; font-weight: bolder; }
 
+        &.preview-differs { background-color: @input-preview-bg; }
+
         input[type=text] {
             width: 100%;
             height: 2em;
             border: 0;
+            /* Override grey background for input[readonly]. */
+            &.preview { background-color: transparent; }
         }
     }
 }

--- a/t/selenium/Artist_Edit_Form.json5
+++ b/t/selenium/Artist_Edit_Form.json5
@@ -11,10 +11,80 @@
       target: 'id=id-edit-artist.name',
       value: 'new artist',
     },
+    // Mouse over the "guess case" button and check that a preview is displayed.
     {
-      command: 'type',
+      command: 'mouseOver',
+      target: 'css=button.guesscase-title',
+      value: '',
+    },
+    {
+      command: 'assertValue',
+      target: 'id=id-edit-artist.name',
+      value: 'New Artist',
+    },
+    {
+      command: 'assertEval',
+      target: "document.getElementById('id-edit-artist.name').classList.contains('preview')",
+      value: 'true',
+    },
+    // Move the mouse away and check that the preview is hidden.
+    {
+      command: 'mouseOver',
+      target: 'id=id-edit-artist.name',
+      value: '',
+    },
+    {
+      command: 'assertValue',
+      target: 'id=id-edit-artist.name',
+      value: 'new artist',
+    },
+    {
+      command: 'assertEval',
+      target: "document.getElementById('id-edit-artist.name').classList.contains('preview')",
+      value: 'false',
+    },
+    // Click the "Guess case" button and check that the name is updated.
+    {
+      command: 'click',
+      target: 'css=button.guesscase-title',
+      value: '',
+    },
+    {
+      command: 'assertValue',
+      target: 'id=id-edit-artist.name',
+      value: 'New Artist',
+    },
+    // Check that hovering over "Guess sort name" also displays a preview.
+    {
+      command: 'mouseOver',
+      target: 'css=button.guesscase-sortname',
+      value: '',
+    },
+    {
+      command: 'assertValue',
       target: 'id=id-edit-artist.sort_name',
-      value: 'artist, new',
+      value: 'Artist, New',
+    },
+    {
+      command: 'assertEval',
+      target: "document.getElementById('id-edit-artist.sort_name').classList.contains('preview')",
+      value: 'true',
+    },
+    // Click "Guess sort name" and check that the change is applied.
+    {
+      command: 'click',
+      target: 'css=button.guesscase-sortname',
+      value: '',
+    },
+    {
+      command: 'assertValue',
+      target: 'id=id-edit-artist.sort_name',
+      value: 'Artist, New',
+    },
+    {
+      command: 'assertEval',
+      target: "document.getElementById('id-edit-artist.sort_name').classList.contains('preview')",
+      value: 'false',
     },
     {
       command: 'select',
@@ -167,8 +237,8 @@
           gender_id: null,
           ipi_codes: [],
           isni_codes: [],
-          name: 'new artist',
-          sort_name: 'artist, new',
+          name: 'New Artist',
+          sort_name: 'Artist, New',
           type_id: 2,
         },
       },
@@ -185,7 +255,7 @@
           entity0: {
             gid: '$$__IGNORE__$$',
             id: 4,
-            name: 'new artist',
+            name: 'New Artist',
           },
           entity1: {
             gid: '$$__IGNORE__$$',
@@ -236,7 +306,7 @@
           entity1: {
             gid: '$$__IGNORE__$$',
             id: 4,
-            name: 'new artist',
+            name: 'New Artist',
           },
           entity_id: 1,
           link_type: {
@@ -282,7 +352,7 @@
           entity1: {
             gid: '$$__IGNORE__$$',
             id: 4,
-            name: 'new artist',
+            name: 'New Artist',
           },
           entity_id: 2,
           link_type: {

--- a/t/selenium/Recording_Edit_Form.json5
+++ b/t/selenium/Recording_Edit_Form.json5
@@ -6,6 +6,49 @@
       target: '/recording/96f64611-49df-4e54-84e7-0f9a30f01766/edit',
       value: '',
     },
+    // A preview should be displayed when hovering over the "Guess case" button.
+    {
+      command: 'mouseOver',
+      target: 'css=button.guesscase-title',
+      value: '',
+    },
+    {
+      command: 'assertValue',
+      target: 'id=id-edit-recording.name',
+      value: 'Mr Self Destruct',
+    },
+    {
+      command: 'assertEval',
+      target: "document.getElementById('id-edit-recording.name').classList.contains('preview')",
+      value: 'true',
+    },
+    // The originally-typed name should be restored when the mouse is moved away.
+    {
+      command: 'mouseOver',
+      target: 'id=id-edit-recording.name',
+      value: '',
+    },
+    {
+      command: 'assertValue',
+      target: 'id=id-edit-recording.name',
+      value: 'mr self destruct',
+    },
+    {
+      command: 'assertEval',
+      target: "document.getElementById('id-edit-recording.name').classList.contains('preview')",
+      value: 'false',
+    },
+    // Clicking the button should update the name.
+    {
+      command: 'click',
+      target: 'css=button.guesscase-title',
+      value: '',
+    },
+    {
+      command: 'assertValue',
+      target: 'id=id-edit-recording.name',
+      value: 'Mr Self Destruct',
+    },
     // MBS-12694: In the recording edit form, adding a relationship to an
     // artist that appears in the recording AC, by selecting it from the
     // recent entities list, triggers a JavaScript error which prevents
@@ -105,6 +148,7 @@
                 },
               ],
             },
+            name: "Mr Self Destruct",
           },
           old: {
             artist_credit: {
@@ -119,6 +163,7 @@
                 },
               ],
             },
+            name: "mr self destruct",
           },
         },
       },

--- a/t/selenium/release-editor/The_Downward_Spiral.json5
+++ b/t/selenium/release-editor/The_Downward_Spiral.json5
@@ -370,17 +370,17 @@
     },
     {
       command: 'assertEval',
-      target: "document.querySelector('#tracklist table.medium tr.track:nth-child(8) td.title input.preview').style.display === 'none'",
-      value: 'true',
-    },
-    {
-      command: 'assertEval',
-      target: "document.querySelector('#tracklist table.medium tr.track:nth-child(9) td.title input.preview').style.display === 'none'",
+      target: "document.querySelector('#tracklist table.medium tr.track:nth-child(8) td.title input.track-name').classList.contains('preview')",
       value: 'false',
     },
     {
+      command: 'assertEval',
+      target: "document.querySelector('#tracklist table.medium tr.track:nth-child(9) td.title input.track-name').classList.contains('preview')",
+      value: 'true',
+    },
+    {
       command: 'assertValue',
-      target: 'css=#tracklist table.medium tr.track:nth-child(9) td.title input.preview',
+      target: 'css=#tracklist table.medium tr.track:nth-child(9) td.title input',
       value: 'Big Man With a Gun',
     },
     {
@@ -390,13 +390,23 @@
     },
     {
       command: 'assertEval',
-      target: "document.querySelector('#tracklist table.medium tr.track:nth-child(9) td.title input.preview').style.display === 'none'",
-      value: 'true',
+      target: "document.querySelector('#tracklist table.medium tr.track:nth-child(9) td.title input.track-name').classList.contains('preview')",
+      value: 'false',
+    },
+    {
+      command: 'assertValue',
+      target: 'css=#tracklist table.medium tr.track:nth-child(9) td.title input.track-name',
+      value: 'big man with a gun',
     },
     {
       command: 'click',
       target: 'id=guess-case-button',
       value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelector('#tracklist table.medium tr.track:nth-child(9) td.title input.track-name').classList.contains('preview')",
+      value: 'false',
     },
     {
       command: 'assertValue',

--- a/t/selenium/release-editor/The_Downward_Spiral.json5
+++ b/t/selenium/release-editor/The_Downward_Spiral.json5
@@ -361,11 +361,47 @@
       target: "xpath=(//tr[contains(@id, 'track-row-new')])[16]//input[contains(@class, 'track-name')]",
       value: 'data track',
     },
-    // Guess case.
+    // Guess case. First check that previews are shown only for modified tracks
+    // while hovering over the button, and then click the button.
+    {
+      command: 'mouseOver',
+      target: 'id=guess-case-button',
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelector('#tracklist table.medium tr.track:nth-child(8) td.title input.preview').style.display === 'none'",
+      value: 'true',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelector('#tracklist table.medium tr.track:nth-child(9) td.title input.preview').style.display === 'none'",
+      value: 'false',
+    },
+    {
+      command: 'assertValue',
+      target: 'css=#tracklist table.medium tr.track:nth-child(9) td.title input.preview',
+      value: 'Big Man With a Gun',
+    },
+    {
+      command: 'mouseOver',
+      target: 'id=format-unknown',
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelector('#tracklist table.medium tr.track:nth-child(9) td.title input.preview').style.display === 'none'",
+      value: 'true',
+    },
     {
       command: 'click',
       target: 'id=guess-case-button',
       value: '',
+    },
+    {
+      command: 'assertValue',
+      target: 'css=#tracklist table.medium tr.track:nth-child(9) td.title input.track-name',
+      value: 'Big Man With a Gun',
     },
     // Set the format to "unknown."
     {


### PR DESCRIPTION
# MBS-8217

When the user hovers over a "Guess case" button, display a preview of the updated name.

# Problem

It's hard to predict how names or titles will be changed when clicking "Guess case" or "Aa" buttons, and impossible to undo unwanted changes.

In a wide browser window, it's also difficult to see which track will be affected by a given "Aa" button in the tracklist editor.

# Solution

Display updated strings with a gray background while the user is hovering over the buttons. When the mouse exits the button, restore original values.

I updated various "Guess case" implementations:

* `root/release/edit/tracklist.tt`, `root/static/scripts/release-editor`: Knockout implementation used for the release editor's tracklist tab.
* `root/components/forms.tt`, `root/static/scripts/guess-case/MB/Control/GuessCase.js`: `guesscase` TT macro and jQuery implementation used for almost all other "Guess case" buttons (artist, label, release, RG, work, place, series, event).
* `root/static/scripts/edit/components/FormRowNameWithGuessCase.js`, `root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js`: React components used for just a few entity types (alias, recording, genre).

# Testing

I've manually tested that previews are shown on mousenter and hidden on mouseleave in almost all of the above pages, and that clicking the button still applies the changes. The one exception is the genre page (I assume that there's some flag I could set on my account in my dev server to let me edit genres).

I've also added Selenium tests for the artist, recording, and release tracklist pages.