### PR TITLE
MBS-13683: Always show event dates on JSON API

### DIFF
--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Utils.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Utils.pm
@@ -224,7 +224,8 @@ sub serialize_isnis {
 sub serialize_life_span {
     my ($into, $entity, $inc, $stash, $toplevel) = @_;
 
-    return unless $toplevel;
+    return unless $toplevel ||
+                  $entity->isa('MusicBrainz::Server::Entity::Event');
 
     my $life_span = {};
     serialize_date_period($life_span, $entity);

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupArtist.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupArtist.pm
@@ -256,6 +256,66 @@ test 'basic artist lookup, inc=url-rels' => sub {
         };
 };
 
+test 'basic artist lookup, inc=event-rels' => sub {
+
+    MusicBrainz::Server::Test->prepare_test_database(shift->c, '+webservice');
+
+    ws_test_json 'basic artist lookup, inc=event-rels',
+    '/artist/05d83760-08b5-42bb-a8d7-00d80b3bf47c?inc=event-rels' =>
+        {
+            id => '05d83760-08b5-42bb-a8d7-00d80b3bf47c',
+            name => 'Paul Allgood',
+            'sort-name' => 'Allgood, Paul',
+            country => JSON::null,
+            area => JSON::null,
+            'begin-area' => JSON::null,
+            'end-area' => JSON::null,
+            disambiguation => '',
+            'life-span' => {
+                begin => JSON::null,
+                end => JSON::null,
+                ended => JSON::false,
+            },
+            type => 'Person',
+            'type-id' => 'b6e035f4-3ce9-331c-97df-83397230b0df',
+            relations => [
+                {
+                    attributes => [],
+                    'attribute-ids' => {},
+                    'attribute-values' => {},
+                    direction => 'forward',
+                    event => {
+                        cancelled => JSON::true,
+                        disambiguation => 'A Comment',
+                        id => '166359d1-5a63-4033-945c-a6707844fb19',
+                        'life-span' => {
+                            begin => '2014-05-12',
+                            end => '2014-05-13',
+                            ended => JSON::true,
+                        },
+                        name => 'Sadly Cancelled Festival',
+                        setlist => '',
+                        time => '20:00',
+                        type => 'Festival',
+                        'type-id' => 'b6ded574-b592-3f0e-b56e-5b5f06aa0678',
+                    },
+                    type => 'main performer',
+                    'type-id' => '936c7c95-3156-3889-a062-8a0cd57f8946',
+                    begin => JSON::null,
+                    end => JSON::null,
+                    ended => JSON::false,
+                    'source-credit' => '',
+                    'target-credit' => '',
+                    'target-type' => 'event',
+                },
+            ],
+            ipis => [],
+            isnis => [],
+            gender => JSON::null,
+            'gender-id' => JSON::null,
+        };
+};
+
 test 'artist lookup with releases' => sub {
 
     MusicBrainz::Server::Test->prepare_test_database(shift->c, '+webservice');

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupArtist.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupArtist.pm
@@ -532,6 +532,31 @@ ws_test 'artist lookup with artist relations',
     </artist>
 </metadata>';
 
+ws_test 'artist lookup with event relations',
+    '/artist/05d83760-08b5-42bb-a8d7-00d80b3bf47c?inc=event-rels' =>
+    '<?xml version="1.0"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+    <artist type="Person" type-id="b6e035f4-3ce9-331c-97df-83397230b0df" id="05d83760-08b5-42bb-a8d7-00d80b3bf47c">
+        <name>Paul Allgood</name>
+        <sort-name>Allgood, Paul</sort-name>
+        <relation-list target-type="event">
+            <relation type-id="936c7c95-3156-3889-a062-8a0cd57f8946" type="main performer">
+                <target>166359d1-5a63-4033-945c-a6707844fb19</target>
+                <direction>forward</direction>
+                <event id="166359d1-5a63-4033-945c-a6707844fb19" type="Festival" type-id="b6ded574-b592-3f0e-b56e-5b5f06aa0678">
+                    <cancelled>true</cancelled>
+                    <disambiguation>A Comment</disambiguation>
+                    <life-span>
+                        <begin>2014-05-12</begin>
+                        <end>2014-05-13</end>
+                    </life-span>
+                    <name>Sadly Cancelled Festival</name>
+                    <time>20:00</time>
+                </event>
+            </relation>
+        </relation-list>
+    </artist>
+</metadata>';
 };
 
 1;

--- a/t/sql/webservice.sql
+++ b/t/sql/webservice.sql
@@ -148,6 +148,8 @@ INSERT INTO artist_credit_name (artist, artist_credit, join_phrase, name, positi
 -- Events
 INSERT INTO event (id, gid, name, type) VALUES (7, 'eb668bdc-a928-49a1-beb7-8e37db2a5b65', 'Cool Festival', 2);
 INSERT INTO event (begin_date_day, begin_date_month, begin_date_year, cancelled, comment, edits_pending, end_date_day, end_date_month, end_date_year, ended, gid, id, last_updated, name, time, type) VALUES (12, 5, 2014, '1', 'A Comment', 0, 13, 5, 2014, '1', '166359d1-5a63-4033-945c-a6707844fb19', 8, '2014-08-01 22:16:44.339332+00', 'Sadly Cancelled Festival', '20:00', 2);
+INSERT INTO link (attribute_count, begin_date_day, begin_date_month, begin_date_year, created, end_date_day, end_date_month, end_date_year, ended, id, link_type) VALUES (0, NULL, NULL, NULL, '2011-01-18 15:31:00.495651+00', NULL, NULL, NULL, '0', 52512, 798);
+INSERT INTO l_artist_event (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 398598, 8, 201, '2011-01-18 15:31:00.495651+00', 52512);
 
 INSERT INTO event_alias (id, event, name, sort_name) VALUES
     (1, 7, 'El Festival Cool', 'Festival Cool, El'),


### PR DESCRIPTION
### Fix MBS-13683

# Description
We show these for all events on the XML API, but we were serializing them only for toplevel events in JSON. This brings parity to both APIs in this regard.

# Testing
Tested manually with the `/ws/2/artist/7dc8f5bd-9d0b-4087-9f73-dc164950bbd8?inc=aliases+artist-rels+place-rels+event-rels+series-rels&fmt=json` URL listed in the ticket.