### PR TITLE
Releasing with prebuilt Docker image for mirrors

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,7 +13,7 @@
 
 - [Prerequisites](#prerequisites)
 - [Release production](#release-production)
-  * [Prepare MBS version in Jira](#prepare-mbs-version-in-jira)
+  * [Prepare Jira](#prepare-jira)
   * [Update translated messages](#update-translated-messages)
   * [Merge Git branches](#merge-git-branches)
   * [Build Docker images](#build-docker-images)
@@ -39,10 +39,24 @@ See the private system administration wiki for additional prerequisites.
 
 ## Release production
 
-### Prepare MBS version in Jira
+### Prepare Jira
+
+Those steps should be followed when releasing beta, and then double-checked when releasing production.
 
 1. Make sure a version with status “Unreleased”, usually named “next”, is present in the
    [Jira MBS project administration panel](https://tickets.metabrainz.org/projects/MBS?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page). Its serial ID will be used for tagging the branch `production` in Git.
+
+2. Make sure that the field “Fix Version” is set to this version for all the
+   [tickets in beta testing](http://tickets.musicbrainz.org/secure/IssueNavigator.jspa?reset=true&jqlQuery=status+%3D+%22In+Beta+Testing%22+and+project+%3D+mbs). If needed, use “Tools”, “Bulk Change”, “Edit Issues”, without “Send mail for this update”.
+
+3. Make sure that all of these tickets also have:
+
+   * A “type” that makes sense;
+   * A “summary” that makes sense for the type, and is clear even in a list that does not include other fields;
+   * A “description” that explains the why and the how, the situation before and after;
+   * The appropriate “components” and “labels” set.
+
+   (It is fairly common to have to update both summary and description after implementation.)
 
 ### Update translated messages
 
@@ -113,22 +127,16 @@ Now that you have done the release, you will need to update Jira:
 1. Edit the unreleased version “next” in the
    [Jira MBS project administration panel](https://tickets.metabrainz.org/projects/MBS?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page) to set the field “Release date” to the current date and the field “Name” also to the current date (or to “Schema Change, Year Q#” for schema change release).
 
-2. Make sure that the field “Fix Version” is set to this version for all the
-   [tickets in beta testing](http://tickets.musicbrainz.org/secure/IssueNavigator.jspa?reset=true&jqlQuery=status+%3D+%22In+Beta+Testing%22+and+project+%3D+mbs). If needed, use “Tools”, “Bulk Change”, “Edit Issues”, without “Send mail for this update”.
-
-3. Close all tickets
+2. Close all tickets
    [`status = "In Beta Testing" and project = MBS`](http://tickets.musicbrainz.org/secure/IssueNavigator.jspa?reset=true&jqlQuery=status+%3D+%22In+Beta+Testing%22+and+project+%3D+mbs)
    as "Fixed."
 
-4. Make sure all the tickets have a type that makes sense, enough information
-   to be understandable, and the appropriate components set.
+3. Create a new version named “next” with “TBD” as description.
 
-5. Create a new version named “next” with “TBD” as description.
-
-6. Release the current version. All open tickets should be moved to the next
+4. Release the current version. All open tickets should be moved to the next
    version.
 
-7. Archive any previous versions still marked as "Released", except for
+5. Archive any previous versions still marked as "Released", except for
    the latest schema change release.
 
 ### Blog
@@ -167,7 +175,10 @@ Once the draft has been reviewed, publish it, then update the description of the
 
 It has some differences with the production release process; follow these steps:
 
-1. On the translations update step, do not just update translated messages,
+1. On the [prepare Jira](#prepare-jira) step, it might take some more time
+   to update tickets than for production release when everything is ready.
+
+2. On the translations update step, do not just update translated messages,
    also update source messages for translation. This involves four steps:
 
    1. _Commit_ and _push_ any change from the
@@ -188,22 +199,22 @@ It has some differences with the production release process; follow these steps:
       if you updated `master` here then `beta` will be updated
       in the next step.
 
-2. On the git branches merge step, to update the `beta` branch with the changes from the `master` branch,
+3. On the git branches merge step, to update the `beta` branch with the changes from the `master` branch,
    merge `master` into `beta` (with `git merge --log=876423 --no-ff master`) and push to `beta`.
    (Skip this, of course, if you're just deploying changes pushed directly to the `beta` branch.)
 
-3. On the [build Docker images step](#build-docker-images),
+4. On the [build Docker images step](#build-docker-images),
    enter `beta` for _IMAGE_BRANCH_ when doing “Build with Parameters”.
    Wait until the build has completed.
 
-4. On the [deployment’s announcement step](#announce-the-deployment),
+5. On the [deployment’s announcement step](#announce-the-deployment),
    [set the banner message on beta](https://beta.musicbrainz.org/admin/banner/edit) to
 
    ```html
    Beta website is being updated, slowdowns may occur for a few minutes, thanks for your patience.
    ```
 
-5. On the [deployment step](#deploy-to-production) itself,
+6. On the [deployment step](#deploy-to-production) itself,
    run `./script/update_containers.sh beta`. Wait until the deployment has completed.
 
    Notes:
@@ -211,7 +222,7 @@ It has some differences with the production release process; follow these steps:
      which means that new reports are not available on the beta website for now.
    - The banner’s website is updated only after updating tickets; see below.
 
-6. On the [Jira step](#update-jira), set all the tickets
+7. On the [Jira step](#update-jira), set all the tickets
    [`status = "In Development Branch" and project = MBS`](http://tickets.musicbrainz.org/secure/IssueNavigator.jspa?reset=true&jqlQuery=status+%3D+%22In+Development+Branch%22+and+project+%3D+mbs)
    as status "In Beta Testing." For tickets which fixed a beta-only issue not
    present in production, close the ticket as fixed and set the fix version
@@ -223,7 +234,7 @@ It has some differences with the production release process; follow these steps:
    - Add git tag
    - Release `musicbrainz-docker`
 
-7. Again, [set the banner message on beta](https://beta.musicbrainz.org/admin/banner/edit) to
+8. Again, [set the banner message on beta](https://beta.musicbrainz.org/admin/banner/edit) to
 
    ```html
    Beta MusicBrainz Server has been updated on Month DD, see the list of <a href="https://tickets.metabrainz.org/issues/?filter=10715">tickets available for beta testing</a>.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -99,8 +99,13 @@ move these to the section “React Conversion Task” at the end,
 and move other (sub-)tasks under the section “Other Task”.
 Otherwise, just put all the tasks under a unique section “Task”.
 
-Thank reporters of each addressed issue at least, and every other
-contributor/tester/translator if possible, but contractors.
+Last but not least, thank (in order of rarity):
+* code contributors,
+* translators, who can be listed with `./po/list_translators`,
+* reporters of each addressed issue at least,
+  and every other constructive feedback providers if possible.
+
+(Avoid thanking ourselves, contractors.)
 
 ### Merge Git branches
 
@@ -177,6 +182,10 @@ just make sure to update the following if any changes occurred:
 
 * Tickets’ title and type
 * Acknowledgments (including translators and beta reporters)
+
+To do so, you can adapt the draft section with:
+* appending a Git revision range `v-prev-io-us..v-curr-en-t`
+  to the listing command (see `--help` for details).
 
 Once the draft has been reviewed, then update the description of the MBS version in Jira with the blog post URL.
 This URL will also be used in the following section.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,6 +66,11 @@ process below first!), you need to start by updating the translated messages:
 
 2. Merge `production` to `master` (`git merge --log=876423 --no-ff production`) and push.
 
+### Add Git tag
+
+You should tag production releases by using `./script/tag.sh`, which will ask you
+the necessary questions. Skip this step if you're releasing beta or test.
+
 ### Build Docker images
 
 Then, you must build new MusicBrainz Server Docker images from Jenkins:
@@ -142,11 +147,6 @@ Thank reporters of each addressed issue at least, and every other
 contributor/tester/translator if possible, but contractors.
 
 Once the draft has been reviewed, publish it, then update the description of the Jira version with the blog post URL.
-
-### Add Git tag
-
-You should tag production releases by using `./script/tag.sh`, which will ask you
-the necessary questions. Skip this step if you're releasing beta or test.
 
 ### Release musicbrainz-docker
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -171,18 +171,31 @@ Once the draft has been reviewed, publish it, then update the description of the
 
 ### Release musicbrainz-docker
 
-1. Update the current MB version in the musicbrainz-docker repository. See example commit <https://github.com/metabrainz/musicbrainz-docker/commit/83da2d3602030da9596a8899513ccda11498f077>.
+In your clone of [MusicBrainz’s Docker Compose project](https://github.com/metabrainz/musicbrainz-docker):
 
-2. Tag the release (`git tag -u CE33CF04 $version_number -m 'Upgrade MusicBrainz Server.'`) and push.
+1. Update the version of MusicBrainz Server to dockerize.
+   See example commit <https://github.com/metabrainz/musicbrainz-docker/commit/a0930848751a9b923e8c7261f2ff2904af2577ec>.
+   See also prerequisites from `admin/repository/prebuild-musicbrainz --help`.
 
-3. Do a git release of name `$version_number` (copy the structure from previous [releases](https://github.com/metabrainz/musicbrainz-docker/releases)).
+   Check files under `build/musicbrainz/` and `build/musicbrainz-dev/` and update those if needed.
+   It can usually be needed when changing `DBDefs`, dependencies, or scripts in MusicBrainz Server.
 
-4. Release the appropriate [Jira version](https://tickets.metabrainz.org/projects/MBVM?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page);
-   as its description, set the git release URL (https://github.com/metabrainz/musicbrainz-docker/releases/tag/$version_number).
+2. Build, tag and push Docker image for mirrors using the script `admin/repository/prebuild-musicbrainz`
+
+3. Manually test running a mirror with this image.
+   (Test development setup too if there is any change to it.)
+
+4. Tag your local Git branch `master` (`git tag -u CE33CF04 $version_number -m 'Upgrade MusicBrainz Server.'`)
+   and push both the commits and the tag.
+
+5. Do a GitHub release of name `$version_number` (copy the structure from previous [releases](https://github.com/metabrainz/musicbrainz-docker/releases)).
+
+6. Release the appropriate [Jira version](https://tickets.metabrainz.org/projects/MBVM?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page);
+   as its description, set the GitHub release URL (`https://github.com/metabrainz/musicbrainz-docker/releases/tag/$version_number`).
    Archive the previous non-schema change releases, if not yet archived. Create a new version
-   for the next expected release, with the description "next release".
+   for the next expected release, with the description "TBD".
 
-5. Edit the blog post to link to the new musicbrainz-docker release.
+7. Edit the blog post to link to the new musicbrainz-docker release.
 
 ## Release beta
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,6 +15,7 @@
 - [Release production](#release-production)
   * [Prepare Jira](#prepare-jira)
   * [Update translated messages](#update-translated-messages)
+  * [Draft blog post](#draft-blog-post)
   * [Merge Git branches](#merge-git-branches)
   * [Build Docker images](#build-docker-images)
   * [Announce the deployment](#announce-the-deployment)
@@ -83,6 +84,23 @@ process below first!), you need to start by updating the translated messages:
    ```
    Wait until [CircleCI](https://circleci.com/gh/metabrainz/musicbrainz-server) is happy
    with this merge as some unmatching translations can break building Docker images.
+
+### Draft blog post
+
+[Create a new draft from the template](https://wordpress.com/post/blog.metabrainz.org?jetpack-copy=8634).
+The list of tickets can be copied from the auto-generated release notes,
+by going to the [Releases](http://tickets.musicbrainz.org/browse/MBS#selectedTab=com.atlassian.jira.plugin.system.project%3Aversions-panel) tab,
+selecting the version you are going to release,
+and clicking “Release Notes” in the top.
+
+If there are any React conversion tasks
+(which should be sub-tasks of [MBS-8609](https://tickets.metabrainz.org/browse/MBS-8609)),
+move these to the section “React Conversion Task” at the end,
+and move other (sub-)tasks under the section “Other Task”.
+Otherwise, just put all the tasks under a unique section “Task”.
+
+Thank reporters of each addressed issue at least, and every other
+contributor/tester/translator if possible, but contractors.
 
 ### Merge Git branches
 
@@ -154,20 +172,15 @@ Now that you have done the release, you will need to update Jira:
 
 ### Blog
 
-[Create a new draft from the template](https://wordpress.com/post/blog.metabrainz.org?jetpack-copy=8634).
-The list of tickets can be copied from the auto-generated release notes,
-by going to the [Releases](http://tickets.musicbrainz.org/browse/MBS#selectedTab=com.atlassian.jira.plugin.system.project%3Aversions-panel) tab,
-selecting the version you just released,
-and clicking “Release Notes” in the top.
+Assuming that you [drafted a blog post](#draft-blog-post) already,
+just make sure to update the following if any changes occurred:
 
-Move sub-tasks of MBS-8609 to the “React Conversion Task” section at the end,
-and move other sub-tasks under the “Other Task” section (rename to just “Task”
-if there are no React conversion tasks in this release).
+* Tickets’ title and type
+* Acknowledgments (including translators and beta reporters)
 
-Thank reporters of each addressed issue at least, and every other
-contributor/tester/translator if possible, but contractors.
-
-Once the draft has been reviewed, publish it, then update the description of the Jira version with the blog post URL.
+Once the draft has been reviewed, then update the description of the MBS version in Jira with the blog post URL.
+This URL will also be used in the following section.
+The blog post will be published only after that.
 
 ### Release musicbrainz-docker
 
@@ -196,6 +209,8 @@ In your clone of [MusicBrainz’s Docker Compose project](https://github.com/met
    for the next expected release, with the description “TBD”.
 
 7. Edit the blog post to link to the new musicbrainz-docker release.
+
+8. Publish both the blog post and the musicbrainz-docker release.
 
 ## Release beta
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -100,7 +100,7 @@ and move other (sub-)tasks under the section “Other Task”.
 Otherwise, just put all the tasks under a unique section “Task”.
 
 Last but not least, thank (in order of rarity):
-* code contributors,
+* code contributors, who can be listed with `./script/list_code_contributors`,
 * translators, who can be listed with `./po/list_translators`,
 * reporters of each addressed issue at least,
   and every other constructive feedback providers if possible.
@@ -185,7 +185,7 @@ just make sure to update the following if any changes occurred:
 
 To do so, you can adapt the draft section with:
 * appending a Git revision range `v-prev-io-us..v-curr-en-t`
-  to the listing command (see `--help` for details).
+  to the listing commands (see `--help` for details).
 
 Once the draft has been reviewed, then update the description of the MBS version in Jira with the blog post URL.
 This URL will also be used in the following section.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,6 +13,7 @@
 
 - [Prerequisites](#prerequisites)
 - [Release production](#release-production)
+  * [Prepare MBS version in Jira](#prepare-mbs-version-in-jira)
   * [Update translated messages](#update-translated-messages)
   * [Merge Git branches](#merge-git-branches)
   * [Build Docker images](#build-docker-images)
@@ -37,6 +38,11 @@
 See the private system administration wiki for additional prerequisites.
 
 ## Release production
+
+### Prepare MBS version in Jira
+
+1. Make sure a version with status “Unreleased”, usually named “next”, is present in the
+   [Jira MBS project administration panel](https://tickets.metabrainz.org/projects/MBS?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page). Its serial ID will be used for tagging the branch `production` in Git.
 
 ### Update translated messages
 
@@ -99,20 +105,25 @@ Beta website is currently the same as the main website, nothing to be tested for
 
 Now that you have done the release, you will need to update Jira:
 
-1. Make sure a new release version is present in the
-   [Jira project administration panel](https://tickets.metabrainz.org/projects/MBS?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page).
+1. Edit the unreleased version “next” in the
+   [Jira MBS project administration panel](https://tickets.metabrainz.org/projects/MBS?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page) to set the field “Release date” to the current date and the field “Name” also to the current date (or to “Schema Change, Year Q#” for schema change release).
 
-2. Close all tickets
+2. Make sure that the field “Fix Version” is set to this version for all the
+   [tickets in beta testing](http://tickets.musicbrainz.org/secure/IssueNavigator.jspa?reset=true&jqlQuery=status+%3D+%22In+Beta+Testing%22+and+project+%3D+mbs). If needed, use “Tools”, “Bulk Change”, “Edit Issues”, without “Send mail for this update”.
+
+3. Close all tickets
    [`status = "In Beta Testing" and project = MBS`](http://tickets.musicbrainz.org/secure/IssueNavigator.jspa?reset=true&jqlQuery=status+%3D+%22In+Beta+Testing%22+and+project+%3D+mbs)
    as "Fixed."
 
-3. Make sure all the tickets have a type that makes sense, enough information
+4. Make sure all the tickets have a type that makes sense, enough information
    to be understandable, and the appropriate components set.
 
-4. Release the current version. All open tickets should be moved to the next
+5. Create a new version named “next” with “TBD” as description.
+
+6. Release the current version. All open tickets should be moved to the next
    version.
 
-5. Archive any previous versions still marked as "Released", except for
+7. Archive any previous versions still marked as "Released", except for
    the latest schema change release.
 
 ### Blog

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -103,7 +103,10 @@ Last but not least, thank (in order of rarity):
 * code contributors, who can be listed with `./script/list_code_contributors`,
 * translators, who can be listed with `./po/list_translators`,
 * reporters of each addressed issue at least,
-  and every other constructive feedback providers if possible.
+  and every other constructive feedback providers if possible:
+  * reporters of [tickets addressed in beta](https://tickets.metabrainz.org/issues/?filter=10715&jql=project%20%3D%20MBS%20AND%20status%20%3D%20%22In%20Beta%20Testing%22%20ORDER%20BY%20reporter%20ASC%2C%20type%2C%20key)
+  * reporters of [tickets about beta](https://tickets.metabrainz.org/issues/?jql=project%20%3D%20MBS%20AND%20%28summary%20~%20Beta%20OR%20fixVersion%20%3D%20Beta%29%20AND%20created%20%3E%3D%20-2weeks%20ORDER%20BY%20reporter%20ASC) (assuming a two weeks cycle)
+  * especially good comment authors if possible (using the same lists ordered by “Watchers” to find the most popular tickets, see also pull requests)
 
 (Avoid thanking ourselves, contractors.)
 
@@ -185,7 +188,10 @@ just make sure to update the following if any changes occurred:
 
 To do so, you can adapt the draft section with:
 * appending a Git revision range `v-prev-io-us..v-curr-en-t`
-  to the listing commands (see `--help` for details).
+  to the listing commands (see `--help` for details),
+* replacing some condition with
+  `fixVersion = ` _the current version_
+  in the Jira queries.
 
 Once the draft has been reviewed, then update the description of the MBS version in Jira with the blog post URL.
 This URL will also be used in the following section.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,6 +37,8 @@
 
 See the private system administration wiki for additional prerequisites.
 
+The Git remote `origin` is assumed to point at `https://github.com/metabrainz/musicbrainz-server.git`.
+
 ## Release production
 
 ### Prepare Jira
@@ -63,11 +65,22 @@ Those steps should be followed when releasing beta, and then double-checked when
 Assuming the source messages were updated when releasing beta (if not, see that under the beta
 process below first!), you need to start by updating the translated messages:
 
-1. _Commit_ and _push_ any change from the
-   [repository in Weblate](https://translations.metabrainz.org/projects/musicbrainz/#repository),
-   and update your local `translations` branch.
+1. From the [repository in Weblate](https://translations.metabrainz.org/projects/musicbrainz/#repository):
 
-2. Merge `translations` to `beta` (`git merge --log=876423 --no-ff translations`) and push.
+   1. If there are any _Pending changes_, _Commit_ those and wait a bit before reloading the page.
+
+   2. If there are any commits _missing in the push branch_, _Push_ those and wait (some more time) before reloading the page.
+
+   3. If there are any _missing commits_ from _upstream_ (beta branch), _Update_ the _Weblate repository_ and wait (even longer) before reloading the page.
+
+2. Update your local `translations` branch and merge it to `beta` and push as follows:
+   ```sh
+   git fetch origin && \
+   git checkout origin/translations -B translations && \
+   git checkout beta && \
+   git merge --log=876423 --no-ff translations && \
+   git push
+   ```
    Wait until [CircleCI](https://circleci.com/gh/metabrainz/musicbrainz-server) is happy
    with this merge as some unmatching translations can break building Docker images.
 
@@ -178,14 +191,15 @@ It has some differences with the production release process; follow these steps:
 1. On the [prepare Jira](#prepare-jira) step, it might take some more time
    to update tickets than for production release when everything is ready.
 
-2. On the translations update step, do not just update translated messages,
-   also update source messages for translation. This involves four steps:
+2. On the [translations update](#update-translated-messages) step,
+   start with following the exact same two steps (more detailed above):
 
-   1. _Commit_ and _push_ any change from the
-      [repository in Weblate](https://translations.metabrainz.org/projects/musicbrainz/#repository),
-      and update your local `translations` branch.
+   1. _Commit_ any pending change, _push_ any missing commit to downstream, and _update_ any missing commit from upstream, all from the
+      [repository in Weblate](https://translations.metabrainz.org/projects/musicbrainz/#repository).
 
-   2. Merge `translations` to `beta` (`git merge --log=876423 --no-ff translations`) and push.
+   2. Update your local `translations` branch and merge it to `beta` and push.
+
+   Then additionally update source messages for translation as follows:
 
    3. On `master` (or `beta` if changes have been pushed directly there),
       run `./po/update_pot.sh` to generate new .pot files from the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -67,11 +67,11 @@ process below first!), you need to start by updating the translated messages:
 
 1. From the [repository in Weblate](https://translations.metabrainz.org/projects/musicbrainz/#repository):
 
-   1. If there are any _Pending changes_, _Commit_ those and wait a bit before reloading the page.
+   1. If there are any “Pending changes”, “Commit” those and wait a bit before reloading the page.
 
-   2. If there are any commits _missing in the push branch_, _Push_ those and wait (some more time) before reloading the page.
+   2. If there are any commits “missing in the push branch”, “Push” those and wait (some more time) before reloading the page.
 
-   3. If there are any _missing commits_ from _upstream_ (beta branch), _Update_ the _Weblate repository_ and wait (even longer) before reloading the page.
+   3. If there are any “missing commits” from “upstream” (beta branch), “Update” the “Weblate repository” and wait (even longer) before reloading the page.
 
 2. Update your local `translations` branch and merge it to `beta` and push as follows:
    ```sh
@@ -140,16 +140,16 @@ Now that you have done the release, you will need to update Jira:
 1. Edit the unreleased version “next” in the
    [Jira MBS project administration panel](https://tickets.metabrainz.org/projects/MBS?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page) to set the field “Release date” to the current date and the field “Name” also to the current date (or to “Schema Change, Year Q#” for schema change release).
 
-2. Close all tickets
-   [`status = "In Beta Testing" and project = MBS`](http://tickets.musicbrainz.org/secure/IssueNavigator.jspa?reset=true&jqlQuery=status+%3D+%22In+Beta+Testing%22+and+project+%3D+mbs)
-   as "Fixed."
+2. Close all the 
+   [tickets in beta testing](http://tickets.musicbrainz.org/secure/IssueNavigator.jspa?reset=true&jqlQuery=status+%3D+%22In+Beta+Testing%22+and+project+%3D+mbs)
+   as “Fixed”.
 
 3. Create a new version named “next” with “TBD” as description.
 
-4. Release the current version. All open tickets should be moved to the next
-   version.
+4. “Release” the current version. Any tickets remaining in this version and
+   having a status other than “Closed” should be moved to the version “next”.
 
-5. Archive any previous versions still marked as "Released", except for
+5. “Archive” any previous versions still marked as “Released”, except for
    the latest schema change release.
 
 ### Blog
@@ -193,7 +193,7 @@ In your clone of [MusicBrainz’s Docker Compose project](https://github.com/met
 6. Release the appropriate [Jira version](https://tickets.metabrainz.org/projects/MBVM?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page);
    as its description, set the GitHub release URL (`https://github.com/metabrainz/musicbrainz-docker/releases/tag/$version_number`).
    Archive the previous non-schema change releases, if not yet archived. Create a new version
-   for the next expected release, with the description "TBD".
+   for the next expected release, with the description “TBD”.
 
 7. Edit the blog post to link to the new musicbrainz-docker release.
 
@@ -207,7 +207,7 @@ It has some differences with the production release process; follow these steps:
 2. On the [translations update](#update-translated-messages) step,
    start with following the exact same two steps (more detailed above):
 
-   1. _Commit_ any pending change, _push_ any missing commit to downstream, and _update_ any missing commit from upstream, all from the
+   1. “Commit” any pending change, “push” any missing commit to downstream, and “update” any missing commit from upstream, all from the
       [repository in Weblate](https://translations.metabrainz.org/projects/musicbrainz/#repository).
 
    2. Update your local `translations` branch and merge it to `beta` and push.
@@ -249,12 +249,12 @@ It has some differences with the production release process; follow these steps:
      which means that new reports are not available on the beta website for now.
    - The banner’s website is updated only after updating tickets; see below.
 
-7. On the [Jira step](#update-jira), set all the tickets
-   [`status = "In Development Branch" and project = MBS`](http://tickets.musicbrainz.org/secure/IssueNavigator.jspa?reset=true&jqlQuery=status+%3D+%22In+Development+Branch%22+and+project+%3D+mbs)
-   as status "In Beta Testing." For tickets which fixed a beta-only issue not
-   present in production, close the ticket as fixed and set the fix version
-   to "Beta." Make sure all the tickets have a type that makes sense, enough information
-   to be understandable, and the appropriate components set.
+7. On the [Jira step](#update-jira), transition all the
+   [tickets marked as in development branch](http://tickets.musicbrainz.org/secure/IssueNavigator.jspa?reset=true&jqlQuery=status+%3D+%22In+Development+Branch%22+and+project+%3D+mbs)
+   to the status “In Beta Testing”. For tickets which fixed a beta-only issue not
+   present in production, close the ticket as fixed and set the field “Fix Version”
+   to “Beta”. Make sure all the tickets have a type that makes sense, enough information
+   to be understandable, and the appropriate components and labels set.
 
    Notes: None of the following steps are involved in releasing beta:
    - Blog

--- a/po/list_translators
+++ b/po/list_translators
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -e -u
+
+SCRIPT_NAME=$(basename "$0")
+
+MB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
+source "$MB_SERVER_ROOT"/script/macos_compat.inc.sh
+
+declare -a OMITTED_AUTHORS=(
+  # From the add-on "Update PO files to match POT (msgmerge)"
+  'Hosted Weblate'
+  # Contractors, avoiding to be self-congratulatory
+  bitmap
+  'Michael Wiencek'
+  reosarevok
+  'Nicolás Tamargo'
+  yvanzo
+)
+
+GIT_REVISION_RANGE='origin/production..origin/beta'
+
+HELP=$(cat <<EOH
+Usage: $SCRIPT_NAME [<git-revision-range>]
+
+List the translators for the given Git revision range.
+
+The default Git revision range is $GIT_REVISION_RANGE
+assuming that this script is called before merging to production.
+
+The following translation authors are intentionally unlisted:
+    $(printf '%s, ' "${OMITTED_AUTHORS[@]}" | sed "s_, \$__")
+
+Commas (and surrounding spaces) in author names are replaced with slashes (/).
+EOH
+)
+
+if [[ $# -gt 1 ]]
+then
+  echo >&2 "$SCRIPT_NAME: too many arguments"
+  echo >&2 "$HELP"
+  exit 64
+elif [[ $# -eq 1 ]]
+then
+  if echo "$1" | grep -Eqx -- '-*h(elp)?'
+  then
+    echo "$HELP"
+    exit
+  else
+    GIT_REVISION_RANGE=$1
+  fi
+fi
+
+cd "$MB_SERVER_ROOT"
+
+git log --no-merges "$GIT_REVISION_RANGE" -- 'po/*.po' | \
+  # Capture translation author full names
+  sed -n 's/^Author: \(.*\) <.*$/\1/p' | \
+  # Omit Weblate authors and blog post authors
+  grep -iv "^\($(printf '%s\|' "${OMITTED_AUTHORS[@]}" | sed 's/\\|$//')\)$" | \
+  # Replace commas with slashes in names
+  sed 's_\s*,\s*_/_g' | \
+  # Deduplicate and sort alphabetically
+  sort -u | \
+  # Separate with commas
+  tr '\n' ',' | \
+  sed 's/,/, /g' | \
+  sed 's/, $/\n/'
+
+# vi: set et sts=2 sw=2 ts=2 :

--- a/script/list_code_contributors
+++ b/script/list_code_contributors
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -e -u
+
+SCRIPT_NAME=$(basename "$0")
+
+MB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
+source "$MB_SERVER_ROOT"/script/macos_compat.inc.sh
+
+declare -a OMITTED_AUTHORS=(
+  # Contractors, avoiding to be self-congratulatory
+  bitmap
+  'Michael Wiencek'
+  reosarevok
+  'Nicolás Tamargo'
+  yvanzo
+)
+
+GIT_REVISION_RANGE='origin/production..origin/beta'
+
+HELP=$(cat <<EOH
+Usage: $SCRIPT_NAME [<git-revision-range>]
+
+List the code contributors for the given Git revision range.
+
+The default Git revision range is $GIT_REVISION_RANGE
+assuming that this script is called before merging to production.
+Please use the latest Git tags for the revision range otherwise.
+
+The following code contributors are intentionally unlisted:
+    $(printf '%s, ' "${OMITTED_AUTHORS[@]}" | sed "s_, \$__")
+
+Commas (and surrounding spaces) in author names are replaced with slashes (/).
+
+Note that it lists commit authors by their names, not by their GitHub handles.
+EOH
+)
+
+if [[ $# -gt 1 ]]
+then
+  echo >&2 "$SCRIPT_NAME: too many arguments"
+  echo >&2 "$HELP"
+  exit 64
+elif [[ $# -eq 1 ]]
+then
+  if echo "$1" | grep -Eqx -- '-*h(elp)?'
+  then
+    echo "$HELP"
+    exit
+  else
+    GIT_REVISION_RANGE=$1
+  fi
+fi
+
+cd "$MB_SERVER_ROOT"
+
+git log "$GIT_REVISION_RANGE" -- ':(exclude)po/*.po' | \
+  # Capture code contributor full names
+  sed -n 's/^Author: \(.*\) <.*$/\1/p' | \
+  # Omit blog post authors
+  grep -iv "^\($(printf '%s\|' "${OMITTED_AUTHORS[@]}" | sed 's/\\|$//')\)$" | \
+  # Replace commas with slashes in names
+  sed 's_\s*,\s*_/_g' | \
+  # Deduplicate and sort alphabetically
+  sort -u | \
+  # Separate with commas
+  tr '\n' ',' | \
+  sed 's/,/, /g' | \
+  sed 's/, $/\n/'
+
+# vi: set et sts=2 sw=2 ts=2 :

--- a/script/tag.sh
+++ b/script/tag.sh
@@ -38,7 +38,9 @@ year=$(date +%Y)
 month=$(date +%m)
 day=$(date +%d)
 
-tag="v-$year-$month-$day"
+today_version_prefix="v-$year-$month-$day"
+today_versions_count=$(git tag -l "${today_version_prefix}*" | wc -l | sed 's/\s//g')
+tag="${today_version_prefix}.${today_versions_count}"
 read -e -i "$tag" -p 'Tag? ' -r tag
 
 jira_versions_json=$(curl -sS 'https://tickets.metabrainz.org/rest/api/2/version?projectIds=10000')


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Since the last schema change 2024 Q2 that features MBVM-42, the releasing instructions were outdated.
It requires changing our workflow a bit and also the way we used to set Git tags.

Also, some clarifications about handling translations from Weblate have been asked in the meantime.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Update the releasing documentation about:
* Preparing tickets and version in Jira earlier
* Prebuilding Docker image for mirrors
* Handling translations

Change the Git tagging script to:
* Link to the MBS version in Jira (instead of the blog post directly)
* Follow the same tag format as other MetaBrainz projects do (as a bonus)

Additionally:
* Clarify steps to draft and publish the blog post
* Add scripts to list code contributors and translators
* Add Jira queries to list ticket reporters

See commit messages for details.

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

Just tested the tag script manually with echoing the git commands.

Passed each script to `shellcheck -x`.

# Further action (after merge)
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

List the new sections in the corresponding syswiki page:
*  “Prepare Jira”
* “Draft blog post”