### PR TITLE
MBS-13453: Avoid double-decoding some errors

### DIFF
--- a/lib/MusicBrainz/Server/Connector.pm
+++ b/lib/MusicBrainz/Server/Connector.pm
@@ -56,7 +56,11 @@ sub _build_conn
             my $exception = 'MusicBrainz::Server::Exceptions::DatabaseError';
             $exception .= '::StatementTimedOut'
                 if $state eq '57014';
-            $exception->throw( sqlstate => $state, message => decode_utf8($msg) );
+            # Sometimes we receive a byte string that doesn't have the UTF8
+            # flag set; other times it's already been decoded (MBS-11207).
+            $msg = decode_utf8($msg)
+                unless utf8::is_utf8($msg);
+            $exception->throw( sqlstate => $state, message => $msg );
         },
         RaiseError        => 0,
         PrintError        => 0,


### PR DESCRIPTION
### Fix MBS-13453

# Problem
We are getting wide error ISEs that hide the real errors sometimes when there are PSQL problems.

# Solution

While the idea in https://github.com/metabrainz/musicbrainz-server/commit/20640deaa0841d7d55533dc3e7c8a8cbe2722fc1 was correct, the change was too wide in application; it was also decoding errors that did not need it, causing a wide character ISE because of the double decoding.

mwiencek looked into the root causes and said: "We do always get a UTF-8 string. But sometimes it's just a raw byte string (with no UTF8 flag set), and other times it's already been decoded (UTF8 flag on)."

So this checks whether the flag is on, and only decodes the string if it is not.

# Testing
Manually.

This specific issue can be triggered for testing by changing the host in `DBDefs` to something dumb and utf8ish. I used `'♥localhost'`.

The double-decoding could be triggered (before this patch) by doing a similar change on a `.sql` data file for a test and then running it - I changed `work.sql` to have an invalid artist ID (to trigger an error) and `'♥'` instead of `'ABBA'` as an AC name. Then I just triggered the error with `prove -lv t/tests.t :: --tests Edit::Work::Create`