### PR TITLE
MBS-13681: Also show recent events with art on homepage

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -60,6 +60,7 @@ sub index : Path Args(0)
 {
     my ($self, $c) = @_;
 
+    my @newest_events = $c->model('Event')->newest_events_with_artwork;
     my @newest_releases = $c->model('Release')->newest_releases_with_artwork;
     $c->model('ArtistCredit')->load(map { $_->{release} } @newest_releases);
 
@@ -68,6 +69,7 @@ sub index : Path Args(0)
         component_path => 'main/index',
         component_props => {
             blogEntries => $c->model('Blog')->get_latest_entries,
+            newestEvents => to_json_array(\@newest_events),
             newestReleases => to_json_array(\@newest_releases),
         },
     );

--- a/root/main/index.js
+++ b/root/main/index.js
@@ -23,6 +23,7 @@ type BlogEntryT = {
 
 component Homepage(
   blogEntries: $ReadOnlyArray<BlogEntryT> | null,
+  newestEvents: $ReadOnlyArray<EventArtT>,
   newestReleases: $ReadOnlyArray<ReleaseArtT>,
 ) {
   return (
@@ -246,7 +247,7 @@ component Homepage(
         className="feature-column"
         style={{clear: 'both', paddingTop: '1%'}}
       >
-        <h2>{l('Recent additions')}</h2>
+        <h2>{l('Recently added releases')}</h2>
         <div style={{height: '160px', overflow: 'hidden'}}>
           {newestReleases.map((artwork, index) => (
             <ReleaseArtwork
@@ -256,7 +257,58 @@ component Homepage(
           ))}
         </div>
       </div>
+
+      <div
+        className="feature-column"
+        style={{clear: 'both', paddingTop: '1%'}}
+      >
+        <h2>{l('Recently added events')}</h2>
+        <div style={{height: '160px', overflow: 'hidden'}}>
+          {newestEvents.map((artwork, index) => (
+            <EventArtwork
+              artwork={artwork}
+              key={index}
+            />
+          ))}
+        </div>
+      </div>
     </Layout>
+  );
+}
+
+component Artwork(
+  artwork: ArtworkT,
+  description: string,
+  entity: EventT | ReleaseT,
+) {
+  return (
+    <div className="artwork-cont" style={{textAlign: 'center'}}>
+      <div className="artwork">
+        <a
+          href={entityHref(entity)}
+          title={description}
+        >
+          <ArtworkImage
+            artwork={artwork}
+            hover={description}
+          />
+        </a>
+      </div>
+    </div>
+  );
+}
+
+component EventArtwork(artwork: EventArtT) {
+  const event = artwork.event;
+  if (!event) {
+    return null;
+  }
+  return (
+    <Artwork
+      artwork={artwork}
+      description={event.name}
+      entity={event}
+    />
   );
 }
 
@@ -270,19 +322,11 @@ component ReleaseArtwork(artwork: ReleaseArtT) {
     entity: release.name,
   });
   return (
-    <div className="artwork-cont" style={{textAlign: 'center'}}>
-      <div className="artwork">
-        <a
-          href={entityHref(release)}
-          title={releaseDescription}
-        >
-          <ArtworkImage
-            artwork={artwork}
-            hover={releaseDescription}
-          />
-        </a>
-      </div>
-    </div>
+    <Artwork
+      artwork={artwork}
+      description={releaseDescription}
+      entity={release}
+    />
   );
 }
 


### PR DESCRIPTION
### Implement MBS-13681

# Description
@Aerozol suggested that we should showcase these, and that it's not a particularly big issue that it makes the page taller.

This just copies the recent releases implementation, but showing the event name on hover as the equivalent of `{releaseName} by {artist}`.

# Testing
Manually, with live data:
![Screenshot from 2024-07-11 09-24-46](https://github.com/metabrainz/musicbrainz-server/assets/1069224/f108f70c-cecd-4aaa-88f2-e7b435fd04a0)
