### PR TITLE
MBS-13682: Add language filter to Works tab

### DIFF
--- a/lib/MusicBrainz/Server/Data/Language.pm
+++ b/lib/MusicBrainz/Server/Data/Language.pm
@@ -8,6 +8,7 @@ use MusicBrainz::Server::Data::Utils qw( load_subobjects );
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::EntityCache',
+     'MusicBrainz::Server::Data::Role::Name',
      'MusicBrainz::Server::Data::Role::SelectAll' => {
         order_by => ['name'],
      },

--- a/lib/MusicBrainz/Server/FilterUtils.pm
+++ b/lib/MusicBrainz/Server/FilterUtils.pm
@@ -69,6 +69,7 @@ sub create_artist_works_form {
 
     my %form_args = (
         entity_type => 'work',
+        languages => $c->model('Work')->find_languages_by_artist($artist_id),
         types => [ $c->model('WorkType')->get_all ],
     );
 

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -77,6 +77,7 @@ export type ReleaseGroupFilterT = $ReadOnly<{
 
 type WorkFilterFormT = FormT<{
   ...GenericFilterFormFieldsT,
+  +language_id: FieldT<number>,
   +role_type: FieldT<number>,
   +type_id: FieldT<number>,
 }>;
@@ -84,6 +85,7 @@ type WorkFilterFormT = FormT<{
 export type WorkFilterT = $ReadOnly<{
   ...WorkFilterFormT,
   +entity_type: 'work',
+  +options_language_id: SelectOptionsT,
   +options_role_type: SelectOptionsT,
   +options_type_id: SelectOptionsT,
 }>;
@@ -346,6 +348,22 @@ component FilterForm(form: FilterFormT) {
                   field={form.field.type_id}
                   options={form.options_type_id}
                 />
+                <tr>
+                  <td>
+                    {addColonText(l('Language'))}
+                  </td>
+                  <td>
+                    <SelectField
+                      field={form.field.language_id}
+                      options={{
+                        grouped: false,
+                        options: form.options_language_id,
+                      }}
+                      style={{maxWidth: '40em'}}
+                      uncontrolled
+                    />
+                  </td>
+                </tr>
                 <tr>
                   <td>
                     {addColonText(l('Role'))}

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
@@ -647,7 +647,7 @@ test 'Work page filtering' => sub {
 
     $mech->get_ok(
         '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/works?filter.language_id=-1',
-        'Fetched artist works page with language filter "[none]"',
+        'Fetched artist works page with language filter "[not set]"',
     );
 
     $tx = test_xpath_html($mech->content);

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
@@ -654,7 +654,7 @@ test 'Work page filtering' => sub {
     $tx->is(
         'count(//table[@class="tbl"]/tbody/tr)',
         '3',
-        'There are three entries in the work table after filtering by no language',
+        'There are three entries in the work table after filtering by no language set',
     );
 
     $mech->get_ok(

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
@@ -634,6 +634,30 @@ test 'Work page filtering' => sub {
     );
 
     $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/works?filter.language_id=120',
+        'Fetched artist works page with language filter "English"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '2',
+        'There are two entries in the work table after filtering by "English" language',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/works?filter.language_id=-1',
+        'Fetched artist works page with language filter "[none]"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '3',
+        'There are three entries in the work table after filtering by no language',
+    );
+
+    $mech->get_ok(
         '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/works?filter.name=Interlude',
         'Fetched artist works page with name filter "Interlude"',
     );

--- a/t/sql/filtering.sql
+++ b/t/sql/filtering.sql
@@ -109,6 +109,11 @@ INSERT INTO work (id, gid, name, type, comment)
            (3403, 'fcedfaf3-63ad-4ea2-949a-b16cdc2cd019', 'Mini Overture', 12, 'Testy'),
            (3404, 'dbb7157a-5dc3-41c4-aacc-4e3d4705e132', 'Brandenburgisches Konzert Nr. 5 D-Dur, BWV 1050', 4, '');
 
+INSERT INTO work_language (work, language)
+    VALUES (3401, 120),
+           (3401, 486),
+           (3402, 120);
+
 -- Relationships
 
 INSERT INTO link (id, link_type, attribute_count)


### PR DESCRIPTION
### Implement MBS-13682

# Description
This allows filtering an artist's works by the lyrics language. Since giving all languages as options would be overwhelming and not very useful, this looks at what languages are actually used and offers any of these or [none] for works with no languages set. It's implemented in a very similar way to the existing release label filter.

# Testing
Manually. Left to do:
* [x] Add a test for this to the `Filtering` Perl test.