### PR TITLE
Fixes and improvements for e-onkyo URL validation

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2544,7 +2544,7 @@ const CLEANUPS: CleanupEntries = {
     restrict: [LINK_TYPES.downloadpurchase],
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?e-onkyo\.com\//, 'https://www.e-onkyo.com/');
-      return url.replace(/^(https:\/\/www\.e-onkyo\.com)\/music\/album\/([a-z]+\d+).*$/, '$1/music/album/$2/');
+      return url.replace(/^(https:\/\/www\.e-onkyo\.com)\/(?:music|sp)\/album\/([a-z]+\d+).*$/, '$1/music/album/$2/');
     },
     validate: function (url, id) {
       if (/e-onkyo\.com\/search\//.test(url)) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2541,17 +2541,29 @@ const CLEANUPS: CleanupEntries = {
   },
   'eonkyo': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?e-onkyo\\.com', 'i')],
-    restrict: [
-      {release: LINK_TYPES.downloadpurchase.release},
-    ],
+    restrict: [LINK_TYPES.downloadpurchase],
     clean: function (url) {
       return url.replace(/^(?:https?:\/\/)?(?:www\.)?e-onkyo\.com\/music\/album\/([a-z]+\d+).*$/, 'https://www.e-onkyo.com/music/album/$1/');
     },
-    validate: function (url) {
-      return {
-        result: /^https:\/\/www\.e-onkyo\.com\/music\/album\/[a-z]+\d+\/$/.test(url),
-        target: ERROR_TARGETS.URL,
-      };
+    validate: function (url, id) {
+      const m = /^https:\/\/www\.e-onkyo\.com\/music\/album\/[a-z]+\d+\/$/.exec(url);
+      if (m) {
+        switch (id) {
+          case LINK_TYPES.downloadpurchase.release:
+            return {
+              result: true,
+            };
+          case LINK_TYPES.downloadpurchase.artist:
+          case LINK_TYPES.downloadpurchase.label:
+          case LINK_TYPES.downloadpurchase.recording:
+            return {
+              result: false,
+              target: ERROR_TARGETS.ENTITY,
+            };
+        }
+        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+      }
+      return {result: false, target: ERROR_TARGETS.URL};
     },
   },
   'ester': {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2543,9 +2543,17 @@ const CLEANUPS: CleanupEntries = {
     match: [new RegExp('^(https?://)?([^/]+\\.)?e-onkyo\\.com', 'i')],
     restrict: [LINK_TYPES.downloadpurchase],
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?(?:www\.)?e-onkyo\.com\/music\/album\/([a-z]+\d+).*$/, 'https://www.e-onkyo.com/music/album/$1/');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?e-onkyo\.com\//, 'https://www.e-onkyo.com/');
+      return url.replace(/^(https:\/\/www\.e-onkyo\.com)\/music\/album\/([a-z]+\d+).*$/, '$1/music/album/$2/');
     },
     validate: function (url, id) {
+      if (/e-onkyo\.com\/search\//.test(url)) {
+        return {
+          error: noLinkToSearchMsg(),
+          result: false,
+          target: ERROR_TARGETS.URL,
+        };
+      }
       const m = /^https:\/\/www\.e-onkyo\.com\/music\/album\/[a-z]+\d+\/$/.exec(url);
       if (m) {
         switch (id) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2363,8 +2363,8 @@ limited_link_type_combinations: [
                      input_url: 'http://e-onkyo.com/music/album/vpcd81809/',
              input_entity_type: 'release',
     expected_relationship_type: 'downloadpurchase',
-       only_valid_entity_types: ['release'],
             expected_clean_url: 'https://www.e-onkyo.com/music/album/vpcd81809/',
+       only_valid_entity_types: ['release'],
   },
   // excite
   {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2366,6 +2366,18 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://www.e-onkyo.com/music/album/vpcd81809/',
        only_valid_entity_types: ['release'],
   },
+  {
+                     input_url: 'http://e-onkyo.com/search/search.aspx?artist=ZORN',
+             input_entity_type: 'artist',
+    expected_relationship_type: undefined,
+            expected_clean_url: 'https://www.e-onkyo.com/search/search.aspx?artist=ZORN',
+       input_relationship_type: 'downloadpurchase',
+                expected_error: {
+                                  error: 'a link to a search result',
+                                  target: 'url',
+                                },
+       only_valid_entity_types: [],
+  },
   // excite
   {
                      input_url: 'http://psgarden.exblog.jp/',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2360,7 +2360,7 @@ limited_link_type_combinations: [
   },
   // e-onkyo music
   {
-                     input_url: 'http://e-onkyo.com/music/album/vpcd81809/',
+                     input_url: 'http://e-onkyo.com/sp/album/vpcd81809?tr=2',
              input_entity_type: 'release',
     expected_relationship_type: 'downloadpurchase',
             expected_clean_url: 'https://www.e-onkyo.com/music/album/vpcd81809/',


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

I approved and merged the pull request #3328 too quickly without noticing that tests were failing.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Further strengthen the validation of e-onkyo URLs by:
* blocking search URLs with an explanatory error message,
* blocking e-onkyo URL for other entity types than release,
* converting /sp path to the redirect target path /album,
* fixing and updating tests accordingly.

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

Tested locally and waited for [CI build-and-test 11846](https://app.circleci.com/pipelines/github/metabrainz/musicbrainz-server/11846) to succeed.

# Note
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

Self-approving and merging ASAP to fix CI tests in the branch `master`.