### PR TITLE
MBS-8217 (II): Don't show guess case preview while dragging

### DIFF
--- a/root/static/scripts/edit/components/FormRowNameWithGuessCase.js
+++ b/root/static/scripts/edit/components/FormRowNameWithGuessCase.js
@@ -119,10 +119,15 @@ component FormRowNameWithGuessCase(
     }
   }
 
-  function showGuessCasePreview() {
-    setPreview(
-      GuessCase.entities[entity.entityType].guess(field.value ?? ''),
-    );
+  function showGuessCasePreview(
+    event: SyntheticMouseEvent<HTMLInputElement>,
+  ) {
+    // Don't change the value while the user is dragging to select text.
+    if (event.nativeEvent.buttons === 0) {
+      setPreview(
+        GuessCase.entities[entity.entityType].guess(field.value ?? ''),
+      );
+    }
   }
 
   function hidePreview() {

--- a/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
+++ b/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
@@ -84,8 +84,13 @@ component FormRowSortNameWithGuessCase(
     setPreview(null);
   }
 
-  function showGuessCasePreview() {
-    setPreview(guessSortName(nameField.value ?? '', entity));
+  function showGuessCasePreview(
+    event: SyntheticMouseEvent<HTMLInputElement>,
+  ) {
+    // Don't change the value while the user is dragging to select text.
+    if (event.nativeEvent.buttons === 0) {
+      setPreview(guessSortName(nameField.value ?? '', entity));
+    }
   }
 
   function handleSortNameCopy() {
@@ -93,8 +98,12 @@ component FormRowSortNameWithGuessCase(
     setPreview(null);
   }
 
-  function showSortNameCopyPreview() {
-    setPreview(nameField.value ?? '');
+  function showSortNameCopyPreview(
+    event: SyntheticMouseEvent<HTMLInputElement>,
+  ) {
+    if (event.nativeEvent.buttons === 0) {
+      setPreview(nameField.value ?? '');
+    }
   }
 
   function hidePreview() {

--- a/root/static/scripts/guess-case/MB/Control/GuessCase.js
+++ b/root/static/scripts/guess-case/MB/Control/GuessCase.js
@@ -53,7 +53,12 @@ MB.Control.initializeGuessCase = function (type, formPrefix) {
   $name.parent()
     .find('button.guesscase-title')
     .on('click', () => setVal($name, guess.guess($name.val())))
-    .on('mouseenter', () => showPreview($name, guess.guess($name.val())))
+    .on('mouseenter', (event) => {
+      // Don't change the value while the user is dragging to select text.
+      if (event.originalEvent.buttons === 0) {
+        showPreview($name, guess.guess($name.val()));
+      }
+    })
     .on('mouseleave', () => hidePreview($name))
     .end()
     .find('button.guesscase-options')
@@ -75,7 +80,11 @@ MB.Control.initializeGuessCase = function (type, formPrefix) {
   $sortname.parent()
     .find('button.guesscase-sortname')
     .on('click', () => setVal($sortname, guessSortName()))
-    .on('mouseenter', () => showPreview($sortname, guessSortName()))
+    .on('mouseenter', (event) => {
+      if (event.originalEvent.buttons === 0) {
+        showPreview($sortname, guessSortName());
+      }
+    })
     .on('mouseleave', () => hidePreview($sortname))
     .end()
     .find('button.sortname-copy')

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -148,7 +148,10 @@ const actions = {
 
     switch (event.type) {
       case 'mouseenter':
-        medium.previewName(GuessCase.entities.release.guess(name));
+        // Don't change the value while the user is dragging to select text.
+        if (event.buttons === 0) {
+          medium.previewName(GuessCase.entities.release.guess(name));
+        }
         break;
       case 'mouseleave':
         medium.previewName(null);
@@ -266,7 +269,12 @@ const actions = {
   guessCaseTrackName: function (track, event) {
     switch (event.type) {
       case 'mouseenter':
-        track.previewName(GuessCase.entities.track.guess(track.name.peek()));
+        // Don't change the value while the user is dragging to select text.
+        if (event.buttons === 0) {
+          track.previewName(
+            GuessCase.entities.track.guess(track.name.peek()),
+          );
+        }
         break;
       case 'mouseleave':
         track.previewName(null);


### PR DESCRIPTION
# MBS-8217 (II)

Make the FormRowNameWithGuessCase and
FormRowSortNameWithGuessCase components, the GuessCase control, and the tracklist editor code avoid showing previews if a button is held while the mouse enters a "guess case" or "guess sort name" button.

Otherwise, it's easy to clear the user's selection if they accidentally mouse over the button while dragging to select text.

# Problem

See [this comment](https://tickets.metabrainz.org/browse/MBS-8217?focusedId=72891&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-72891). If you accidentally overshoot the text field while dragging to the right, displaying the guess case preview clears the selection.

# Solution

Don't show the preview if a mouse button is held in the `mouseenter` event.

# Testing

Manually tested that previews aren't shown while dragging in the edit artist and edit release forms (both for the release name and medium/track titles).