### PR TITLE
MBS-8217 (III): Highlight tracklist names after guess case

### DIFF
--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -210,7 +210,7 @@
     </td>
 
     <td class="title">
-      <input type="text" class="track-name" data-bind="value: inputName, valueUpdate: 'input', css: { preview: previewNameDiffers() }" />
+      <input type="text" class="track-name" data-bind="value: inputName, valueUpdate: 'input', css: { modified: nameModified(), preview: previewNameDiffers() }, event: { focus: $root.focusTrackName }" />
     </td>
 
     <td class="artist autocomplete" data-bind="artistCreditEditor: $data">
@@ -316,7 +316,7 @@
           (<a href="[% c.uri_for('/doc/Release/Format') %]" target="_blank">[% l('help') %]</a>)
           <!-- ko if: release.mediums().length > 1 || name() -->
             <label data-bind="attr: { for: 'medium-title-' + uniqueID }">[% l('Medium title:') %]</label>
-            <input type="text" data-bind="attr: { id: 'medium-title-' + uniqueID }, value: inputName, valueUpdate: 'input', css: { preview: previewNameDiffers() }" />
+            <input type="text" data-bind="attr: { id: 'medium-title-' + uniqueID }, value: inputName, valueUpdate: 'input', css: { modified: nameModified(), preview: previewNameDiffers() }, event: { focus: $root.focusMediumName }" />
             <button type="button" class="icon guesscase-title" title="[% l('Guess case medium title') %]" data-bind="click: $root.guessCaseMediumName, event: { mouseenter: $root.guessCaseMediumName, mouseleave: $root.guessCaseMediumName }"></button>
           <!-- /ko -->
           <p class="error field-error" style="padding-left: 1em" data-bind="showErrorWhenTabIsSwitched: needsFormat">

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -127,6 +127,10 @@ const actions = {
     }
   },
 
+  focusMediumName: function (medium) {
+    medium.nameModified(false);
+  },
+
   guessCaseAllMedia: function (data, event) {
     for (const medium of this.mediums.peek()) {
       releaseEditor.guessCaseMediumName(medium, event);
@@ -161,6 +165,7 @@ const actions = {
           medium.previewName() ??
             GuessCase.entities.release.guess(name),
         );
+        medium.nameModified(medium.name() !== name);
         medium.previewName(null);
     }
   },
@@ -262,6 +267,10 @@ const actions = {
     medium.toc(null);
   },
 
+  focusTrackName: function (track) {
+    track.nameModified(false);
+  },
+
   /*
    * Shows or hides a preview if event.type is 'mouseenter' or 'mouseleave'.
    * Otherwise, updates the current name.
@@ -280,10 +289,11 @@ const actions = {
         track.previewName(null);
         break;
       default:
+        const origName = track.name.peek();
         track.name(
-          track.previewName() ??
-            GuessCase.entities.track.guess(track.name.peek()),
+          track.previewName() ?? GuessCase.entities.track.guess(origName),
         );
+        track.nameModified(track.name() !== origName);
         track.previewName(null);
     }
   },

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -69,6 +69,9 @@ class Track {
       owner: this,
     });
 
+    // True after the name has been modified by the "guess case" button.
+    this.nameModified = ko.observable(false);
+
     this.length = ko.observable(data.length);
     this.length.original = data.length;
 
@@ -370,6 +373,8 @@ class Medium {
       write: this.name,
       owner: this,
     });
+    // True after the name has been modified by the "guess case" button.
+    this.nameModified = ko.observable(false);
     this.position = ko.observable(data.position || 1);
     this.formatID = ko.observable(data.format_id);
     this.originalFormatID = data.format_id

--- a/root/static/styles/colors.less
+++ b/root/static/styles/colors.less
@@ -86,4 +86,5 @@
 @edit-merge-bg: #DDA0DD;                             // merge edit header
 @edit-other-bg: #ADD8E6;                             // other edit header
 
+@input-modified-bg: @very-light-bg;                  // background color for <input> after modified by "guess case"
 @input-preview-bg: #FFF59D;                          // background color for <input> previews, e.g. for "guess case"

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -317,8 +317,9 @@ button.guessfeat {
     background-size: @form-icon-size @form-icon-size;
 }
 
-input[type=text].preview {
-    background-color: @input-preview-bg;
+input[type=text] {
+    &.modified { background-color: @input-modified-bg; }
+    &.preview { background-color: @input-preview-bg; }
 }
 
 /* __________________________________

--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -151,7 +151,6 @@ fieldset.advanced-medium {
             height: 2em;
             border: 0;
             padding: 0 5px;
-            &.preview { background-color: @input-preview-bg; }
         }
     }
 }

--- a/t/selenium/release-editor/The_Downward_Spiral.json5
+++ b/t/selenium/release-editor/The_Downward_Spiral.json5
@@ -413,6 +413,28 @@
       target: 'css=#tracklist table.medium tr.track:nth-child(9) td.title input.track-name',
       value: 'Big Man With a Gun',
     },
+    // The background color should be changed for tracks whose names were modified (MBS-8217).
+    {
+      command: 'assertEval',
+      target: "document.querySelector('#tracklist table.medium tr.track:nth-child(8) td.title input.track-name').classList.contains('modified')",
+      value: 'false',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelector('#tracklist table.medium tr.track:nth-child(9) td.title input.track-name').classList.contains('modified')",
+      value: 'true',
+    },
+    // Focusing the modified track should clear the highlight.
+    {
+      command: 'click',
+      target: "document.querySelector('#tracklist table.medium tr.track:nth-child(9) td.title input.track-name')",
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelector('#tracklist table.medium tr.track:nth-child(9) td.title input.track-name').classList.contains('modified')",
+      value: 'false',
+    },
     // Set the format to "unknown."
     {
       command: 'check',


### PR DESCRIPTION
Use a light gray background for medium and tracklist name inputs in the release editor after they've been updated using a "guess case" button. The background is cleared after the inputs are focused.

# Problem MBS-8217 (III)

After clicking a "guess case" button in the tracklist editor, it can be hard to tell what was changed, especially if all of the media/tracks don't fit onscreen (so that changes can't be seen in the preview when hovering over the button).

# Solution

Make updated medium and track name inputs use a light gray background color after they're updated by a "guess case" button:

![Screenshot 2024-07-15 08 21 00](https://github.com/user-attachments/assets/ef7c806c-d52d-4b97-8af5-ff1473d21c0d)

The background is reset after an input is focused.

# Testing

Manually tested that medium and track name inputs behave as expected. Also updated `t/selenium/release-editor/The_Downward_Spiral.json5` to check that the new CSS class is added and removed appropriately.