### PR TITLE
Fix test failure from 434684613971

### DIFF
--- a/t/selenium/release-editor/The_Downward_Spiral.json5
+++ b/t/selenium/release-editor/The_Downward_Spiral.json5
@@ -427,7 +427,7 @@
     // Focusing the modified track should clear the highlight.
     {
       command: 'click',
-      target: "document.querySelector('#tracklist table.medium tr.track:nth-child(9) td.title input.track-name')",
+      target: 'css=#tracklist table.medium tr.track:nth-child(9) td.title input.track-name',
       value: '',
     },
     {


### PR DESCRIPTION
Specify the click target using the 'css=' syntax rather than a document.querySelector() call.