### PR TITLE
MBS-13692: Beta: release editor edits the same release label twice

### DIFF
--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -715,6 +715,7 @@ const seleniumTests = [
   {name: 'release-editor/MBS-13207.json5', login: true},
   {name: 'release-editor/MBS-13273.json5', login: true},
   {name: 'release-editor/MBS-13579.json5', login: true},
+  {name: 'release-editor/MBS-13692.json5', login: true},
   {
     name: 'Check_Duplicates.json5',
     login: true,

--- a/t/selenium/release-editor/MBS-13692.json5
+++ b/t/selenium/release-editor/MBS-13692.json5
@@ -1,0 +1,97 @@
+{
+  title: 'MBS-13692',
+  commands: [
+    {
+      command: 'open',
+      target: '/release/24d4159a-99d9-425d-a7b8-1b9ec0261a33/edit',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: "xpath=//button[contains(text(), 'Add label')]",
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=label-1',
+      value: '10f97e56-1ebe-4b1e-848f-9c5ae0f292ec',
+    },
+    {
+      command: 'pause',
+      target: '1000',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=catno-0',
+      value: '123',
+    },
+    {
+      command: 'type',
+      target: 'id=catno-1',
+      value: '456',
+    },
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#edit-note']",
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'id=enter-edit',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 1,
+      value: {
+        type: 37,
+        status: 2,
+        data: {
+          new: {
+            catalog_number: "123",
+          },
+          old: {
+            catalog_number: "",
+            label: {
+              gid: "10f97e56-1ebe-4b1e-848f-9c5ae0f292ec",
+              id: 62565,
+              name: "ISO Records",
+            },
+          },
+          release: {
+            barcode: "888751738621",
+            events: [],
+            gid: "24d4159a-99d9-425d-a7b8-1b9ec0261a33",
+            id: 1693299,
+            medium_formats: ["CD"],
+            name: "★",
+          },
+          release_label_id: 1237936,
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 2,
+      value: {
+        type: 34,
+        status: 2,
+        data: {
+          catalog_number: "456",
+          entity_id: 1,
+          label: {
+            gid: "10f97e56-1ebe-4b1e-848f-9c5ae0f292ec",
+            id: 62565,
+            name: "ISO Records",
+          },
+          release: {
+            gid: "24d4159a-99d9-425d-a7b8-1b9ec0261a33",
+            id: 1693299,
+            name: "★",
+          },
+        },
+      },
+    },
+  ],
+}


### PR DESCRIPTION
# Problem

If a release has at least one existing label, and you add a duplicate of it (triggering visible error messages adjacent to the fields), and then edit both of them, then it's expected that this would produce two edits: one to modify the existing release label, and one to add a new one. Instead, f0613577fd0e58060417afd3ce46a718f8baeb8e introduced a regression whereby the same release label is edited twice, causing the second edit to immediately trigger a failed dependency error.

# Solution

This patch tracks which existing release labels have already been modified, so that we don't attempt to reuse the same one twice when producing edits.

# Testing

Added a new Selenium test which reproduced the issue prior to the patch being applied.