### PR TITLE
[WIP] MBS-6741: Include area containment in WS responses

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/2/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Artist.pm
@@ -59,6 +59,13 @@ sub artist_toplevel
     $c->model('ArtistType')->load(@artists);
     $c->model('Gender')->load(@artists);
     $c->model('Area')->load(@artists);
+    $c->model('Area')->load_containment(map { $_->{area} } @artists);
+    $c->model('Relationship')->load_subset(['area'], map { @{ $_->area->containment } } @artists);
+    $c->model('Area')->load_containment(map { $_->{begin_area} } @artists);
+    $c->model('Relationship')->load_subset(['area'], map { $_->{begin_area} } @artists);
+    $c->model('Relationship')->load_subset(['area'], map { @{ $_->begin_area->containment } } @artists);
+    $c->model('Area')->load_containment(map { $_->{end_area} } @artists);
+    #$c->model('Relationship')->load_subset(['area'], map { @{ $_->end_area->containment } } @artists);
     $c->model('Artist')->ipi->load_for(@artists);
     $c->model('Artist')->isni->load_for(@artists);
 


### PR DESCRIPTION
### Implement MBS-6741

This is a small start that currently fails because the area objects loaded by load_containment and load_subset are different. mwiencek is supposed to have a patch for that somewhere which might unlock further progress here.

Putting this up to remember to work on it if and when that patch appears, or to look for an alternative option if that ends up not working.