### PR TITLE
Adjust e-onkyo validation/cleanup regex for special case

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2452,7 +2452,7 @@ const CLEANUPS: CleanupEntries = {
     restrict: [LINK_TYPES.downloadpurchase],
     clean(url) {
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?e-onkyo\.com\//, 'https://www.e-onkyo.com/');
-      return url.replace(/^(https:\/\/www\.e-onkyo\.com)\/(?:music|sp)\/album\/([a-z]+\d+).*$/, '$1/music/album/$2/');
+      return url.replace(/^(https:\/\/www\.e-onkyo\.com)\/(?:music|sp)\/album\/([a-z0-9]+).*$/, '$1/music/album/$2/');
     },
     validate(url, id) {
       if (/e-onkyo\.com\/search\//.test(url)) {
@@ -2462,7 +2462,7 @@ const CLEANUPS: CleanupEntries = {
           target: ERROR_TARGETS.URL,
         };
       }
-      const m = /^https:\/\/www\.e-onkyo\.com\/music\/album\/[a-z]+\d+\/$/.exec(url);
+      const m = /^https:\/\/www\.e-onkyo\.com\/music\/album\/[a-z0-9]+\/$/.exec(url);
       if (m) {
         switch (id) {
           case LINK_TYPES.downloadpurchase.release:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2369,6 +2369,13 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['release'],
   },
   {
+                     input_url: 'http://e-onkyo.com/music/album/ve5hd43611',
+             input_entity_type: 'release',
+    expected_relationship_type: 'downloadpurchase',
+            expected_clean_url: 'https://www.e-onkyo.com/music/album/ve5hd43611/',
+       only_valid_entity_types: ['release'],
+  },
+  {
                      input_url: 'http://e-onkyo.com/search/search.aspx?artist=ZORN',
              input_entity_type: 'artist',
     expected_relationship_type: undefined,


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

#3328 added e-onkyo link validation/cleanup/etc., and #3329 further improved upon it, but it turns out that neither accounted for a special case I came upon today, where numbers come earlier in the final chunk of the URL than were previously expected.

If I paste `https://www.e-onkyo.com/music/album/ve5hd43611/` into a release's links section, MB currently cuts it off at `https://www.e-onkyo.com/music/album/ve5/` because the regex isn't built to handle a number surrounded by letters in the final section.


# Solution

This PR lightly generalizes e-onkyo's validation/cleanup regex to account for edge cases like this, and adds a new test accordingly.


# Testing

Tested the new regex with both non-edge-case and edge-case release URLs in regex101 and it seemed to handle both without a problem.

