### PR TITLE
MBS-13703: Recognize tokens issued by the MeB OAuth Provider

### DIFF
--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -373,6 +373,12 @@ sub MAPBOX_ACCESS_TOKEN { '' }
 # Feature toggle used for pre-schema change release of safe schema change code
 sub ACTIVE_SCHEMA_SEQUENCE { 29 }
 
+# MetaBrainz OAuth endpoint (and associated application) used to introspect
+# "meba_*" tokens issued by metabrainz.org. See MBS-13703 for details.
+sub METABRAINZ_OAUTH_URL { '' }
+sub METABRAINZ_OAUTH_CLIENT_ID { '' }
+sub METABRAINZ_OAUTH_CLIENT_SECRET { '' }
+
 # Disallow OAuth2 requests over plain HTTP
 sub OAUTH2_ENFORCE_TLS { my $self = shift; !$self->DB_STAGING_SERVER || $self->IS_BETA }
 

--- a/lib/MusicBrainz/Server/Authentication/Store.pm
+++ b/lib/MusicBrainz/Server/Authentication/Store.pm
@@ -5,6 +5,9 @@ use warnings;
 
 use DateTime;
 use MusicBrainz::Server::Authentication::User;
+use MusicBrainz::Server::Authentication::Utils qw(
+    find_oauth_access_token
+);
 
 sub new
 {
@@ -18,7 +21,7 @@ sub find_user
     my $editor;
 
     if (exists $authinfo->{oauth_access_token}) {
-        my $token = $c->model('EditorOAuthToken')->get_by_access_token($authinfo->{oauth_access_token});
+        my $token = find_oauth_access_token($c, $authinfo->{oauth_access_token});
         if (defined $token) {
             $editor = $c->model('Editor')->get_by_id($token->editor_id);
         }

--- a/lib/MusicBrainz/Server/Authentication/Utils.pm
+++ b/lib/MusicBrainz/Server/Authentication/Utils.pm
@@ -1,0 +1,68 @@
+package MusicBrainz::Server::Authentication::Utils;
+
+use strict;
+use warnings;
+
+use base 'Exporter';
+use DateTime;
+use HTTP::Request::Common qw( POST );
+use HTTP::Status qw( HTTP_OK );
+
+use DBDefs;
+use MusicBrainz::Server::Entity::EditorOAuthToken;
+use MusicBrainz::Server::Constants qw( :access_scope );
+
+our @EXPORT_OK = qw(
+    find_oauth_access_token
+);
+
+sub find_oauth_access_token {
+    my ($c, $oauth_access_token) = @_;
+
+    if (
+        DBDefs->METABRAINZ_OAUTH_URL &&
+        $oauth_access_token =~ /^meba_/
+    ) {
+        my $ctx = $c->model('MB')->context;
+        my $introspect_url = DBDefs->METABRAINZ_OAUTH_URL . '/introspect';
+        my $res = $ctx->lwp->request(
+            POST $introspect_url,
+            {
+                client_id => DBDefs->METABRAINZ_OAUTH_CLIENT_ID,
+                client_secret => DBDefs->METABRAINZ_OAUTH_CLIENT_SECRET,
+                token => $oauth_access_token,
+            },
+        );
+        if ($res->code == HTTP_OK) {
+            my $res_content = $c->json_utf8->decode($res->content);
+            if ($res_content->{active}) {
+                my $scope = 0;
+                for my $scope_name (@{ $res_content->{scope} }) {
+                    $scope |= $ACCESS_SCOPE_BY_NAME{$scope_name};
+                }
+                return MusicBrainz::Server::Entity::EditorOAuthToken->new(
+                    access_token => $oauth_access_token,
+                    editor_id => $res_content->{metabrainz_user_id},
+                    expire_time => DateTime->from_epoch($res_content->{expires_at}),
+                    granted => DateTime->from_epoch($res_content->{issued_at}),
+                    scope => $scope,
+                );
+            }
+        }
+    } else {
+        return $c->model('EditorOAuthToken')->get_by_access_token($oauth_access_token);
+    }
+    return;
+}
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2024 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Authentication/WS/Store.pm
+++ b/lib/MusicBrainz/Server/Authentication/WS/Store.pm
@@ -6,6 +6,9 @@ use warnings;
 use DateTime;
 use Encode qw( decode );
 use MusicBrainz::Server::Authentication::WS::User;
+use MusicBrainz::Server::Authentication::Utils qw(
+    find_oauth_access_token
+);
 
 sub new
 {
@@ -19,7 +22,7 @@ sub find_user
     my $user;
 
     if (exists $authinfo->{oauth_access_token}) {
-        my $token = $c->model('EditorOAuthToken')->get_by_access_token($authinfo->{oauth_access_token});
+        my $token = find_oauth_access_token($c, $authinfo->{oauth_access_token});
         if (defined $token) {
             my $editor = $c->model('Editor')->get_by_id($token->editor_id);
             if (defined $editor) {

--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -36,7 +36,12 @@ our %EXPORT_TAGS = (
     editor             => _get(qr/^EDITOR_/),
     vote               => _get(qr/^VOTE_/),
     edit_status        => _get(qr/^STATUS_/),
-    access_scope       => _get(qr/^ACCESS_SCOPE_/),
+    access_scope       => [
+        qw( $ACCESS_SCOPE_PROFILE $ACCESS_SCOPE_EMAIL $ACCESS_SCOPE_TAG
+            $ACCESS_SCOPE_RATING $ACCESS_SCOPE_COLLECTION
+            $ACCESS_SCOPE_SUBMIT_ISRC $ACCESS_SCOPE_SUBMIT_BARCODE
+            %ACCESS_SCOPE_BY_NAME ),
+    ],
     privileges         => _get(qr/_FLAGS?$/),
     language_frequency => _get(qr/^LANGUAGE_FREQUENCY/),
     script_frequency   => _get(qr/^SCRIPT_FREQUENCY/),
@@ -401,6 +406,16 @@ Readonly our $ACCESS_SCOPE_RATING         => 8;
 Readonly our $ACCESS_SCOPE_COLLECTION     => 16;
 Readonly our $ACCESS_SCOPE_SUBMIT_ISRC    => 64;
 Readonly our $ACCESS_SCOPE_SUBMIT_BARCODE => 128;
+
+Readonly our %ACCESS_SCOPE_BY_NAME => (
+    'profile'        => $ACCESS_SCOPE_PROFILE,
+    'email'          => $ACCESS_SCOPE_EMAIL,
+    'tag'            => $ACCESS_SCOPE_TAG,
+    'rating'         => $ACCESS_SCOPE_RATING,
+    'collection'     => $ACCESS_SCOPE_COLLECTION,
+    'submit_isrc'    => $ACCESS_SCOPE_SUBMIT_ISRC,
+    'submit_barcode' => $ACCESS_SCOPE_SUBMIT_BARCODE,
+);
 
 Readonly our $ARTIST_ARTIST_COLLABORATION => '75c09861-6857-4ec0-9729-84eefde7fc86';
 

--- a/lib/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/lib/MusicBrainz/Server/Controller/OAuth2.pm
@@ -16,16 +16,6 @@ use MusicBrainz::Server::Constants qw( :access_scope );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json is_valid_token );
 use Readonly;
 
-Readonly our %ACCESS_SCOPE_BY_NAME => (
-    'profile'        => $ACCESS_SCOPE_PROFILE,
-    'email'          => $ACCESS_SCOPE_EMAIL,
-    'tag'            => $ACCESS_SCOPE_TAG,
-    'rating'         => $ACCESS_SCOPE_RATING,
-    'collection'     => $ACCESS_SCOPE_COLLECTION,
-    'submit_isrc'    => $ACCESS_SCOPE_SUBMIT_ISRC,
-    'submit_barcode' => $ACCESS_SCOPE_SUBMIT_BARCODE,
-);
-
 Readonly our @AUTHORIZE_PARAMETERS => qw(
     client_id
     scope


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-13703

# Problem

Tokens issued by the new MeB OAuth provider (prefixed with `meba_`) should be authenticated using the provider's introspect endpoint.

# Solution

Adds a new utility, `find_oauth_access_token`, which either introspects `meba_` tokens on the new provider, or fetches them directly from the MB database.

# Testing

Tested manually by fetching an access token from the new provider, and passing it via `Authorization` header to a web service request requiring authentication. I noted that the scope was correctly validated, too.