### PR TITLE
MBS-13700: Only open edit note links in new tab if needed

### DIFF
--- a/root/edit/components/EditNote.js
+++ b/root/edit/components/EditNote.js
@@ -51,6 +51,7 @@ component EditNote(
   edit: GenericEditWithIdT,
   editNote: EditNoteT,
   index: number,
+  isOnEditList: boolean = false,
   isOnEditPage: boolean = false,
   showEditControls: boolean = true,
 ) {
@@ -143,8 +144,8 @@ component EditNote(
         <a
           className="date"
           href={isOnEditPage ? `#${anchor}` : `/edit-note/${editNote.id}`}
-          rel={isOnEditPage ? null : 'noopener noreferrer'}
-          target={isOnEditPage ? null : '_blank'}
+          rel={isOnEditList ? 'noopener noreferrer' : null}
+          target={isOnEditList ? '_blank' : null}
         >
           {nonEmpty(editNote.post_time)
             ? formatUserDate($c, editNote.post_time)

--- a/root/edit/components/EditNotes.js
+++ b/root/edit/components/EditNotes.js
@@ -22,6 +22,7 @@ component EditNotes(
   edit: GenericEditWithIdT,
   hide: boolean = false,
   index: number = 0,
+  isOnEditList?: boolean,
   isOnEditPage?: boolean,
   verbose: boolean = true,
 ) {
@@ -38,6 +39,7 @@ component EditNotes(
             edit={edit}
             editNote={note}
             index={index}
+            isOnEditList={isOnEditList}
             isOnEditPage={isOnEditPage}
             key={index}
           />

--- a/root/edit/components/ListEdit.js
+++ b/root/edit/components/ListEdit.js
@@ -48,7 +48,13 @@ component ListEdit(
 
       {$c.user ? (
         <>
-          <EditNotes edit={edit} hide index={index} verbose={false} />
+          <EditNotes
+            edit={edit}
+            hide
+            index={index}
+            isOnEditList
+            verbose={false}
+          />
           <div className="seperator" />
         </>
       ) : null}


### PR DESCRIPTION
### Implement MBS-13700

# Problem
We decided to open edit note links in new tabs to avoid users accidentally navigating away from their unsent notes and votes but we are actually doing that everywhere except from the single edit pages. This is overkill - the only place we really need to do this is `ListEdit`.

# Solution
This separates `isOnEditPage` and a new flag `isOnEditList`, and opens anything not on an edit list in the same tab. We can consider later on to replace the new tab opening on edit lists with an alert you need to dismiss if you have unsent notes or votes, but this is a simple improvement to start with.

# Testing
Manually on the new notes list, all edits list and single edit pages.