### PR TITLE
Fix showing `ArtistCreditRenamer` in development

### DIFF
--- a/root/static/scripts/artist/components/ArtistCreditRenamer.js
+++ b/root/static/scripts/artist/components/ArtistCreditRenamer.js
@@ -183,7 +183,6 @@ const ArtistCreditRenamer = ({
 
   const rows = rowsRef.current;
   const tooManyRows = rows.length > 10;
-  const installedArtistNameEvent = React.useRef(false);
 
   const handleArtistNameChange = React.useCallback((
     event: SyntheticInputEvent<HTMLInputElement>,
@@ -192,14 +191,11 @@ const ArtistCreditRenamer = ({
   }, [dispatch]);
 
   React.useEffect(() => {
-    if (!installedArtistNameEvent.current) {
-      $(document).on(
-        'input',
-        '#id-edit-artist\\.name',
-        handleArtistNameChange,
-      );
-      installedArtistNameEvent.current = true;
-    }
+    $(document).on(
+      'input',
+      '#id-edit-artist\\.name',
+      handleArtistNameChange,
+    );
     return () => {
       $(document).off(
         'input',


### PR DESCRIPTION
# Problem

The `ArtistCreditRenamer` component doesn't display on development servers.

# Solution

React [runs effects twice](https://react.dev/learn/synchronizing-with-effects#how-to-handle-the-effect-firing-twice-in-development) in development. Prior to this patch, the `installedArtistNameEvent` check would prevent reinstalling the event after the cleanup function first runs. It serves no actual purpose in production or development.

This removes it entirely.

# Testing

Tested manually.