### PR TITLE
MBS-9373: Split voting and editing privilege revoking

### DIFF
--- a/admin/sql/updates/20240726-mbs-9373.sql
+++ b/admin/sql/updates/20240726-mbs-9373.sql
@@ -1,0 +1,9 @@
+\set ON_ERROR_STOP 1
+
+BEGIN;
+
+UPDATE editor
+   SET privs = privs | 16384 -- set new voting disabled flag
+ WHERE (privs & 1024) > 0; -- where editor had editing disabled flag
+
+COMMIT;

--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -364,6 +364,7 @@ Readonly our $EDITING_DISABLED_FLAG         => 1024;
 Readonly our $ADDING_NOTES_DISABLED_FLAG    => 2048;
 Readonly our $SPAMMER_FLAG                  => 4096;
 Readonly our $BEGINNER_FLAG                 => 8192;
+Readonly our $VOTING_DISABLED_FLAG          => 16384;
 # If you update this, also update root/utility/sanitizedEditor.js
 Readonly our $PUBLIC_PRIVILEGE_FLAGS        => $AUTO_EDITOR_FLAG |
                                                $BOT_FLAG |

--- a/lib/MusicBrainz/Server/Controller/Admin.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin.pm
@@ -41,6 +41,7 @@ sub edit_user : Path('/admin/user/edit') Args(1) RequireAuth HiddenOnMirrors Sec
             account_admin           => $user->is_account_admin,
             editing_disabled        => $user->is_editing_disabled,
             adding_notes_disabled   => $user->is_adding_notes_disabled,
+            voting_disabled         => $user->is_voting_disabled,
             spammer                 => $user->is_spammer,
             # user profile
             username                => $user->name,
@@ -292,6 +293,7 @@ sub privilege_search : Path('/admin/privilege-search') Args(0) RequireAuth(accou
                     + ($values->{account_admin}         // 0) * $ACCOUNT_ADMIN_FLAG
                     + ($values->{editing_disabled}      // 0) * $EDITING_DISABLED_FLAG
                     + ($values->{adding_notes_disabled} // 0) * $ADDING_NOTES_DISABLED_FLAG
+                    + ($values->{voting_disabled}       // 0) * $VOTING_DISABLED_FLAG
                     + ($values->{spammer}               // 0) * $SPAMMER_FLAG;
         $results = $self->_load_paged($c, sub {
             $c->model('Editor')->find_by_privileges(

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -121,7 +121,7 @@ sub enter_votes : Local RequireAuth DenyWhenReadonly
     if ($c->form_posted_and_valid($form)) {
         my @submissions = @{ $form->field('vote')->value };
         my @votes = grep { defined($_->{vote}) } @submissions;
-        unless ($c->user->is_editing_enabled || scalar @votes == 0) {
+        unless ($c->user->is_voting_enabled || scalar @votes == 0) {
             $c->stash(
                 current_view => 'Node',
                 component_path => 'edit/CannotVote',
@@ -140,7 +140,7 @@ sub enter_votes : Local RequireAuth DenyWhenReadonly
     $c->detach;
 }
 
-sub approve : Chained('load') RequireAuth(auto_editor) RequireAuth(editing_enabled) DenyWhenReadonly
+sub approve : Chained('load') RequireAuth(auto_editor) RequireAuth(voting_enabled) DenyWhenReadonly
 {
     my ($self, $c) = @_;
 

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -392,8 +392,9 @@ sub update_profile
 sub update_privileges {
     my ($self, $editor, $values) = @_;
 
-    # Setting Spammer should also block editing and notes
+    # Setting Spammer should also block editing, voting and notes
     $values->{editing_disabled} ||= $values->{spammer};
+    $values->{voting_disabled} ||= $values->{spammer};
     $values->{adding_notes_disabled} ||= $values->{spammer};
 
     my $privs =   ($values->{auto_editor}           // 0) * $AUTO_EDITOR_FLAG
@@ -408,6 +409,7 @@ sub update_privileges {
                 + ($values->{account_admin}         // 0) * $ACCOUNT_ADMIN_FLAG
                 + ($values->{editing_disabled}      // 0) * $EDITING_DISABLED_FLAG
                 + ($values->{adding_notes_disabled} // 0) * $ADDING_NOTES_DISABLED_FLAG
+                + ($values->{voting_disabled}       // 0) * $VOTING_DISABLED_FLAG
                 + ($values->{spammer}               // 0) * $SPAMMER_FLAG;
 
     Sql::run_in_transaction(sub {

--- a/lib/MusicBrainz/Server/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit.pm
@@ -13,9 +13,9 @@ use MusicBrainz::Server::Constants qw(
     :expire_action
     :vote
     $AUTO_EDITOR_FLAG
-    $EDITING_DISABLED_FLAG
     $OPEN_EDIT_DURATION
     $REQUIRED_VOTES
+    $VOTING_DISABLED_FLAG
 );
 use MusicBrainz::Server::Translation qw( l lp );
 use MusicBrainz::Server::Types
@@ -206,7 +206,7 @@ sub editor_may_approve {
          $self->is_open
       && $conditions->{auto_edit}
       && ($editor->privileges & $AUTO_EDITOR_FLAG)
-      && !($editor->privileges & $EDITING_DISABLED_FLAG);
+      && !($editor->privileges & $VOTING_DISABLED_FLAG);
 }
 
 sub editor_may_cancel {

--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -115,13 +115,21 @@ sub is_editing_enabled {
     (shift->privileges & $EDITING_DISABLED_FLAG) == 0;
 }
 
+sub is_voting_disabled {
+    (shift->privileges & $VOTING_DISABLED_FLAG) > 0;
+}
+
+sub is_voting_enabled {
+    (shift->privileges & $VOTING_DISABLED_FLAG) == 0;
+}
+
 sub may_vote {
     my $self = shift;
 
     return $self->has_confirmed_email_address &&
            !$self->is_beginner &&
            !$self->is_bot &&
-           $self->is_editing_enabled;
+           $self->is_voting_enabled;
 }
 
 sub is_adding_notes_disabled {
@@ -280,7 +288,10 @@ sub l_restrictions {
     my @restrictions;
 
     if ($self->is_editing_disabled) {
-        push(@restrictions, l('Editing/voting disabled'));
+        push(@restrictions, l('Editing disabled'));
+    }
+    if ($self->is_voting_disabled) {
+        push(@restrictions, l('Voting disabled'));
     }
     if ($self->is_adding_notes_disabled) {
         push(@restrictions, l('Edit notes disabled'));
@@ -456,6 +467,10 @@ The editor is able to change the banner message
 =head2 is_beginner
 
 The editor is a beginner (< 2 weeks old and/or < 10 accepted edits)
+
+=head2 is_voting_disabled
+
+The editor's voting rights have been revoked by an admin
 
 =head2 new_privileged
 

--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -16,6 +16,7 @@ use MusicBrainz::Server::Entity::Types qw( Area ); ## no critic 'ProhibitUnusedI
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
 use MusicBrainz::Server::Constants qw( :privileges );
 use MusicBrainz::Server::Filters qw( format_wikitext );
+use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Types DateTime => { -as => 'DateTimeType' };
 
 my $LATEST_SECURITY_VULNERABILITY = DateTime->new( year => 2013, month => 3, day => 28 );
@@ -272,6 +273,21 @@ has deleted => (
     isa => 'Bool',
     is => 'rw',
 );
+
+sub l_restrictions {
+    my $self = shift;
+
+    my @restrictions;
+
+    if ($self->is_editing_disabled) {
+        push(@restrictions, l('Editing/voting disabled'));
+    }
+    if ($self->is_adding_notes_disabled) {
+        push(@restrictions, l('Edit notes disabled'));
+    }
+
+    return @restrictions;
+}
 
 sub identity_string {
     my ($self) = @_;

--- a/lib/MusicBrainz/Server/Form/Admin/EditUser.pm
+++ b/lib/MusicBrainz/Server/Form/Admin/EditUser.pm
@@ -59,6 +59,10 @@ has_field 'editing_disabled' => (
     type => 'Boolean',
 );
 
+has_field 'voting_disabled' => (
+    type => 'Boolean',
+);
+
 has_field 'adding_notes_disabled' => (
     type => 'Boolean',
 );

--- a/lib/MusicBrainz/Server/Form/Admin/PrivilegeSearch.pm
+++ b/lib/MusicBrainz/Server/Form/Admin/PrivilegeSearch.pm
@@ -56,6 +56,10 @@ has_field 'editing_disabled' => (
     type => 'Boolean',
 );
 
+has_field 'voting_disabled' => (
+    type => 'Boolean',
+);
+
 has_field 'adding_notes_disabled' => (
     type => 'Boolean',
 );

--- a/root/admin/EditUser.js
+++ b/root/admin/EditUser.js
@@ -46,6 +46,7 @@ type EditUserFormT = FormT<{
   +spammer: FieldT<boolean>,
   +untrusted: FieldT<boolean>,
   +username: FieldT<string>,
+  +voting_disabled: FieldT<boolean>,
   +website: FieldT<string>,
   +wiki_transcluder: FieldT<boolean>,
 }>;
@@ -100,7 +101,12 @@ component EditUser(form: EditUserFormT, user: AccountLayoutUserT) {
         />
         <FormRowCheckbox
           field={form.field.editing_disabled}
-          label="Editing/voting disabled"
+          label="Editing disabled"
+          uncontrolled
+        />
+        <FormRowCheckbox
+          field={form.field.voting_disabled}
+          label="Voting disabled"
           uncontrolled
         />
         <FormRowCheckbox

--- a/root/admin/PrivilegeSearch.js
+++ b/root/admin/PrivilegeSearch.js
@@ -29,6 +29,7 @@ type PrivilegeSearchFormT = FormT<{
   +show_exact: FieldT<boolean>,
   +spammer: FieldT<boolean>,
   +untrusted: FieldT<boolean>,
+  +voting_disabled: FieldT<boolean>,
   +wiki_transcluder: FieldT<boolean>,
 }>;
 
@@ -96,7 +97,12 @@ component PrivilegeSearch(
 
             <FormRowCheckbox
               field={form.field.editing_disabled}
-              label="Editing/voting disabled"
+              label="Editing disabled"
+              uncontrolled
+            />
+            <FormRowCheckbox
+              field={form.field.voting_disabled}
+              label="Voting disabled"
               uncontrolled
             />
             <FormRowCheckbox

--- a/root/admin/components/UserList.js
+++ b/root/admin/components/UserList.js
@@ -19,6 +19,7 @@ import {
   isEditingDisabled,
   isSpammer,
   isUntrusted,
+  isVotingDisabled,
 } from '../../static/scripts/common/utility/privileges.js';
 import formatUserDate from '../../utility/formatUserDate.js';
 import loopParity from '../../utility/loopParity.js';
@@ -45,6 +46,9 @@ component UserList(users: $ReadOnlyArray<UnsanitizedEditorT>) {
           const restrictions = [];
           if (isEditingDisabled(user)) {
             restrictions.push('Editing');
+          }
+          if (isVotingDisabled(user)) {
+            restrictions.push('Voting');
           }
           if (isAddingNotesDisabled(user)) {
             restrictions.push('Notes');

--- a/root/constants.js
+++ b/root/constants.js
@@ -70,6 +70,7 @@ export const EDITING_DISABLED_FLAG: 1024 = 1024;
 export const ADDING_NOTES_DISABLED_FLAG: 2048 = 2048;
 export const SPAMMER_FLAG: 4096 = 4096;
 export const BEGINNER_FLAG: 8192 = 8192;
+export const VOTING_DISABLED_FLAG: 16384 = 16384;
 export const PUBLIC_FLAGS: number = AUTO_EDITOR_FLAG &
                                     BOT_FLAG &
                                     RELATIONSHIP_EDITOR_FLAG &

--- a/root/layout.tt
+++ b/root/layout.tt
@@ -10,22 +10,16 @@
     <body>
         [%- React.embed(c, 'layout/components/Header') -%]
 
-        [%- IF c.user.is_editing_disabled || c.user.is_adding_notes_disabled -%]
+        [%- IF c.user.l_restrictions.size -%]
             <div class="banner editing-disabled">
                 <p>
-                    [%- IF c.user.is_editing_disabled && c.user.is_adding_notes_disabled -%]
-                        [% l('You’re currently not allowed to edit, vote or leave edit notes because an admin has revoked your privileges.
-                            If you haven’t already been contacted about why, please {uri|send us a message}.',
-                            { uri => { href => 'https://metabrainz.org/contact', target => '_blank' } }) %]
-                    [%- ELSIF c.user.is_editing_disabled -%]
-                        [% l('You’re currently not allowed to edit or vote because an admin has revoked your privileges.
-                            If you haven’t already been contacted about why, please {uri|send us a message}.',
-                            { uri => { href => 'https://metabrainz.org/contact', target => '_blank' } }) %]
-                    [%- ELSE -%]
-                        [% l('You’re currently not allowed to leave or change edit notes because an admin has revoked your privileges.
-                            If you haven’t already been contacted about why, please {uri|send us a message}.',
-                            { uri => { href => 'https://metabrainz.org/contact', target => '_blank' } }) %]
-                    [%- END -%]
+                    [% l('An admin has set the following restrictions on your account: {list}.
+                          If you haven’t already been contacted about why, please {uri|send us a message}.',
+                         {
+                            list => comma_only_list(c.user.l_restrictions),
+                            uri => {href => 'https://metabrainz.org/contact', target => '_blank'},
+                         },
+                    ) %]
                 </p>
             </div>
         [%- END -%]

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -12,11 +12,12 @@ import * as React from 'react';
 import {CatalystContext} from '../context.mjs';
 import {RT_MIRROR} from '../static/scripts/common/constants.js';
 import DBDefs from '../static/scripts/common/DBDefs.mjs';
+import {commaOnlyListText}
+  from '../static/scripts/common/i18n/commaOnlyList.js';
 import parseDate from '../static/scripts/common/utility/parseDate.js';
 import {
-  isAddingNotesDisabled,
+  getRestrictionsForUser,
   isBeginner,
-  isEditingDisabled,
 } from '../static/scripts/common/utility/privileges.js';
 import {age} from '../utility/age.js';
 import {formatUserDateObject} from '../utility/formatUserDate.js';
@@ -182,6 +183,8 @@ component Layout(
       (isBeginner($c.user) || !$c.user.has_confirmed_email_address)) ||
       getRequestCookie($c.req, 'alert_new_edit_notes', 'true') !== 'false');
 
+  const restrictions = getRestrictionsForUser($c.user);
+
   return (
     <html lang={$c.stash.current_language_html}>
       <Head {...headProps} />
@@ -189,35 +192,18 @@ component Layout(
       <body>
         <Header />
 
-        {isEditingDisabled($c.user) || isAddingNotesDisabled($c.user) ? (
+        {restrictions.length > 0 ? (
           <div className="banner editing-disabled">
             <p>
-              {isEditingDisabled($c.user) ? (
-                isAddingNotesDisabled($c.user) ? (
-                  exp.l(
-                    `You’re currently not allowed to edit, vote or leave edit
-                     notes because an admin has revoked your privileges.
-                     If you haven’t already been contacted
-                     about why, please {uri|send us a message}.`,
-                    {uri: {href: 'https://metabrainz.org/contact', target: '_blank'}},
-                  )
-                ) : (
-                  exp.l(
-                    `You’re currently not allowed to edit or vote because an
-                     admin has revoked your privileges. If you haven’t already
-                     been contacted about why,
-                     please {uri|send us a message}.`,
-                    {uri: {href: 'https://metabrainz.org/contact', target: '_blank'}},
-                  )
-                )
-              ) : (
-                exp.l(
-                  `You’re currently not allowed to leave or change edit notes
-                   because an admin has revoked your privileges.
-                   If you haven’t already been contacted about why,
-                   please {uri|send us a message}.`,
-                  {uri: {href: 'https://metabrainz.org/contact', target: '_blank'}},
-                )
+              {exp.l(
+                `An admin has set the following restrictions
+                 on your account: {list}.
+                 If you haven’t already been contacted
+                 about why, please {uri|send us a message}.`,
+                {
+                  list: commaOnlyListText(restrictions),
+                  uri: {href: 'https://metabrainz.org/contact', target: '_blank'},
+                },
               )}
             </p>
           </div>

--- a/root/static/scripts/common/utility/privileges.js
+++ b/root/static/scripts/common/utility/privileges.js
@@ -138,3 +138,16 @@ export function isAdmin(editor: EditorPropT): boolean {
          isRelationshipEditor(editor) ||
          isWikiTranscluder(editor);
 }
+
+export function getRestrictionsForUser(editor: EditorPropT): Array<string> {
+  const restrictions = [];
+
+  if (isEditingDisabled(editor)) {
+    restrictions.push(l('Editing/voting disabled'));
+  }
+  if (isAddingNotesDisabled(editor)) {
+    restrictions.push(l('Edit notes disabled'));
+  }
+
+  return restrictions;
+}

--- a/root/static/scripts/common/utility/privileges.js
+++ b/root/static/scripts/common/utility/privileges.js
@@ -21,6 +21,7 @@ import {
   RELATIONSHIP_EDITOR_FLAG,
   SPAMMER_FLAG,
   UNTRUSTED_FLAG,
+  VOTING_DISABLED_FLAG,
   WIKI_TRANSCLUSION_FLAG,
 } from '../../../../constants.js';
 
@@ -124,6 +125,20 @@ export function isAddingNotesDisabled(editor: EditorPropT): boolean {
   return (editor.privileges & ADDING_NOTES_DISABLED_FLAG) > 0;
 }
 
+export function isVotingDisabled(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & VOTING_DISABLED_FLAG) > 0;
+}
+
+export function isVotingEnabled(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & VOTING_DISABLED_FLAG) === 0;
+}
+
 export function isSpammer(editor: EditorPropT): boolean {
   if (editor == null) {
     return false;
@@ -143,7 +158,10 @@ export function getRestrictionsForUser(editor: EditorPropT): Array<string> {
   const restrictions = [];
 
   if (isEditingDisabled(editor)) {
-    restrictions.push(l('Editing/voting disabled'));
+    restrictions.push(l('Editing disabled'));
+  }
+  if (isVotingDisabled(editor)) {
+    restrictions.push(l('Voting disabled'));
   }
   if (isAddingNotesDisabled(editor)) {
     restrictions.push(l('Edit notes disabled'));

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -29,12 +29,12 @@ import bracketed, {bracketedText}
 import escapeRegExp from '../static/scripts/common/utility/escapeRegExp.mjs';
 import nonEmpty from '../static/scripts/common/utility/nonEmpty.js';
 import {
+  getRestrictionsForUser,
   isAccountAdmin,
   isAddingNotesDisabled,
   isAutoEditor,
   isBeginner,
   isBot,
-  isEditingDisabled,
   isLocationEditor,
   isRelationshipEditor,
   isSpammer,
@@ -867,13 +867,7 @@ component UserProfile(
   const viewingOwnProfile = $c.user != null && $c.user.id === user.id;
   const adminViewing = $c.user != null && isAccountAdmin($c.user);
   const encodedName = encodeURIComponent(user.name);
-  const restrictions = [];
-  if (isEditingDisabled(user)) {
-    restrictions.push(l('Editing/voting disabled'));
-  }
-  if (isAddingNotesDisabled(user)) {
-    restrictions.push(l('Edit notes disabled'));
-  }
+  const restrictions = getRestrictionsForUser(user);
   // We specifically never show "untrusted" to non-admin users
   if (adminViewing && isUntrusted(user)) {
     restrictions.push(l_admin('Untrusted'));

--- a/root/utility/edit.js
+++ b/root/utility/edit.js
@@ -28,7 +28,7 @@ import {
   isAutoEditor,
   isBeginner,
   isBot,
-  isEditingEnabled,
+  isVotingEnabled,
 } from '../static/scripts/common/utility/privileges.js';
 import {kebabCase} from '../static/scripts/common/utility/strings.js';
 
@@ -141,7 +141,7 @@ export function editorMayApprove(
     editor != null &&
     edit.status === EDIT_STATUS_OPEN &&
     isAutoEditor(editor) &&
-    isEditingEnabled(editor)
+    isVotingEnabled(editor)
   );
 
   if (!minimalRequirements) {
@@ -192,7 +192,7 @@ export function editorMayVote(
     !isBeginner(editor) &&
     nonEmpty(editor.email_confirmation_date) &&
     !isBot(editor) &&
-    isEditingEnabled(editor)
+    isVotingEnabled(editor)
   );
 }
 

--- a/t/lib/t/MusicBrainz/Server/Data/Editor.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Editor.pm
@@ -14,8 +14,8 @@ use DateTime::Format::Pg;
 use MusicBrainz::Server::Constants qw(
     :edit_status
     $EDIT_ARTIST_EDIT
-    $EDITING_DISABLED_FLAG
     $UNTRUSTED_FLAG
+    $VOTING_DISABLED_FLAG
     :vote
 );
 use MusicBrainz::Server::Context;
@@ -362,10 +362,10 @@ test 'Editor subscription methods' => sub {
         @editors = $editor_data->editors_with_subscriptions(2, 1000);
         is(@editors => 0, 'Found no editors searching with offset 2');
 
-        note('We mark editor #2 as a spammer (+ block edit & notes privs)');
+        note('We mark editor #2 as a spammer (+ block edit, voting & notes privs)');
         $test->c->sql->do(<<~'SQL');
             UPDATE editor
-            SET privs = 7168
+            SET privs = 23552
             WHERE id = 2
             SQL
 
@@ -627,9 +627,9 @@ test 'Deleting an editor changes all Yes/No votes on open edits to Abstain, even
     is($edit->votes->[0]->vote, $VOTE_NO, 'Vote is No');
     is($edit->votes->[0]->editor_id, 2, 'Vote is by editor 2');
 
-    note('We revoke the editing/voting privileges for editor 2');
+    note('We revoke the voting privileges for editor 2');
     $test->c->sql->do(
-        "UPDATE editor SET privs = $EDITING_DISABLED_FLAG WHERE id = 2",
+        "UPDATE editor SET privs = $VOTING_DISABLED_FLAG WHERE id = 2",
     );
 
     note('We delete editor 2');


### PR DESCRIPTION
### Implement MBS-9373

# Description
I have had several times where I would have liked to block someone from voting, at least temporarily, but not from editing.
That's not currently possible, so this splits the editing and voting privileges into two flags.

# Further tasks
A one-off script (to be added) should be ran to add voting blocks to all editors that previously had the editing/voting combined flag.

# Testing
Manually (including trying to submit votes from JS and ensuring Perl blocks it), plus any existing tests that already check for limited votes.