### PR TITLE
MBS-12523: Don't treat "mix" ETI as Roman numerals

### DIFF
--- a/root/static/scripts/guess-case/utils.js
+++ b/root/static/scripts/guess-case/utils.js
@@ -294,11 +294,14 @@ export function titleString(
         !followedByPunctuation) {
       outputString = lowercase;
     } else if (
-      guessCaseMode.isRomanNumber(lowercase) && !followedByApostrophe
+      guessCaseMode.isRomanNumber(lowercase) &&
+      !followedByApostrophe &&
+      !(flags.isInsideBrackets() && isLowerCaseBracketWord(lowercase))
     ) {
       /*
        * Uppercase Roman numerals unless followed by apostrophe
-       * (likely false positive, "d'amore", "c'est")
+       * (likely false positive, "d'amore", "c'est") or a bracketed word
+       * that's typically lowercased (e.g. "mix").
        */
       outputString = uppercase;
     } else if (guessCaseMode.isUpperCaseWord(lowercase)) {

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -223,7 +223,7 @@ test('Release', function (t) {
 });
 
 test('Work', function (t) {
-  t.plan(24);
+  t.plan(26);
 
   const tests = [
     {
@@ -398,6 +398,22 @@ test('Work', function (t) {
       bug: 'MBS-11854',
       mode: 'English',
       roman: false,
+      keepuppercase: false,
+    },
+    {
+      input: 'Some Song (Club Mix)',
+      expected: 'Some Song (club mix)',
+      bug: 'MBS-12523',
+      mode: 'English',
+      roman: true,
+      keepuppercase: false,
+    },
+    {
+      input: 'cmxcix + x = mix',
+      expected: 'CMXCIX + X = MIX',
+      bug: 'MBS-12523',
+      mode: 'English',
+      roman: true,
       keepuppercase: false,
     },
   ];


### PR DESCRIPTION
Update the guess case titleString() function to avoid uppercasing typically-lowercased ETI words like "mix" that are also Roman numerals.

# Problem

The word "mix" is a frequent occurrence in extra title information ("extended mix", "club mix", etc.), but "MIX" is also 1009 in Roman numerals. When "Uppercase Roman numerals" is checked in the guess case options, "MIX" is always capitalized, resulting incorrect e.g. "extended MIX" ETI.

# Solution

Avoid capitalizing "mix" when it appears in parentheses/brackets. I'm actually ignoring Roman numerals whenever `flags.isInsideBrackets() && isLowerCaseBracketWord(lowercase)` is true since that feels cleaner than introducing a new list, even though I think that "mix" is the only problematic word here.

# Testing

Manually tested, plus added unit test cases verifying that "mix" is lowercased in ETI and capitalized otherwise.