### PR TITLE
MBS-13707: Calculate needed columns first in getRelationshipRows

### DIFF
--- a/root/components/RelationshipsTable.js
+++ b/root/components/RelationshipsTable.js
@@ -120,9 +120,6 @@ component RelationshipsTable(
         }
       }
     }
-  };
-
-  const setColumnsCount = () => {
     columnsCount = (
       2 +
       (hasCreditColumn ? 1 : 0) +
@@ -218,9 +215,6 @@ component RelationshipsTable(
         pagedLinkTypeGroup.relationships[0].target_type,
         pagedLinkTypeGroup.relationships,
       );
-
-      setColumnsCount();
-
       getRelationshipRows(pagedLinkTypeGroup, tableRows);
     }
   } else if (pagedRelationshipGroups) {
@@ -248,8 +242,6 @@ component RelationshipsTable(
         }
         return accum;
       }, []);
-
-    setColumnsCount();
 
     for (const targetTypeGroup of targetTypeGroups) {
       const linkTypeGroups: $ReadOnlyArray<$ReadOnly<{

--- a/root/components/RelationshipsTable.js
+++ b/root/components/RelationshipsTable.js
@@ -104,6 +104,34 @@ component RelationshipsTable(
 
     totalRelationships += linkTypeGroup.total_relationships;
 
+    hasCreditColumn = linkTypeGroup.relationships.some(relationship => {
+      let sourceCredit = '';
+      if (relationship.backward) {
+        sourceCredit = relationship.entity1_credit;
+      } else {
+        sourceCredit = relationship.entity0_credit;
+      }
+
+      return nonEmpty(sourceCredit);
+    });
+    hasAttributeColumn = linkTypeGroup.relationships.some(
+      relationship => Boolean(relationship.attributes?.length),
+    );
+    hasArtistColumn = linkTypeGroup.relationships.some(
+      relationship => Object.hasOwn(relationship.target, 'artistCredit'),
+    );
+    hasLengthColumn = linkTypeGroup.relationships.some(
+      relationship => Object.hasOwn(relationship.target, 'length'),
+    );
+
+    columnsCount = (
+      1 +
+      (hasCreditColumn ? 1 : 0) +
+      (hasAttributeColumn ? 1 : 0) +
+      (hasArtistColumn ? 1 : 0) +
+      (hasLengthColumn ? 1 : 0)
+    );
+
     for (const relationship of linkTypeGroup.relationships) {
       let sourceCredit = '';
       let targetCredit = '';
@@ -119,21 +147,6 @@ component RelationshipsTable(
       const artistCredit = Object.hasOwn(target, 'artistCredit')
         ? target.artistCredit
         : null;
-
-      hasCreditColumn ||= nonEmpty(sourceCredit);
-      hasAttributeColumn ||= Boolean(relationship.attributes?.length);
-      hasArtistColumn ||= (artistCredit != null);
-      hasLengthColumn ||= (
-        Object.hasOwn(target, 'length') &&
-        target.length != null
-      );
-      columnsCount = (
-        1 +
-        (hasCreditColumn ? 1 : 0) +
-        (hasAttributeColumn ? 1 : 0) +
-        (hasArtistColumn ? 1 : 0) +
-        (hasLengthColumn ? 1 : 0)
-      );
 
       rows.push(
         <React.Fragment key={relationship.id}>


### PR DESCRIPTION
### Fix MBS-13707

# Problem
The first row(s) in `RelationshipTable` weren't getting all needed columns after 7072352ad4084e6bd21ef6249520c276998f7737 removed the nested component, which means it probably only worked before because of things getting re-rendered.

# Solution
The actual right way to do this would seem to be to calculate it once per relationship group, since we want it to apply to the whole group anyway.

# Testing
Manually, with the work given on the ticket (`/work/9abc3eb0-e541-4342-aed3-1040d91525a4`) and a full server tunnel.