### PR TITLE
MBS-13714: Clean up Genius artists links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2689,7 +2689,9 @@ const CLEANUPS: CleanupEntries = {
       place: LINK_TYPES.otherdatabases.place,
     }],
     clean(url) {
-      return url.replace(/^https?:\/\/([^/]+\.)?genius\.com/, 'https://genius.com');
+      url = url.replace(/^https?:\/\/([^/]+\.)?genius\.com/, 'https://genius.com');
+      url = url.replace(/^https:\/\/genius\.com\/artists\/([\w-]+)(?:\/.*)?/, 'https://genius.com/artists/$1');
+      return url;
     },
     validate(url, id) {
       switch (id) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2651,7 +2651,7 @@ limited_link_type_combinations: [
   },
   // Genius
   {
-                     input_url: 'http://genius.com/artists/Dramatik',
+                     input_url: 'http://genius.com/artists/Dramatik/songs',
              input_entity_type: 'artist',
     expected_relationship_type: 'lyrics',
             expected_clean_url: 'https://genius.com/artists/Dramatik',


### PR DESCRIPTION
### Implement MBS-13714

# Problem
Genius artist pages have optional subpages such as `/songs` which we were leaving unchanged and then rejecting.

# Solution
This drops anything after the artist name section so we get the URL form we all know and love.

# Testing
Edited one of the URLCleanup tests to include `/songs`.