### PR TITLE
Completely avoid conflicting keys in `VarArgs.prototype.getKey`

### DIFF
--- a/root/static/scripts/common/i18n/expand2.js
+++ b/root/static/scripts/common/i18n/expand2.js
@@ -35,14 +35,13 @@ export interface VarArgsClass<+T> {
   has(name: string): boolean,
 }
 
+let nextKey = 1;
+
 export class VarArgs<+T> implements VarArgsClass<T> {
   +data: VarArgsObject<T>;
 
-  #nextKey: number;
-
   constructor(data: VarArgsObject<T>) {
     this.data = data;
-    this.#nextKey = 1;
   }
 
   get(name: string): T {
@@ -62,7 +61,7 @@ export class VarArgs<+T> implements VarArgsClass<T> {
   }
 
   getKey(name: string): string {
-    return name + '-' + String(this.#nextKey++);
+    return name + '-' + String(nextKey++);
   }
 
   has(name: string): boolean {


### PR DESCRIPTION
# Problem

The `getKey` method added in 6f57c167a3996f35cb1012d05f93e709f66cbdd6 doesn't prevent conflicts in cases like this example (pulled from externalLinks.js):

    typeDescription = exp.l('{description} ({url|more documentation})', {
      description: expand2react(l_relationships(linkType.description)),
      url: '/relationship/' + linkType.gid,
    });

This is because the inner `expand2react` call does not share a `VarArgs` instance with the `exp.l` call, so separate `nextKey` counters are used. Thus the first link in the `description` will get the key "a-1", and so will the link generated for `url`.

# Solution

We can avoid this by just using a global counter for `nextKey`. This is not entirely ideal, because changing the key on every render prevents React's reconciliation algorithm from reusing the same elements. I'd like to submit a better fix soon, but it's much more involved. It's also not too big of a deal, because the elements that are typically interpolated are small (like links), not giant subtrees that would benefit more from consistent keys.

# Testing

Checked http://localhost:5000/artist/109958eb-a335-4c5e-907e-597ff4c6af46/edit which no longer throws a key warning.