### PR TITLE
MBS-13718: Support The Session composer pages

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5388,7 +5388,7 @@ const CLEANUPS: CleanupEntries = {
     match: [/^(https?:\/\/)?(www\.)?thesession\.org/i],
     restrict: [LINK_TYPES.otherdatabases],
     clean(url) {
-      return url.replace(/^(?:https?:\/\/)?(?:www\.)?thesession\.org\/(tunes|events|recordings(?:\/artists)?|sessions)(?:\/.*)?\/([0-9]+).*$/, 'https://thesession.org/$1/$2');
+      return url.replace(/^(?:https?:\/\/)?(?:www\.)?thesession\.org\/(tunes(?:\/composers)?|events|recordings(?:\/artists)?|sessions)(?:\/.*)?\/([0-9]+).*$/, 'https://thesession.org/$1/$2');
     },
     validate(url, id) {
       const m = /^https:\/\/thesession\.org\/([a-z/]+)\/[0-9]+$/.exec(url);
@@ -5397,7 +5397,8 @@ const CLEANUPS: CleanupEntries = {
         switch (id) {
           case LINK_TYPES.otherdatabases.artist:
             return {
-              result: prefix === 'recordings/artists',
+              result: prefix === 'recordings/artists' ||
+                      prefix === 'tunes/composers',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.event:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5537,6 +5537,13 @@ limited_link_type_combinations: ['downloadpurchase', 'mailorder'],
        only_valid_entity_types: ['artist'],
   },
   {
+                     input_url: 'https://thesession.org/tunes/composers/897',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://thesession.org/tunes/composers/897',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'https://thesession.org/members/01234',
              input_entity_type: 'artist',
     expected_relationship_type: undefined,


### PR DESCRIPTION
### Implement MBS-13718

# Description
We supported `/recordings/artists` links for thesession.org, but we didn't currently support the equivalent `/tunes/composers` links, such as https://thesession.org/tunes/composers/897 - we should accept those too.

# Testing
Added an `URLCleanup` test for this.