### PR TITLE
Log plackup response time

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -75,7 +75,10 @@ builder {
     enable_if {
         my $plack_env = $ENV{PLACK_ENV};
         defined $plack_env && $plack_env eq 'deployment'
-    } 'Plack::Middleware::AccessLog', format => 'combined';
+    } 'Plack::Middleware::AccessLog',
+        format => '%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i" %{X-Runtime}o';
+
+    enable 'Plack::Middleware::Runtime';
 
     MusicBrainz::Server->psgi_app;
 };


### PR DESCRIPTION
# Problem

It's difficult to determine which requests are leading to increased response times from the plackup logs.

# Solution

This copies the "combined" plackup log format and appends the value of the `X-Runtime` header which is injected by `Plack::Middleware::Runtime`.

Note that the modified log format is only used in production. (The `AccessLog` middleware is enabled by default in development, though I didn't find out how to change the log format used in that case.)

# Testing

This is currently running on hip; I'll copy it to other servers with spikes in response time too.