### PR TITLE
MBS-13723: Allow "download"-only relationships to Qobuz URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4666,17 +4666,6 @@ const CLEANUPS: CleanupEntries = {
       LINK_TYPES.streamingpaid,
       multiple(LINK_TYPES.downloadpurchase, LINK_TYPES.streamingpaid),
     ],
-    select(url, sourceType) {
-      switch (sourceType) {
-        case 'artist':
-          return LINK_TYPES.streamingpaid.artist;
-        case 'label':
-          return LINK_TYPES.streamingpaid.label;
-        case 'release':
-          return LINK_TYPES.streamingpaid.release;
-      }
-      return false;
-    },
     clean(url) {
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?qobuz\.com\//, 'https://www.qobuz.com/');
       return url;

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4662,6 +4662,7 @@ const CLEANUPS: CleanupEntries = {
   'qobuz': {
     match: [/^(https?:\/\/)?(www\.)?qobuz\.com\//i],
     restrict: [
+      LINK_TYPES.downloadpurchase,
       LINK_TYPES.streamingpaid,
       multiple(LINK_TYPES.downloadpurchase, LINK_TYPES.streamingpaid),
     ],

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4952,6 +4952,7 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://www.qobuz.com/gb-en/interpreter/nitepunk/3241976',
     expected_relationship_type: 'streamingpaid',
 limited_link_type_combinations: [
+                                  'downloadpurchase',
                                   'streamingpaid',
                                   ['downloadpurchase', 'streamingpaid'],
                                 ],
@@ -4964,10 +4965,11 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://www.qobuz.com/fr-fr/label/ecm/download-streaming-albums/92473',
     expected_relationship_type: 'streamingpaid',
 limited_link_type_combinations: [
+                                  'downloadpurchase',
                                   'streamingpaid',
                                   ['downloadpurchase', 'streamingpaid'],
                                 ],
-       input_relationship_type: 'streamingpaid',
+       input_relationship_type: ['downloadpurchase', 'streamingpaid'],
        only_valid_entity_types: ['label'],
   },
   {
@@ -4976,10 +4978,11 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://www.qobuz.com/es-es/album/the-koln-concert-live-at-the-opera-koln-1975-keith-jarrett/0060254707654',
     expected_relationship_type: 'streamingpaid',
 limited_link_type_combinations: [
+                                  'downloadpurchase',
                                   'streamingpaid',
                                   ['downloadpurchase', 'streamingpaid'],
                                 ],
-       input_relationship_type: 'streamingpaid',
+       input_relationship_type: 'downloadpurchase',
        only_valid_entity_types: ['release'],
   },
   // Rock.com.ar

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4950,6 +4950,7 @@ limited_link_type_combinations: [
                      input_url: 'https://www.qobuz.com/gb-en/interpreter/nitepunk/3241976',
              input_entity_type: 'artist',
             expected_clean_url: 'https://www.qobuz.com/gb-en/interpreter/nitepunk/3241976',
+    expected_relationship_type: 'streamingpaid',
 limited_link_type_combinations: [
                                   'streamingpaid',
                                   ['downloadpurchase', 'streamingpaid'],
@@ -4961,6 +4962,7 @@ limited_link_type_combinations: [
                      input_url: 'https://www.qobuz.com/fr-fr/label/ecm/download-streaming-albums/92473',
              input_entity_type: 'label',
             expected_clean_url: 'https://www.qobuz.com/fr-fr/label/ecm/download-streaming-albums/92473',
+    expected_relationship_type: 'streamingpaid',
 limited_link_type_combinations: [
                                   'streamingpaid',
                                   ['downloadpurchase', 'streamingpaid'],
@@ -4972,6 +4974,7 @@ limited_link_type_combinations: [
                      input_url: 'https://www.qobuz.com/es-es/album/the-koln-concert-live-at-the-opera-koln-1975-keith-jarrett/0060254707654',
              input_entity_type: 'release',
             expected_clean_url: 'https://www.qobuz.com/es-es/album/the-koln-concert-live-at-the-opera-koln-1975-keith-jarrett/0060254707654',
+    expected_relationship_type: 'streamingpaid',
 limited_link_type_combinations: [
                                   'streamingpaid',
                                   ['downloadpurchase', 'streamingpaid'],

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4950,7 +4950,7 @@ limited_link_type_combinations: [
                      input_url: 'https://www.qobuz.com/gb-en/interpreter/nitepunk/3241976',
              input_entity_type: 'artist',
             expected_clean_url: 'https://www.qobuz.com/gb-en/interpreter/nitepunk/3241976',
-    expected_relationship_type: 'streamingpaid',
+    expected_relationship_type: undefined,
 limited_link_type_combinations: [
                                   'downloadpurchase',
                                   'streamingpaid',
@@ -4963,7 +4963,7 @@ limited_link_type_combinations: [
                      input_url: 'https://www.qobuz.com/fr-fr/label/ecm/download-streaming-albums/92473',
              input_entity_type: 'label',
             expected_clean_url: 'https://www.qobuz.com/fr-fr/label/ecm/download-streaming-albums/92473',
-    expected_relationship_type: 'streamingpaid',
+    expected_relationship_type: undefined,
 limited_link_type_combinations: [
                                   'downloadpurchase',
                                   'streamingpaid',
@@ -4976,7 +4976,7 @@ limited_link_type_combinations: [
                      input_url: 'https://www.qobuz.com/es-es/album/the-koln-concert-live-at-the-opera-koln-1975-keith-jarrett/0060254707654',
              input_entity_type: 'release',
             expected_clean_url: 'https://www.qobuz.com/es-es/album/the-koln-concert-live-at-the-opera-koln-1975-keith-jarrett/0060254707654',
-    expected_relationship_type: 'streamingpaid',
+    expected_relationship_type: undefined,
 limited_link_type_combinations: [
                                   'downloadpurchase',
                                   'streamingpaid',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4949,34 +4949,34 @@ limited_link_type_combinations: [
   {
                      input_url: 'https://www.qobuz.com/gb-en/interpreter/nitepunk/3241976',
              input_entity_type: 'artist',
-       input_relationship_type: 'streamingpaid',
+            expected_clean_url: 'https://www.qobuz.com/gb-en/interpreter/nitepunk/3241976',
 limited_link_type_combinations: [
                                   'streamingpaid',
                                   ['downloadpurchase', 'streamingpaid'],
                                 ],
-            expected_clean_url: 'https://www.qobuz.com/gb-en/interpreter/nitepunk/3241976',
+       input_relationship_type: 'streamingpaid',
        only_valid_entity_types: ['artist'],
   },
   {
                      input_url: 'https://www.qobuz.com/fr-fr/label/ecm/download-streaming-albums/92473',
              input_entity_type: 'label',
-       input_relationship_type: 'streamingpaid',
+            expected_clean_url: 'https://www.qobuz.com/fr-fr/label/ecm/download-streaming-albums/92473',
 limited_link_type_combinations: [
                                   'streamingpaid',
                                   ['downloadpurchase', 'streamingpaid'],
                                 ],
-            expected_clean_url: 'https://www.qobuz.com/fr-fr/label/ecm/download-streaming-albums/92473',
+       input_relationship_type: 'streamingpaid',
        only_valid_entity_types: ['label'],
   },
   {
                      input_url: 'https://www.qobuz.com/es-es/album/the-koln-concert-live-at-the-opera-koln-1975-keith-jarrett/0060254707654',
              input_entity_type: 'release',
-       input_relationship_type: 'streamingpaid',
+            expected_clean_url: 'https://www.qobuz.com/es-es/album/the-koln-concert-live-at-the-opera-koln-1975-keith-jarrett/0060254707654',
 limited_link_type_combinations: [
                                   'streamingpaid',
                                   ['downloadpurchase', 'streamingpaid'],
                                 ],
-            expected_clean_url: 'https://www.qobuz.com/es-es/album/the-koln-concert-live-at-the-opera-koln-1975-keith-jarrett/0060254707654',
+       input_relationship_type: 'streamingpaid',
        only_valid_entity_types: ['release'],
   },
   // Rock.com.ar


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem MBS-13723
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

When implementing MBS-13438 it was thought that Qobuz always has a streaming option, but some releases are available for download only which isn’t currently allowed in the external links editor.


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Just allow "download"-only additionally to the already allowed "streaming"-only (auto-selected) and "download"+"streaming".

Additionally, now that download-only is an option, the streaming relationship type is no longer a subset of all possible options. It would be misleading to keep auto-selecting the streaming relationship type for Qobuz URLs. Therefore this patch also disables auto-selecting relationship type for Qobuz URLs.



# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

Tested locally in a release editor and updated CI tests.