### PR TITLE
MBS-3255: Support reordering artist credits

### DIFF
--- a/root/static/scripts/edit/components/ArtistCreditBubble.js
+++ b/root/static/scripts/edit/components/ArtistCreditBubble.js
@@ -260,11 +260,10 @@ component _ArtistCreditBubble(
     return names;
   }, [names, initialBubbleFocus, initialFocusRef]);
 
-  const allowNameRemoval = React.useMemo(() => {
-    return state.names.reduce((accum, name) => {
-      return accum + (name.removed ? 0 : 1);
-    }, 0) > 1;
-  }, [state.names]);
+  const allowNameMoveOrRemoval = React.useMemo(
+    () => state.names.filter((n) => !n.removed).length > 1,
+    [state.names],
+  );
 
   return (
     <form onSubmit={handleSubmit}>
@@ -281,12 +280,15 @@ component _ArtistCreditBubble(
         <tbody>
           {namesWithInitialFocus.map((name, index) => (
             <ArtistCreditNameEditor
-              allowRemoval={allowNameRemoval}
+              allowMoveDown={index < names.length - 1}
+              allowMoveUp={index > 0}
+              allowRemoval={allowNameMoveOrRemoval}
               artistCreditEditorId={state.id}
               dispatch={dispatch}
               index={index}
               key={name.key}
               name={name}
+              showMoveButtons={allowNameMoveOrRemoval && !name.removed}
             />
           ))}
           <AddArtistCreditRow dispatch={dispatch} />

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -145,6 +145,24 @@ function addEmptyCredit(stateCtx: CowContext<StateT>) {
   setAutoJoinPhrases(namesCtx);
 }
 
+function swapCredits(
+  stateCtx: CowContext<StateT>,
+  i: number,
+  j: number,
+) {
+  const tmpName = stateCtx.read().names[i];
+  stateCtx.set('names', i, stateCtx.read().names[j]);
+  stateCtx.set('names', j, tmpName);
+
+  // Preserve join phrase positions if neither credit is removed.
+  const names = stateCtx.read().names;
+  if (!names[i].removed && !names[j].removed) {
+    const tmpJoinPhrase = names[i].joinPhrase;
+    stateCtx.set('names', i, 'joinPhrase', names[j].joinPhrase);
+    stateCtx.set('names', j, 'joinPhrase', tmpJoinPhrase);
+  }
+}
+
 export function closeDialog(
   stateCtx: CowContext<StateT>,
 ): void {
@@ -241,6 +259,20 @@ export function reducer(
         }
       });
 
+      break;
+    }
+
+    case 'move-name-down': {
+      if (action.index < names.length - 1) {
+        swapCredits(stateCtx, action.index, action.index + 1);
+      }
+      break;
+    }
+
+    case 'move-name-up': {
+      if (action.index > 0) {
+        swapCredits(stateCtx, action.index, action.index - 1);
+      }
       break;
     }
 

--- a/root/static/scripts/edit/components/ArtistCreditEditor/types.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor/types.js
@@ -70,6 +70,8 @@ export type ActionT =
   | {+type: 'close-dialog'}
   | {+type: 'toggle-dialog'}
   | {+type: 'add-name'}
+  | {+type: 'move-name-down', +index: number}
+  | {+type: 'move-name-up', +index: number}
   | {+type: 'remove-name', +index: number}
   | {+type: 'undo-remove-name', +index: number}
   | {

--- a/root/static/scripts/edit/components/ArtistCreditNameEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditNameEditor.js
@@ -21,11 +21,14 @@ import type {
 } from './ArtistCreditEditor/types.js';
 
 component _ArtistCreditNameEditor(
+  allowMoveDown: boolean,
+  allowMoveUp: boolean,
   allowRemoval: boolean,
   artistCreditEditorId: string,
   dispatch: (ActionT) => void,
   index: number,
   name as artistCreditName: ArtistCreditNameStateT,
+  showMoveButtons: boolean,
 ) {
   const artistDispatch = React.useCallback((
     action: AutocompleteActionT<ArtistT>,
@@ -114,6 +117,20 @@ component _ArtistCreditNameEditor(
     });
   }
 
+  function handleMoveDown() {
+    dispatch({
+      index,
+      type: 'move-name-down',
+    });
+  }
+
+  function handleMoveUp() {
+    dispatch({
+      index,
+      type: 'move-name-up',
+    });
+  }
+
   function handleRemove() {
     if (!artistCreditName.removed) {
       dispatch({
@@ -168,6 +185,28 @@ component _ArtistCreditNameEditor(
           </td>
         </>
       )}
+      <td>
+        {showMoveButtons ? (
+          <button
+            className="icon move-down"
+            disabled={!allowMoveDown}
+            onClick={handleMoveDown}
+            title={lp('Move artist credit down', 'interactive')}
+            type="button"
+          />
+        ) : null}
+      </td>
+      <td>
+        {showMoveButtons ? (
+          <button
+            className="icon move-up"
+            disabled={!allowMoveUp}
+            onClick={handleMoveUp}
+            title={lp('Move artist credit up', 'interactive')}
+            type="button"
+          />
+        ) : null}
+      </td>
       <td className="align-right">
         {artistCreditName.removed ? (
           <button

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -623,6 +623,10 @@ div.artist-credit-editor {
 
     .removed-ac-name { text-align: right; }
 
+    button.move-down:disabled, button.move-up:disabled { opacity: 50%; }
+
+    button.remove-artist-credit { margin-left: 0.5em; }
+
     .buttons {
         #copy-ac, #paste-ac { float: left; }
         #next-track-ac, #prev-track-ac, button.positive { float: right; }

--- a/script/reset_selenium_env.sh
+++ b/script/reset_selenium_env.sh
@@ -86,7 +86,7 @@ if [[ $SIR_DIR ]]; then
 
         wait_time=0
         while kill -0 $SIR_PID > /dev/null 2>&1; do
-            if [[ $wait_time -ge 10 ]]; then
+            if [[ $wait_time -ge 30 ]]; then
                 kill -TERM $SIR_PID || continue
                 if [[ $reindex_attempts -ge 5 ]]; then
                     cat "$SIR_REINDEX_LOG_FILE"

--- a/t/selenium/Artist_Credit_Editor.json5
+++ b/t/selenium/Artist_Credit_Editor.json5
@@ -108,6 +108,11 @@
       value: '',
     },
     {
+      command: 'assertText',
+      target: 'id=ac-preview-cell',
+      value: 'Preview: David Robert Jones & Bing Crosby',
+    },
+    {
       command: 'assertEval',
       target: "window.document.querySelectorAll('#artist-credit-editor input[type=hidden]').length",
       value: '8',
@@ -151,6 +156,27 @@
       command: 'assertValue',
       target: 'css=input[type=hidden][name="edit-recording.artist_credit.names.1.artist.id"]',
       value: '99',
+    },
+    // artist credits can be reordered (MBS-3255)
+    {
+      command: 'click',
+      target: 'xpath=(//*[@id="artist-credit-bubble"]//button[contains(@class, "move-down")])[1]',
+      value: '',
+    },
+    {
+      command: 'assertText',
+      target: 'id=ac-preview-cell',
+      value: 'Preview: Bing Crosby & David Robert Jones',
+    },
+    {
+      command: 'click',
+      target: 'xpath=(//*[@id="artist-credit-bubble"]//button[contains(@class, "move-up")])[2]',
+      value: '',
+    },
+    {
+      command: 'assertText',
+      target: 'id=ac-preview-cell',
+      value: 'Preview: David Robert Jones & Bing Crosby',
     },
     // removing all credits but one should clear the join phrase (MBS-8896)
     {


### PR DESCRIPTION
# MBS-3255

Add up and down buttons next to artist credits that can be used to reorder them, similar to how mediums and tracks can be reordered.

# Problem

There's currently no easy way to reorder artist credits (e.g. when the order in MusicBrainz doesn't match what's on an album's packaging).

# Solution

Add up and down buttons to the right of each credit that can be used to move it up or down:

![Screenshot 2024-08-10 09 57 27](https://github.com/user-attachments/assets/9821ae81-031d-4a6a-b245-6ec916d75ba1)

Join phrases keep their original positions when reordering. For example, pressing the first credit's down button in the above example produces `Metallica & Megadeth` rather than `MetallicaMegadeth & `.

These buttons are patterned after the medium up/down and track up/down icons in the tracklist editor: the first credit has an up button and the last item has a down buttons even though they don't do anything. Let me know if it'd be better to hide these no-op buttons or give them a lower opacity.

I'm also omitting the buttons from removed credits since that looks a bit cleaner to me, although I could show them if that'd be better (since removed credits still participate in the overall ordering):

![Screenshot 2024-08-10 09 57 58](https://github.com/user-attachments/assets/e2db48b2-180e-4667-9b82-e218bce5aeab)

# Testing

I manually tested reordering release, release group, and track credits, and I added some commands to the `Artist_Credit_Editor.json5` Selenium test that will hopefully work (sorry, I'm still not set up to run Selenium tests locally).