### PR TITLE
MBS-13724: Make up/down keys move between tracklist inputs

### DIFF
--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -155,7 +155,7 @@
     </div>
 
     <!-- ko if: expanded() && loaded() -->
-    <table class="medium tbl">
+    <table class="medium tbl" data-bind="delegatedHandler: 'keydown'">
       <thead>
         <tr>
           <th class="position">[% l('#') %]</th>
@@ -206,18 +206,18 @@
     </td>
 
     <td class="position">
-      <input class="pos" type="text" data-bind="value: number" />
+      <input class="pos" type="text" data-bind="value: number" data-keydown="onTrackInputKeyDown" />
     </td>
 
     <td class="title">
-      <input type="text" class="track-name" data-bind="value: inputName, valueUpdate: 'input', css: { modified: nameModified(), preview: previewNameDiffers() }, event: { focus: $root.focusTrackName }" />
+      <input type="text" class="track-name" data-bind="value: inputName, valueUpdate: 'input', css: { modified: nameModified(), preview: previewNameDiffers() }, event: { focus: $root.focusTrackName }" data-keydown="onTrackInputKeyDown" />
     </td>
 
     <td class="artist autocomplete" data-bind="artistCreditEditor: $data">
     </td>
 
     <td class="length">
-      <input type="text" class="track-length" size="5" data-bind="value: formattedLength, disableBecauseDiscIDs: position() > 0 && !isDataTrack(), css: { error: position() == 0 && medium.hasInvalidPregapLength() }" placeholder="?:??" />
+      <input type="text" class="track-length" size="5" data-bind="value: formattedLength, disableBecauseDiscIDs: position() > 0 && !isDataTrack(), css: { error: position() == 0 && medium.hasInvalidPregapLength() }" data-keydown="onTrackInputKeyDown" placeholder="?:??" />
     </td>
 
     <td class="icon">

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -270,6 +270,43 @@ const actions = {
     track.nameModified(false);
   },
 
+  onTrackInputKeyDown(track, event) {
+    /*
+     * If a bare up or down arrow key event occurs while the cursor is
+     * at the beginning or end of the input, move the focus up or down.
+     */
+    if (
+      (event.key === 'ArrowUp' || event.key === 'ArrowDown') &&
+      !event.altKey && !event.ctrlKey && !event.metaKey &&
+      !event.shiftKey
+    ) {
+      const up = event.key === 'ArrowUp';
+      const input = event.target;
+      if (input.selectionStart === input.selectionEnd && (
+        (up && input.selectionStart === 0) ||
+        (!up && input.selectionStart === input.value.length)
+      )) {
+        const row = input.closest('tr');
+        const rows = [...row.parentNode.children];
+        const rowIndex = rows.indexOf(row);
+        const newRowIndex = rowIndex + (up ? -1 : 1);
+        if (newRowIndex >= 0 && newRowIndex < rows.length) {
+          const cell = input.closest('td');
+          const cellIndex = [...cell.parentNode.children].indexOf(cell);
+          const newCell = [...rows[newRowIndex].children][cellIndex];
+          const newInput = newCell.querySelector('input');
+          deferFocus(newInput);
+          newInput.selectionStart = newInput.selectionEnd =
+            (up ? 0 : newInput.value.length);
+          event.stopPropagation();
+          return false;
+        }
+      }
+    }
+    // If we made it here, let the event be handled like usual.
+    return true;
+  },
+
   /*
    * Shows or hides a preview if event.type is 'mouseenter' or 'mouseleave'.
    * Otherwise, updates the current name.


### PR DESCRIPTION
# MBS-13724

Make the up and down arrow keys move the focus between adjacent tracks' number, title, and length fields in the tracklist editor.

Only do this when the cursor is already at the beginning or end of the input to avoid overriding the browser's default text-editing shortcuts.

# Problem

Fixing multiple track titles or editing durations requires either switching frequently between the keyboard and mouse or pressing the Tab key six times to move down to the next row.

# Solution

Make the up and down arrow keys move the focus to the corresponding input in the previous or next row.

The default behavior on all (I think) platforms is for these keys to move the caret to the beginning or end of the current input, so this change only moves the focus when the caret is already at the beginning or end of the input.

# Testing

I tested this locally in the tracklist editor.