### PR TITLE
MBS-13729: `TypeError` while trying to merge releases

### DIFF
--- a/root/static/scripts/common/i18n/expand2.js
+++ b/root/static/scripts/common/i18n/expand2.js
@@ -110,9 +110,9 @@ export function getString(x: mixed): string {
   return '';
 }
 
-export function getVarSubstScalarArg(x: Expand2ReactInput):
-  | React$MixedElement
-  | string {
+export function getVarSubstScalarArg(
+  x: Expand2ReactInput,
+): Expand2ReactScalarOutput {
   if (React.isValidElement(x)) {
     // $FlowIgnore[unclear-type] We know this is a valid element
     return ((x: any): React$MixedElement);

--- a/root/static/scripts/common/i18n/expand2.js
+++ b/root/static/scripts/common/i18n/expand2.js
@@ -110,7 +110,7 @@ export function getString(x: mixed): string {
   return '';
 }
 
-function getVarSubstScalarArg(
+function mapVarSubstArgToScalar(
   x: Expand2ReactInput,
 ): Expand2ReactScalarOutput {
   if (React.isValidElement(x)) {
@@ -120,11 +120,11 @@ function getVarSubstScalarArg(
   return getString(x);
 }
 
-export function getVarSubstArg(x: Expand2ReactInput): Expand2ReactOutput {
+export function mapVarSubstArg(x: Expand2ReactInput): Expand2ReactOutput {
   if (Array.isArray(x)) {
-    return x.map(getVarSubstScalarArg);
+    return x.map(mapVarSubstArgToScalar);
   }
-  return getVarSubstScalarArg(x);
+  return mapVarSubstArgToScalar(x);
 }
 
 export function accept(pattern: RegExp): NO_MATCH | string {
@@ -227,7 +227,7 @@ export const createTextContentParser = <T, V>(
 
 const varSubst = /^\{([0-9A-z_]+)\}/;
 export const createVarSubstParser = <T, V>(
-  argFilter: (V) => T,
+  argMapper: (V) => T,
 ): Parser<T | string | NO_MATCH, V> => saveMatch(
   function (args: VarArgsClass<V>) {
     const name = accept(varSubst);
@@ -235,7 +235,7 @@ export const createVarSubstParser = <T, V>(
       return NO_MATCH_VALUE;
     }
     if (args.has(name)) {
-      return argFilter(args.get(name));
+      return argMapper(args.get(name));
     }
     return state.match;
   },
@@ -258,7 +258,7 @@ export const createCondSubstParser = <T, V: Expand2ReactInput>(
 
   const savedReplacement = state.replacement;
   if (args.has(name)) {
-    state.replacement = getVarSubstArg(args.get(name));
+    state.replacement = mapVarSubstArg(args.get(name));
   }
 
   const thenChildren = thenParser(args);

--- a/root/static/scripts/common/i18n/expand2.js
+++ b/root/static/scripts/common/i18n/expand2.js
@@ -84,7 +84,7 @@ type State = {
   // Portion of the source string that hasn't been parsed yet.
   remainder: string,
   // The value of % in conditional substitutions, from `args`.
-  replacement: VarSubstArg | NO_MATCH,
+  replacement: Expand2ReactOutput | NO_MATCH,
   // Whether expand is currently running. Used to detect nested calls.
   running: boolean,
   // A copy of the source string, used in error messages.
@@ -110,7 +110,7 @@ export function getString(x: mixed): string {
   return '';
 }
 
-export function getVarSubstScalarArg(
+function getVarSubstScalarArg(
   x: Expand2ReactInput,
 ): Expand2ReactScalarOutput {
   if (React.isValidElement(x)) {

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -94,7 +94,7 @@ function handleTextContentReact(text: string) {
 
   if (gotMatch(replacement) && percentSign.test(text)) {
     const parts = text.split(percentSign);
-    const result: Array<React$MixedElement | string> = [];
+    const result: Array<Expand2ReactScalarOutput> = [];
     for (let i = 0; i < parts.length; i++) {
       const part = parts[i];
       if (part === '%') {

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -31,7 +31,6 @@ import expand, {
   createVarSubstParser,
   error,
   getVarSubstArg,
-  getVarSubstScalarArg,
   gotMatch,
   NO_MATCH_VALUE,
   parseContinuous,
@@ -100,10 +99,10 @@ function handleTextContentReact(text: string) {
       if (part === '%') {
         if (Array.isArray(replacement)) {
           for (let k = 0; k < replacement.length; k++) {
-            result.push(getVarSubstScalarArg(replacement[k]));
+            result.push(replacement[k]);
           }
         } else {
-          result.push(getVarSubstScalarArg(replacement));
+          result.push(replacement);
         }
       } else {
         result.push(he.decode(part));

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -30,7 +30,7 @@ import expand, {
   createTextContentParser,
   createVarSubstParser,
   error,
-  getVarSubstArg,
+  mapVarSubstArg,
   gotMatch,
   NO_MATCH_VALUE,
   parseContinuous,
@@ -126,7 +126,7 @@ const parseRootTextContent = createTextContentParser<Output, Input>(
 );
 
 const parseVarSubst = createVarSubstParser<Output, Input>(
-  getVarSubstArg,
+  mapVarSubstArg,
 );
 
 const parseLinkSubst: Parser<

--- a/root/static/scripts/edit/components/ReleaseMergeStrategy.js
+++ b/root/static/scripts/edit/components/ReleaseMergeStrategy.js
@@ -21,6 +21,7 @@ import {ExpandedArtistCreditList}
 import Warning from '../../common/components/Warning.js';
 import formatTrackLength
   from '../../common/utility/formatTrackLength.js';
+import {createCompoundFieldFromObject} from '../utility/createField.js';
 import isUselessMediumTitle from '../utility/isUselessMediumTitle.js';
 
 import FormRowSelect from './FormRowSelect.js';
@@ -78,7 +79,7 @@ component ReleaseMergeStrategy(
 
   const [mediumTitles, setMediumTitles] =
     React.useState(mediumsMap.field.map(
-      field => field.field.name.value,
+      (field, index) => (field?.field.name.value) ?? (mediums[index]?.name),
     ));
 
   function updateTitles(
@@ -117,7 +118,19 @@ component ReleaseMergeStrategy(
         <table className="tbl">
           <tbody>
             {mediums.map((medium, index) => {
-              const mediumField = mediumsMap.field[index].field;
+              let mediumField = mediumsMap.field[index];
+              if (!mediumField) {
+                mediumField = createCompoundFieldFromObject(
+                  mediumsMap.html_name + '.' + String(index),
+                  {
+                    id: medium.id,
+                    name: medium.name,
+                    position: medium.position,
+                    release_id: medium.release_id,
+                  },
+                );
+              }
+              const mediumSubFields = mediumField.field;
 
               return (
                 <React.Fragment key={medium.id}>
@@ -126,37 +139,37 @@ component ReleaseMergeStrategy(
                       <label>{l('New position:')}</label>
                       {' '}
                       <input
-                        defaultValue={mediumField.position.value}
-                        name={mediumField.position.html_name}
+                        defaultValue={mediumSubFields.position.value}
+                        name={mediumSubFields.position.html_name}
                         size="2"
                         type="text"
                       />
-                      {mediumField.position.has_errors ? (
+                      {mediumSubFields.position.has_errors ? (
                         <span
                           className="error"
                           style={{margin: '0 12px 0 6px'}}
                         >
-                          {mediumField.position.errors[0]}
+                          {mediumSubFields.position.errors[0]}
                         </span>
                       ) : null}
                       {' '}
                       <label>{l('New disc title:')}</label>
                       {' '}
                       <input
-                        defaultValue={mediumField.name.value}
-                        name={mediumField.name.html_name}
+                        defaultValue={mediumSubFields.name.value}
+                        name={mediumSubFields.name.html_name}
                         onChange={event => updateTitles(event, index)}
                         type="text"
                       />
                       <input
-                        name={mediumField.id.html_name}
+                        name={mediumSubFields.id.html_name}
                         type="hidden"
-                        value={mediumField.id.value}
+                        value={mediumSubFields.id.value}
                       />
                       <input
-                        name={mediumField.release_id.html_name}
+                        name={mediumSubFields.release_id.html_name}
                         type="hidden"
-                        value={mediumField.release_id.value}
+                        value={mediumSubFields.release_id.value}
                       />
                       {' '}
                       {medium.name ? (

--- a/root/statistics/StatisticsLayout.js
+++ b/root/statistics/StatisticsLayout.js
@@ -17,12 +17,12 @@ component LinkStatisticsTab(
   link: string,
   page: string,
   selected: string,
-  title: string | (() => string | React$MixedElement),
+  title: string | (() => Expand2ReactScalarOutput),
 ) {
   return (
     <li className={page === selected ? 'sel' : ''}>
       <a href={link}>
-        {unwrapNl<string | React$MixedElement>(title)}
+        {unwrapNl<Expand2ReactScalarOutput>(title)}
       </a>
     </li>
   );

--- a/root/types/forms.js
+++ b/root/types/forms.js
@@ -35,7 +35,7 @@ declare type MergeReleasesFormT = FormT<{
   +edit_note: FieldT<string>,
   +make_votable: FieldT<boolean>,
   +medium_positions: CompoundFieldT<{
-    +map: CompoundFieldT<$ReadOnlyArray<MediumFieldT>>,
+    +map: CompoundFieldT<$ReadOnlyArray<MediumFieldT | void>>,
   }>,
   +merge_strategy: FieldT<StrOrNum>,
   +merging: RepeatableFieldT<FieldT<StrOrNum>>,

--- a/root/types/i18n.js
+++ b/root/types/i18n.js
@@ -27,10 +27,13 @@ declare type VarSubstArg =
 
 declare type Expand2ReactInput = VarSubstArg | AnchorProps;
 
-declare type Expand2ReactOutput =
+declare type Expand2ReactScalarOutput =
   | string
-  | React$MixedElement
-  | Array<string | React$MixedElement>;
+  | React$MixedElement;
+
+declare type Expand2ReactOutput =
+  | Expand2ReactScalarOutput
+  | Array<Expand2ReactScalarOutput>;
 
 declare type ExpandLFunc<-Input, Output> = (
   key: string,


### PR DESCRIPTION
# Problem

https://tickets.metabrainz.org/browse/MBS-13729

# Solution

The commit "New way of assigning React keys to variables substitutions" addresses the issue that broke the "mb. MERGE HELPOR 2" script.

The commit "MBS-13729: Handle missing `medium_positions` on release merge" prevents a stack trace from being shown to the user.

# Testing

Only manual testing on my local development server.