### PR TITLE
MBS-9479: Warn about duplicate release groups

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/js/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Area.pm
@@ -14,7 +14,7 @@ my $ws_defs = Data::OptList::mkopt([
     'area' => {
         method   => 'GET',
         required => [ qw(q) ],
-        optional => [ qw(direct limit page timestamp) ],
+        optional => [ qw(advanced direct limit page timestamp) ],
     },
 ]);
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Artist.pm
@@ -14,7 +14,7 @@ my $ws_defs = Data::OptList::mkopt([
     'artist' => {
         method   => 'GET',
         required => [ qw(q) ],
-        optional => [ qw(direct limit page timestamp) ],
+        optional => [ qw(advanced direct limit page timestamp) ],
     },
 ]);
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Editor.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Editor.pm
@@ -11,7 +11,7 @@ my $ws_defs = Data::OptList::mkopt([
     'editor' => {
         method   => 'GET',
         required => [ qw(q) ],
-        optional => [ qw(direct limit page timestamp) ],
+        optional => [ qw(advanced direct limit page timestamp) ],
     },
 ]);
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Event.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Event.pm
@@ -14,7 +14,7 @@ my $ws_defs = Data::OptList::mkopt([
     'event' => {
         method   => 'GET',
         required => [ qw(q) ],
-        optional => [ qw(direct limit page timestamp) ],
+        optional => [ qw(advanced direct limit page timestamp) ],
     },
 ]);
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Genre.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Genre.pm
@@ -11,7 +11,7 @@ my $ws_defs = Data::OptList::mkopt([
     'genre' => {
         method   => 'GET',
         required => [ qw(q) ],
-        optional => [ qw(direct limit page timestamp) ],
+        optional => [ qw(advanced direct limit page timestamp) ],
     },
 ]);
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Instrument.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Instrument.pm
@@ -14,7 +14,7 @@ my $ws_defs = Data::OptList::mkopt([
     'instrument' => {
         method   => 'GET',
         required => [ qw(q) ],
-        optional => [ qw(direct limit page timestamp) ],
+        optional => [ qw(advanced direct limit page timestamp) ],
     },
 ]);
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Label.pm
@@ -14,7 +14,7 @@ my $ws_defs = Data::OptList::mkopt([
     'label' => {
         method   => 'GET',
         required => [ qw(q) ],
-        optional => [ qw(direct limit page timestamp) ],
+        optional => [ qw(advanced direct limit page timestamp) ],
     },
 ]);
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Place.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Place.pm
@@ -14,7 +14,7 @@ my $ws_defs = Data::OptList::mkopt([
     'place' => {
         method   => 'GET',
         required => [ qw(q) ],
-        optional => [ qw(direct limit page timestamp) ],
+        optional => [ qw(advanced direct limit page timestamp) ],
     },
 ]);
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Release.pm
@@ -17,7 +17,7 @@ my $ws_defs = Data::OptList::mkopt([
     'release' => {
         method   => 'GET',
         required => [ qw(q) ],
-        optional => [ qw(direct limit page timestamp) ],
+        optional => [ qw(advanced direct limit page timestamp) ],
     },
     'release' => {
         method => 'GET',

--- a/lib/MusicBrainz/Server/Controller/WS/js/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/ReleaseGroup.pm
@@ -14,7 +14,7 @@ my $ws_defs = Data::OptList::mkopt([
     'release-group' => {
         method   => 'GET',
         required => [ qw(q) ],
-        optional => [ qw(direct limit page timestamp) ],
+        optional => [ qw(advanced direct limit page timestamp) ],
     },
 ]);
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/ReleaseGroup.pm
@@ -35,6 +35,7 @@ sub search : Chained('root') PathPart('release-group')
 
 after _load_entities => sub {
     my ($self, $c, @entities) = @_;
+    $c->model('ReleaseGroup')->load_meta(@entities);
     $c->model('ReleaseGroupType')->load(@entities);
 };
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Role/Autocompletion.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Role/Autocompletion.pm
@@ -90,15 +90,12 @@ sub _indexed_search {
         $c->detach;
     } else {
         $pager = $response->{pager};
-
-        for my $result (@{ $response->{results} })
-        {
-            next unless $result->entity->{gid};
-            my $entity = $model->get_by_gid($result->{entity}->gid);
-            next unless $entity;
-            push @output, $entity;
-        }
-
+        my @gids = map {
+            my $gid = $_->entity->{gid};
+            $gid ? $gid : ()
+        } @{ $response->{results} };
+        my $entity_map = $model->get_by_gids(@gids);
+        @output = map { $entity_map->{$_} } @gids;
         $self->_load_entities($c, @output);
     }
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Role/Autocompletion.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Role/Autocompletion.pm
@@ -22,6 +22,7 @@ sub dispatch_search {
     my $limit = $args->{limit} || 10;
     my $page = $args->{page} || 1;
     my $direct = $args->{direct} || '';
+    my $advanced = $args->{advanced} || '';
 
     unless ($query) {
         $c->detach('bad_req');
@@ -29,7 +30,8 @@ sub dispatch_search {
 
     my ($output, $pager) =
         $direct eq 'true' ? $self->_direct_search($c, $query, $page, $limit)
-                          : $self->_indexed_search($c, $query, $page, $limit);
+                          : $self->_indexed_search($c, $query, $page, $limit,
+                                                   $advanced eq 'true');
     my $serialization_routine = 'autocomplete_' . $self->type;
 
     $c->res->content_type($c->stash->{serializer}->mime_type . '; charset=utf-8');
@@ -75,11 +77,17 @@ sub _format_output {
 }
 
 sub _indexed_search {
-    my ($self, $c, $query, $page, $limit) = @_;
+    my ($self, $c, $query, $page, $limit, $advanced) = @_;
 
     my $model = $self->model($c);
 
-    my $response = $c->model('Search')->external_search($self->type, $query, $limit, $page, 0);
+    my $response = $c->model('Search')->external_search(
+        $self->type,
+        $query,
+        $limit,
+        $page,
+        $advanced,
+    );
     my (@output, $pager);
 
     if ($response->{error}) {

--- a/lib/MusicBrainz/Server/Controller/WS/js/Role/Autocompletion.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Role/Autocompletion.pm
@@ -17,10 +17,11 @@ sub model {
 sub dispatch_search {
     my ($self, $c) = @_;
 
-    my $query = trim $c->stash->{args}->{q};
-    my $limit = $c->stash->{args}->{limit} || 10;
-    my $page = $c->stash->{args}->{page} || 1;
-    my $direct = $c->stash->{args}->{direct} || '';
+    my $args = $c->stash->{args};
+    my $query = trim $args->{q};
+    my $limit = $args->{limit} || 10;
+    my $page = $args->{page} || 1;
+    my $direct = $args->{direct} || '';
 
     unless ($query) {
         $c->detach('bad_req');

--- a/lib/MusicBrainz/Server/Controller/WS/js/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Series.pm
@@ -14,7 +14,7 @@ my $ws_defs = Data::OptList::mkopt([
     'series' => {
         method   => 'GET',
         required => [ qw(q) ],
-        optional => [ qw(direct limit page timestamp) ],
+        optional => [ qw(advanced direct limit page timestamp) ],
     },
 ]);
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Work.pm
@@ -14,7 +14,7 @@ my $ws_defs = Data::OptList::mkopt([
     'work' => {
         method   => 'GET',
         required => [ qw(q) ],
-        optional => [ qw(direct limit page timestamp) ],
+        optional => [ qw(advanced direct limit page timestamp) ],
     },
 ]);
 

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -51,6 +51,39 @@
         </td>
       </tr>
 
+      <tr data-bind="if: $root.loadingDuplicateRGs()">
+        <td></td>
+        <td colspan="2">
+          <div class="duplicate-rgs-loading loading-message">
+            [% l('Checking existing release groups…') %]
+          </div>
+        </td>
+      </tr>
+
+      <tr data-bind="if: $root.duplicateRGs().length > 0">
+        <td></td>
+        <td colspan="2">
+          <div class="duplicate-rgs-label">
+            [% add_colon(l('Existing release groups with similar names')) %]
+          </div>
+          <div class="duplicate-rgs-list">
+            <!-- ko foreach: $root.duplicateRGs -->
+              <label>
+                <input name="rg-selection" type="radio" data-change="selectReleaseGroup" />
+                <div>
+                  <a target="_blank" data-bind="attr: { href: '/release-group/' + $data.gid }, text: $data.name"></a>
+                  <span data-bind="text: $data.details"></span>
+                </div>
+              </label>
+            <!-- /ko -->
+            <label>
+              <input name="rg-selection" type="radio" checked data-change="clearReleaseGroup" />
+              <div>[% l('Add a new release group') %]</div>
+            </label>
+          </div>
+        </td>
+      </tr>
+
       [% table_row_help_message(2, 'showMessageRightAway: willCreateReleaseGroup', l('If you don’t select an existing release group, a new one will be added with the types selected below.')) %]
 
       [% table_row_error(2, 'showErrorWhenTabIsSwitched: needsReleaseGroup', l('You must select an existing release group.')) %]

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -57,6 +57,16 @@ const actions = {
 
   // Information tab
 
+  selectReleaseGroup(releaseGroup) {
+    // Start loading the MBID and then update the input to display the name.
+    $('#release-group').val(releaseGroup.gid).trigger('input');
+    $('#release-group').val(releaseGroup.name);
+  },
+
+  clearReleaseGroup() {
+    $('#release-group').val('').trigger('input');
+  },
+
   copyTitleToReleaseGroup: ko.observable(false),
   copyArtistToReleaseGroup: ko.observable(false),
 

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -58,13 +58,15 @@ const actions = {
   // Information tab
 
   selectReleaseGroup(releaseGroup) {
-    // Start loading the MBID and then update the input to display the name.
-    $('#release-group').val(releaseGroup.gid).trigger('input');
-    $('#release-group').val(releaseGroup.name);
+    const release = this.rootField.release.peek();
+    release.releaseGroup(releaseGroup);
   },
 
   clearReleaseGroup() {
-    $('#release-group').val('').trigger('input');
+    const release = this.rootField.release.peek();
+    release.releaseGroup(new fields.ReleaseGroup({
+      name: release.name.peek(),
+    }));
   },
 
   copyTitleToReleaseGroup: ko.observable(false),

--- a/root/static/scripts/release-editor/duplicates.js
+++ b/root/static/scripts/release-editor/duplicates.js
@@ -138,10 +138,11 @@ function formatReleaseData(release) {
 
   var events = release['release-events'];
   var labels = release['label-info'];
+  const media = release.media ?? [];
 
-  clean.formats = combinedMediumFormatName(release.media) ||
+  clean.formats = combinedMediumFormatName(media) ||
                   l('[missing media]');
-  clean.tracks = release.media.map(x => x['track-count']).join(' + ') ||
+  clean.tracks = media.map(x => x['track-count']).join(' + ') ||
     lp('-', 'missing data');
 
   clean.dates = events

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -9,14 +9,17 @@
 import $ from 'jquery';
 import ko from 'knockout';
 
+import commaOnlyList from '../common/i18n/commaOnlyList.js';
 import {
   artistCreditsAreEqual,
   hasVariousArtists,
 } from '../common/immutable-entities.js';
 import MB from '../common/MB.js';
+import {bracketedText} from '../common/utility/bracketed.js';
 import {getSourceEntityData} from '../common/utility/catalyst.js';
 import clean from '../common/utility/clean.js';
 import {cloneObjectDeep} from '../common/utility/cloneDeep.mjs';
+import {debounceComputed} from '../common/utility/debounce.js';
 import request from '../common/utility/request.js';
 import * as externalLinks from '../edit/externalLinks.js';
 import getUpdatedTrackArtists from
@@ -28,6 +31,8 @@ import recordingAssociation from './recordingAssociation.js';
 import utils from './utils.js';
 import releaseEditor from './viewModel.js';
 
+const maxDuplicateRGs = 5;
+
 Object.assign(releaseEditor, {
   activeTabID: ko.observable('#information'),
   activeTabIndex: ko.observable(0),
@@ -38,6 +43,8 @@ Object.assign(releaseEditor, {
       {error: releaseEditor.loadError()},
     );
   },
+  loadingDuplicateRGs: ko.observable(false),
+  duplicateRGs: ko.observableArray([]),
   externalLinksEditData: ko.observable({}),
   hasInvalidLinks: validation.errorField(ko.observable(false)),
 });
@@ -259,6 +266,71 @@ releaseEditor.init = function (options) {
 
     getRecordings();
   });
+
+  /**
+   * Check for similarly-named existing release groups when the release
+   * title or artist credits change.
+   */
+  let duplicateRGsRequest = null;
+  let duplicateRGsQuery = null;
+  debounceComputed(utils.withRelease((release) => {
+    const query = utils.constructLuceneFieldConjunction({
+      arid: release.artistCredit().names
+        .map((a) => a.artist?.gid)
+        .filter(Boolean),
+      releasegroup: [utils.escapeLuceneValue(release.name() ?? '')],
+    });
+    if (query === duplicateRGsQuery) {
+      return;
+    }
+
+    // Cancel any in-progress lookup and clear existing results.
+    duplicateRGsRequest?.abort();
+    duplicateRGsRequest = null;
+    duplicateRGsQuery = query;
+    releaseEditor.duplicateRGs.removeAll();
+
+    /*
+     * Make sure that an existing release group isn't selected
+     * and that there's a title and artist to use for searching.
+     */
+    if (
+      release.releaseGroup().gid ||
+      (release.name() ?? '') === '' ||
+      !release.artistCredit().names.some((a) => a.artist?.gid)
+    ) {
+      return;
+    }
+
+    releaseEditor.loadingDuplicateRGs(true);
+    duplicateRGsRequest = utils.search(
+      'release-group', query, maxDuplicateRGs,
+    ).always(() => {
+      releaseEditor.loadingDuplicateRGs(false);
+      duplicateRGsRequest = null;
+    }).done((data) => {
+      ko.utils.arrayPushAll(
+        releaseEditor.duplicateRGs,
+        data['release-groups'].map((rg) => ({
+          name: rg.title,
+          gid: rg.id,
+          details: bracketedText(
+            commaOnlyList([
+              lp_attributes(
+                rg['primary-type'], 'release_group_primary_type',
+              ),
+              texp.ln(
+                '{num} release',
+                '{num} releases',
+                rg.count,
+                {num: rg.count},
+              ),
+            ].filter(Boolean)),
+          ),
+        })),
+      );
+    });
+  }));
 
   /*
    * Make sure the user actually wants to close the page/tab if they've made

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -303,32 +303,32 @@ releaseEditor.init = function (options) {
     }
 
     releaseEditor.loadingDuplicateRGs(true);
-    duplicateRGsRequest = utils.search(
-      'release-group', query, maxDuplicateRGs,
-    ).always(() => {
+
+    duplicateRGsRequest = request({
+      url: '/ws/js/release-group' +
+        '?direct=false' +
+        '&advanced=true' +
+        '&limit=' + encodeURIComponent(maxDuplicateRGs) +
+        '&q=' + encodeURIComponent(query),
+    }).always(() => {
       releaseEditor.loadingDuplicateRGs(false);
       duplicateRGsRequest = null;
     }).done((data) => {
-      ko.utils.arrayPushAll(
-        releaseEditor.duplicateRGs,
-        data['release-groups'].map((rg) => ({
-          name: rg.title,
-          gid: rg.id,
-          details: bracketedText(
-            commaOnlyList([
-              lp_attributes(
-                rg['primary-type'], 'release_group_primary_type',
-              ),
-              texp.ln(
-                '{num} release',
-                '{num} releases',
-                rg.count,
-                {num: rg.count},
-              ),
-            ].filter(Boolean)),
-          ),
-        })),
-      );
+      const results = data.slice(0, -1).map((rg) => {
+        rg.details = bracketedText(
+          commaOnlyList([
+            rg.l_type_name,
+            texp.ln(
+              '{num} release',
+              '{num} releases',
+              rg.release_count,
+              {num: rg.release_count},
+            ),
+          ].filter(Boolean)),
+        );
+        return new fields.ReleaseGroup(rg);
+      });
+      ko.utils.arrayPushAll(releaseEditor.duplicateRGs, results);
     });
   }));
 

--- a/root/static/scripts/tests/release-editor/seeds/mbs-9479.html
+++ b/root/static/scripts/tests/release-editor/seeds/mbs-9479.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <form action="/release/add" method="POST">
+      <input type="hidden" name="name" value="Demons" />
+      <input type="hidden" name="artist_credit.names.0.artist.name" value="Super Furry Animals" />
+      <input type="hidden" name="artist_credit.names.0.mbid" value="c5f5dc27-3059-49c0-ae45-5009a01bb9ec" />
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>

--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -54,6 +54,23 @@ div.half-width {
 
     td.release-artist { width: 100%; }
 
+    .duplicate-rgs-loading { margin-bottom: 0.5em; }
+    .duplicate-rgs-label { font-weight: bold; }
+    .duplicate-rgs-list {
+        margin-bottom: 0.5em;
+
+        > * {
+            align-items: baseline;
+            display: flex;
+            text-align: left;
+
+            input[type="radio"] {
+                margin-right: 0.5em;
+                width: auto;
+            }
+        }
+    }
+
     #annotation {
         width: @form-input-width;
         max-width: @form-input-width;

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -726,6 +726,7 @@ const seleniumTests = [
     sql: 'vision_creation_newsun.sql',
   },
   {name: 'release-editor/MBS-4555.json5', login: false},
+  {name: 'release-editor/MBS-9479.json5', login: true},
   {name: 'release-editor/MBS-10221.json5', login: true},
   {name: 'release-editor/MBS-10359.json5', login: true},
   {name: 'release-editor/MBS-11015.json5', login: true},

--- a/t/selenium/release-editor/MBS-9479.json5
+++ b/t/selenium/release-editor/MBS-9479.json5
@@ -38,7 +38,7 @@
     {
       command: 'assertEval',
       target: "document.querySelector('#release-group').value",
-      value: '',
+      value: 'Demons',
     },
     {
       command: 'assertEval',

--- a/t/selenium/release-editor/MBS-9479.json5
+++ b/t/selenium/release-editor/MBS-9479.json5
@@ -1,0 +1,60 @@
+{
+  title: 'MBS-9479',
+  commands: [
+    // Seed a release sharing the name of an existing release group by the
+    // artist.
+    {
+      command: 'open',
+      target: '/static/scripts/tests/release-editor/seeds/mbs-9479.html',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=button[type=submit]',
+      value: '',
+    },
+    // Click the existing release group's radio button.
+    {
+      command: 'click',
+      target: 'css=#information .duplicate-rgs-list :first-child input',
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelector('#release-group').value",
+      value: 'Demons',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelector('#release-group').classList.contains('lookup-performed')",
+      value: 'true',
+    },
+    // Click the "Add a new release group" radio button.
+    {
+      command: 'click',
+      target: 'css=#information .duplicate-rgs-list :last-child input',
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelector('#release-group').value",
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelector('#release-group').classList.contains('lookup-performed')",
+      value: 'false',
+    },
+    // Navigate back to the main page.
+    {
+      command: 'open',
+      target: '/',
+      value: '',
+    },
+    {
+      command: 'assertBeforeUnloadAlertWasShown',
+      target: '',
+      value: '',
+    },
+  ],
+}


### PR DESCRIPTION
# MBS-9479

Update the release editor to search for release groups credited to any of the current artists with similar names and display them in a list.

# Problem

When adding new releases, it's easy for editors to accidentally create duplicate release groups, particularly when the discography is spread over multiple pages or when the existing RG has an unexpected secondary type that makes it get listed in a lower section.

# Solution

Perform a search for similarly-named release groups when the release name or credited artists change and display the results in a list to make it easier for the editor to choose an existing RG.

![Screenshot 2024-08-18 18 38 25](https://github.com/user-attachments/assets/1a5b7faa-db0c-4fb2-919c-f14ee5f549d4)

# Testing

Manual testing on my local MBS instance using production search, plus a new Selenium test.