### PR TITLE
MBS-13725: Support RYM song pages for recordings

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4782,7 +4782,7 @@ const CLEANUPS: CleanupEntries = {
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.recording:
-            if (prefix === 'release' && !(subPath === 'musicvideo')) {
+            if (prefix === 'release' && subPath !== 'musicvideo') {
               return {
                 error:
                   l('Only RYM music videos can be linked to recordings.'),

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4782,9 +4782,17 @@ const CLEANUPS: CleanupEntries = {
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.recording:
+            if (prefix === 'release' && !(subPath === 'musicvideo')) {
+              return {
+                error:
+                  l('Only RYM music videos can be linked to recordings.'),
+                result: false,
+                target: ERROR_TARGETS.RELATIONSHIP,
+              };
+            }
             return {
-              error: l('Only RYM music videos can be linked to recordings.'),
-              result: prefix === 'release' && subPath === 'musicvideo',
+              result: prefix === 'song' ||
+                      (prefix === 'release' && subPath === 'musicvideo'),
               target: ERROR_TARGETS.RELATIONSHIP,
             };
           case LINK_TYPES.otherdatabases.release:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4742,6 +4742,13 @@ limited_link_type_combinations: [
         only_valid_entity_types: ['place'],
   },
   {
+                     input_url: 'https://rateyourmusic.com/song/rick-astley/never-gonna-give-you-up/',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://rateyourmusic.com/song/rick-astley/never-gonna-give-you-up/',
+        only_valid_entity_types: ['recording'],
+  },
+  {
                      input_url: 'https://rateyourmusic.com/release/musicvideo/metallica/one/',
              input_entity_type: 'recording',
     expected_relationship_type: 'otherdatabases',


### PR DESCRIPTION
### Implement MBS-13725

# Problem
RYM has now implemented `/song` pages that have performer and engineer info and link the song to different releases it appears on, such as [this one](https://rateyourmusic.com/song/rick-astley/never-gonna-give-you-up/). This is separate from previously existing `/work` pages (mostly for classical). The best fit seems to be the recording level.

# Solution
Support `/song` for recordings, move the check that says only video releases are allowed to actually appear only if the user tries to add a non-video `/release` link.

# Testing
Added a new test for this. Manually tested the right error is still shown for non-video release links on recording pages.