### PR TITLE
MBS-13697: Use right domain more in timeline page

### DIFF
--- a/root/statistics/layout.tt
+++ b/root/statistics/layout.tt
@@ -1,6 +1,7 @@
 [%- MACRO link_statistics_tab(link, title) BLOCK -%]
 <span class="mp"><a href="[% link %]">[% title %]</a></span>
 [%- END -%]
+[%- USE Translation('statistics') -%]
 [%- info_links = [
     ['index', link_statistics_tab('/statistics', l('Overview')) ]
     ['countries', link_statistics_tab('/statistics/countries', l('Countries')) ],
@@ -13,22 +14,24 @@
     ['timeline', link_statistics_tab('/statistics/timeline/main', l('Timeline')) ],
 ] -%]
 [%- html_title = l('Database statistics - {title}', {title => title} ) -%]
-[%- PROCESS "statistics/macros-footer.tt" -%]
+[%- USE Translation('mb_server') -%]
 
 
 [%- IF full_width -%]
     [%- WRAPPER "layout.tt" title=html_title full_width=1 -%]
-        [%- PROCESS "statistics/macros-header.tt" -%]
+        [%- USE Translation('statistics') -%]
+        [%- React.embed(c, 'statistics/StatisticsCSS') -%]
         <div class="statisticsheader">
             <h1>[%- l('Database statistics') -%]</h1>
         </div>
         [% INCLUDE 'components/tabs.tt' list=info_links %]
         [%- content -%]
-        [%- PROCESS "statistics/macros-footer.tt" -%]
+        [%- USE Translation('mb_server') -%]
     [%- END -%]
 [%- ELSE -%]
     [%- WRAPPER "layout.tt" title=html_title -%]
-        [%- PROCESS "statistics/macros-header.tt" -%]
+        [%- USE Translation('statistics') -%]
+        [%- React.embed(c, 'statistics/StatisticsCSS') -%]
         <div id="content">
             <div class="statisticsheader">
                 <h1>[%- l('Database statistics') -%]</h1>
@@ -40,6 +43,6 @@
         <div id="sidebar">
             [%- sidebar -%]
         </div>
-        [%- PROCESS "statistics/macros-footer.tt" -%]
+        [%- USE Translation('mb_server') -%]
     [%- END -%]
 [%- END -%]

--- a/root/statistics/macros-footer.tt
+++ b/root/statistics/macros-footer.tt
@@ -1,1 +1,0 @@
-[%- USE Translation('mb_server') -%]

--- a/root/statistics/macros-header.tt
+++ b/root/statistics/macros-header.tt
@@ -1,3 +1,0 @@
-[%- USE Translation('statistics') -%]
-
-[%- React.embed(c, 'statistics/StatisticsCSS') -%]

--- a/root/statistics/timeline.tt
+++ b/root/statistics/timeline.tt
@@ -1,4 +1,5 @@
 [%~ sidebar = BLOCK ~%]
+    [%- USE Translation('statistics') -%]
     <h2 id="graph-toggle-header">[% l('Legend') %]</h2>
         <div id="graph-lines">
         <h2>
@@ -20,10 +21,11 @@
         </table>
         <div id="overview" data-bind="flot: 'overview'"></div>
     </div>
+    [%- USE Translation('mb_server') -%]
 [%~ END ~%]
 
 [%~ WRAPPER "statistics/layout.tt" title=l("Timeline graph") sidebar=sidebar page='timeline' ~%]
-[%~ PROCESS "statistics/macros-header.tt" ~%]
+[%- USE Translation('statistics') -%]
 
 <h2>[% l('Exact values (items vs. day)') %]</h2>
 <div id="graph-container" data-bind="flot: 'main'"></div>
@@ -43,7 +45,8 @@
         </div>
     </div>
 </script>
-[%~ PROCESS "statistics/macros-footer.tt" ~%]
+
+[%- USE Translation('mb_server') -%]
 
 [%~ script_manifest('timeline.js') ~%]
 


### PR DESCRIPTION
### Fix MBS-13697

# Problem
Several parts of the timeline page were using the `mb_server` translation domain, but clearly should be using the `statistics` one. This means the tabs were untranslated, and so were the legend entries that were hardcoded in TT.

# Solution
Get rid of the mostly useless by now `macros-header.tt` and `macros-footer.tt` processes, and calling `USE Translation` in more places to set the right translation domain.

# Testing
Manually, ensuring the right French translations appear now for the tabs and strings like "Rate of change graph" on the legend.