### PR TITLE
MBS-13744: Avoid showing "Update title" without a recording

### DIFF
--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -267,24 +267,23 @@ class Track {
   }
 
   titleDiffersFromRecording() {
-    return this.name() !== this.recording().name;
+    return this.hasExistingRecording() &&
+      this.name() !== this.recording().name;
   }
 
   artistDiffersFromRecording() {
-    const recording = this.recording();
-
     /*
      * This function is used to determine whether we can update the
      * recording AC, so if there's no recording, then there's nothing
      * to compare against.
      */
-    if (!recording || !recording.gid) {
+    if (!this.hasExistingRecording()) {
       return false;
     }
 
     return !artistCreditsAreEqual(
       this.artistCredit(),
-      recording.artistCredit,
+      this.recording().artistCredit,
     );
   }
 

--- a/t/selenium/release-editor/The_Downward_Spiral.json5
+++ b/t/selenium/release-editor/The_Downward_Spiral.json5
@@ -447,18 +447,32 @@
       target: "xpath=//a[@href='#recordings']",
       value: '',
     },
-    // Set the first track to an existing recording, pasting an MBID.
+    // Open the recording bubble for the first (non-pregap) track.
     {
       command: 'click',
       target: "xpath=(//button[contains(@class, 'edit-track-recording')])[2]",
       value: '',
     },
+    // Type some text into the input without selecting an existing recording
+    // and check that the "Update the recording title to match the track
+    // title" checkbox isn't shown (MBS-13744).
+    {
+      command: 'type',
+      target: "xpath=//div[@id='recording-assoc-bubble']//span[contains(@class, 'autocomplete')]//input[contains(@class, 'name')]",
+      value: 'Some text to search for',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelectorAll('input.update-recording-title').length",
+      value: '0',
+    },
+    // Set the first track to an existing recording, pasting an MBID.
     {
       command: 'type',
       target: "xpath=//div[@id='recording-assoc-bubble']//span[contains(@class, 'autocomplete')]//input[contains(@class, 'name')]",
       value: '96f64611-49df-4e54-84e7-0f9a30f01766',
     },
-    // Set the first track to an existing recording, searching for it.
+    // Set the second track to an existing recording, searching for it.
     {
       command: 'click',
       target: "xpath=(//button[contains(@class, 'edit-track-recording')])[3]",


### PR DESCRIPTION
# MBS-13744

Update the release editor to avoid showing the "Update the recording title to match the track title" checkbox when the recording search input differs from the track title but an existing recording hasn't been selected.

# Problem

1. Start adding a new release that isn't based on an existing one.
2. On the recordings tab, click a track's "Edit" button and then type something into the "Search" field.

The "Update the recording title to match the track title" checkbox is shown even though there's no existing recording to update.

# Solution

Update the `Track` class's `titleDiffersFromRecording` method to return false if there's no existing recording. The `artistDiffersFromRecording` method already did this.

# Testing

I manually tested locally that the checkbox is now only shown after an existing recording (with a different title) has been selected.

I also added a check to the existing `The_Downward_Spiral` Selenium test (not sure if it'll pass yet).