### PR TITLE
MBS-9063: Ignore dates in rels editor for rel types without them

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/EditRelationships.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/EditRelationships.pm
@@ -395,7 +395,12 @@ role {
 
             $link_types_by_id->{$link_type->id} = $link_type;
 
-            if (my $period = $field->{period}) {
+            if (!($link_type->has_dates)) {
+                # Enforce blank dates for types that do not support them
+                $args{begin_date} = { year => undef, month => undef, day => undef };
+                $args{end_date} = { year => undef, month => undef, day => undef };
+                $args{ended} = 0;
+            } elsif (my $period = $field->{period}) {
                 $args{begin_date} = $period->{begin_date} if $period->{begin_date};
                 $args{end_date} = $period->{end_date} if $period->{end_date};
                 $args{ended} = $period->{ended} if defined $period->{ended};

--- a/root/static/scripts/relationship-editor/components/DialogPreview.js
+++ b/root/static/scripts/relationship-editor/components/DialogPreview.js
@@ -21,6 +21,7 @@ import type {
   RelationshipStateT,
 } from '../types.js';
 import getBatchSelectionMessage from '../utility/getBatchSelectionMessage.js';
+import getRelationshipLinkType from '../utility/getRelationshipLinkType.js';
 import relationshipsHaveSamePhraseGroup
   from '../utility/relationshipsHaveSamePhraseGroup.js';
 
@@ -30,13 +31,16 @@ const createRelationshipTFromState = (
   backward: boolean,
 ) => {
   const target = backward ? relationship.entity0 : relationship.entity1;
+  const linkType = getRelationshipLinkType(relationship);
+  const hasDates = linkType ? linkType.has_dates : true;
+
   return {
     attributes: tree.toArray(relationship.attributes),
     backward,
-    begin_date: relationship.begin_date,
+    begin_date: hasDates ? relationship.begin_date : null,
     editsPending: relationship.editsPending,
-    end_date: relationship.end_date,
-    ended: relationship.ended,
+    end_date: hasDates ? relationship.end_date : null,
+    ended: hasDates ? relationship.ended : false,
     entity0: relationship.entity0,
     entity0_credit: relationship.entity0_credit,
     entity0_id: relationship.entity0.id,

--- a/root/static/scripts/relationship-editor/components/RelationshipItem.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipItem.js
@@ -126,10 +126,10 @@ component _RelationshipItem(
     dispatch({relationship, source, type: 'move-relationship-up'});
   }
 
-  const dateText = bracketedText(
-    relationshipDateText(relationship, /* brackedEnded = */ false),
-  );
   const linkType = getRelationshipLinkType(relationship);
+  const dateText = (!linkType || linkType.has_dates) ? bracketedText(
+    relationshipDateText(relationship, /* brackedEnded = */ false),
+  ) : '';
 
   const attributeText = React.useMemo(() => {
     if (!linkType) {

--- a/root/static/scripts/release/components/ReleaseRelationshipEditor.js
+++ b/root/static/scripts/release/components/ReleaseRelationshipEditor.js
@@ -645,6 +645,10 @@ function* getAllRelationshipEdits(
             if (relationship.ended !== origRelationship.ended) {
               editData.ended = relationship.ended;
             }
+          } else {
+            editData.begin_date = EMPTY_PARTIAL_DATE;
+            editData.end_date = EMPTY_PARTIAL_DATE;
+            editData.ended = false;
           }
           if (relationship.linkOrder !== origRelationship.linkOrder) {
             const linkType = getRelationshipLinkType(relationship);

--- a/t/sql/ws_js_edit.sql
+++ b/t/sql/ws_js_edit.sql
@@ -11,3 +11,12 @@ INSERT INTO artist (id, gid, name, sort_name)
 
 INSERT INTO url (id, gid, url)
     VALUES (2, 'de409476-4ad8-4ce8-af2f-d47bee0edf97', 'http://en.wikipedia.org/wiki/Boredoms');
+
+INSERT INTO work (id, gid, name)
+    VALUES (123, '145c079d-374e-4436-9448-da92dedef3cf', 'a fake work');
+
+INSERT INTO link (id, link_type, attribute_count, begin_date_year, end_date_year, ended)
+    VALUES (333, 168, 0, 2006, 2006, '1');
+
+INSERT INTO l_artist_work (entity0, entity1, id, last_updated, link)
+    VALUES (66666, 123, 66666123, '2013-04-02 17:42:38.063723+00', 333);


### PR DESCRIPTION
### Fix MBS-9063

# Problem
We keep having issues where people will hit an ISE after changing from a relationship type with dates (such as member) to one without (such as founder), because the dates are still stored and submitted with the relationship even though it doesn't make sense.

It's even more confusing with the new editor because the relationship preview will still show the dates, even though the type does not support them, and even though the user has no way to actually change them anymore.


# Solution
Since we do not want to lose the dates in a situation where the user ends up selecting a second type that does support them, I was originally stashing and blanking them if a type without dates is selected, and restoring them if a type with dates was selected again (https://github.com/metabrainz/musicbrainz-server/pull/2873). @mwiencek suggested that rather than going through the effort of removing and re-adding the dates as the link types change, we could just ignore them for display while editing and only remove them from the data being sent once the edits are being submitted using a rel type that does not support dates. This implements that approach - submitted as a separate PR just in case we find problems in it and decide to go back to the previous approach, although it seems sensible to me.

The second commit implements a Perl level fallback that still fixes the dates being present in the case JS sends them through for whatever reason.

# Testing
Tested both the JS and the Perl implementations (without the other being present, obviously) manually by changing from a writer relationship with dates to a previous attribution one, both in the work editor and the release editor (since they use different ways of submitting so the dates need to be stripped separately), and ensuring they are correctly submitted with no dates.

Added a basic for the Perl implementation.