### PR TITLE
MBS-9479 (II): Show errors for dupe RG failures

### DIFF
--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -51,25 +51,35 @@
         </td>
       </tr>
 
-      <tr data-bind="if: $root.loadingDuplicateRGs()">
+      <tr data-bind="if: $root.loadingDuplicateReleaseGroups()">
         <td></td>
         <td colspan="2">
-          <div class="duplicate-rgs-loading loading-message">
+          <div class="duplicate-release-groups-loading loading-message">
             [% l('Checking existing release groups…') %]
           </div>
         </td>
       </tr>
 
-      <tr data-bind="if: $root.duplicateRGs().length > 0">
+      <tr data-bind="if: $root.failedLoadingDuplicateReleaseGroups()">
         <td></td>
         <td colspan="2">
-          <div class="duplicate-rgs-label">
+          <div class="duplicate-release-groups-error">
+            [% l('Release group search error') %]
+            <a data-click="loadDuplicateReleaseGroups">[% l('Retry') %]</a>
+          </div>
+        </td>
+      </tr>
+
+      <tr data-bind="if: $root.duplicateReleaseGroups().length > 0">
+        <td></td>
+        <td colspan="2">
+          <div class="duplicate-release-groups-label">
             [% add_colon(l('Existing release groups with similar names')) %]
           </div>
-          <div class="duplicate-rgs-list">
-            <!-- ko foreach: $root.duplicateRGs -->
+          <div class="duplicate-release-groups-list">
+            <!-- ko foreach: $root.duplicateReleaseGroups -->
               <label>
-                <input name="rg-selection" type="radio" data-change="selectReleaseGroup" />
+                <input name="release-group-selection" type="radio" data-change="selectReleaseGroup" />
                 <div>
                   <a target="_blank" data-bind="attr: { href: '/release-group/' + $data.gid }, text: $data.name"></a>
                   <span data-bind="text: $data.details"></span>
@@ -77,7 +87,7 @@
               </label>
             <!-- /ko -->
             <label>
-              <input name="rg-selection" type="radio" checked data-change="clearReleaseGroup" />
+              <input name="release-group-selection" type="radio" checked data-change="clearReleaseGroup" />
               <div>[% l('Add a new release group') %]</div>
             </label>
           </div>

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -9,17 +9,23 @@
 import $ from 'jquery';
 import ko from 'knockout';
 
+import commaOnlyList from '../common/i18n/commaOnlyList.js';
 import {
   hasVariousArtists,
   isComplexArtistCredit,
   reduceArtistCredit,
 } from '../common/immutable-entities.js';
+import {bracketedText} from '../common/utility/bracketed.js';
+import request from '../common/utility/request.js';
 import deferFocus from '../edit/utility/deferFocus.js';
 import guessFeat from '../edit/utility/guessFeat.js';
 import GuessCase from '../guess-case/MB/GuessCase/Main.js';
 
 import fields from './fields.js';
+import utils from './utils.js';
 import releaseEditor from './viewModel.js';
+
+const maxDuplicateReleaseGroups = 5;
 
 const actions = {
 
@@ -67,6 +73,83 @@ const actions = {
     release.releaseGroup(new fields.ReleaseGroup({
       name: release.name.peek(),
     }));
+  },
+
+  duplicateReleaseGroups: ko.observableArray([]),
+  loadingDuplicateReleaseGroups: ko.observable(false),
+  failedLoadingDuplicateReleaseGroups: ko.observable(false),
+  duplicateReleaseGroupsRequest: null,
+  duplicateReleaseGroupsQuery: null,
+
+  /**
+   * Query for existing release groups that are credited to any of the
+   * currently-credited artists and have similar names to the release.
+   */
+  loadDuplicateReleaseGroups() {
+    const release = this.rootField.release.peek();
+    const query = utils.constructLuceneFieldConjunction({
+      arid: release.artistCredit().names
+        .map((a) => a.artist?.gid)
+        .filter(Boolean),
+      releasegroup: [utils.escapeLuceneValue(release.name() ?? '')],
+    });
+    if (query === this.duplicateReleaseGroupsQuery) {
+      return;
+    }
+
+    // Cancel any in-progress lookup and clear existing results.
+    this.duplicateReleaseGroupsRequest?.abort();
+    this.duplicateReleaseGroupsRequest = null;
+    this.loadingDuplicateReleaseGroups(false);
+    this.failedLoadingDuplicateReleaseGroups(false);
+    this.duplicateReleaseGroupsQuery = query;
+    this.duplicateReleaseGroups.removeAll();
+
+    /*
+     * Make sure that an existing release group isn't selected
+     * and that there's a title and artist to use for searching.
+     */
+    if (
+      release.releaseGroup().gid ||
+      (release.name() ?? '') === '' ||
+      !release.artistCredit().names.some((a) => a.artist?.gid)
+    ) {
+      return;
+    }
+
+    this.loadingDuplicateReleaseGroups(true);
+    this.duplicateReleaseGroupsRequest = request({
+      url: '/ws/js/release-group' +
+        '?direct=false' +
+        '&advanced=true' +
+        '&limit=' + encodeURIComponent(maxDuplicateReleaseGroups) +
+        '&q=' + encodeURIComponent(query),
+    })
+      .always(() => {
+        this.duplicateReleaseGroupsRequest = null;
+        this.loadingDuplicateReleaseGroups(false);
+      })
+      .fail(() => {
+        this.failedLoadingDuplicateReleaseGroups(true);
+        this.duplicateReleaseGroupsQuery = null;
+      })
+      .done((data) => {
+        const results = data.slice(0, -1).map((rg) => {
+          rg.details = bracketedText(
+            commaOnlyList([
+              rg.l_type_name,
+              texp.ln(
+                '{num} release',
+                '{num} releases',
+                rg.release_count,
+                {num: rg.release_count},
+              ),
+            ].filter(Boolean)),
+          );
+          return new fields.ReleaseGroup(rg);
+        });
+        ko.utils.arrayPushAll(this.duplicateReleaseGroups, results);
+      });
   },
 
   copyTitleToReleaseGroup: ko.observable(false),

--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -54,9 +54,18 @@ div.half-width {
 
     td.release-artist { width: 100%; }
 
-    .duplicate-rgs-loading { margin-bottom: 0.5em; }
-    .duplicate-rgs-label { font-weight: bold; }
-    .duplicate-rgs-list {
+    .duplicate-release-groups-loading { margin-bottom: 0.5em; }
+    .duplicate-release-groups-error {
+        font-style: italic;
+        margin-bottom: 0.5em;
+        a {
+            cursor: pointer;
+            font-style: normal;
+            margin-left: 0.5em;
+        }
+    }
+    .duplicate-release-groups-label { font-weight: bold; }
+    .duplicate-release-groups-list {
         margin-bottom: 0.5em;
 
         > * {

--- a/t/selenium/release-editor/MBS-9479.json5
+++ b/t/selenium/release-editor/MBS-9479.json5
@@ -16,7 +16,7 @@
     // Click the existing release group's radio button.
     {
       command: 'click',
-      target: 'css=#information .duplicate-rgs-list :first-child input',
+      target: 'css=#information .duplicate-release-groups-list :first-child input',
       value: '',
     },
     {
@@ -32,7 +32,7 @@
     // Click the "Add a new release group" radio button.
     {
       command: 'click',
-      target: 'css=#information .duplicate-rgs-list :last-child input',
+      target: 'css=#information .duplicate-release-groups-list :last-child input',
       value: '',
     },
     {


### PR DESCRIPTION
# MBS-9479 (II)

Make the release editor display a "Failed loading existing release groups" error and retry link when a request to load possibly-duplicate release groups fails.

# Problem

#3359 made the release editor query for release groups with names similar to the release's, but it didn't display an error if the request failed due to network or server issues.

# Solution

Display a "Failed loading existing release groups." message and a "Retry" link:

![Screenshot 2024-08-27 12 11 54](https://github.com/user-attachments/assets/599c7455-2043-4c29-a0a0-38e3cbfcc81a)

I moved the lookup code from `init.js` to `actions.js` so it can be called from the retry link.

# Testing

Manually tested using my local dev server. (I think I'm unable to test the no-error path now, since I think I can't make cross-origin calls to the `/ws/js/release-group` endpoint due to CORS restrictions.)