### PR TITLE
Update Flow to 0.245.0

### DIFF
--- a/flow-typed/npm/react-dom_v18.x.x.js
+++ b/flow-typed/npm/react-dom_v18.x.x.js
@@ -112,13 +112,13 @@ declare module 'react-dom' {
   ): null | Element | Text;
 
   declare function render<ElementType: React.ElementType>(
-    element: React.Element<ElementType>,
+    element: React.MixedElement,
     container: Element,
     callback?: () => void
   ): React.ElementRef<ElementType>;
 
   declare function hydrate<ElementType: React.ElementType>(
-    element: React.Element<ElementType>,
+    element: React.MixedElement,
     container: Element,
     callback?: () => void
   ): React.ElementRef<ElementType>;
@@ -145,7 +145,7 @@ declare module 'react-dom' {
     ElementType: React.ElementType
   >(
     parentComponent: React$Component<any, any>,
-    nextElement: React.Element<ElementType>,
+    nextElement: React.MixedElement,
     container: any,
     callback?: () => void
   ): React.ElementRef<ElementType>;
@@ -229,7 +229,7 @@ declare module 'react-dom/test-utils' {
   };
 
   declare function renderIntoDocument(
-    instance: React.Element<any>
+    instance: React.MixedElement
   ): React$Component<any, any>;
 
   declare function mockComponent(
@@ -237,10 +237,10 @@ declare module 'react-dom/test-utils' {
     mockTagName?: string
   ): { [key: string]: mixed, ... };
 
-  declare function isElement(element: React.Element<any>): boolean;
+  declare function isElement(element: React.MixedElement): boolean;
 
   declare function isElementOfType(
-    element: React.Element<any>,
+    element: React.MixedElement,
     componentClass: React.ElementType
   ): boolean;
 

--- a/root/components/Aliases/index.js
+++ b/root/components/Aliases/index.js
@@ -40,7 +40,7 @@ type Props = {
   +entity: EntityWithAliasesT,
 };
 
-const Aliases = ({aliases, entity}: Props): React$MixedElement => {
+const Aliases = ({aliases, entity}: Props): React.MixedElement => {
   const $c = React.useContext(CatalystContext);
   const entityType = entity.entityType;
   const allowEditing = canEdit($c, entityType);

--- a/root/components/EntityHeader.js
+++ b/root/components/EntityHeader.js
@@ -9,12 +9,10 @@
 
 import EntityLink from '../static/scripts/common/components/EntityLink.js';
 
-import typeof EntityTabLink from './EntityTabLink.js';
 import EntityTabs from './EntityTabs.js';
 import SubHeader from './SubHeader.js';
 
 component EntityHeader(
-  editTab?: React.Element<EntityTabLink>,
   entity: RelatableEntityT,
   headerClass: string,
   heading?: Expand2ReactOutput,
@@ -31,11 +29,7 @@ component EntityHeader(
         </h1>
         <SubHeader subHeading={subHeading} />
       </div>
-      <EntityTabs
-        editTab={editTab}
-        entity={entity}
-        page={page}
-      />
+      <EntityTabs entity={entity} page={page} />
     </>
   );
 }

--- a/root/components/EntityTabs.js
+++ b/root/components/EntityTabs.js
@@ -76,7 +76,7 @@ function buildLinks(
   $c: CatalystContextT,
   entity: RelatableEntityT,
   page?: string,
-): $ReadOnlyArray<React.Element<typeof EntityTabLink>> {
+): $ReadOnlyArray<React.MixedElement> {
   const links = [buildLink(l('Overview'), entity, '', page, false, 'index')];
   const user = $c.user;
 

--- a/root/components/EntityTabs.js
+++ b/root/components/EntityTabs.js
@@ -76,7 +76,6 @@ function buildLinks(
   $c: CatalystContextT,
   entity: RelatableEntityT,
   page?: string,
-  editTab: ?React.Element<typeof EntityTabLink>,
 ): $ReadOnlyArray<React.Element<typeof EntityTabLink>> {
   const links = [buildLink(l('Overview'), entity, '', page, false, 'index')];
   const user = $c.user;
@@ -165,13 +164,9 @@ function buildLinks(
   }
 
   if (showEditTab(user, entity)) {
-    if (editTab) {
-      links.push(editTab);
-    } else {
-      links.push(
-        buildLink(lp('Edit', 'verb, interactive'), entity, 'edit', page),
-      );
-    }
+    links.push(
+      buildLink(lp('Edit', 'verb, interactive'), entity, 'edit', page),
+    );
   }
 
   if (entity.entityType === 'release') {
@@ -187,14 +182,13 @@ function buildLinks(
 }
 
 component EntityTabs(
-  editTab: ?React.Element<typeof EntityTabLink>,
   entity: RelatableEntityT,
   page?: string,
 ) {
   return (
     <Tabs>
       <CatalystContext.Consumer>
-        {($c: CatalystContextT) => buildLinks($c, entity, page, editTab)}
+        {($c: CatalystContextT) => buildLinks($c, entity, page)}
       </CatalystContext.Consumer>
     </Tabs>
   );

--- a/root/components/RelationshipTargetLinks.js
+++ b/root/components/RelationshipTargetLinks.js
@@ -80,7 +80,7 @@ component RelationshipTargetLinks(
   const datesAndAttributes = semicolonOnlyList(
     relationship.datedExtraAttributesList.map(displayDatedExtraAttributes),
   );
-  let result: React$MixedElement = (
+  let result: React.MixedElement = (
     <>
       {link}
       {datesAndAttributes ? (

--- a/root/components/RelationshipsTable.js
+++ b/root/components/RelationshipsTable.js
@@ -97,7 +97,7 @@ component RelationshipsTable(
     +phrase: string,
   }>;
 
-  const tableRows: Array<React$MixedElement> = [];
+  const tableRows: Array<React.MixedElement> = [];
 
   const setColumnVariables = (
     targetType: RelatableEntityTypeT,
@@ -130,7 +130,7 @@ component RelationshipsTable(
 
   const getRelationshipRows = (
     linkTypeGroup: PagedLinkTypeGroupT | PagedLinkTypeGroupWithPhraseT,
-    rows: Array<React$MixedElement>,
+    rows: Array<React.MixedElement>,
   ) => {
     let index = 0;
 
@@ -255,7 +255,7 @@ component RelationshipsTable(
         .sort((a, b) => compare(a.phrase, b.phrase));
 
       for (const linkTypeGroup of linkTypeGroups) {
-        const relationshipRows: Array<React$MixedElement> = [];
+        const relationshipRows: Array<React.MixedElement> = [];
         getRelationshipRows(linkTypeGroup, relationshipRows);
 
         const key = linkTypeGroup.link_type_id + '-' +
@@ -329,7 +329,7 @@ component RelationshipsTable(
       </tbody>
     </table>
   );
-  let pageContent: React$MixedElement = tableElement;
+  let pageContent: React.MixedElement = tableElement;
   let finalHeading = heading;
 
   if (pagedLinkTypeGroup /*:: && pager */) {

--- a/root/components/ReleaseCatnoList.js
+++ b/root/components/ReleaseCatnoList.js
@@ -9,7 +9,7 @@
 
 import commaOnlyList from '../static/scripts/common/i18n/commaOnlyList.js';
 
-const displayCatno = (catno: string): React.Element<'span'> => (
+const displayCatno = (catno: string): React.MixedElement => (
   <span className="catalog-number" key={catno}>
     {catno}
   </span>

--- a/root/components/UserAccountTabs.js
+++ b/root/components/UserAccountTabs.js
@@ -19,7 +19,7 @@ function buildTabs(
   $c: CatalystContextT,
   user: AccountLayoutUserT,
   page: string,
-): $ReadOnlyArray<React.Element<'li'>> {
+): $ReadOnlyArray<React.MixedElement> {
   const viewingOwnProfile = Boolean($c.user && $c.user.id === user.id);
 
   const userName = encodeURIComponent(user.name);

--- a/root/components/list/GenreList.js
+++ b/root/components/list/GenreList.js
@@ -16,20 +16,12 @@ import {
   defineNameColumn,
 } from '../../utility/tableColumns.js';
 
-type Props = {
-  +checkboxes?: string,
-  +genres: $ReadOnlyArray<GenreT>,
-  +mergeForm?: MergeFormT,
-  +order?: string,
-  +sortable?: boolean,
-};
-
-const GenreList = ({
-  checkboxes,
-  genres,
-  order,
-  sortable,
-}: Props): React.Element<'table'> => {
+component GenreList(
+  checkboxes?: string,
+  genres: $ReadOnlyArray<GenreT>,
+  order?: string,
+  sortable?: boolean,
+) {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -52,6 +44,6 @@ const GenreList = ({
   );
 
   return useTable<GenreT>({columns, data: genres});
-};
+}
 
 export default GenreList;

--- a/root/edit/details/AddEventArt.js
+++ b/root/edit/details/AddEventArt.js
@@ -9,17 +9,15 @@
 
 import AddArt from './AddArt.js';
 
-type Props = {
-  +edit: AddEventArtEditT,
-};
-
-const AddEventArt = ({edit}: Props): React.Element<typeof AddArt> => (
-  <AddArt
-    archiveName="event"
-    edit={edit}
-    entityType="event"
-    formattedEntityType={l('Event')}
-  />
-);
+component AddEventArt(edit: AddEventArtEditT) {
+  return (
+    <AddArt
+      archiveName="event"
+      edit={edit}
+      entityType="event"
+      formattedEntityType={l('Event')}
+    />
+  );
+}
 
 export default AddEventArt;

--- a/root/edit/details/EditEventArt.js
+++ b/root/edit/details/EditEventArt.js
@@ -9,19 +9,15 @@
 
 import EditArt from './EditArt.js';
 
-type Props = {
-  +edit: EditEventArtEditT,
-};
-
-const EditEventArt = ({
-  edit,
-}: Props): React.Element<typeof EditArt> => (
-  <EditArt
-    archiveName="event"
-    edit={edit}
-    entityType="event"
-    formattedEntityType={l('Event')}
-  />
-);
+component EditEventArt(edit: EditEventArtEditT) {
+  return (
+    <EditArt
+      archiveName="event"
+      edit={edit}
+      entityType="event"
+      formattedEntityType={l('Event')}
+    />
+  );
+}
 
 export default EditEventArt;

--- a/root/edit/details/RemoveEventArt.js
+++ b/root/edit/details/RemoveEventArt.js
@@ -9,19 +9,15 @@
 
 import RemoveArt from './RemoveArt.js';
 
-type Props = {
-  +edit: RemoveEventArtEditT,
-};
-
-const RemoveEventArt = ({
-  edit,
-}: Props): React.Element<typeof RemoveArt> => (
-  <RemoveArt
-    archiveName="event"
-    edit={edit}
-    entityType="event"
-    formattedEntityType={l('Event')}
-  />
-);
+component RemoveEventArt(edit: RemoveEventArtEditT) {
+  return (
+    <RemoveArt
+      archiveName="event"
+      edit={edit}
+      entityType="event"
+      formattedEntityType={l('Event')}
+    />
+  );
+}
 
 export default RemoveEventArt;

--- a/root/edit/details/ReorderEventArt.js
+++ b/root/edit/details/ReorderEventArt.js
@@ -9,19 +9,15 @@
 
 import ReorderArt from './ReorderArt.js';
 
-type Props = {
-  +edit: ReorderEventArtEditT,
-};
-
-const ReorderEventArt = ({
-  edit,
-}: Props): React.Element<typeof ReorderArt> => (
-  <ReorderArt
-    archiveName="event"
-    edit={edit}
-    entityType="event"
-    formattedEntityType={l('Event')}
-  />
-);
+component ReorderEventArt(edit: ReorderEventArtEditT) {
+  return (
+    <ReorderArt
+      archiveName="event"
+      edit={edit}
+      entityType="event"
+      formattedEntityType={l('Event')}
+    />
+  );
+}
 
 export default ReorderEventArt;

--- a/root/edit/details/historic/EditReleaseEvents.js
+++ b/root/edit/details/historic/EditReleaseEvents.js
@@ -14,7 +14,7 @@ import formatDate from '../../../static/scripts/common/utility/formatDate.js';
 function buildEventComp(
   event: OldReleaseEventCompT,
   key: string,
-): React.Element<'tr'> {
+): React.MixedElement {
   return (
     <tr key={key}>
       <td>
@@ -71,7 +71,7 @@ function buildEventComp(
 function buildEvent(
   event: OldReleaseEventT,
   key: string,
-): React.Element<'tr'> {
+): React.MixedElement {
   return (
     <tr key={key}>
       <td>

--- a/root/edit/utility/getEditDetailsElement.js
+++ b/root/edit/utility/getEditDetailsElement.js
@@ -124,7 +124,7 @@ import SetTrackLengths from '../details/SetTrackLengths.js';
 
 export default function getEditDetailsElement(
   edit: EditT,
-): React$MixedElement {
+): React.MixedElement {
   switch (edit.edit_type) {
     case EDIT_TYPES.EDIT_AREA_ADD_ANNOTATION:
     case EDIT_TYPES.EDIT_ARTIST_ADD_ANNOTATION:

--- a/root/event/EventArt.js
+++ b/root/event/EventArt.js
@@ -19,15 +19,10 @@ import {commaOnlyListText}
 
 import EventLayout from './EventLayout.js';
 
-type Props = {
-  +event: EventT,
-  +eventArt: $ReadOnlyArray<EventArtT>,
-};
-
-const EventArt = ({
-  eventArt,
-  event,
-}: Props): React.Element<typeof EventLayout> => {
+component EventArt(
+  event: EventT,
+  eventArt: $ReadOnlyArray<EventArtT>,
+) {
   const $c = React.useContext(SanitizedCatalystContext);
   const title = lp('Event art', 'plural, header');
 
@@ -141,6 +136,6 @@ const EventArt = ({
       ) : null}
     </EventLayout>
   );
-};
+}
 
 export default EventArt;

--- a/root/event/EventArtDarkened.js
+++ b/root/event/EventArtDarkened.js
@@ -9,13 +9,7 @@
 
 import EventLayout from './EventLayout.js';
 
-type Props = {
-  +event: EventT,
-};
-
-const EventArtDarkened = ({
-  event,
-}: Props): React.Element<typeof EventLayout> => {
+component EventArtDarkened(event: EventT) {
   const title = lp('Cannot add event art', 'plural');
 
   return (
@@ -27,6 +21,6 @@ const EventArtDarkened = ({
       </p>
     </EventLayout>
   );
-};
+}
 
 export default EventArtDarkened;

--- a/root/event/EventArtFields.js
+++ b/root/event/EventArtFields.js
@@ -11,10 +11,10 @@ import ArtFields, {
   type CommonProps as Props,
 } from '../components/ArtFields.js';
 
-const EventArtFields = ({
+component EventArtFields(...{
   form,
   typeIdOptions,
-}: Props): React.Element<typeof ArtFields> => {
+}: Props) {
   return (
     <ArtFields
       archiveName="event"
@@ -28,6 +28,6 @@ const EventArtFields = ({
       typeIdOptions={typeIdOptions}
     />
   );
-};
+}
 
 export default EventArtFields;

--- a/root/event/RemoveEventArt.js
+++ b/root/event/RemoveEventArt.js
@@ -15,17 +15,11 @@ import EnterEditNote
 
 import EventLayout from './EventLayout.js';
 
-type Props = {
-  +artwork: EventArtT,
-  +event: EventT,
-  +form: ConfirmFormT,
-};
-
-const RemoveEventArt = ({
-  artwork,
-  event,
-  form,
-}: Props): React.Element<typeof EventLayout> => {
+component RemoveEventArt(
+  artwork: EventArtT,
+  event: EventT,
+  form: ConfirmFormT,
+) {
   const title = lp('Remove event art', 'singular, header');
 
   return (
@@ -46,6 +40,6 @@ const RemoveEventArt = ({
       </form>
     </EventLayout>
   );
-};
+}
 
 export default RemoveEventArt;

--- a/root/hooks/useTable.js
+++ b/root/hooks/useTable.js
@@ -38,7 +38,7 @@ const renderTableCell = (cell: Cell<mixed>) => (
   </td>
 );
 
-const renderTableRow = <D>(row: Row<D>, i: number): React.Element<'tr'> => (
+const renderTableRow = <D>(row: Row<D>, i: number): React.MixedElement => (
   <tr {...row.getRowProps({className: loopParity(i)})}>
     {row.cells.map(renderTableCell)}
   </tr>
@@ -54,7 +54,7 @@ const useRenderedTable = <D>({
   className: passedClassName,
   columns,
   data,
-}: Props<D>): React.Element<'table'> => {
+}: Props<D>): React.MixedElement => {
   const {
     getTableProps,
     getTableBodyProps,

--- a/root/layout/components/BottomMenu.js
+++ b/root/layout/components/BottomMenu.js
@@ -74,7 +74,7 @@ component LanguageMenu(
       </span>
       <ul>
         {serverLanguages.map(function (language, index) {
-          let inner: React$MixedElement =
+          let inner: React.MixedElement =
             <LanguageLink language={language} />;
 
           if (language.name === currentBCP47Language) {

--- a/root/layout/components/globalsScript.mjs
+++ b/root/layout/components/globalsScript.mjs
@@ -78,4 +78,4 @@ export default ((
       );
     }}
   </CatalystContext.Consumer>
-): React$MixedElement);
+): React.MixedElement);

--- a/root/layout/components/sidebar/CollectionList.js
+++ b/root/layout/components/sidebar/CollectionList.js
@@ -8,8 +8,6 @@
  */
 
 import {CatalystContext} from '../../../context.mjs';
-import typeof EntityLink
-  from '../../../static/scripts/common/components/EntityLink.js';
 import entityHref from '../../../static/scripts/common/utility/entityHref.js';
 import {returnToCurrentPage} from '../../../utility/returnUri.js';
 
@@ -117,7 +115,7 @@ component CollectionList(
   ownCollectionsNoneText: string,
   sectionClass: string,
   userExists: boolean,
-  usersLink: React.Element<EntityLink>,
+  usersLink: React.MixedElement,
   usersLinkHeader: string,
 ) {
   return (

--- a/root/layout/components/sidebar/SidebarLicenses.js
+++ b/root/layout/components/sidebar/SidebarLicenses.js
@@ -112,8 +112,8 @@ component LicenseDisplay(url: UrlT) {
 }
 
 const cmpLinkPhrase = (
-  a: [string, React$MixedElement],
-  b: [string, React$MixedElement],
+  a: [string, React.MixedElement],
+  b: [string, React.MixedElement],
 ) => compare(a[0], b[0]);
 
 component SidebarLicenses(entity: RelatableEntityT) {
@@ -123,7 +123,7 @@ component SidebarLicenses(entity: RelatableEntityT) {
     return null;
   }
 
-  const licenses: Array<[string, React$MixedElement]> = [];
+  const licenses: Array<[string, React.MixedElement]> = [];
   for (const r of relationships) {
     const target = r.target;
     if (target.entityType === 'url' &&

--- a/root/layout/components/sidebar/SidebarTags.js
+++ b/root/layout/components/sidebar/SidebarTags.js
@@ -24,7 +24,7 @@ component TagList(
 ) {
   const upvotedTags = tags ? tags.filter(tag => tag.count > 0) : null;
   const links = upvotedTags ? upvotedTags.reduce((
-    accum: Array<React.Element<typeof TagLink>>,
+    accum: Array<React.MixedElement>,
     aggregatedTag,
   ) => {
     if (Boolean(aggregatedTag.tag.genre) === isGenreList) {

--- a/root/series/SeriesIndex.js
+++ b/root/series/SeriesIndex.js
@@ -36,7 +36,7 @@ type ListPickerProps = $Values<{
 
 const listPicker = (
   props: ListPickerProps,
-): React$MixedElement => {
+): React.MixedElement => {
   const sharedProps = {
     seriesItemNumbers: props.seriesItemNumbers,
   };

--- a/root/static/manifest.mjs
+++ b/root/static/manifest.mjs
@@ -49,7 +49,7 @@ const jsExt = /\.js(?:on)?$/;
 function manifest(
   manifest: string,
   extraAttrs?: {+'async'?: 'async', +'data-args'?: mixed} | null = null,
-): React.Element<'script'> {
+): React.MixedElement {
   if (jsExt.test(manifest)) {
     throw new Error(
       'Do not include .js in the manifest path name',

--- a/root/static/scripts/account/components/ApplicationForm.js
+++ b/root/static/scripts/account/components/ApplicationForm.js
@@ -77,7 +77,7 @@ class ApplicationForm extends React.Component<Props, State> {
       .final());
   }
 
-  render(): React.Element<'form'> {
+  render(): React.MixedElement {
     return (
       <form method="post">
         <FormCsrfToken form={this.state.form} />

--- a/root/static/scripts/account/components/EditProfileForm.js
+++ b/root/static/scripts/account/components/EditProfileForm.js
@@ -197,7 +197,7 @@ class EditProfileForm extends React.Component<Props, State> {
     });
   }
 
-  render(): React.Element<'form'> {
+  render(): React.MixedElement {
     const form = this.state.form;
     const field = form.field;
     const areaField = field.area.field;

--- a/root/static/scripts/account/components/PreferencesForm.js
+++ b/root/static/scripts/account/components/PreferencesForm.js
@@ -157,7 +157,7 @@ class PreferencesForm extends React.Component<Props, State> {
       .final());
   }
 
-  render(): React.Element<'form'> {
+  render(): React.MixedElement {
     const field = this.state.form.field;
     return (
       <form method="post">

--- a/root/static/scripts/annotation/AnnotationHistoryTable.js
+++ b/root/static/scripts/annotation/AnnotationHistoryTable.js
@@ -15,11 +15,6 @@ import EditorLink from '../common/components/EditorLink.js';
 import bracketed from '../common/utility/bracketed.js';
 import parseInteger from '../common/utility/parseInteger.js';
 
-type Props = {
-  +annotations: $ReadOnlyArray<AnnotationT>,
-  +baseUrl: string,
-};
-
 /* eslint-disable ft-flow/sort-keys */
 type ActionT =
   | {+type: 'update-new', +index: number}
@@ -60,10 +55,10 @@ function reducer(state: StateT, action: ActionT): StateT {
   return newState;
 }
 
-const AnnotationHistoryTable = ({
-  annotations,
-  baseUrl,
-}: Props): React.Element<'table'> => {
+component AnnotationHistoryTable(
+  annotations: $ReadOnlyArray<AnnotationT>,
+  baseUrl: string,
+) {
   const $c = React.useContext(SanitizedCatalystContext);
 
   const canCompare = annotations.length > 1;
@@ -159,9 +154,9 @@ const AnnotationHistoryTable = ({
       </tbody>
     </table>
   );
-};
+}
 
-export default (hydrate<Props>(
+export default (hydrate<React.PropsOf<AnnotationHistoryTable>>(
   'div.annotation-history-table',
   AnnotationHistoryTable,
-): React.AbstractComponent<Props, void>);
+): React.AbstractComponent<React.PropsOf<AnnotationHistoryTable>>);

--- a/root/static/scripts/artist/components/ArtistCreditRenamer.js
+++ b/root/static/scripts/artist/components/ArtistCreditRenamer.js
@@ -168,7 +168,7 @@ const ArtistCreditRenamer = ({
   artistName,
   initialArtistName,
   initialSelectedArtistCreditIds,
-}: ArtistCreditRenamerPropsT): React$MixedElement | null => {
+}: ArtistCreditRenamerPropsT): React.MixedElement | null => {
   const rowsRef =
     React.useRef<$ReadOnlyArray<React.MixedElement> | null>(null);
 

--- a/root/static/scripts/artist/components/ArtistCreditRenamer.js
+++ b/root/static/scripts/artist/components/ArtistCreditRenamer.js
@@ -169,9 +169,8 @@ const ArtistCreditRenamer = ({
   initialArtistName,
   initialSelectedArtistCreditIds,
 }: ArtistCreditRenamerPropsT): React$MixedElement | null => {
-  const rowsRef = React.useRef<
-    $ReadOnlyArray<React.Element<typeof ArtistCreditRow>> | null,
-  >(null);
+  const rowsRef =
+    React.useRef<$ReadOnlyArray<React.MixedElement> | null>(null);
 
   const [state, dispatch] = React.useReducer(
     reducer,

--- a/root/static/scripts/collection/components/CollectionEditForm.js
+++ b/root/static/scripts/collection/components/CollectionEditForm.js
@@ -181,7 +181,7 @@ function reducer(state: StateT, action: ActionT): StateT {
 const CollectionEditForm = ({
   collectionTypes,
   form,
-}: Props): React$MixedElement => {
+}: Props): React.MixedElement => {
   const typeOptions = {
     grouped: false,
     options: collectionTypes,

--- a/root/static/scripts/common/components/ButtonPopover.js
+++ b/root/static/scripts/common/components/ButtonPopover.js
@@ -43,7 +43,7 @@ component ButtonPopover(
   isDisabled: boolean = false,
   isOpen: boolean,
   toggle: (boolean) => void,
-  wrapButton?: (React$MixedElement) => React$MixedElement,
+  wrapButton?: (React.MixedElement) => React.MixedElement,
   ...dialogProps: {id: string}
 ) {
   const buttonId = buttonProps?.id;
@@ -80,7 +80,7 @@ component ButtonPopover(
       : unwrapNl<string>(buttonProps.title),
   } : null;
 
-  let buttonElement: React$MixedElement = (
+  let buttonElement: React.MixedElement = (
     <button
       {...getReferenceProps()}
       {...customButtonProps}
@@ -107,7 +107,7 @@ component ButtonPopover(
 
   const initialFocusRef = React.useRef<HTMLElement | null>(null);
 
-  let popoverElement: React$MixedElement | null = isOpen ? (
+  let popoverElement: React.MixedElement | null = isOpen ? (
     <FloatingPortal>
       <FloatingFocusManager
         closeOnFocusOut

--- a/root/static/scripts/common/components/CodeLink.js
+++ b/root/static/scripts/common/components/CodeLink.js
@@ -10,7 +10,7 @@
 import entityHref from '../utility/entityHref.js';
 
 component CodeLink(code: IsrcT | IswcT) {
-  let link: React$MixedElement = (
+  let link: React.MixedElement = (
     <a href={entityHref(code)}>
       <bdi>
         {/* $FlowIssue[prop-missing] */}

--- a/root/static/scripts/common/components/Collapsible.js
+++ b/root/static/scripts/common/components/Collapsible.js
@@ -51,7 +51,7 @@ class Collapsible extends React.Component<Props, State> {
     }));
   }
 
-  render(): React$MixedElement {
+  render(): React.MixedElement {
     const {className, html} = this.props;
     const {isCollapsed, isCollapsible} = this.state;
 

--- a/root/static/scripts/common/components/CollapsibleList.js
+++ b/root/static/scripts/common/components/CollapsibleList.js
@@ -9,8 +9,6 @@
 
 import * as React from 'react';
 
-import {SidebarProperty}
-  from '../../../../layout/components/sidebar/SidebarProperties.js';
 import {bracketedText} from '../utility/bracketed.js';
 
 export type BuildRowPropsT = {
@@ -20,7 +18,7 @@ export type BuildRowPropsT = {
 component CollapsibleList<T>(
   ariaLabel: string,
   buildRow:
-    (T, ?BuildRowPropsT) => React.Element<'li' | typeof SidebarProperty>,
+    (T, ?BuildRowPropsT) => React.MixedElement,
   buildRowProps?: BuildRowPropsT,
   className: string,
   ContainerElement?: 'dl' | 'ul' = 'ul',

--- a/root/static/scripts/common/components/CommonsImage.js
+++ b/root/static/scripts/common/components/CommonsImage.js
@@ -36,7 +36,7 @@ class CommonsImage extends React.Component<Props, State> {
     }
   }
 
-  render(): React$MixedElement | null {
+  render(): React.MixedElement | null {
     const {image} = this.state;
     return image ? (
       <div className="picture">

--- a/root/static/scripts/common/components/CountryAbbr.js
+++ b/root/static/scripts/common/components/CountryAbbr.js
@@ -22,7 +22,7 @@ component CountryAbbr(
   const combinedClass =
     ('flag flag-' + primaryCode) +
     (nonEmpty(className) ? (' ' + className) : '');
-  let content: React$MixedElement = (
+  let content: React.MixedElement = (
     <abbr title={l_countries(country.name)}>
       {primaryCode}
     </abbr>

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -113,51 +113,53 @@ function getSubmitText(type: string) {
   return '';
 }
 
-type FieldProps = {
+component ArtistCreditField(
   field: FieldT<number>,
   options: SelectOptionsT,
-};
+) {
+  return (
+    <tr>
+      <td>
+        {addColonText(l('Artist credit'))}
+      </td>
+      <td>
+        <SelectField
+          field={field}
+          options={{
+            grouped: false,
+            options,
+          }}
+          style={{maxWidth: '40em'}}
+          uncontrolled
+        />
+      </td>
+    </tr>
+  );
+}
 
-const ArtistCreditField = ({
-  field,
-  options,
-}: FieldProps): React.Element<'tr'> => (
-  <tr>
-    <td>
-      {addColonText(l('Artist credit'))}
-    </td>
-    <td>
-      <SelectField
-        field={field}
-        options={{
-          grouped: false,
-          options,
-        }}
-        style={{maxWidth: '40em'}}
-        uncontrolled
-      />
-    </td>
-  </tr>
-);
-
-const TypeField = ({field, options}: FieldProps): React.Element<'tr'> => (
-  <tr>
-    <td>
-      {addColonText(l('Type'))}
-    </td>
-    <td>
-      <SelectField
-        field={field}
-        options={{
-          grouped: false,
-          options,
-        }}
-        style={{maxWidth: '40em'}}
-        uncontrolled
-      />
-    </td>
-  </tr>
-);
+component TypeField(
+  field: FieldT<number>,
+  options: SelectOptionsT,
+) {
+  return (
+    <tr>
+      <td>
+        {addColonText(l('Type'))}
+      </td>
+      <td>
+        <SelectField
+          field={field}
+          options={{
+            grouped: false,
+            options,
+          }}
+          style={{maxWidth: '40em'}}
+          uncontrolled
+        />
+      </td>
+    </tr>
+  );
+}
 
 component FilterForm(form: FilterFormT) {
   return (

--- a/root/static/scripts/common/components/Relationship.js
+++ b/root/static/scripts/common/components/Relationship.js
@@ -25,7 +25,7 @@ type MakeEntityLinkT = (
   content: string,
   relationship: RelationshipT,
   allowNew: ?boolean,
-) => React$MixedElement;
+) => React.MixedElement;
 
 const makeDescriptiveLink = (
   entity: RelatableEntityT,

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -303,15 +303,15 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
   }
 
   createTagRows(): {
-    +genres: $ReadOnlyArray<React$MixedElement>,
-    +tags: $ReadOnlyArray<React$MixedElement>,
+    +genres: $ReadOnlyArray<React.MixedElement>,
+    +tags: $ReadOnlyArray<React.MixedElement>,
     } {
     const tags = this.state.tags;
 
     return tags.reduce((
       accum: {
-        +genres: Array<React$MixedElement>,
-        +tags: Array<React$MixedElement>,
+        +genres: Array<React.MixedElement>,
+        +tags: Array<React.MixedElement>,
       },
       t: UserTagT,
       index: number,
@@ -514,7 +514,7 @@ export const MainTagEditor = (hydrate<TagEditorProps>(
       this.setState({positiveTagsOnly: false});
     }
 
-    render(): React$MixedElement {
+    render(): React.MixedElement {
       const {tags, positiveTagsOnly} = this.state;
       const tagRows = this.createTagRows();
 
@@ -650,7 +650,7 @@ export const MainTagEditor = (hydrate<TagEditorProps>(
 export const SidebarTagEditor = (hydrate<TagEditorProps>(
   'div.sidebar-tags',
   class extends TagEditor {
-    render(): React$MixedElement {
+    render(): React.MixedElement {
       const tagRows = this.createTagRows();
       return (
         <>

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -77,27 +77,14 @@ function splitTags(tags: string) {
 
 type VoteT = 1 | 0 | -1;
 
-type GenericVoteButtonPropsT = {
+component VoteButton(
+  activeTitle: string | () => string,
   callback: (VoteT) => void,
   currentVote: VoteT,
-};
-
-type VoteButtonPropsT = {
-  ...GenericVoteButtonPropsT,
-  activeTitle: string | () => string,
   text: string,
   title: string | () => string,
   vote: VoteT,
-};
-
-const VoteButton = ({
-  activeTitle,
-  callback,
-  currentVote,
-  text,
-  title,
-  vote,
-}: VoteButtonPropsT): React.Element<'button'> => {
+ ) {
   const isActive = vote === currentVote;
   const className = 'tag-vote tag-' + VOTE_ACTIONS[vote];
   const buttonTitle = isActive
@@ -117,47 +104,45 @@ const VoteButton = ({
       {text}
     </button>
   );
-};
+}
 
-const UpvoteButton = ({
-  callback,
-  currentVote,
-}: GenericVoteButtonPropsT): React.Element<typeof VoteButton> => (
-  <VoteButton
-    activeTitle={lp('You’ve upvoted this tag', 'folksonomy')}
-    callback={callback}
-    currentVote={currentVote}
-    text="+"
-    title={l('Upvote')}
-    vote={1}
-  />
-);
+component UpvoteButton(
+  callback: (VoteT) => void,
+  currentVote: VoteT,
+) renders VoteButton {
+  return (
+    <VoteButton
+      activeTitle={lp('You’ve upvoted this tag', 'folksonomy')}
+      callback={callback}
+      currentVote={currentVote}
+      text="+"
+      title={l('Upvote')}
+      vote={1}
+    />
+  );
+}
 
-const DownvoteButton = ({
-  callback,
-  currentVote,
-}: GenericVoteButtonPropsT): React.Element<typeof VoteButton> => (
-  <VoteButton
-    activeTitle={lp('You’ve downvoted this tag', 'folksonomy')}
-    callback={callback}
-    currentVote={currentVote}
-    text={'\u2212'}
-    title={l('Downvote')}
-    vote={-1}
-  />
-);
+component DownvoteButton(
+  callback: (VoteT) => void,
+  currentVote: VoteT,
+) renders VoteButton {
+  return (
+    <VoteButton
+      activeTitle={lp('You’ve downvoted this tag', 'folksonomy')}
+      callback={callback}
+      currentVote={currentVote}
+      text={'\u2212'}
+      title={l('Downvote')}
+      vote={-1}
+    />
+  );
+}
 
-type VoteButtonsPropsT = {
+component VoteButtons(
   callback: (VoteT) => void,
   count: number,
   currentVote: VoteT,
-};
-
-const VoteButtons = ({
-  callback,
-  count,
-  currentVote,
-}: VoteButtonsPropsT): React.Element<'span'> => {
+) {
   const $c = React.useContext(SanitizedCatalystContext);
 
   let className = '';
@@ -178,32 +163,26 @@ const VoteButtons = ({
       <span className="tag-count">{count}</span>
     </span>
   );
-};
+}
 
-type TagRowPropsT = {
+component TagRow(
   callback: (VoteT) => void,
   count: number,
   currentVote: VoteT,
   index: number,
   tag: TagT,
-};
-
-const TagRow = ({
-  callback,
-  count,
-  currentVote,
-  index,
-  tag,
-}: TagRowPropsT): React.Element<'li'> => (
-  <li className={loopParity(index)} key={tag.name}>
-    <TagLink tag={tag.name} />
-    <VoteButtons
-      callback={callback}
-      count={count}
-      currentVote={currentVote}
-    />
-  </li>
-);
+) {
+  return (
+    <li className={loopParity(index)} key={tag.name}>
+      <TagLink tag={tag.name} />
+      <VoteButtons
+        callback={callback}
+        count={count}
+        currentVote={currentVote}
+      />
+    </li>
+  );
+}
 
 type TagEditorProps = {
   +aggregatedTags: $ReadOnlyArray<AggregatedTagT>,

--- a/root/static/scripts/common/components/WikipediaExtract.js
+++ b/root/static/scripts/common/components/WikipediaExtract.js
@@ -57,7 +57,7 @@ class WikipediaExtract extends React.Component<Props, State> {
     }
   }
 
-  render(): React$MixedElement | null {
+  render(): React.MixedElement | null {
     const {wikipediaExtract} = this.state;
     return wikipediaExtract ? (
       <>

--- a/root/static/scripts/common/hooks/usePagedMediumTable.js
+++ b/root/static/scripts/common/hooks/usePagedMediumTable.js
@@ -41,8 +41,8 @@ type TracksResponseT = {
 type PagedMediumTableVarsT = {
   +columnCount: number,
   +loadedTrackCount: number,
-  +mediumHeaderLink: React$MixedElement,
-  +pagingElements: React$MixedElement,
+  +mediumHeaderLink: React.MixedElement,
+  +pagingElements: React.MixedElement,
   +showArtists: boolean,
 };
 

--- a/root/static/scripts/common/i18n/expand2.js
+++ b/root/static/scripts/common/i18n/expand2.js
@@ -106,7 +106,7 @@ function mapVarSubstArgToScalar(
     return (
       <React.Fragment key={key}>
         {/* $FlowIgnore[unclear-type] We know this is a valid element */}
-        {((x: any): React$MixedElement)}
+        {((x: any): React.MixedElement)}
       </React.Fragment>
     );
   }

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -130,7 +130,7 @@ const parseVarSubst = createVarSubstParser<Output, Input>(
 );
 
 const parseLinkSubst: Parser<
-  React.Element<'a'> | string | NO_MATCH,
+  React.MixedElement | string | NO_MATCH,
   Input,
 > = saveMatch(function (args) {
   const name = accept(linkSubstStart);

--- a/root/static/scripts/common/utility/isolateText.js
+++ b/root/static/scripts/common/utility/isolateText.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-function isolateText(content: ?React.Node): React.Element<'bdi'> | string {
+function isolateText(content: ?React.Node): React.MixedElement | string {
   if (content != null && content !== '') {
     return <bdi>{content}</bdi>;
   }

--- a/root/static/scripts/edit/components/ArtistCreditBubble.js
+++ b/root/static/scripts/edit/components/ArtistCreditBubble.js
@@ -39,7 +39,7 @@ const Buttons = React.memo<ButtonsPropsT>(({
   initialBubbleFocus,
   initialFocusRef,
   isTrack,
-}: ButtonsPropsT): React$MixedElement => (
+}: ButtonsPropsT): React.MixedElement => (
   <div className="buttons">
     <button
       id="copy-ac"
@@ -108,7 +108,7 @@ const ArtistCreditPreview = (React.memo<ArtistCreditPreviewPropsT>(({
   editsPending,
   entity,
   names,
-}: ArtistCreditPreviewPropsT): React$MixedElement => {
+}: ArtistCreditPreviewPropsT): React.MixedElement => {
   const artistCredit = React.useMemo(() => ({
     ...artistCreditFromState(names),
     editsPending,

--- a/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
+++ b/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
@@ -206,7 +206,7 @@ component ExternalLinkAttributeDialog(...props: {
   };
 
   const buildPopoverChildren =
-    (closeAndReturnFocus: () => void): React.Element<'form'> => {
+    (closeAndReturnFocus: () => void): React.MixedElement => {
       return (
         <form
           className="external-link-attribute-dialog"

--- a/root/static/scripts/edit/components/Multiselect.js
+++ b/root/static/scripts/edit/components/Multiselect.js
@@ -171,7 +171,7 @@ export const MultiselectValue: MultiselectValueComponentT = React.memo(<
   buildExtraChildren,
   dispatch,
   state,
-}: MultiselectValuePropsT<V, VS>): React$MixedElement => {
+}: MultiselectValuePropsT<V, VS>): React.MixedElement => {
   const autocompleteDispatch = React.useCallback(
     (action: AutocompleteActionT<V>) => {
       dispatch({
@@ -223,7 +223,7 @@ const Multiselect = (React.memo(<
   buildExtraValueChildren,
   dispatch,
   state,
-}: MultiselectPropsT<V, VS, S>): React$MixedElement => {
+}: MultiselectPropsT<V, VS, S>): React.MixedElement => {
   const handleAdd = React.useCallback(() => {
     dispatch({type: 'add-value'});
   }, [dispatch]);

--- a/root/static/scripts/edit/components/edit/RelationshipDiff.js
+++ b/root/static/scripts/edit/components/edit/RelationshipDiff.js
@@ -42,7 +42,7 @@ type MakeEntityLinkT = (
   entity: RelatableEntityT,
   content: string,
   relationship: RelationshipT,
-) => React$MixedElement;
+) => React.MixedElement;
 
 const getTypeId = (x: LinkAttrT) => String(x.typeID);
 

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -970,7 +970,7 @@ export class _ExternalLinksEditor
     return Boolean(linkChanged || linkTypeChanged);
   }
 
-  render(): React.Element<'table'> {
+  render(): React.MixedElement {
     this.errorObservable(false);
 
     const linksArray = this.state.links;
@@ -1140,21 +1140,12 @@ export class _ExternalLinksEditor
   }
 }
 
-type LinkTypeSelectPropsT = {
-  +handleTypeBlur:
-    (SyntheticFocusEvent<HTMLSelectElement>) => void,
-  +handleTypeChange:
-    (SyntheticEvent<HTMLSelectElement>) => void,
-  +options: Array<LinkTypeOptionT>,
-  +type: number | null,
-};
-
-const LinkTypeSelect = ({
-  handleTypeBlur,
-  handleTypeChange,
-  options,
-  type,
-}: LinkTypeSelectPropsT): React.Element<'select'> => {
+component LinkTypeSelect(
+  handleTypeBlur: (SyntheticFocusEvent<HTMLSelectElement>) => void,
+  handleTypeChange: (SyntheticEvent<HTMLSelectElement>) => void,
+  options: Array<LinkTypeOptionT>,
+  type: number | null,
+) {
   const optionAvailable = options.some(option => option.value === type);
   // If the selected type is not available, display it as placeholder
   const linkType = type ? linkedEntities.link_type[type] : null;
@@ -1184,33 +1175,27 @@ const LinkTypeSelect = ({
       ))}
     </select>
   );
-};
+}
 
-type TypeDescriptionProps = {
-  +type: number | null,
-  +url: string,
-};
+component TypeDescription(type: number | null) renders HelpIcon {
+  const linkType = type ? linkedEntities.link_type[type] : null;
+  let typeDescription: Expand2ReactOutput = '';
 
-const TypeDescription =
-  (props: TypeDescriptionProps): React.Element<typeof HelpIcon> => {
-    const linkType = props.type ? linkedEntities.link_type[props.type] : null;
-    let typeDescription: Expand2ReactOutput = '';
+  if (linkType && linkType.description) {
+    typeDescription = exp.l('{description} ({url|more documentation})', {
+      description: expand2react(l_relationships(linkType.description)),
+      url: '/relationship/' + linkType.gid,
+    });
+  }
 
-    if (linkType && linkType.description) {
-      typeDescription = exp.l('{description} ({url|more documentation})', {
-        description: expand2react(l_relationships(linkType.description)),
-        url: '/relationship/' + linkType.gid,
-      });
-    }
-
-    return (
-      <HelpIcon
-        content={
-          <div style={{textAlign: 'left'}}>{typeDescription}</div>
-        }
-      />
-    );
-  };
+  return (
+    <HelpIcon
+      content={
+        <div style={{textAlign: 'left'}}>{typeDescription}</div>
+      }
+    />
+  );
+}
 
 type ExternalLinkRelationshipProps = {
   +creditableEntityProp: 'entity0_credit' | 'entity1_credit' | null,
@@ -1228,7 +1213,7 @@ type ExternalLinkRelationshipProps = {
 };
 
 const ExternalLinkRelationship =
-  (props: ExternalLinkRelationshipProps): React.Element<'tr'> => {
+  (props: ExternalLinkRelationshipProps): React.MixedElement => {
     const {
       creditableEntityProp,
       link,
@@ -1319,7 +1304,7 @@ const ExternalLinkRelationship =
                   )
               }
               {link.url && !link.error && !hasUrlError
-                ? <TypeDescription type={link.type} url={link.url} />
+                ? <TypeDescription type={link.type} />
                 : null}
               <RelationshipPendingEditsWarning relationship={link} />
               {hasDate ? (

--- a/root/static/scripts/edit/utility/linkPhrase.js
+++ b/root/static/scripts/edit/utility/linkPhrase.js
@@ -323,8 +323,8 @@ export const interpolate = (
   attributes: $ReadOnlyArray<LinkAttrT>,
   phraseProp: LinkPhraseProp,
   forGrouping?: boolean = false, // eslint-disable-line default-param-last
-  entity0?: React$MixedElement,
-  entity1?: React$MixedElement,
+  entity0?: React.MixedElement,
+  entity1?: React.MixedElement,
 ): Expand2ReactOutput | string => getPhraseAndExtraAttributes<
   Expand2ReactOutput,
   Expand2ReactInput,

--- a/root/static/scripts/relationship-editor/components/DialogAttributes.js
+++ b/root/static/scripts/relationship-editor/components/DialogAttributes.js
@@ -314,9 +314,9 @@ const wrapAttributeElement = (
     | DialogBooleanAttributeStateT
     | DialogMultiselectAttributeStateT
     | DialogTextAttributeStateT,
-  attributeElement: React$MixedElement,
+  attributeElement: React.MixedElement,
   isHelpVisible: boolean,
-): React$MixedElement => (
+): React.MixedElement => (
   <div
     className={
       'attribute-container ' +
@@ -377,12 +377,12 @@ component _DialogAttributes(
   }, [dispatch]);
 
   const attributesByControl: {
-    checkbox: Array<[DialogBooleanAttributeStateT, React$MixedElement]>,
+    checkbox: Array<[DialogBooleanAttributeStateT, React.MixedElement]>,
     multiselect: Array<[
       DialogMultiselectAttributeStateT,
-      React$MixedElement,
+      React.MixedElement,
     ]>,
-    text: Array<[DialogTextAttributeStateT, React$MixedElement]>,
+    text: Array<[DialogTextAttributeStateT, React.MixedElement]>,
   } = {
     checkbox: [],
     multiselect: [],

--- a/root/static/scripts/relationship-editor/components/RelationshipEditor.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipEditor.js
@@ -559,7 +559,7 @@ export const ErrorMessage:
   React.AbstractComponent<ErrorMessagePropsT, mixed> =
   React.memo<ErrorMessagePropsT>(({
     error,
-  }: ErrorMessagePropsT): React$MixedElement => (
+  }: ErrorMessagePropsT): React.MixedElement => (
     <div className="error">
       <strong className="error">
         {l('Oops, something went wrong!')}

--- a/root/static/scripts/relationship-editor/hooks/useRelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/hooks/useRelationshipDialogContent.js
@@ -63,7 +63,7 @@ export default function useRelationshipDialogContent(
 ): (
   closeAndReturnFocus: () => void,
   initialFocusRef: {current: HTMLElement | null},
-) => React$MixedElement {
+) => React.MixedElement {
   const {
     batchSelectionCount,
     dispatch,
@@ -146,7 +146,7 @@ export function useAddRelationshipDialogContent(
 ): (
   closeAndReturnFocus: () => void,
   initialFocusRef: {current: HTMLElement | null},
-) => React$MixedElement {
+) => React.MixedElement {
   const {
     backward,
     buildNewRelationshipData,

--- a/root/static/scripts/release/components/TrackRelationshipEditor.js
+++ b/root/static/scripts/release/components/TrackRelationshipEditor.js
@@ -97,7 +97,7 @@ component RelatedWorkHeading(
   dispatch: (ReleaseRelationshipEditorActionT) => void,
   isRemoved: boolean,
   isSelected: boolean,
-  removeWorkButton: React$MixedElement,
+  removeWorkButton: React.MixedElement,
   work: WorkT,
 ) {
   const selectWork = React.useCallback((
@@ -110,7 +110,7 @@ component RelatedWorkHeading(
     });
   }, [dispatch, work]);
 
-  let workLink: React$MixedElement = <WorkLink work={work} />;
+  let workLink: React.MixedElement = <WorkLink work={work} />;
   if (isRemoved) {
     workLink = (
       <span className="rel-remove">
@@ -138,7 +138,7 @@ component RelatedWorkHeading(
 component NewRelatedWorkHeading(
   dispatch: (ReleaseRelationshipEditorActionT) => void,
   isSelected: boolean,
-  removeWorkButton: React$MixedElement,
+  removeWorkButton: React.MixedElement,
   work: WorkT,
 ) {
   const selectWork = React.useCallback((

--- a/root/static/scripts/release/components/WorkLanguageMultiselect.js
+++ b/root/static/scripts/release/components/WorkLanguageMultiselect.js
@@ -138,7 +138,7 @@ const WorkLanguageMultiselect: React.AbstractComponent<
 >(({
   dispatch,
   state,
-}: WorkLanguageMultiselectPropsT): React$MixedElement => (
+}: WorkLanguageMultiselectPropsT): React.MixedElement => (
   <tr>
     <td className="section">
       {addColonText(l('Lyrics languages'))}

--- a/root/statistics/utilities.js
+++ b/root/statistics/utilities.js
@@ -34,7 +34,7 @@ export function formatCount($c: CatalystContextT, num: ?number): string {
 
 export const TimelineLink = ({
   statName,
-}: {statName: string}): React.Element<'a'> => (
+}: {statName: string}): React.MixedElement => (
   <a
     href={'/statistics/timeline/' + encodeURIComponent(statName)}
     title={l_statistics('See on timeline')}

--- a/root/types/i18n.js
+++ b/root/types/i18n.js
@@ -19,7 +19,7 @@ declare type AnchorProps = {
 
 declare type VarSubstScalarArg =
   | StrOrNum
-  | React$MixedElement;
+  | React.MixedElement;
 
 declare type VarSubstArg =
   | VarSubstScalarArg
@@ -29,7 +29,7 @@ declare type Expand2ReactInput = VarSubstArg | AnchorProps;
 
 declare type Expand2ReactScalarOutput =
   | string
-  | React$MixedElement;
+  | React.MixedElement;
 
 declare type Expand2ReactOutput =
   | Expand2ReactScalarOutput

--- a/root/utility/buildTab.js
+++ b/root/utility/buildTab.js
@@ -13,7 +13,7 @@ const buildTab = (
   path: string,
   tabPage: string,
   className?: string,
-): React.Element<'li'> => {
+): React.MixedElement => {
   const isSelected = tabPage === page;
   const passedClass = nonEmpty(className) ? className : null;
   const tabClass = isSelected && nonEmpty(passedClass)


### PR DESCRIPTION
https://github.com/facebook/flow/releases/tag/v0.245.0

`React.Element` is no longer allowed. When possible, I get rid of the need entirely by using components. When not, I change it to `React.MixedElement` which seems less specific but in reality apparently has the same effect.