### PR TITLE
Add a `createContainer` flag to `hydrate`

### DIFF
--- a/root/static/scripts/common/components/Annotation.js
+++ b/root/static/scripts/common/components/Annotation.js
@@ -113,32 +113,34 @@ component Annotation(
 export default (hydrate<React.PropsOf<Annotation>>(
   'div.annotation',
   Annotation,
-  function (props) {
-    const newProps: {...React.PropsOf<Annotation>} = {...props};
-    const entity = props.entity;
-    const annotation = props.annotation;
+  {
+    mungeProps(props) {
+      const newProps: {...React.PropsOf<Annotation>} = {...props};
+      const entity = props.entity;
+      const annotation = props.annotation;
 
-    // editor data is usually missing on mirror server
-    if (annotation && annotation.editor) {
-      const newAnnotation = {...annotation};
-      newAnnotation.editor = sanitizedEditor(annotation.editor);
-      newProps.annotation = newAnnotation;
-    }
+      // editor data is usually missing on mirror server
+      if (annotation && annotation.editor) {
+        const newAnnotation = {...annotation};
+        newAnnotation.editor = sanitizedEditor(annotation.editor);
+        newProps.annotation = newAnnotation;
+      }
 
-    const newEntity: {...MinimalAnnotatedEntityT} = {
-      entityType: entity.entityType,
-      gid: entity.gid,
-    };
+      const newEntity: {...MinimalAnnotatedEntityT} = {
+        entityType: entity.entityType,
+        gid: entity.gid,
+      };
 
-    const latestAnnotation = entity.latest_annotation;
-    if (latestAnnotation && latestAnnotation.editor) {
-      newEntity.latest_annotation = ({
-        ...latestAnnotation,
-        editor: sanitizedEditor(latestAnnotation.editor),
-      }: {...AnnotationT});
-    }
+      const latestAnnotation = entity.latest_annotation;
+      if (latestAnnotation && latestAnnotation.editor) {
+        newEntity.latest_annotation = ({
+          ...latestAnnotation,
+          editor: sanitizedEditor(latestAnnotation.editor),
+        }: {...AnnotationT});
+      }
 
-    newProps.entity = newEntity;
-    return newProps;
+      newProps.entity = newEntity;
+      return newProps;
+    },
   },
 ): React.AbstractComponent<React.PropsOf<Annotation>>);

--- a/root/static/scripts/common/components/CommonsImage.js
+++ b/root/static/scripts/common/components/CommonsImage.js
@@ -55,5 +55,5 @@ class CommonsImage extends React.Component<Props, State> {
 export default (hydrate<Props>(
   'div.commons-image',
   CommonsImage,
-  minimalEntity,
+  {mungeProps: minimalEntity},
 ): React.AbstractComponent<Props, void>);

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -644,7 +644,7 @@ export const MainTagEditor = (hydrate<TagEditorProps>(
       );
     }
   },
-  minimalEntity,
+  {mungeProps: minimalEntity},
 ): React.AbstractComponent<TagEditorProps, void>);
 
 export const SidebarTagEditor = (hydrate<TagEditorProps>(
@@ -702,7 +702,7 @@ export const SidebarTagEditor = (hydrate<TagEditorProps>(
       );
     }
   },
-  minimalEntity,
+  {mungeProps: minimalEntity},
 ): React.AbstractComponent<TagEditorProps, void>);
 
 function createInitialTagState(

--- a/root/static/scripts/common/components/WikipediaExtract.js
+++ b/root/static/scripts/common/components/WikipediaExtract.js
@@ -85,5 +85,5 @@ class WikipediaExtract extends React.Component<Props, State> {
 export default (hydrate<Props>(
   'div.wikipedia-extract',
   WikipediaExtract,
-  minimalEntity,
+  {mungeProps: minimalEntity},
 ): React.AbstractComponent<Props, void>);

--- a/root/utility/hydrate.js
+++ b/root/utility/hydrate.js
@@ -99,8 +99,10 @@ export default function hydrate<
 >(
   containerSelector: string,
   Component: React.AbstractComponent<Config | SanitizedConfig>,
-  mungeProps?: (Config) => SanitizedConfig,
-  createContainer?: boolean = true,
+  options?: {
+    +createContainer?: boolean,
+    +mungeProps?: (Config) => SanitizedConfig,
+  },
 ): React.AbstractComponent<Config, void> {
   const [ContainerTag, ...classes] = containerSelector.split('.');
   if (typeof document !== 'undefined') {
@@ -145,6 +147,8 @@ export default function hydrate<
       }
     });
   }
+  const mungeProps = options?.mungeProps;
+  const createContainer = (options?.createContainer) ?? true;
   return (props: Config) => {
     invariant(
       !Object.hasOwn(props, '$c'),

--- a/root/utility/hydrate.js
+++ b/root/utility/hydrate.js
@@ -100,6 +100,7 @@ export default function hydrate<
   containerSelector: string,
   Component: React.AbstractComponent<Config | SanitizedConfig>,
   mungeProps?: (Config) => SanitizedConfig,
+  createContainer?: boolean = true,
 ): React.AbstractComponent<Config, void> {
   const [ContainerTag, ...classes] = containerSelector.split('.');
   if (typeof document !== 'undefined') {
@@ -153,6 +154,7 @@ export default function hydrate<
     if (mungeProps) {
       sanitizedProps = mungeProps(props);
     }
+    const content = <Component {...props} />;
     return (
       <>
         <script
@@ -165,9 +167,11 @@ export default function hydrate<
           }}
           type="application/json"
         />
-        <ContainerTag className={classes.join(' ')}>
-          <Component {...props} />
-        </ContainerTag>
+        {createContainer ? (
+          <ContainerTag className={classes.join(' ')}>
+            {content}
+          </ContainerTag>
+        ) : content}
       </>
     );
   };

--- a/root/vars.js
+++ b/root/vars.js
@@ -31,8 +31,10 @@ declare var hydrate: (
   >(
     containerSelector: string,
     Component: React.AbstractComponent<Config | SanitizedConfig, mixed>,
-    mungeProps?: (Config) => SanitizedConfig,
-    createContainer?: boolean,
+    options?: {
+      +createContainer?: boolean,
+      +mungeProps?: (Config) => SanitizedConfig,
+    },
   ) => React.AbstractComponent<Config, void>
 );
 declare var hyphenateTitle: (title: string, subtitle: string) => string;

--- a/root/vars.js
+++ b/root/vars.js
@@ -32,6 +32,7 @@ declare var hydrate: (
     containerSelector: string,
     Component: React.AbstractComponent<Config | SanitizedConfig, mixed>,
     mungeProps?: (Config) => SanitizedConfig,
+    createContainer?: boolean,
   ) => React.AbstractComponent<Config, void>
 );
 declare var hyphenateTitle: (title: string, subtitle: string) => string;


### PR DESCRIPTION
In some cases you may want to specify that a container should not be created as the hydration root, but that the `containerSelector` already identifies a containing element *within the hydrated component*. This is useful where the component is already self-contained, and adding an additional wrapper may interfere with its display/styling.