### PR TITLE
MBS-13757: Support unchecking recordings to update

### DIFF
--- a/root/release/edit/recordings.tt
+++ b/root/release/edit/recordings.tt
@@ -89,12 +89,12 @@
             <td></td>
             <td colspan="5" class="checkbox">
               <label data-bind="if: titleDiffersFromRecording()">
-                <input class="update-recording-title" type="checkbox" data-bind="checked: updateRecordingTitle, disable: $root.copyTrackTitlesToRecordings" />
+                <input class="update-recording-title" type="checkbox" data-bind="checked: updateRecordingTitle" />
                 [% l('Update the recording title to match the track title.') %]
               </label>
               <br />
               <label data-bind="if: artistDiffersFromRecording()">
-                <input class="update-recording-artist" type="checkbox" data-bind="checked: updateRecordingArtist, disable: $root.copyTrackArtistsToRecordings" />
+                <input class="update-recording-artist" type="checkbox" data-bind="checked: updateRecordingArtist" />
                 [% l('Update the recording artist credit to match the track artist credit.') %]
               </label>
             </td>

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -518,8 +518,39 @@ const actions = {
     }
   },
 
-  copyTrackTitlesToRecordings: ko.observable(false),
-  copyTrackArtistsToRecordings: ko.observable(false),
+  copyTrackTitlesToRecordings: ko.computed({
+    read: () => {
+      const release = releaseEditor.rootField.release();
+      if (!release) {
+        return false;
+      }
+      const tracks = release.countTracks(Boolean);
+      const checked = release.countTracks((t) => t.updateRecordingTitle());
+      return tracks > 0 && checked === tracks;
+    },
+    write: (value) => {
+      for (const track of releaseEditor.rootField.release().allTracks()) {
+        track.updateRecordingTitle(value);
+      }
+    },
+  }),
+
+  copyTrackArtistsToRecordings: ko.computed({
+    read: () => {
+      const release = releaseEditor.rootField.release();
+      if (!release) {
+        return false;
+      }
+      const tracks = release.countTracks(Boolean);
+      const checked = release.countTracks((t) => t.updateRecordingArtist());
+      return tracks > 0 && checked === tracks;
+    },
+    write: (value) => {
+      for (const track of releaseEditor.rootField.release().allTracks()) {
+        track.updateRecordingArtist(value);
+      }
+    },
+  }),
 };
 
 Object.assign(releaseEditor, actions);

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -115,6 +115,21 @@ class Track {
       releaseEditor.copyTrackArtistsToRecordings(),
     );
 
+    /*
+     * When a "copy all" checkbox is unchecked, uncheck our corresponding
+     * checkbox if it isn't currently shown.
+     */
+    releaseEditor.copyTrackTitlesToRecordings.subscribe((checked) => {
+      if (!checked && !this.titleDiffersFromRecording()) {
+        this.updateRecordingTitle(false);
+      }
+    });
+    releaseEditor.copyTrackArtistsToRecordings.subscribe((checked) => {
+      if (!checked && !this.artistDiffersFromRecording()) {
+        this.updateRecordingArtist(false);
+      }
+    });
+
     this.recordingValue = ko.observable(
       new mbEntity.Recording({name: data.name}),
     );

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -115,13 +115,6 @@ class Track {
       releaseEditor.copyTrackArtistsToRecordings(),
     );
 
-    releaseEditor.copyTrackTitlesToRecordings.subscribe(
-      this.updateRecordingTitle,
-    );
-    releaseEditor.copyTrackArtistsToRecordings.subscribe(
-      this.updateRecordingArtist,
-    );
-
     this.recordingValue = ko.observable(
       new mbEntity.Recording({name: data.name}),
     );
@@ -1229,6 +1222,26 @@ class Release extends mbEntity.Release {
       }
       return result;
     }, []);
+  }
+
+  // Returns a generator for iterating over all tracks.
+  * allTracks() {
+    for (const medium of this.mediums()) {
+      for (const track of medium.tracks()) {
+        yield track;
+      }
+    }
+  }
+
+  // Returns the number of tracks for which trackFunc returns true.
+  countTracks(trackFunc) {
+    let count = 0;
+    for (const track of this.allTracks()) {
+      if (trackFunc(track)) {
+        count++;
+      }
+    }
+    return count;
   }
 
   existingMediumData() {


### PR DESCRIPTION
# MBS-13757

Update the release editor so that individual tracks' checkboxes to update recording titles or artists can be unchecked after the "copy all" checkboxes have been checked.

# Problem

Updating most (but not all) of the recording titles/artists on a release (common when fixing compilations) currently requires a bunch of clicking. There's no way to uncheck individual tracks after clicking one of the "copy all" checkboxes, so you need to individually click each of the tracks whose recordings should be updated. It's easy to make mistakes here since each track may have two checkboxes with similarly-worded text (for updating the title vs. artist).

# Solution

Stop disabling the per-track checkboxes when a "copy all" checkbox is checked, and make the "copy all" checkboxes use computed values so they can be updated in response to the per-track checkboxes.

The "copy all" checkboxes are automatically checked if all of the tracks are checked and unchecked otherwise. This code feels a bit strange to me since tracks have hidden state even when their checkboxes are hidden because they already match their recordings, but that was already the case before this change.

# Testing

Manually tested using my dev server.