### PR TITLE
MBS-13759: Add info about do-nots in add_cover_art

### DIFF
--- a/root/release/add_cover_art.tt
+++ b/root/release/add_cover_art.tt
@@ -163,6 +163,17 @@
 
     <div style="clear: left;"> </div>
 
+    <div>
+      <p>
+        [% l('Please make sure that you only upload images that match this specific release
+              (for example, ensure the images show the right barcode and catalog number
+              if appropriate). Additionally, do not upload fan-made or edited artwork;
+              this includes AI improvements and square versions of non-square art.
+              See the {cover_art_doc|documentation} for more details.',
+              {cover_art_doc => { href => doc_link('Cover_Art'), target => '_blank' } }) %]
+      </p>
+    </div>
+
     [%- INCLUDE 'forms/edit-note.tt' -%]
     [%- make_votable() -%]
     <div class="row no-label buttons">

--- a/root/release/add_cover_art.tt
+++ b/root/release/add_cover_art.tt
@@ -165,10 +165,10 @@
 
     <div>
       <p>
-        [% l('Please make sure that you only upload images that match this specific release
-              (for example, ensure the images show the right barcode and catalog number
-              if appropriate). Additionally, do not upload fan-made or edited artwork;
-              this includes AI improvements and square versions of non-square art.
+        [% l('Only upload images that match this specific release (for example, check
+              it shows the right barcode and catalog number). Do not upload fan-made,
+              edited or improved artwork; this includes AI improvements and square
+              versions of non-square art.
               See the {cover_art_doc|documentation} for more details.',
               {cover_art_doc => { href => doc_link('Cover_Art'), target => '_blank' } }) %]
       </p>


### PR DESCRIPTION
### Implement MBS-13759

# Problem
We are seeing plenty of issues with users carelessly uploading cover art to the wrong release, or uploading "improved" cover art (square versions of non-square covers, AI "improvements", removing "uglier" bits of the cover such as parental advisory marks, etc). Most of this is probably due to the fact that the page gives them no help, and most beginners are not going to find https://musicbrainz.org/doc/Cover_Art on their own.

# Solution
This presents users with some basic indication about what *not* to upload to the CAA, in hopes that they will actually avoid adding these sorts of images instead of them needing to be voted down.

# Testing
Manually, to ensure the string appears as expected.