### PR TITLE
MBS-13761: Reject Twitter id redirects instead of breaking them

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5815,16 +5815,36 @@ const CLEANUPS: CleanupEntries = {
         'https://twitter.com/',
       );
       url = url.replace(
-        /^(https:\/\/twitter\.com)\/intent\/user\/?\?screen_name=([^/?#]+)/,
-        '$1/$2',
+        /^https:\/\/twitter\.com\/intent\/user\/?\?screen_name=([^/?#]+)/,
+        'https://twitter.com/$1',
       );
+      if (/twitter\.com\/i\/user/i.test(url)) {
+        return url;
+      }
       url = url.replace(
-        /^(https:\/\/twitter\.com)\/@?([^/?#]+(?:\/status\/\d+)?)(?:[/?#].*)?$/,
-        '$1/$2',
+        /^https:\/\/twitter\.com\/@?([^/?#]+(?:\/status\/\d+)?)(?:[/?#].*)?$/,
+        'https://twitter.com/$1',
       );
       return url;
     },
     validate(url, id) {
+      if (/twitter\.com\/i\/user/i.test(url)) {
+        return {
+          error: exp.l(
+            `This is a redirect link. Please follow {redirect_url|your link}
+             and add the link it redirects to instead.`,
+            {
+              redirect_url: {
+                href: url,
+                rel: 'noopener noreferrer',
+                target: '_blank',
+              },
+            },
+          ),
+          result: false,
+          target: ERROR_TARGETS.URL,
+        };
+      }
       const m = /^https:\/\/twitter\.com\/([^/?#]+)(\/status\/\d+)?$/.exec(url);
       if (m) {
         const username = m[1];

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -6026,6 +6026,17 @@ limited_link_type_combinations: ['downloadpurchase', 'mailorder'],
        only_valid_entity_types: ['recording'],
   },
   {
+                     input_url: 'https://x.com/i/user/19373710',
+             input_entity_type: 'artist',
+    expected_relationship_type: undefined,
+       input_relationship_type: 'socialnetwork',
+       only_valid_entity_types: [],
+                expected_error: {
+                                  error: 'is a redirect link',
+                                  target: 'url',
+                                },
+  },
+  {
                      input_url: 'https://twitter.com/privacy',
              input_entity_type: 'artist',
     expected_relationship_type: undefined,


### PR DESCRIPTION
### Fix MBS-13761

# Problem
We are "cleaning up" links such as https://twitter.com/i/user/19373710 to `https://twitter.com/i` and then accepting them as a "username" but in reality these are redirects to a normal Twitter/X link.

# Solution
I blocked these redirects like we do for Spotify ones, where we request the editor to follow the link and provide the final one instead - the same error string is reused.

# Testing
Manually, plus I added a test case to `URLCleanup`.