### PR TITLE
MBS-13715: Pressing enter on track AC search dropdown should not move to the next track

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -542,6 +542,7 @@ component _Autocomplete2<T: EntityItemT>(...props: PropsT<T>) {
       case 'Tab': {
         if (isOpen && highlightedItem) {
           event.preventDefault();
+          event.stopPropagation();
           selectItem(highlightedItem);
         }
         break;

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -741,6 +741,7 @@ const seleniumTests = [
   {name: 'release-editor/MBS-13273.json5', login: true},
   {name: 'release-editor/MBS-13579.json5', login: true},
   {name: 'release-editor/MBS-13692.json5', login: true},
+  {name: 'release-editor/MBS-13715.json5', login: true},
   {
     name: 'Check_Duplicates.json5',
     login: true,

--- a/t/selenium/release-editor/MBS-13715.json5
+++ b/t/selenium/release-editor/MBS-13715.json5
@@ -1,0 +1,56 @@
+{
+  title: 'MBS-13715: Pressing enter on tracklist AC search dropdown should not move to the next track',
+  commands: [
+    {
+      command: 'open',
+      target: '/release/24d4159a-99d9-425d-a7b8-1b9ec0261a33/edit',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#tracklist']",
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=div.add-tracks button.add-item',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'id=open-ac-18674665',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=ac-18674665-artist-0',
+      value: 'nine',
+    },
+    {
+      command: 'pause',
+      target: '2000',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'id=ac-18674665-artist-0',
+      value: '${KEY_ENTER}',
+    },
+    {
+      command: 'assertEval',
+      target: 'document.getElementById("artist-credit-bubble").contains(document.getElementById("ac-18674665-artist-0"))',
+      value: 'true',
+    },
+    // Navigate back to the main page.
+    {
+      command: 'open',
+      target: '/',
+      value: '',
+    },
+    {
+      command: 'assertBeforeUnloadAlertWasShown',
+      target: '',
+      value: '',
+    },
+  ],
+}


### PR DESCRIPTION
# Problem

MBS-13715

# Solution

Stops propagation for the enter (and tab) keys on the artist input fields within the track AC bubble.

# Testing

Tested manually + added a Selenium test.