### PR TITLE
MBS-13777: Update RG selection when autocomplete is used

### DIFF
--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -270,6 +270,27 @@ releaseEditor.init = function (options) {
     () => this.loadDuplicateReleaseGroups(),
   ));
 
+  // When the release group changes, update the radio buttons.
+  debounceComputed(
+    utils.withRelease(r => r.releaseGroup()), 100,
+  ).subscribe((releaseGroup) => {
+    const gid = releaseGroup?.gid ?? '';
+    const idx = this.duplicateReleaseGroups().findIndex(
+      (rg) => rg.gid === gid,
+    );
+    const inputs = $('.duplicate-release-groups-list input[type="radio"]');
+    if (idx >= 0) {
+      // The chosen RG is listed, so check its input.
+      inputs.eq(idx).prop('checked', true);
+    } else if (gid === '') {
+      // No RG is chosen, so check "Add a new release group".
+      inputs.last().prop('checked', true);
+    } else {
+      // The chosen RG isn't listed, so uncheck the checked input.
+      inputs.filter(':checked').prop('checked', false);
+    }
+  });
+
   /*
    * Make sure the user actually wants to close the page/tab if they've made
    * any changes.


### PR DESCRIPTION
# MBS-13777

When a new release is being added, update the state of the "Existing release groups with similar names" radio buttons when the user selects a release group using the autocomplete field.

# Problem

#3359 added radio buttons listing potentially-duplicate release groups, but the radio buttons weren't updated if the user instead searched for and selected an existing release group using the autocomplete field. This could result in a confusing state where the autocomplete field would show one release group, while the radio button corresponding to a different release group or to "Add a new release group" would remain selected.

# Solution

Listen for changes to the chosen release group and update the radio buttons correspondingly:

* If the chosen RG is in the list, check the corresponding radio button.
* If the chosen RG isn't in the list, leave all radio buttons unchecked.
* If no RG is chosen, check the "Add a new release group" radio button.

# Testing

I manually tested this, but I had to manually hardcode the duplicate RG search results (I don't have a search server running, and I had CORS problems when trying to hack the code to send the query to `musicbrainz.org` -- jQuery's XHR code didn't seem to want to send unauthenticated requests). More help checking that this is working as intended would be appreciated. :-)