### PR TITLE
Temporarily disable image editing

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Art.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Art.pm
@@ -189,12 +189,22 @@ role {
         $c->stash->{filename} = $c->req->params->{key};
     };
 
+    method image_editing_unavailable => sub : Private {
+        my ($self, $c) = @_;
+        $c->stash(
+            current_view => 'Node',
+            component_path => 'main/ImageEditingUnavailable',
+        );
+    };
+
     method "add_${archive}_art" => sub :
         Chained('load')
         PathPart("add-$archive-art")
         Edit
     {
         my ($self, $c) = @_;
+
+        $c->detach('image_editing_unavailable');
 
         my $entity = $get_entity->($c);
         my $art_archive_model = $c->model($art_archive_model_name);
@@ -283,6 +293,8 @@ role {
     {
         my ($self, $c, $artwork_id) = @_;
 
+        $c->detach('image_editing_unavailable');
+
         my $entity = $get_entity->($c);
         my $art_archive_model = $c->model($art_archive_model_name);
         my $entity_type = $art_archive_model->art_archive_entity;
@@ -346,6 +358,8 @@ role {
     {
         my ($self, $c, $artwork_id) = @_;
 
+        $c->detach('image_editing_unavailable');
+
         my $entity = $get_entity->($c);
         my $art_archive_model = $c->model($art_archive_model_name);
         my $entity_type = $art_archive_model->art_archive_entity;
@@ -398,6 +412,8 @@ role {
         Edit
     {
         my ($self, $c) = @_;
+
+        $c->detach('image_editing_unavailable');
 
         my $entity = $get_entity->($c);
         my $art_archive_model = $c->model($art_archive_model_name);

--- a/root/main/ImageEditingUnavailable.js
+++ b/root/main/ImageEditingUnavailable.js
@@ -1,0 +1,29 @@
+/*
+ * @flow strict
+ * Copyright (C) 2024 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import ErrorLayout from './error/ErrorLayout.js';
+
+component ImageEditingUnavailable() {
+  return (
+    <ErrorLayout title="Image editing unavailable">
+      <p>
+        <strong>
+          {'Images currently cannot be edited while the Internet Archive ' +
+           'recovers from a DDoS attack. Follow their '}
+          <a href="https://mastodon.archive.org/@internetarchive">
+            {'Mastodon account'}
+          </a>
+          {' for the latest information.'}
+        </strong>
+      </p>
+    </ErrorLayout>
+  );
+}
+
+export default ImageEditingUnavailable;

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -163,6 +163,7 @@ export default {
   'label/LabelRelationships': (): Promise<mixed> => import('../label/LabelRelationships.js'),
   'label/SpecialPurpose': (): Promise<mixed> => import('../label/SpecialPurpose.js'),
   'main/ConfirmSeed': (): Promise<mixed> => import('../main/ConfirmSeed.js'),
+  'main/ImageEditingUnavailable': (): Promise<mixed> => import('../main/ImageEditingUnavailable.js'),
   'main/error/Error400': (): Promise<mixed> => import('../main/error/Error400.js'),
   'main/error/Error401': (): Promise<mixed> => import('../main/error/Error401.js'),
   'main/error/Error403': (): Promise<mixed> => import('../main/error/Error403.js'),

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -707,8 +707,11 @@ const seleniumTests = [
   {name: 'MBS-13615.json5', login: true},
   {name: 'Artist_Credit_Editor.json5', login: true},
   {name: 'Autocomplete2.json5'},
-  {name: 'CAA.json5', login: true},
-  {name: 'EAA.json5', login: true},
+  /*
+   * Image editing temporarily disabled
+   * {name: 'CAA.json5', login: true},
+   * {name: 'EAA.json5', login: true},
+   */
   {name: 'External_Links_Editor.json5', login: true},
   {name: 'Work_Editor.json5', login: true},
   {name: 'Redirect_Merged_Entities.json5', login: true},

--- a/t/tests.t
+++ b/t/tests.t
@@ -25,6 +25,9 @@ MusicBrainz::Server::Test->prepare_test_server;
 
 @classes = commandline_override('t::MusicBrainz::Server::', @classes);
 
+# Image editing temporarily disabled
+@classes = grep { $_ !~ /Art/ } @classes;
+
 plan tests => scalar(@classes);
 run_tests($_ => $_) for @classes;
 


### PR DESCRIPTION
# Problem

Users can still submit edits to images which cannot be properly reviewed.

I guess it will still be some time before Internet Archive services are fully restored. I expect read-only access to come first.

# Solution

Temporarily disable image editing while the IA works to restore their services. This just adds a temporary error page which shows the user a message explaining the reason.

# Testing

Loaded the relevant endpoints locally.