### PR TITLE
MBS-13719: Enable sending contact emails through new service

### DIFF
--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -167,6 +167,9 @@ sub WEB_SERVER                { 'www.musicbrainz.example.com' }
 
 # sub SMTP_SERVER { 'localhost' }
 
+# An instance of https://github.com/metabrainz/mb-mail-service.
+# sub MAIL_SERVICE_BASE_URL { 'http://localhost:3000' }
+
 # This value should be set to some secret value for your server.  Any old
 # string of stuff should do; something suitably long and random, like for
 # passwords.  However you MUST change it from the default

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -115,6 +115,9 @@ sub STATIC_RESOURCES_LOCATION { '//' . shift->WEB_SERVER . '/static/build' }
 
 sub SMTP_SERVER { 'localhost' }
 
+# An instance of https://github.com/metabrainz/mb-mail-service.
+sub MAIL_SERVICE_BASE_URL { 'http://localhost:3000' }
+
 # This value should be set to some secret value for your server.  Any old
 # string of stuff should do; something suitably long and random, like for
 # passwords.  However you MUST change it from the default

--- a/lib/MusicBrainz/Server/Email.pm
+++ b/lib/MusicBrainz/Server/Email.pm
@@ -38,6 +38,7 @@ has 'c' => (
 );
 
 Readonly our $url_prefix => 'https://' . DBDefs->WEB_SERVER_USED_IN_EMAIL;
+Readonly our $mail_service_base_url => DBDefs->MAIL_SERVICE_BASE_URL;
 
 sub _encode_header {
     my $header = shift;


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem

This is the start of enabling `mb-mail-service` incrementally, as a broken-down version of #3363. 
This adds the configuration option `MAIL_SERVICE_BASE_URL` in DBdefs, and replaces `send_message_to_editor` (aka `/user/<id>/contact`) with the new template.

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

This has been manually tested. 


# Documenting
<!--
    List changes to the documentation, which can be placed in the WikiDoc pages,
    in this Git repository, in another repository, in the database...
-->



# Further action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Ensure beta.musicbrainz.org is configured correctly before deploying
2. Once this has seen some success, enable more new templates
3. Write replacement tests for the new code
