### PR TITLE
MBS-13796: Clarify what tag cloud/list shows

### DIFF
--- a/root/tag/TagCloud.js
+++ b/root/tag/TagCloud.js
@@ -96,7 +96,8 @@ component TagCloud(
         <h1>{lp('Tags', 'folksonomy')}</h1>
         <p>
           {l(
-            'These are the most used genres and other tags in the database.',
+            `These are the most popular tags in MusicBrainz,
+             based on their total counts (upvotes minus downvotes).`,
           )}
           {' '}
           {showList ? (


### PR DESCRIPTION
### Implement MBS-13796

# Problem 
In the tag pages we indicate the number of tagged entities, but we didn't specify what the count here was, so it was kinda confusing to click through and see a different number than the one on this page.

# Solution
This now explains what exactly the counts here show. I dropped the specific mention of genres vs other tags since aerozol suggested it's clear enough from the page design.

# Testing
Manually, by just opening `/tags`.