### PR TITLE
MBS-13799: Resolve "TypeError: Object.hasOwn is not a function"

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -27,7 +27,7 @@ module.exports = function (api) {
 
   const presets = [
     ['@babel/preset-env', {
-      corejs: 3,
+      corejs: 3.38,
       targets: api.caller(caller => caller && caller.target === 'node')
         ? NODE_TARGETS
         : (process.env.MODERN_BROWSERS === '1'


### PR DESCRIPTION
# Problem

MBS-13799

# Solution

Per https://babel.dev/docs/babel-preset-env

"It is recommended to specify the minor version otherwise "3" will be interpreted as "3.0" which may not include polyfills for the latest features."

That would appear to be the case for `Object.hasOwn` at the very least, as specifying the corejs version causes its polyfill to be injected (in addition to other polyfills that weren't being included -- although `Object.hasOwn` is the only one which I see errors on Sentry for).

# Testing

I don't have access to a browser that doesn't support `Object.hasOwn` to begin with, but I compared the un-minified common-chunks.js output before and after this patch.