### PR TITLE
Remove useless API definitions

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/2/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Area.pm
@@ -23,12 +23,6 @@ my $ws_defs = Data::OptList::mkopt([
                          optional => [ qw(fmt limit offset) ],
      },
      area => {
-                         method   => 'GET',
-                         inc      => [ qw(aliases annotation
-                                          _relations tags user-tags genres user-genres ratings user-ratings) ],
-                         optional => [ qw(fmt limit offset) ],
-     },
-     area => {
                          action   => '/ws/2/area/lookup',
                          method   => 'GET',
                          inc      => [ qw(aliases annotation

--- a/lib/MusicBrainz/Server/Controller/WS/2/Instrument.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Instrument.pm
@@ -21,11 +21,7 @@ my $ws_defs = Data::OptList::mkopt([
         optional => [ qw(fmt limit offset) ],
      },
     instrument => {
-        method   => 'GET',
-        inc      => [ qw(aliases annotation _relations tags user-tags genres user-genres) ],
-        optional => [ qw(fmt limit offset) ],
-    },
-    instrument => {
+        action   => '/ws/2/instrument/lookup',
         method   => 'GET',
         inc      => [ qw(aliases annotation _relations tags user-tags genres user-genres) ],
         optional => [ qw(fmt) ],


### PR DESCRIPTION
# Description
This removes two definitions that were neither browse nor lookup, but a seemingly useless mix of the two we do not actually use. It also adds the lookup `action` to instrument, which was missing it.