### PR TITLE
Add needed file for the funding.json system to know that it can speak

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://metabrainz.org/funding.json


### PR DESCRIPTION
Related to https://github.com/metabrainz/metabrainz.org/pull/487 -- we need to have an indication in our repo to give permission for metabrainz.org/funding.json to speak for MB.