### PR TITLE
MBS-13564: Correctly override primary on alias locale change

### DIFF
--- a/lib/MusicBrainz/Server/Data/Alias.pm
+++ b/lib/MusicBrainz/Server/Data/Alias.pm
@@ -285,12 +285,19 @@ sub update
 
     # Clear existing primary for locale flag for the chosen locale
     # if we are overriding them (the user chose this as primary)
-    if ($row{primary_for_locale}) {
-        # We need to load the alias because %row only contains changed values
+    # We need to check if either primary or the locale changed
+    # and then load the alias because %row only contains changed values
+    if ($row{primary_for_locale} || $row{locale}) {
         my $alias = $self->get_by_id($alias_id);
         my $locale = $row{locale} // $alias->{locale};
+        my $primary_for_locale = $row{primary_for_locale} // $alias->{primary_for_locale};
         my $entity_id = $alias->{$type . '_id'};
-        $self->clear_primary_for_locale($locale, $entity_id);
+        # Whether we just set primary or it was already set and we
+        # are keeping it while changing the locale, we need to clear
+        # the existing primary
+        if ($primary_for_locale) {
+            $self->clear_primary_for_locale($locale, $entity_id);
+        }
     }
 
     add_partial_date_to_row(\%row, $alias_hash->{begin_date}, 'begin_date')

--- a/t/lib/t/MusicBrainz/Server/Data/Alias.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Alias.pm
@@ -21,6 +21,17 @@ BEGIN {
 
 with 't::Context';
 
+=head1 DESCRIPTION
+
+This test checks alias loading, alias editing (inserting, updating and
+removing, including changing primary aliases) and the effects of
+merging entities with aliases.
+
+It also checks that instrument alias editing invalidates the attribute
+caches.
+
+=cut
+
 sub verify_artist_alias {
     my ($alias, $name, $sort_name, $id, $locale, $primary_for_locale, $message) = @_;
     ok(
@@ -44,34 +55,80 @@ sub verify_artist_alias {
     );
 }
 
-test all => sub {
+test 'The right roles are set' => sub {
+    my $test = shift;
 
+    my $artist_data = MusicBrainz::Server::Data::Artist->new(c => $test->c);
+
+    does_ok(
+        $artist_data,
+        'MusicBrainz::Server::Data::Role::Alias',
+        'Artists support aliases',
+    );
+
+    my $label_data = MusicBrainz::Server::Data::Label->new(c => $test->c);
+    does_ok(
+        $label_data,
+        'MusicBrainz::Server::Data::Role::Alias',
+        'Labels support aliases',
+    );
+
+    my $work_data = MusicBrainz::Server::Data::Work->new(c => $test->c);
+    does_ok(
+        $work_data,
+        'MusicBrainz::Server::Data::Role::Alias',
+        'Works support aliases',
+    );
+
+    does_ok(
+        $artist_data->alias,
+        'MusicBrainz::Server::Data::Role::PendingEdits',
+        'Aliases can have pending edits',
+    );
+};
+
+test 'Loading aliases and alias artists' => sub {
     my $test = shift;
 
     MusicBrainz::Server::Test->prepare_test_database($test->c, '+artistalias');
 
-    $test->c->sql->begin;
-
-    # Artist data should do the alias role
     my $artist_data = MusicBrainz::Server::Data::Artist->new(c => $test->c);
-    does_ok($artist_data, 'MusicBrainz::Server::Data::Role::Alias');
-    does_ok($artist_data->alias, 'MusicBrainz::Server::Data::Role::PendingEdits');
 
-    # Make sure we can load specific aliases
+    note('We use get_by_id to load the alias with id 1');
     my $alias = $artist_data->alias->get_by_id(1);
-    ok(defined $alias, 'returns an object');
-    isa_ok($alias, 'MusicBrainz::Server::Entity::ArtistAlias', 'not an artist alias');
+    ok(defined $alias, 'An object is loaded');
+    isa_ok(
+        $alias,
+        'MusicBrainz::Server::Entity::ArtistAlias',
+        'The loaded object',
+    );
     verify_artist_alias($alias, 'Alias 1', 'Alias 1', 1, undef, 0);
 
-    # Loading the artist from an alias
+    note('We use artist_data->load to load the artist for the alias');
     $artist_data->load($alias);
-    ok(defined $alias->artist, q(didn't load artist));
-    isa_ok($alias->artist, 'MusicBrainz::Server::Entity::Artist', 'not an artist object');
-    is($alias->artist->id, $alias->artist_id, 'loaded artist id');
+    ok(defined $alias->artist, 'An artist object is loaded');
+    isa_ok(
+        $alias->artist,
+        'MusicBrainz::Server::Entity::Artist',
+        'The loaded object',
+    );
+    is(
+        $alias->artist->id,
+        $alias->artist_id,
+        'The loaded artist id matches the expected one',
+    );
+};
 
-    # Find all aliases for an artist
+test 'Finding aliases for an artist ID' => sub {
+    my $test = shift;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+artistalias');
+
+    my $artist_data = MusicBrainz::Server::Data::Artist->new(c => $test->c);
+
+    note('We use find_by_entity_id to load the aliases for an artist with some');
     my $alias_set = $artist_data->alias->find_by_entity_id(1);
-    is(scalar @$alias_set, 2, 'Expected number of aliases');
+    is(scalar @$alias_set, 2, 'We get the expected number of aliases back');
     verify_artist_alias(
         $alias_set->[0],
         'Alias 2', 'Alias 2', 1, 'en_GB', 0,
@@ -83,135 +140,223 @@ test all => sub {
         'The alias without a locale sorts last and has the expected data',
     );
 
-    # Attempt finding aliases for an artist with no aliases
+    note('We use find_by_entity_id to load the aliases for an artist with none');
     $alias_set = $artist_data->alias->find_by_entity_id(2);
-    is(scalar @$alias_set, 0, 'Expected lack of aliases found');
+    is(scalar @$alias_set, 0, 'We get no aliases back');
+};
 
-    # Make sure we can check if an entity has aliases for a given locale
-    ok($artist_data->alias->has_locale(1, 'en_GB'), 'artist #1 has en_GB locale');
+test 'Test has_locale' => sub {
+    my $test = shift;
 
-    # Test merging aliases together
-    $artist_data->alias->merge(1, 2);
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+artistalias');
 
-    $alias_set = $artist_data->alias->find_by_entity_id(1);
-    is(scalar @$alias_set, 3, 'Expected number of aliases');
-    is($alias_set->[0]->name, 'Alias 2', 'Original alias #1');
-    is($alias_set->[1]->name, 'Alias 1', 'Original alias #2');
-    is($alias_set->[2]->name, 'Empty Artist', 'has the old artist as an alias');
+    my $artist_data = MusicBrainz::Server::Data::Artist->new(c => $test->c);
 
-    $alias_set = $artist_data->alias->find_by_entity_id(2);
-    is(scalar @$alias_set, 0, 'Merged artist has no aliases');
-
-    # Test merging aliases with identical names
-    $artist_data->alias->merge(1, 3);
-
-    $alias_set = $artist_data->alias->find_by_entity_id(1);
-    is(scalar @$alias_set, 4, 'Expected number of aliases');
-    verify_artist_alias($alias_set->[0], 'Alias 2', 'Alias 2', 1, 'en_GB', 0);
-    verify_artist_alias($alias_set->[1], 'Alias 1', 'Alias 1', 1, undef, 0);
-    verify_artist_alias($alias_set->[2], 'Alias 2', 'Alias 2', 1, undef, 0);
-    verify_artist_alias(
-        $alias_set->[3],
-        'Empty Artist', 'Empty Artist', 1, undef, 0,
+    ok(
+        $artist_data->alias->has_locale(1, 'en_GB'),
+        'Artist 1 has an alias with en_GB locale',
     );
+    ok(
+        !$artist_data->alias->has_locale(2, 'en_GB'),
+        'Artist 2 has no alias with en_GB locale',
+    );
+};
 
-    $alias_set = $artist_data->alias->find_by_entity_id(3);
-    is(scalar @$alias_set, 0, 'Merged artist has no aliases');
+test 'Test delete_entities' => sub {
+    my $test = shift;
 
-    # Test deleting aliases
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+artistalias');
+
+    my $artist_data = MusicBrainz::Server::Data::Artist->new(c => $test->c);
+
+    my $alias_set = $artist_data->alias->find_by_entity_id(1);
+    is(scalar @$alias_set, 2, 'Artist 1 has two aliases');
+
+    note('We use delete_entities on Artist 1');
     $artist_data->alias->delete_entities(1);
-    $alias_set = $artist_data->alias->find_by_entity_id(1);
-    is(scalar @$alias_set, 0, 'Artist #1 now has no aliases');
 
-    # Test inserting new aliases
-    my $alias2 = $artist_data->alias->insert({
-                                 artist_id => 1,
+    $alias_set = $artist_data->alias->find_by_entity_id(1);
+    is(scalar @$alias_set, 0, 'Artist 1 now has no aliases');
+};
+
+
+test 'Adding and updating aliases, with primary for locale updates' => sub {
+
+    my $test = shift;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+artistalias');
+
+    $test->c->sql->begin;
+
+    my $artist_data = MusicBrainz::Server::Data::Artist->new(c => $test->c);
+
+    note('We try inserting a new, primary alias');
+    my $alias = $artist_data->alias->insert({
+                                 artist_id => 2,
                                  name => 'New alias',
                                  sort_name => 'New sort name',
                                  locale => 'en_AU',
                                  primary_for_locale => 1,
                                  ended => 0,
                                 });
-    my $alias2_id = $alias2->{id};
-    $alias_set = $artist_data->alias->find_by_entity_id(1);
-    is(scalar @$alias_set, 1, 'Artist #1 has a single newly inserted alias');
+    my $alias_id = $alias->{id};
+    my $alias_set = $artist_data->alias->find_by_entity_id(2);
+    is(
+        scalar @$alias_set,
+        1,
+        'The artist has a single, newly inserted alias',
+    );
     verify_artist_alias(
         $alias_set->[0],
-        'New alias', 'New sort name', 1, 'en_AU', 1,
+        'New alias', 'New sort name', 2, 'en_AU', 1,
+        'The alias data matches the inserted data',
     );
 
-    # Test overriding primary for locale on insert
-    my $alias3 = $artist_data->alias->insert({
-                                 artist_id => 1,
+    note('We try inserting another primary alias for the same locale');
+    my $alias2 = $artist_data->alias->insert({
+                                 artist_id => 2,
                                  name => 'Newer alias',
                                  sort_name => 'Newer sort name',
                                  locale => 'en_AU',
                                  primary_for_locale => 1,
                                  ended => 0,
                                 });
-    my $alias3_id = $alias3->{id};
-    $alias_set = $artist_data->alias->find_by_entity_id(1);
-    is(scalar @$alias_set, 2, 'Artist #1 has a second newly inserted alias');
+    my $alias2_id = $alias2->{id};
+    $alias_set = $artist_data->alias->find_by_entity_id(2);
+    is(scalar @$alias_set, 2, 'The artist has two aliases');
     verify_artist_alias(
         $alias_set->[0],
-        'Newer alias', 'Newer sort name', 1, 'en_AU', 1,
-        'The new (primary) alias is the newly inserted alias and has the expected data',
+        'Newer alias', 'Newer sort name', 2, 'en_AU', 1,
+        'The new primary alias is the newly inserted alias and has the expected data',
     );
-    is(
-        $alias_set->[1]->primary_for_locale,
-        0,
-        'Other (old) alias is no longer primary_for_locale',
+    verify_artist_alias(
+        $alias_set->[1],
+        'New alias', 'New sort name', 2, 'en_AU', 0,
+        'The old alias is still present, but is no longer marked as the primary',
     );
 
-    # Test overriding primary for locale on update
-    $artist_data->alias->update($alias2_id, {primary_for_locale => 1});
-    $alias_set = $artist_data->alias->find_by_entity_id(1);
-    is(scalar @$alias_set, 2, 'Artist #1 still has two aliases');
-    is($alias_set->[1]->primary_for_locale,
-       0,
-       'new alias is no longer primary_for_locale');
-    is($alias_set->[0]->primary_for_locale,
-       1,
-       'old alias is again primary_for_locale');
+    note('We try updating the original alias to set it as primary again');
+    $artist_data->alias->update($alias_id, {primary_for_locale => 1});
+    $alias_set = $artist_data->alias->find_by_entity_id(2);
+    is(scalar @$alias_set, 2, 'The artist still has two aliases');
+    verify_artist_alias(
+        $alias_set->[0],
+        'New alias', 'New sort name', 2, 'en_AU', 1,
+        'The old alias is still present, and marked as the primary again',
+    );
+    verify_artist_alias(
+        $alias_set->[1],
+        'Newer alias', 'Newer sort name', 2, 'en_AU', 0,
+        'The newer alias is still present, but is no longer marked as the primary',
+    );
 
-    # Test overriding primary for locale on locale change of alias set as primary (MBS-13564)
-    my $alias4 = $artist_data->alias->insert({
-                                 artist_id => 1,
+    note('We add a third alias, primary for a different locale');
+    my $alias3 = $artist_data->alias->insert({
+                                 artist_id => 2,
                                  name => 'New US alias',
                                  sort_name => 'New US sort name',
                                  locale => 'en_US',
                                  primary_for_locale => 1,
                                  ended => 0,
                                 });
-    my $alias4_id = $alias4->{id};
-    $alias_set = $artist_data->alias->find_by_entity_id(1);
-    is(scalar @$alias_set, 3, 'Artist #1 now has three aliases');
+    my $alias3_id = $alias3->{id};
+    $alias_set = $artist_data->alias->find_by_entity_id(2);
+    is(scalar @$alias_set, 3, 'The artist now has three aliases');
 
-    $artist_data->alias->update($alias4_id, {locale => 'en_AU'});
-    $alias_set = $artist_data->alias->find_by_entity_id(1);
-    is(scalar @$alias_set, 3, 'Artist #1 still has three aliases');
+    note('We try updating the new alias to have the same locale as the rest');
+    $artist_data->alias->update($alias3_id, {locale => 'en_AU'});
+    $alias_set = $artist_data->alias->find_by_entity_id(2);
+    is(scalar @$alias_set, 3, 'The artist still has three aliases');
+    my $updated_alias2 = first { $_->id == $alias2_id } @$alias_set;
     my $updated_alias3 = first { $_->id == $alias3_id } @$alias_set;
-    my $updated_alias4 = first { $_->id == $alias4_id } @$alias_set;
     verify_artist_alias(
-        $updated_alias3,
-        'Newer alias', 'Newer sort name', 1, 'en_AU', 0,
+        $updated_alias2,
+        'Newer alias', 'Newer sort name', 2, 'en_AU', 0,
         'The previous primary alias is no longer marked as primary',
     );
     verify_artist_alias(
-        $updated_alias4,
-        'New US alias', 'New US sort name', 1, 'en_AU', 1,
+        $updated_alias3,
+        'New US alias', 'New US sort name', 2, 'en_AU', 1,
         'The changed alias has the updated locale and is marked as primary',
     );
 
     $test->c->sql->commit;
+};
 
-    # Make sure other data types support aliases
-    my $label_data = MusicBrainz::Server::Data::Label->new(c => $test->c);
-    does_ok($label_data, 'MusicBrainz::Server::Data::Role::Alias');
+test 'Merging artists correctly merges their aliases' => sub {
+    my $test = shift;
 
-    my $work_data = MusicBrainz::Server::Data::Work->new(c => $test->c);
-    does_ok($work_data, 'MusicBrainz::Server::Data::Role::Alias');
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+artistalias');
 
+    my $artist_data = MusicBrainz::Server::Data::Artist->new(c => $test->c);
+
+    my $alias_set = $artist_data->alias->find_by_entity_id(1);
+    is(scalar @$alias_set, 2, 'Artist 1 has two aliases');
+
+    $alias_set = $artist_data->alias->find_by_entity_id(2);
+    is(scalar @$alias_set, 0, 'Artist 2 has no aliases');
+
+    note('We merge artist 2 into artist 1');
+    $artist_data->alias->merge(1, 2);
+
+    my $alias_set = $artist_data->alias->find_by_entity_id(1);
+    is(scalar @$alias_set, 3, 'The merged artist has 3 aliases');
+    verify_artist_alias(
+        $alias_set->[0],
+        'Alias 2', 'Alias 2', 1, 'en_GB', 0,
+        'The old alias with a locale has been kept and still sorts first',
+    );
+    verify_artist_alias(
+        $alias_set->[1],
+        'Alias 1', 'Alias 1', 1, undef, 0,
+        'The old alias without a locale has been kept',
+    );
+    verify_artist_alias(
+        $alias_set->[2],
+        'Empty Artist', 'Empty Artist', 1, undef, 0,
+        'The artist name of artist 2 has been added as an alias',
+    );
+};
+
+test 'Merging artist aliases works even if aliases have the same name' => sub {
+    my $test = shift;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+artistalias');
+
+    my $artist_data = MusicBrainz::Server::Data::Artist->new(c => $test->c);
+
+    my $alias_set = $artist_data->alias->find_by_entity_id(1);
+    is(scalar @$alias_set, 2, 'Artist 1 has two aliases');
+
+    $alias_set = $artist_data->alias->find_by_entity_id(3);
+    is(scalar @$alias_set, 1, 'Artist 3 has one alias');
+
+    note('We merge artist 2 into artist 1');
+    $artist_data->alias->merge(1, 3);
+
+    $alias_set = $artist_data->alias->find_by_entity_id(1);
+    is(scalar @$alias_set, 3, 'Expected number of aliases');
+    verify_artist_alias(
+        $alias_set->[0], 'Alias 2', 'Alias 2', 1, 'en_GB', 0,
+        'The old alias with a locale has been kept and still sorts first',
+    );
+    verify_artist_alias(
+        $alias_set->[1],
+        'Alias 1', 'Alias 1', 1, undef, 0,
+        'The old alias without a locale has been kept',
+    );
+    verify_artist_alias(
+        $alias_set->[2],
+        'Alias 2', 'Alias 2', 1, undef, 0,
+        'The artist 3 alias with the same name as the locale alias, but without a locale, has been kept and sorts last',
+    );
+
+    $alias_set = $artist_data->alias->find_by_entity_id(3);
+    is(
+        scalar @$alias_set,
+        0,
+        'The merged artist has no aliases anymore',
+    );
 };
 
 test 'Merging should not add aliases identical to new name' => sub {
@@ -225,12 +370,20 @@ test 'Merging should not add aliases identical to new name' => sub {
                    (3, '686cdcc0-7218-11de-8a39-0800200c9a66', 'Old name', 'Old name', '');
         SQL
 
+    note('We merge two artists into a third, but one has the same name as the destination');
     $c->model('Artist')->alias->merge(1, 2, 3);
 
     my $aliases = $c->model('Artist')->alias->find_by_entity_id(1);
-    is(@$aliases, 1, 'has one alias');
-    is($aliases->[0]->name, 'Old name', 'has old name alias');
-    ok(!(grep { $_->name eq 'Name' } @$aliases), 'does not have new name alias');
+    is(@$aliases, 1, 'The artist has one alias');
+    is(
+        $aliases->[0]->name,
+        'Old name',
+        'It is the one not matching its name',
+    );
+    ok(
+        !(grep { $_->name eq 'Name' } @$aliases),
+        'It has no alias matching its name',
+    );
 };
 
 test 'Merging should not add aliases that already exist' => sub {
@@ -244,12 +397,12 @@ test 'Merging should not add aliases that already exist' => sub {
         INSERT INTO artist_alias (artist, name, sort_name) VALUES (1, 'Old name', 'Old name');
         SQL
 
+    note('We merge an artist into another that already has an alias of the same name');
     $c->model('Artist')->alias->merge(1, 2);
 
     my $aliases = $c->model('Artist')->alias->find_by_entity_id(1);
-    is(@$aliases, 1, 'has one alias');
-    is($aliases->[0]->name, 'Old name', 'has old name alias',);
-    ok(!(grep { $_->name eq 'Name' } @$aliases), 'does not have new name alias');
+    is(@$aliases, 1, 'The artist still has one alias');
+    is($aliases->[0]->name, 'Old name', 'It is the expected alias');
 };
 
 test 'Merging should preserve primary_for_locale' => sub {
@@ -265,21 +418,21 @@ test 'Merging should preserve primary_for_locale' => sub {
                    (2, 'Foo name', 'Foo name', 'en_GB', TRUE);
         SQL
 
+    note('We merge an artist with a primary alias into one with a non-primary one');
     $c->model('Artist')->alias->merge(1, 2);
     my $aliases = $c->model('Artist')->alias->find_by_entity_id(1);
 
-    is(@$aliases, 2, 'has two aliases');
+    is(@$aliases, 2, 'The merged artist has two aliases');
 
     my @should_be_primary = grep { $_->name eq 'Foo name' } @$aliases;
-    is(@should_be_primary, 1, 'has one "Foo name" alias');
-    ok(@should_be_primary, 'has "Foo name" alias');
-    ok($should_be_primary[0]->primary_for_locale, 'is primary');
-    is($should_be_primary[0]->locale, 'en_GB', 'has appropriate locale');
+    is(@should_be_primary, 1, 'The merged alias is there');
+    ok($should_be_primary[0]->primary_for_locale, 'Is still primary');
+    is($should_be_primary[0]->locale, 'en_GB', 'Has the appropriate locale');
 
     my @should_be_old = grep { $_->name eq 'Old name' } @$aliases;
-    is(@should_be_old, 1, 'has an "Old name" alias');
-    ok(!$should_be_old[0]->primary_for_locale, 'is not primary');
-    is($should_be_old[0]->locale, 'en_GB', 'has appropriate locale');
+    is(@should_be_old, 1, 'The old alias is there');
+    ok(!$should_be_old[0]->primary_for_locale, 'Is still not primary');
+    is($should_be_old[0]->locale, 'en_GB', 'Has the appropriate locale');
 };
 
 test 'Multiple aliases with a locale are preserved on merge' => sub {
@@ -298,23 +451,22 @@ test 'Multiple aliases with a locale are preserved on merge' => sub {
     $c->model('Artist')->alias->merge(1, 2);
     my $aliases = $c->model('Artist')->alias->find_by_entity_id(1);
 
-    is(@$aliases, 3, 'has three aliases (old, foo, extra)');
+    is(@$aliases, 3, 'The artist has three aliases (old, foo, extra)');
 
     my @should_be_primary = grep { $_->name eq 'Foo name' } @$aliases;
-    is(@should_be_primary, 1, 'has one "Foo name" alias');
-    ok(@should_be_primary, 'has "Foo name" alias');
-    ok($should_be_primary[0]->primary_for_locale, 'is primary');
-    is($should_be_primary[0]->locale, 'en_GB', 'has appropriate locale');
+    is(@should_be_primary, 1, 'There is one "Foo name" alias');
+    ok($should_be_primary[0]->primary_for_locale, 'Is primary');
+    is($should_be_primary[0]->locale, 'en_GB', 'Has the appropriate locale');
 
     my @should_be_old = grep { $_->name eq 'Old name' } @$aliases;
-    is(@should_be_old, 1, 'has an "Old name" alias');
-    ok(!$should_be_old[0]->primary_for_locale, 'is not primary');
-    is($should_be_old[0]->locale, undef, 'has appropriate locale');
+    is(@should_be_old, 1, 'There is one "Old name" alias');
+    ok(!$should_be_old[0]->primary_for_locale, 'Is not primary');
+    is($should_be_old[0]->locale, undef, 'Has the appropriate locale');
 
     my @should_be_extra = grep { $_->name eq 'Extra name' } @$aliases;
-    is(@should_be_extra, 1, 'has an "Extra name" alias');
-    ok(!$should_be_extra[0]->primary_for_locale, 'is not primary');
-    is($should_be_extra[0]->locale, 'en_GB', 'has appropriate locale');
+    is(@should_be_extra, 1, 'There is one "Extra name" alias');
+    ok(!$should_be_extra[0]->primary_for_locale, 'Is not primary');
+    is($should_be_extra[0]->locale, 'en_GB', 'Has the appropriate locale');
 };
 
 test 'Exists only checks a single entity' => sub {


### PR DESCRIPTION
### Fix MBS-13564

# Problem
Attempting to change the locale of an alias marked as primary to one which already has a primary alias crashes with an ISE.

# Solution
I noticed the issue is that we were not clearing the previous primary value first for this case, since we were only looking for a changed `primary_for_locale`. In this case the `locale` changes, not the `primary_for_locale` flag. This change ensures `primary_for_locale` is cleared upon either `primary_for_locale` or `locale` changes if `primary_for_locale` is being set or if it was already set and was not overriden by the row changes.

# Testing
Manually, plus I added a test to Data::Alias. I'm also making Data::Alias less of a mess in a subsequent commit.