### PR TITLE
Use a standard head1 DESCRIPTION for tests

### DIFF
--- a/t/author/eol.t
+++ b/t/author/eol.t
@@ -9,7 +9,7 @@ plan skip_all => 'Test::EOL required' if $EVAL_ERROR;
 use FindBin '$Bin';
 use File::Find;
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether Perl and TT files have lines that end
 with Windows EOL characters rather than Unix ones.

--- a/t/author/notabs.t
+++ b/t/author/notabs.t
@@ -9,7 +9,7 @@ plan skip_all => 'Test::NoTabs required' if $EVAL_ERROR;
 use FindBin '$Bin';
 use File::Find;
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether Perl and TT files use tabs
 when they should use multiple spaces instead.

--- a/t/hydration_i18n.t
+++ b/t/hydration_i18n.t
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Data::Utils qw( contains_string );
 use String::ShellQuote qw( shell_quote );
 use Test::More;
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks that any components using hydration exist under
 root/static/scripts/.  It also checks that any imported files that use

--- a/t/lib/t/MusicBrainz/DataStore/Redis.pm
+++ b/t/lib/t/MusicBrainz/DataStore/Redis.pm
@@ -14,7 +14,7 @@ use DBDefs;
 
 with 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks basic tasks for the Redis store, including adding, deleting
 and expiring keys.

--- a/t/lib/t/MusicBrainz/DataStore/RedisMulti.pm
+++ b/t/lib/t/MusicBrainz/DataStore/RedisMulti.pm
@@ -13,7 +13,7 @@ use MusicBrainz::DataStore::Redis;
 use MusicBrainz::DataStore::RedisMulti;
 use DBDefs;
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks basic tasks for the RedisMulti store (including adding,
 deleting and expiring keys), which distributes queries to multiple underlying

--- a/t/lib/t/MusicBrainz/Script/RemoveEmptyURLs.pm
+++ b/t/lib/t/MusicBrainz/Script/RemoveEmptyURLs.pm
@@ -10,7 +10,7 @@ use MusicBrainz::Script::RemoveEmpty;
 
 with 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether the RemoveEmpty script is working as expected
 for URLS, deleting only URLs that are unused, not new,

--- a/t/lib/t/MusicBrainz/Script/RemoveUnreferencedRows.pm
+++ b/t/lib/t/MusicBrainz/Script/RemoveUnreferencedRows.pm
@@ -14,7 +14,7 @@ use MusicBrainz::Script::RemoveUnreferencedRows;
 
 with 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether the RemoveUnreferencedRows script is working
 as expected for artist credits, deleting only the ones that are unused

--- a/t/lib/t/MusicBrainz/Server/Authentication/WS.pm
+++ b/t/lib/t/MusicBrainz/Server/Authentication/WS.pm
@@ -12,7 +12,7 @@ use URI::QueryParam;
 
 with 't::Context', 't::Mechanize';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks OAuth authentication in the web service, by attempting
 to request data for a private collection.

--- a/t/lib/t/MusicBrainz/Server/Controller/Admin/DeleteEditor.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Admin/DeleteEditor.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether admins can delete an editor account, and whether
 the editors themselves can do it. It also checks whether users are logged out

--- a/t/lib/t/MusicBrainz/Server/Controller/Admin/PrivilegeSearch.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Admin/PrivilegeSearch.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether the privilege search works as expected, and whether
 it's blocked for non-admins.

--- a/t/lib/t/MusicBrainz/Server/Controller/Admin/WikiDoc/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Admin/WikiDoc/Create.pm
@@ -10,7 +10,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks that the WikiDoc Add Page form is blocked for users without
 the appropriate privileges, that it loads for privileged users, and that

--- a/t/lib/t/MusicBrainz/Server/Controller/Admin/WikiDoc/Delete.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Admin/WikiDoc/Delete.pm
@@ -10,7 +10,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks that the WikiDoc Remove Page form is blocked for users
 without the appropriate privileges, that it loads for privileged users, and

--- a/t/lib/t/MusicBrainz/Server/Controller/Admin/WikiDoc/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Admin/WikiDoc/Edit.pm
@@ -10,7 +10,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks that the WikiDoc Edit Page form is blocked for users without
 the appropriate privileges, that it loads for privileged users, and that

--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Aliases.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether area aliases are correctly listed on the area
 alias page, both on the site itself and on the JSON-LD data.

--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Create.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether non-ended areas can be added (which used to ISE, see
 MBS-8661) and, by extension, whether basic area adding works. It also ensures

--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Edit.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether non-ended areas can be edited (which used to ISE, see
 MBS-8661) and, by extension, whether basic area editing works. It also ensures

--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Show.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic area data is correctly listed in the JSON-LD
 of an area's index (main) page.

--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Tags.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Tags.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether area tagging is working correctly. It checks both
 up- and downvoting, plus withdrawing/removing tags.

--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Users.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Users.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether the Users tab for an area correctly lists editors
 who have their area set to it or to an area contained in it.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAlias.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether alias adding for artists works, including whether
 the sort name defaults to the name when not explicitly entered.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAnnotation.pm
@@ -9,7 +9,7 @@ use Time::HiRes qw( gettimeofday tv_interval );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether adding annotations for artists works, including
 whether four spaces at the start of the annotation are left untrimmed

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Aliases.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether artist aliases are correctly listed on the artist
 alias page, both on the site itself and on the JSON-LD data.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/AnnotationRevision.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/AnnotationRevision.pm
@@ -6,7 +6,7 @@ use Test::Routine;
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether artist annotation revision pages load,
 and whether they display the entirety of the annotation.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Create.pm
@@ -11,7 +11,7 @@ with 't::Mechanize', 't::Context';
 
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks that the artist create form works properly with both complete
 and minimal data, plus some edge cases.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/DeleteAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/DeleteAlias.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks that artist alias deletion works, and that it requires
 an edit note.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Details.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Details.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks that the artist details page contains all the expected data.
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Edit.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic artist editing works, including when also
 updating artist credits.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/EditAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/EditAlias.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether alias editing for artists works, including whether
 the sort name defaults to the name when not explicitly entered (blanked).

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/EditExternalLinks.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/EditExternalLinks.pm
@@ -10,7 +10,7 @@ use MusicBrainz::Server::Test qw( capture_edits );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether external links are correctly added, removed and
 modified when editing artists, and whether editing other parts of the artist

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/EditRelationships.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/EditRelationships.pm
@@ -18,7 +18,7 @@ use MusicBrainz::Server::Test qw( capture_edits );
 
 with 't::Context', 't::Mechanize';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether non-URL relationships are correctly added, removed
 and modified when editing artists, including several edge cases.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Edits.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Edits.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( accept_edit html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether artist edits are correctly listed under both the
 "all edits" and the "open edits" lists.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/EligibleForCleanup.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/EligibleForCleanup.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether artists are correctly displayed as eligible for
 cleanup (in risk of being auto-removed).

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether filtering works for different entity lists
 in artist pages (events, RGs, recordings, releases, works).

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Merge.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Merge.pm
@@ -30,7 +30,7 @@ around run_test => sub {
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks artist merges, and especially the artist credit renaming
 code.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Ratings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Ratings.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( html_ok test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether artist ratings are properly displayed on the ratings
 page, and that private ratings are hidden.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Recordings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Recordings.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether the artist recordings page properly displays
 recordings for the artist, both on the site itself and on the JSON-LD data.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Relationships.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Relationships.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether the artist relationships page properly displays
 relationships for the artist, and also the expected JSON-LD data.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Releases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Releases.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether the artist releases page properly displays
 releases for the artist.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Show.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic artist data is correctly listed on an artist’s
 index (main) page both on the site itself and on the JSON-LD data.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Split.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Split.pm
@@ -29,7 +29,7 @@ around run_test => sub {
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks the artist split function, and whether it removes
 collaboration relationships as intended.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Tags.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Tags.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether artist tagging is working correctly. It checks both
 up- and downvoting, plus withdrawing/removing tags.

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Works.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Works.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether the artist releases page properly displays
 works for the artist.

--- a/t/lib/t/MusicBrainz/Server/Controller/ArtistCredit/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ArtistCredit/Show.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( html_ok test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic artist credit data is correctly listed in an
 artist credit page, and whether trying to load a nonexistent artist credit

--- a/t/lib/t/MusicBrainz/Server/Controller/CDStub/Browse.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/CDStub/Browse.pm
@@ -9,7 +9,7 @@ use Hook::LexWrap;
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether the Browse CD Stubs page shows data as expected.
 

--- a/t/lib/t/MusicBrainz/Server/Controller/CDStub/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/CDStub/Show.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether the page for a specific CD stub
 shows data as expected.

--- a/t/lib/t/MusicBrainz/Server/Controller/CDTOC/Attach.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/CDTOC/Attach.pm
@@ -6,7 +6,7 @@ use Test::Routine;
 
 with 't::Context', 't::Mechanize';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether release and CD stub matches are shown when a user
 tries to submit a CD TOC / disc ID to MusicBrainz.

--- a/t/lib/t/MusicBrainz/Server/Controller/CDTOC/SetDurations.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/CDTOC/SetDurations.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether the set track lengths page for disc IDs allows
 entering edits.

--- a/t/lib/t/MusicBrainz/Server/Controller/CDTOC/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/CDTOC/Show.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether the disc ID page displays data about both the disc ID
 itself and the releases the disc ID is attached to.

--- a/t/lib/t/MusicBrainz/Server/Controller/Collection/AddAndRemove.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Collection/AddAndRemove.pm
@@ -21,7 +21,7 @@ around run_test => sub {
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether adding entities to collections and removing them
 works, and whether trying to add a non-existing entity fails gracefully.

--- a/t/lib/t/MusicBrainz/Server/Controller/Collection/Merge.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Collection/Merge.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( html_ok test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether collection merges work as intended, display the
 expected user warnings, and makes sure merges can't happen in ways

--- a/t/lib/t/MusicBrainz/Server/Controller/Collection/New.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Collection/New.pm
@@ -19,7 +19,7 @@ around run_test => sub {
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks collection creation, with and without seeded entities,
 including the addition of collaborators.

--- a/t/lib/t/MusicBrainz/Server/Controller/Collection/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Collection/Show.pm
@@ -20,7 +20,7 @@ around run_test => sub {
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether collection index pages display the expected data.
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Edit/Cancel.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Edit/Cancel.pm
@@ -14,7 +14,7 @@ use MusicBrainz::Server::Constants qw(
 
 with 't::Context', 't::Mechanize';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether an editor's open edits can be cancelled, whether
 the cancel page leaves edit notes appropriately, and whether cancelling edits

--- a/t/lib/t/MusicBrainz/Server/Controller/Edit/Open.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Edit/Open.pm
@@ -15,7 +15,7 @@ use MusicBrainz::Server::Test qw( accept_edit html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether the /edit/open page (for all open edits in the
 database) works as expected, including not showing your own edits.

--- a/t/lib/t/MusicBrainz/Server/Controller/Edit/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Edit/Show.pm
@@ -12,7 +12,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether the shared components of edit display pages work as
 expected for all kinds of editors: default / author / beginner / logged out.

--- a/t/lib/t/MusicBrainz/Server/Controller/Genre/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Genre/Create.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic genre creation works. It also ensures
 unprivileged users cannot create genres.

--- a/t/lib/t/MusicBrainz/Server/Controller/Genre/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Genre/Edit.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 This test checks whether basic genre editing works. It also ensures
 unprivileged users cannot edit genres.
 =cut

--- a/t/lib/t/MusicBrainz/Server/Controller/ISRC/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ISRC/Show.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether linked recordings are appropriately displayed
 on the ISRC index page.

--- a/t/lib/t/MusicBrainz/Server/Controller/ISWC/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ISWC/Show.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether linked works are appropriately displayed on the ISWC
 index page, and whether different ISWC formats all reach the same page.

--- a/t/lib/t/MusicBrainz/Server/Controller/Instrument/Artists.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Instrument/Artists.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( html_ok test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
   This test checks whether the instrument artists page correctly lists artists
   connected to the instrument.

--- a/t/lib/t/MusicBrainz/Server/Controller/Instrument/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Instrument/Create.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic instrument creation works. It also ensures
 unprivileged users cannot create instruments.

--- a/t/lib/t/MusicBrainz/Server/Controller/Instrument/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Instrument/Edit.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic instrument editing works. It also ensures
 unprivileged users cannot edit instruments.

--- a/t/lib/t/MusicBrainz/Server/Controller/Instrument/Recordings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Instrument/Recordings.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( html_ok test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
   This test checks whether the instrument recordings page correctly lists
   recordings connected to the instrument.

--- a/t/lib/t/MusicBrainz/Server/Controller/Instrument/Releases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Instrument/Releases.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
   This test checks whether the instrument releases page correctly lists
   releases connected to the instrument.

--- a/t/lib/t/MusicBrainz/Server/Controller/Instrument/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Instrument/Show.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
   This test checks whether basic instrument data is correctly listed on an
   instrument's index (main) page.

--- a/t/lib/t/MusicBrainz/Server/Controller/Instrument/Tags.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Instrument/Tags.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether instrument tagging is working correctly. It checks
 both up- and downvoting, plus withdrawing/removing tags.

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/AddAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/AddAlias.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether alias adding for labels works, including whether
 the sort name defaults to the name when not explicitly entered.

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/AddAnnotation.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether adding annotations for labels works, including
 whether four spaces at the start of the annotation are left untrimmed

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Aliases.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether label aliases are correctly listed on the label
 alias page, both on the site itself and on the JSON-LD data.

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Create.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic label creation works.
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/DeleteAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/DeleteAlias.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks that label alias deletion works, and that it requires
 an edit note.

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Details.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Details.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks that the label details page contains all the expected data.
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Edit.pm
@@ -10,7 +10,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic label editing works.
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/EditAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/EditAlias.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether alias editing for labels works, including whether
 the sort name defaults to the name when not explicitly entered (blanked).

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Ratings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Ratings.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( html_ok test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether label ratings are properly displayed on the ratings
 page, and that private ratings are hidden.

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Tags.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Tags.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether label tagging is working correctly. It checks both
 up- and downvoting, plus withdrawing/removing tags.

--- a/t/lib/t/MusicBrainz/Server/Controller/Place/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Place/Aliases.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether place aliases are correctly listed on the place
 alias page, both on the site itself and on the JSON-LD data.

--- a/t/lib/t/MusicBrainz/Server/Controller/Place/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Place/Create.pm
@@ -9,7 +9,7 @@ use utf8;
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic place creation works.
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Place/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Place/Edit.pm
@@ -9,7 +9,7 @@ use utf8;
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic place editing works.
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAlias.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether alias adding for recordings works, including whether
 the sort name defaults to the name when not explicitly entered.

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAnnotation.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether adding annotations for recordings works, including
 whether four spaces at the start of the annotation are left untrimmed

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/Aliases.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether recording aliases are correctly listed on the
 recording alias page, both on the site itself and on the JSON-LD data.

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/DeleteAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/DeleteAlias.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks that recording alias deletion works, and that it requires
 an edit note.

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/Details.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/Details.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks that the recording details page contains all the expected data.
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/Edit.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Edit', 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic recording editing works, including replacing
 ISRCs. It also checks if it still works if you don't indicate

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/EditAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/EditAlias.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether alias editing for recordings works, including whether
 the sort name defaults to the name when not explicitly entered (blanked).

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/Ratings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/Ratings.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( html_ok test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether recording ratings are properly displayed on the
 ratings page, and that private ratings are hidden.

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/AddAnnotation.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether adding annotations for releases works, including
 whether four spaces at the start of the annotation are left untrimmed

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/Aliases.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether release aliases are correctly listed on the release
 alias page, both on the site itself and on the JSON-LD data.

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/Details.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/Details.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks that the release details page contains all the expected data,
 and that it shows the release sidebar data as well.

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/AddAnnotation.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether adding annotations for release groups works,
 including whether four spaces at the start of the annotation are left

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Aliases.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether release group aliases are correctly listed on the
 release group alias page, both on the site itself and on the JSON-LD data.

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Create.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic release group creation works.
 

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Details.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Details.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks that the release group details page contains all the
 expected data.

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Edit.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic release group editing works.
 

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Ratings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Ratings.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( html_ok test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether release group ratings are properly displayed on the
 ratings page, and that private ratings are hidden.

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Tags.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Tags.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether release group tagging is working correctly. It checks
 both up- and downvoting, plus withdrawing/removing tags.

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/AddAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/AddAlias.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Edit', 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether alias adding for series works, including whether
 the sort name defaults to the name when not explicitly entered.

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/AddAnnotation.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits );
 
 with 't::Edit', 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether adding annotations for series works, including
 whether four spaces at the start of the annotation are left untrimmed

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/Aliases.pm
@@ -9,7 +9,7 @@ with 't::Edit';
 with 't::Mechanize';
 with 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether series aliases are correctly listed on the series
 alias page.

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/Create.pm
@@ -10,7 +10,7 @@ use MusicBrainz::Server::Test qw( html_ok capture_edits );
 
 with 't::Edit', 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic series creation works, including adding
 relationships during the creation process.

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/DeleteAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/DeleteAlias.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Edit', 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks that series alias deletion works, and that it requires
 an edit note.

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/Details.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/Details.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks that the series details page contains all the expected data.
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/Edit.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Edit', 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic series editing works, and whether editing
 the parts of series data works.

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/EditAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/EditAlias.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Edit', 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether alias editing for series works, including whether
 the sort name defaults to the name when not explicitly entered (blanked).

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/Tags.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/Tags.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether series tagging is working correctly. It checks both
 up- and downvoting, plus withdrawing/removing tags.

--- a/t/lib/t/MusicBrainz/Server/Controller/URL/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/URL/Edit.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic URL editing works, and whether clearing the
 credited-as fields works as expected.

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/GenreList.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/GenreList.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test::WS qw( ws2_test_xml );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test ensures the full genre list at genre/all is working as intended.
 

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/GenreList.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/GenreList.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test::WS qw( ws2_test_json );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test ensures the full genre list at genre/all is working as intended
 for fmt=json.

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/TXT/GenreList.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/TXT/GenreList.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test::WS qw( ws2_test_txt );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test ensures the full genre names list at genre/all is working for the
 txt format.

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/Validator.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/Validator.pm
@@ -9,7 +9,7 @@ use utf8;
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks different request validation options for API.
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/AddAnnotation.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether adding annotations for works works, including
 whether four spaces at the start of the annotation are left untrimmed

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Aliases.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether work aliases are correctly listed on the work
 alias page, both on the site itself and on the JSON-LD data.

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Create.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic work creation works, including adding ISWCs
 during the creation process.

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Details.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Details.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks that the work details page contains all the expected data.
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Edit.pm
@@ -10,7 +10,7 @@ use MusicBrainz::Server::Test qw( accept_edit capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether basic work editing works, and specifically tests
 work attributes and languages. It also ensures a work can be added to a series

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Ratings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Ratings.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Test qw( html_ok test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether work ratings are properly displayed on the
 ratings page, and that private ratings are hidden.

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Tags.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Tags.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-=head2 Test description
+=head1 DESCRIPTION
 
 This test checks whether work tagging is working correctly. It checks both
 up- and downvoting, plus withdrawing/removing tags. It also checks that


### PR DESCRIPTION
This is more expected and makes it easier to test for it later, with the Critic rule introduced by https://github.com/metabrainz/musicbrainz-server/pull/2740