### PR TITLE
MBS-13802: Always use "Created (in)" for characters

### DIFF
--- a/root/artist/utils.js
+++ b/root/artist/utils.js
@@ -15,6 +15,8 @@ export function artistBeginAreaLabel(typeId: ?number): string {
     case 5:
     case 6:
       return addColonText(lp('Founded in', 'group artist'));
+    case 4:
+      return addColonText(lp('Created in', 'character artist'));
     default:
       return addColonText(l('Begin area'));
   }

--- a/root/static/scripts/edit/MB/Control/ArtistEdit.js
+++ b/root/static/scripts/edit/MB/Control/ArtistEdit.js
@@ -40,6 +40,7 @@ MB.Control.ArtistEdit = function () {
    *   Unknown: 0
    *   Person: 1
    *   Group: 2
+   *   Character: 4
    *   Orchestra: 5
    *   Choir: 6
    */
@@ -68,6 +69,19 @@ MB.Control.ArtistEdit = function () {
           addColonText(lp('Dissolved in', 'group artist')),
         );
         self.disableGender();
+        break;
+
+      case '4':
+        self.changeDateText(
+          addColonText(lp('Created', 'character artist')),
+          addColonText(lp('Ended', 'artist end date')),
+          l('This artist has ended.'),
+        );
+        self.changeAreaText(
+          addColonText(lp('Created in', 'character artist')),
+          addColonText(l('End area')),
+        );
+        self.enableGender();
         break;
 
       case '0':


### PR DESCRIPTION
### Implement MBS-13802

# Description
We changed this for sidebar display for `Created` a while ago, but I missed the artist editor, and area should use `Created in` for consistency.

This keeps the standard end date / end area strings; that section will eventually be hidden for characters with https://github.com/metabrainz/musicbrainz-server/pull/3402 but for now keeping it as default seems best.

# Testing
Manually.