### PR TITLE
Update Flow to 0.256.0

### DIFF
--- a/flow-typed/npm/@floating-ui/react_v0.26.x.js
+++ b/flow-typed/npm/@floating-ui/react_v0.26.x.js
@@ -295,7 +295,7 @@ declare module '@floating-ui/react' {
   };
 
   declare export const FloatingArrow:
-    React.AbstractComponent<FloatingArrowProps, Element>;
+    component(ref: React.RefSetter<Element>, ...FloatingArrowProps);
 
   /*
    * FloatingFocusManager
@@ -310,7 +310,7 @@ declare module '@floating-ui/react' {
   };
 
   declare export const FloatingFocusManager:
-    React.AbstractComponent<FloatingFocusManagerProps>;
+    component(...FloatingFocusManagerProps);
 
   /*
    * FloatingNode
@@ -321,7 +321,7 @@ declare module '@floating-ui/react' {
   };
 
   declare export const FloatingNode:
-    React.AbstractComponent<FloatingNodeProps>;
+    component(...FloatingNodeProps);
 
   /*
    * FloatingOverlay
@@ -334,7 +334,7 @@ declare module '@floating-ui/react' {
   };
 
   declare export const FloatingOverlay:
-    React.AbstractComponent<FloatingOverlayProps>;
+    component(...FloatingOverlayProps);
 
   /*
    * FloatingPortal
@@ -345,7 +345,7 @@ declare module '@floating-ui/react' {
   };
 
   declare export const FloatingPortal:
-    React.AbstractComponent<FloatingPortalProps>;
+    component(...FloatingPortalProps);
 
   /*
    * FloatingTree
@@ -355,5 +355,5 @@ declare module '@floating-ui/react' {
   };
 
   declare export const FloatingTree:
-    React.AbstractComponent<FloatingTreeProps>;
+    component(...FloatingTreeProps);
 }

--- a/flow-typed/npm/react-table_v7.x.x.js
+++ b/flow-typed/npm/react-table_v7.x.x.js
@@ -22,7 +22,7 @@ declare module 'react-table' {
      * `D` contravariant above.
      */
     +accessor?: (D) => V,
-    +Cell?: React.AbstractComponent<CellRenderProps<D, V>, mixed>,
+    +Cell?: component(...CellRenderProps<D, V>),
     +Header?: React.ComponentType<mixed> | React.Node,
     +id?: string,
     ...
@@ -30,7 +30,7 @@ declare module 'react-table' {
 
   declare export type ColumnOptionsNoValue<-D> = {
     +accessor?: (D) => mixed,
-    +Cell?: React.AbstractComponent<CellRenderProps<D, empty>, mixed>,
+    +Cell?: component(...CellRenderProps<D, empty>),
     +Header?: React.ComponentType<mixed> | React.Node,
     +id?: string,
     ...

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "eslint-plugin-react": "7.37.2",
     "eslint-plugin-react-hooks": "5.0.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
-    "flow-bin": "0.254.2",
+    "flow-bin": "0.255.0",
     "gettext-parser": "4.2.0",
     "globals": "15.9.0",
     "hermes-eslint": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "eslint-plugin-react": "7.37.2",
     "eslint-plugin-react-hooks": "5.0.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
-    "flow-bin": "0.250.0",
+    "flow-bin": "0.251.1",
     "gettext-parser": "4.2.0",
     "globals": "15.9.0",
     "hermes-eslint": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "eslint-plugin-react": "7.37.2",
     "eslint-plugin-react-hooks": "5.0.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
-    "flow-bin": "0.252.0",
+    "flow-bin": "0.253.0",
     "gettext-parser": "4.2.0",
     "globals": "15.9.0",
     "hermes-eslint": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "eslint-plugin-react": "7.37.2",
     "eslint-plugin-react-hooks": "5.0.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
-    "flow-bin": "0.253.0",
+    "flow-bin": "0.254.2",
     "gettext-parser": "4.2.0",
     "globals": "15.9.0",
     "hermes-eslint": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "eslint-plugin-react": "7.37.2",
     "eslint-plugin-react-hooks": "5.0.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
-    "flow-bin": "0.251.1",
+    "flow-bin": "0.252.0",
     "gettext-parser": "4.2.0",
     "globals": "15.9.0",
     "hermes-eslint": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "eslint-plugin-react": "7.37.2",
     "eslint-plugin-react-hooks": "5.0.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
-    "flow-bin": "0.255.0",
+    "flow-bin": "0.256.0",
     "gettext-parser": "4.2.0",
     "globals": "15.9.0",
     "hermes-eslint": "0.24.0",

--- a/root/static/scripts/account/components/ApplicationForm.js
+++ b/root/static/scripts/account/components/ApplicationForm.js
@@ -126,4 +126,4 @@ export type ApplicationFormPropsT = Props;
 export default (hydrate<Props>(
   'div.application-form',
   ApplicationForm,
-): React.AbstractComponent<Props, void>);
+): component(...Props));

--- a/root/static/scripts/account/components/EditProfileForm.js
+++ b/root/static/scripts/account/components/EditProfileForm.js
@@ -354,5 +354,5 @@ export type EditProfileFormPropsT = Props;
 
 export default (
   hydrate<Props>('div.edit-profile-form', EditProfileForm):
-  React.AbstractComponent<Props, void>
+  component(...Props)
 );

--- a/root/static/scripts/account/components/PreferencesForm.js
+++ b/root/static/scripts/account/components/PreferencesForm.js
@@ -287,4 +287,4 @@ export type PreferencesFormPropsT = Props;
 export default (hydrate<Props>(
   'div.preferences-form',
   PreferencesForm,
-): React.AbstractComponent<Props, void>);
+): component(...Props));

--- a/root/static/scripts/account/components/RegisterForm.js
+++ b/root/static/scripts/account/components/RegisterForm.js
@@ -122,4 +122,4 @@ component RegisterForm(captcha?: string, form: RegisterFormT) {
 export default (hydrate<React.PropsOf<RegisterForm>>(
   'div.register-form',
   RegisterForm,
-): React.AbstractComponent<React.PropsOf<RegisterForm>, void>);
+): component(...React.PropsOf<RegisterForm>));

--- a/root/static/scripts/alias/AliasEditForm.js
+++ b/root/static/scripts/alias/AliasEditForm.js
@@ -363,4 +363,4 @@ const AliasEditForm = ({
 export default (hydrate<Props>(
   'div.alias-edit-form',
   AliasEditForm,
-): React.AbstractComponent<Props, void>);
+): component(...Props));

--- a/root/static/scripts/annotation/AnnotationHistoryTable.js
+++ b/root/static/scripts/annotation/AnnotationHistoryTable.js
@@ -159,4 +159,4 @@ component AnnotationHistoryTable(
 export default (hydrate<React.PropsOf<AnnotationHistoryTable>>(
   'div.annotation-history-table',
   AnnotationHistoryTable,
-): React.AbstractComponent<React.PropsOf<AnnotationHistoryTable>>);
+): component(...React.PropsOf<AnnotationHistoryTable>));

--- a/root/static/scripts/artist/components/ArtistCreditRenamer.js
+++ b/root/static/scripts/artist/components/ArtistCreditRenamer.js
@@ -332,4 +332,4 @@ const ArtistCreditRenamer = ({
 export default (hydrate<ArtistCreditRenamerPropsT>(
   'div.artist-credit-renamer',
   ArtistCreditRenamer,
-): React.AbstractComponent<ArtistCreditRenamerPropsT, void>);
+): component(...ArtistCreditRenamerPropsT));

--- a/root/static/scripts/collection/components/CollectionEditForm.js
+++ b/root/static/scripts/collection/components/CollectionEditForm.js
@@ -293,7 +293,7 @@ const CollaboratorsFormList = (hydrate<CollaboratorsFormListPropsT>(
       </div>
     );
   }),
-): React.AbstractComponent<CollaboratorsFormListPropsT, void>);
+): component(...CollaboratorsFormListPropsT));
 
 type CollaboratorRowPropsT = {
   +collaborator: CollaboratorStateT,

--- a/root/static/scripts/common/components/AcoustIdCell.js
+++ b/root/static/scripts/common/components/AcoustIdCell.js
@@ -134,5 +134,5 @@ export default (
   hydrate<React.PropsOf<AcoustIdCell>>(
     'div.acoustids',
     AcoustIdCell,
-  ): React.AbstractComponent<React.PropsOf<AcoustIdCell>>
+  ): component(...React.PropsOf<AcoustIdCell>)
 );

--- a/root/static/scripts/common/components/Annotation.js
+++ b/root/static/scripts/common/components/Annotation.js
@@ -141,4 +141,4 @@ export default (hydrate<React.PropsOf<Annotation>>(
     newProps.entity = newEntity;
     return newProps;
   },
-): React.AbstractComponent<React.PropsOf<Annotation>>);
+): component(...React.PropsOf<Annotation>));

--- a/root/static/scripts/common/components/ArtistCreditLink.js
+++ b/root/static/scripts/common/components/ArtistCreditLink.js
@@ -49,7 +49,7 @@ component _MpIcon(artistCredit: ArtistCreditT) {
 export const MpIcon = (hydrate<React.PropsOf<_MpIcon>>(
   'span.ac-mp',
   _MpIcon,
-): React.AbstractComponent<React.PropsOf<_MpIcon>>);
+): component(...React.PropsOf<_MpIcon>));
 
 component ArtistCreditLink(
   artistCredit: ArtistCreditT,

--- a/root/static/scripts/common/components/ArtistRoles.js
+++ b/root/static/scripts/common/components/ArtistRoles.js
@@ -53,4 +53,4 @@ component ArtistRoles(relations: $ReadOnlyArray<RelationT>) {
 export default (hydrate<React.PropsOf<ArtistRoles>>(
   'div.artist-roles-container',
   ArtistRoles,
-): React.AbstractComponent<React.PropsOf<ArtistRoles>>);
+): component(...React.PropsOf<ArtistRoles>));

--- a/root/static/scripts/common/components/AttributeList.js
+++ b/root/static/scripts/common/components/AttributeList.js
@@ -73,4 +73,4 @@ component AttributeList(
 export default (hydrate<React.PropsOf<AttributeList>>(
   'div.entity-attributes-container',
   AttributeList,
-): React.AbstractComponent<React.PropsOf<AttributeList>>);
+): component(...React.PropsOf<AttributeList>));

--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -863,14 +863,8 @@ component _Autocomplete2<T: EntityItemT>(...props: PropsT<T>) {
   );
 }
 
-// $FlowIgnore[unclear-type]
-const Autocomplete2: React.AbstractComponent<PropsT<any>, mixed> =
+const Autocomplete2: typeof _Autocomplete2 =
+  // $FlowIssue[incompatible-type]
   React.memo(_Autocomplete2);
 
 export default Autocomplete2;
-
-// XXX Until Flow supports https://github.com/facebook/flow/issues/7672
-export const ArtistAutocomplete:
-  React.AbstractComponent<PropsT<ArtistT>, void> =
-  // $FlowIgnore[unclear-type]
-  (Autocomplete2: any);

--- a/root/static/scripts/common/components/CDTocReleaseListTable.js
+++ b/root/static/scripts/common/components/CDTocReleaseListTable.js
@@ -89,4 +89,4 @@ component CDTocReleaseListTable(
 export default (hydrate<React.PropsOf<CDTocReleaseListTable>>(
   'div.cd-toc-release-list-table-container',
   CDTocReleaseListTable,
-): React.ComponentType<React.PropsOf<CDTocReleaseListTable>>);
+): component(...React.PropsOf<CDTocReleaseListTable>));

--- a/root/static/scripts/common/components/CritiqueBrainzReview.js
+++ b/root/static/scripts/common/components/CritiqueBrainzReview.js
@@ -57,4 +57,4 @@ component CritiqueBrainzReview(review: CritiqueBrainzReviewT, title: string) {
 export default (hydrate<React.PropsOf<CritiqueBrainzReview>>(
   'div.critiquebrainz-review',
   CritiqueBrainzReview,
-): React.AbstractComponent<React.PropsOf<CritiqueBrainzReview>>);
+): component(...React.PropsOf<CritiqueBrainzReview>));

--- a/root/static/scripts/common/components/Filter.js
+++ b/root/static/scripts/common/components/Filter.js
@@ -78,5 +78,5 @@ component Filter(
 
 export default (
   hydrate<React.PropsOf<Filter>>('div.filter', Filter):
-  React.AbstractComponent<React.PropsOf<Filter>>
+  component(...React.PropsOf<Filter>)
 );

--- a/root/static/scripts/common/components/FingerprintTable.js
+++ b/root/static/scripts/common/components/FingerprintTable.js
@@ -119,4 +119,4 @@ component FingerprintTable(recording: RecordingT) {
 export default (hydrate<React.PropsOf<FingerprintTable>>(
   'div.acoustid-fingerprints',
   FingerprintTable,
-): React.AbstractComponent<React.PropsOf<FingerprintTable>>);
+): component(...React.PropsOf<FingerprintTable>));

--- a/root/static/scripts/common/components/IsrcList.js
+++ b/root/static/scripts/common/components/IsrcList.js
@@ -52,4 +52,4 @@ component IsrcList(
 export default (hydrate<React.PropsOf<IsrcList>>(
   'div.isrc-list-container',
   IsrcList,
-): React.AbstractComponent<React.PropsOf<IsrcList>>);
+): component(...React.PropsOf<IsrcList>));

--- a/root/static/scripts/common/components/IswcList.js
+++ b/root/static/scripts/common/components/IswcList.js
@@ -52,4 +52,4 @@ component IswcList(
 export default (hydrate<React.PropsOf<IswcList>>(
   'div.iswc-list-container',
   IswcList,
-): React.AbstractComponent<React.PropsOf<IswcList>>);
+): component(...React.PropsOf<IswcList>));

--- a/root/static/scripts/common/components/PostParameters.js
+++ b/root/static/scripts/common/components/PostParameters.js
@@ -90,4 +90,4 @@ component PostParameters(params: PostParametersT) {
 export default (hydrate(
   'div.post-parameters',
   PostParameters,
-): React.AbstractComponent<React.PropsOf<PostParameters>>);
+): component(...React.PropsOf<PostParameters>));

--- a/root/static/scripts/common/components/Relationships.js
+++ b/root/static/scripts/common/components/Relationships.js
@@ -127,7 +127,7 @@ component _Relationship(
   );
 }
 
-const Relationships: React.AbstractComponent<React.PropsOf<_Relationship>> =
+const Relationships: component(...React.PropsOf<_Relationship>) =
   React.memo(_Relationship);
 
 export default Relationships;

--- a/root/static/scripts/common/components/ReleaseEvents.js
+++ b/root/static/scripts/common/components/ReleaseEvents.js
@@ -98,4 +98,4 @@ component ReleaseEvents(
 export default (hydrate<React.PropsOf<ReleaseEvents>>(
   'div.release-events-container',
   ReleaseEvents,
-): React.AbstractComponent<React.PropsOf<ReleaseEvents>>);
+): component(...React.PropsOf<ReleaseEvents>));

--- a/root/static/scripts/common/components/StaticRelationshipsDisplay.js
+++ b/root/static/scripts/common/components/StaticRelationshipsDisplay.js
@@ -141,8 +141,8 @@ component _StaticRelationshipsDisplay(
   return tables;
 }
 
-const StaticRelationshipsDisplay: React.AbstractComponent<
-  React.PropsOf<_StaticRelationshipsDisplay>
-> = React.memo(_StaticRelationshipsDisplay);
+const StaticRelationshipsDisplay:
+  component(...React.PropsOf<_StaticRelationshipsDisplay>) =
+  React.memo(_StaticRelationshipsDisplay);
 
 export default StaticRelationshipsDisplay;

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -645,7 +645,7 @@ export const MainTagEditor = (hydrate<TagEditorProps>(
     }
   },
   minimalEntity,
-): React.AbstractComponent<TagEditorProps, void>);
+): component(...TagEditorProps));
 
 export const SidebarTagEditor = (hydrate<TagEditorProps>(
   'div.sidebar-tags',
@@ -703,7 +703,7 @@ export const SidebarTagEditor = (hydrate<TagEditorProps>(
     }
   },
   minimalEntity,
-): React.AbstractComponent<TagEditorProps, void>);
+): component(...TagEditorProps));
 
 function createInitialTagState(
   aggregatedTags: $ReadOnlyArray<AggregatedTagT>,

--- a/root/static/scripts/common/components/TaggerIcon.js
+++ b/root/static/scripts/common/components/TaggerIcon.js
@@ -82,5 +82,5 @@ export default (
   hydrate<React.PropsOf<TaggerIcon>>(
     'span.tagger-icon',
     TaggerIcon,
-  ): React.AbstractComponent<React.PropsOf<TaggerIcon>, void>
+  ): component(...React.PropsOf<TaggerIcon>)
 );

--- a/root/static/scripts/common/components/WorkArtists.js
+++ b/root/static/scripts/common/components/WorkArtists.js
@@ -36,4 +36,4 @@ component WorkArtists(artists: ?$ReadOnlyArray<ArtistCreditT>) {
 export default (hydrate<React.PropsOf<WorkArtists>>(
   'div.work-artists-container',
   WorkArtists,
-): React.AbstractComponent<React.PropsOf<WorkArtists>, void>);
+): component(...React.PropsOf<WorkArtists>));

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -192,7 +192,7 @@ function concatArrayMatch<T: MatchUpperBoundT>(
   match: Array<T> | T,
 ): Array<T> {
   let matchedChildren = children;
-  if (!gotMatch(matchedChildren)) {
+  if (!gotMatch<Array<T>>(matchedChildren)) {
     matchedChildren = [];
   }
   if (Array.isArray(match)) {

--- a/root/static/scripts/edit/components/ArtistCreditBubble.js
+++ b/root/static/scripts/edit/components/ArtistCreditBubble.js
@@ -311,8 +311,8 @@ component _ArtistCreditBubble(
   );
 }
 
-const ArtistCreditBubble: React.AbstractComponent<
-  React.PropsOf<_ArtistCreditBubble>
-> = React.memo(_ArtistCreditBubble);
+const ArtistCreditBubble:
+  component(...React.PropsOf<_ArtistCreditBubble>) =
+  React.memo(_ArtistCreditBubble);
 
 export default ArtistCreditBubble;

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -11,8 +11,7 @@ import ko from 'knockout';
 import mutate, {type CowContext} from 'mutate-cow';
 import * as React from 'react';
 
-import {
-  ArtistAutocomplete,
+import Autocomplete2, {
   createInitialState as createInitialAutocompleteState,
 } from '../../common/components/Autocomplete2.js';
 import {
@@ -547,7 +546,7 @@ component _ArtistCreditEditor(
 
   return (
     <>
-      <ArtistAutocomplete
+      <Autocomplete2
         dispatch={firstArtistDispatch}
         state={singleArtistAutocomplete}
       >
@@ -559,7 +558,7 @@ component _ArtistCreditEditor(
           isOpen={isOpen}
           toggle={toggleDialog}
         />
-      </ArtistAutocomplete>
+      </Autocomplete2>
 
       {hiddenInputsPrefix ? (
         names.filter(isNameNotRemoved).map(function (name, i) {
@@ -596,8 +595,8 @@ component _ArtistCreditEditor(
   );
 }
 
-const ArtistCreditEditor: React.AbstractComponent<
-  React.PropsOf<_ArtistCreditEditor>
-> = React.memo(_ArtistCreditEditor);
+const ArtistCreditEditor:
+  component(...React.PropsOf<_ArtistCreditEditor>) =
+  React.memo(_ArtistCreditEditor);
 
 export default ArtistCreditEditor;

--- a/root/static/scripts/edit/components/ArtistCreditNameEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditNameEditor.js
@@ -9,7 +9,7 @@
 
 import * as React from 'react';
 
-import {ArtistAutocomplete} from '../../common/components/Autocomplete2.js';
+import Autocomplete2 from '../../common/components/Autocomplete2.js';
 import type {
   ActionT as AutocompleteActionT,
 } from '../../common/components/Autocomplete2/types.js';
@@ -158,7 +158,7 @@ component _ArtistCreditNameEditor(
       ) : (
         <>
           <td>
-            <ArtistAutocomplete
+            <Autocomplete2
               dispatch={artistDispatch}
               state={artistCreditName.artist}
             />
@@ -228,8 +228,8 @@ component _ArtistCreditNameEditor(
   );
 }
 
-const ArtistCreditNameEditor: React.AbstractComponent<
-  React.PropsOf<_ArtistCreditNameEditor>
-> = React.memo(_ArtistCreditNameEditor);
+const ArtistCreditNameEditor:
+  component(...React.PropsOf<_ArtistCreditNameEditor>) =
+  React.memo(_ArtistCreditNameEditor);
 
 export default ArtistCreditNameEditor;

--- a/root/static/scripts/edit/components/DateRangeFieldset.js
+++ b/root/static/scripts/edit/components/DateRangeFieldset.js
@@ -222,8 +222,8 @@ component _DateRangeFieldset(
   );
 }
 
-const DateRangeFieldset: React.AbstractComponent<
-  React.PropsOf<_DateRangeFieldset>
-> = React.memo(_DateRangeFieldset);
+const DateRangeFieldset:
+  component(...React.PropsOf<_DateRangeFieldset>) =
+  React.memo(_DateRangeFieldset);
 
 export default DateRangeFieldset;

--- a/root/static/scripts/edit/components/FormRowTextList.js
+++ b/root/static/scripts/edit/components/FormRowTextList.js
@@ -174,4 +174,4 @@ export component NonHydratedFormRowTextList(
 export default (hydrate<React.PropsOf<FormRowTextList>>(
   'div.row.form-row-text-list-container',
   FormRowTextList,
-): React.AbstractComponent<React.PropsOf<FormRowTextList>, void>);
+): component(...React.PropsOf<FormRowTextList>));

--- a/root/static/scripts/edit/components/GuessCaseOptionsPopover.js
+++ b/root/static/scripts/edit/components/GuessCaseOptionsPopover.js
@@ -62,8 +62,8 @@ component _GuessCaseOptionsPopover(
   );
 }
 
-const GuessCaseOptionsPopover: React.AbstractComponent<
-  React.PropsOf<_GuessCaseOptionsPopover>
-> = React.memo(_GuessCaseOptionsPopover);
+const GuessCaseOptionsPopover:
+  component(...React.PropsOf<_GuessCaseOptionsPopover>) =
+  React.memo(_GuessCaseOptionsPopover);
 
 export default GuessCaseOptionsPopover;

--- a/root/static/scripts/edit/components/Multiselect.js
+++ b/root/static/scripts/edit/components/Multiselect.js
@@ -60,17 +60,6 @@ export type MultiselectStateT<
   ...
 };
 
-export type MultiselectPropsT<
-  V: AutocompleteEntityItemT,
-  VS: MultiselectValueStateT<V>,
-  S: MultiselectStateT<V, VS>,
-> = {
-  +addLabel: string,
-  +buildExtraValueChildren?: ($Exact<VS>) => React.Node,
-  +dispatch: (MultiselectActionT<V>) => void,
-  +state: $Exact<S>,
-};
-
 export const ATTR_VALUE_LABEL_STYLE = {
   clear: 'both',
 };
@@ -156,22 +145,16 @@ export function runReducer<
   }
 }
 
-type MultiselectValueComponentT = React.AbstractComponent<
-  MultiselectValuePropsT<
-    AutocompleteEntityItemT,
-    MultiselectValueStateT<AutocompleteEntityItemT>,
-  >,
-  mixed,
->;
-
-export const MultiselectValue: MultiselectValueComponentT = React.memo(<
+component _MultiselectValue<
   V: AutocompleteEntityItemT,
   VS: MultiselectValueStateT<V>,
->({
-  buildExtraChildren,
-  dispatch,
-  state,
-}: MultiselectValuePropsT<V, VS>): React.MixedElement => {
+>(...props: MultiselectValuePropsT<V, VS>) {
+  const {
+    buildExtraChildren,
+    dispatch,
+    state,
+  } = props;
+
   const autocompleteDispatch = React.useCallback(
     (action: AutocompleteActionT<V>) => {
       dispatch({
@@ -212,18 +195,22 @@ export const MultiselectValue: MultiselectValueComponentT = React.memo(<
       />
     </div>
   );
-});
+}
 
-const Multiselect = (React.memo(<
+export const MultiselectValue: typeof _MultiselectValue =
+  // $FlowIssue[incompatible-type]
+  React.memo(_MultiselectValue);
+
+component _Multiselect<
   V: AutocompleteEntityItemT,
   VS: MultiselectValueStateT<V>,
   S: MultiselectStateT<V, VS>,
->({
-  addLabel,
-  buildExtraValueChildren,
-  dispatch,
-  state,
-}: MultiselectPropsT<V, VS, S>): React.MixedElement => {
+>(
+  addLabel: string,
+  buildExtraValueChildren?: (VS) => React.Node,
+  dispatch: (MultiselectActionT<V>) => void,
+  state: S,
+) {
   const handleAdd = React.useCallback(() => {
     dispatch({type: 'add-value'});
   }, [dispatch]);
@@ -232,20 +219,10 @@ const Multiselect = (React.memo(<
     return accum + (valueAttribute.removed ? 0 : 1);
   }, 0);
 
-  // XXX: https://github.com/facebook/flow/issues/7672
-  const GenericMultiselectValue = (
-    // $FlowIgnore[incompatible-cast]
-    MultiselectValue:
-      React.AbstractComponent<
-        MultiselectValuePropsT<V, VS>,
-        mixed,
-      >
-  );
-
   return (
     <>
       {state.values.map(valueAttribute => (
-        <GenericMultiselectValue
+        <MultiselectValue
           buildExtraChildren={buildExtraValueChildren}
           dispatch={dispatch}
           key={valueAttribute.key}
@@ -263,16 +240,10 @@ const Multiselect = (React.memo(<
       ) : null}
     </>
   );
-}): React.AbstractComponent<
-  MultiselectPropsT<
-    AutocompleteEntityItemT,
-    MultiselectValueStateT<AutocompleteEntityItemT>,
-    MultiselectStateT<
-      AutocompleteEntityItemT,
-      MultiselectValueStateT<AutocompleteEntityItemT>,
-    >,
-  >,
-  mixed,
->);
+}
+
+const Multiselect: typeof _Multiselect =
+  // $FlowIssue[incompatible-type]
+  React.memo(_Multiselect);
 
 export default Multiselect;

--- a/root/static/scripts/edit/components/NewNotesAlertCheckbox.js
+++ b/root/static/scripts/edit/components/NewNotesAlertCheckbox.js
@@ -36,5 +36,5 @@ export default (
   hydrate<React.PropsOf<NewNotesAlertCheckbox>>(
     'span.new-notes-alert-checkbox',
     NewNotesAlertCheckbox,
-  ): React.AbstractComponent<React.PropsOf<NewNotesAlertCheckbox>, void>
+  ): component(...React.PropsOf<NewNotesAlertCheckbox>)
 );

--- a/root/static/scripts/edit/components/ReleaseMergeStrategy.js
+++ b/root/static/scripts/edit/components/ReleaseMergeStrategy.js
@@ -301,4 +301,4 @@ component ReleaseMergeStrategy(
 export default (hydrate<React.PropsOf<ReleaseMergeStrategy>>(
   'div.release-merge-strategy',
   ReleaseMergeStrategy,
-): React.AbstractComponent<React.PropsOf<ReleaseMergeStrategy>, void>);
+): component(...React.PropsOf<ReleaseMergeStrategy>));

--- a/root/static/scripts/edit/components/edit/RelationshipDiff.js
+++ b/root/static/scripts/edit/components/edit/RelationshipDiff.js
@@ -240,8 +240,8 @@ component _RelationshipDiff(
   );
 }
 
-const RelationshipDiff: React.AbstractComponent<
-  React.PropsOf<_RelationshipDiff>
-> = React.memo(_RelationshipDiff);
+const RelationshipDiff:
+  component(...React.PropsOf<_RelationshipDiff>) =
+  React.memo(_RelationshipDiff);
 
 export default RelationshipDiff;

--- a/root/static/scripts/edit/components/withLoadedTypeInfo.js
+++ b/root/static/scripts/edit/components/withLoadedTypeInfo.js
@@ -20,10 +20,10 @@ import {
 const typeInfoPromises = new Map<string, Promise<void>>();
 const loadedTypeInfo = new Set<string>();
 
-export default function withLoadedTypeInfo<Config, Instance = mixed>(
-  WrappedComponent: React.AbstractComponent<Config, Instance>,
+export default function withLoadedTypeInfo<Config: {...}, Instance = mixed>(
+  WrappedComponent: component(ref: React.RefSetter<Instance>, ...Config),
   typeInfoToLoad: $ReadOnlySet<string>,
-): React.AbstractComponent<Config, Instance> {
+): component(ref: React.RefSetter<Instance>, ...Config) {
   const ComponentWrapper = React.forwardRef((
     props: Config,
     ref: React.RefSetter<Instance>,
@@ -143,7 +143,7 @@ export default function withLoadedTypeInfo<Config, Instance = mixed>(
           </p>
         )
       ) : (
-        <WrappedComponent ref={ref} {...props} />
+        <WrappedComponent {...props} ref={ref} />
       )
     );
   });
@@ -152,12 +152,12 @@ export default function withLoadedTypeInfo<Config, Instance = mixed>(
 }
 
 export function withLoadedTypeInfoForRelationshipEditor<
-  Config,
+  Config: {...},
   Instance = mixed,
 >(
-  WrappedComponent: React.AbstractComponent<Config, Instance>,
+  WrappedComponent: component(ref: React.RefSetter<Instance>, ...Config),
   extraTypeInfoToLoad?: $ReadOnlyArray<string> = [],
-): React.AbstractComponent<Config, Instance> {
+): component(ref: React.RefSetter<Instance>, ...Config) {
   return withLoadedTypeInfo(
     WrappedComponent,
     new Set([

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -1643,7 +1643,7 @@ export class ExternalLink extends React.Component<LinkProps> {
 }
 
 export const ExternalLinksEditor:
-  React.AbstractComponent<LinksEditorProps, _ExternalLinksEditor> =
+  component(ref: React.RefSetter<_ExternalLinksEditor>, ...LinksEditorProps) =
   withLoadedTypeInfo<LinksEditorProps, _ExternalLinksEditor>(
     _ExternalLinksEditor,
     new Set(['link_type', 'link_attribute_type']),

--- a/root/static/scripts/event/components/EventEditForm.js
+++ b/root/static/scripts/event/components/EventEditForm.js
@@ -367,4 +367,4 @@ component EventEditForm(
 export default (hydrate<React.PropsOf<EventEditForm>>(
   'div.event-edit-form',
   EventEditForm,
-): React.AbstractComponent<React.PropsOf<EventEditForm>>);
+): component(...React.PropsOf<EventEditForm>));

--- a/root/static/scripts/genre/components/GenreEditForm.js
+++ b/root/static/scripts/genre/components/GenreEditForm.js
@@ -165,4 +165,4 @@ component GenreEditForm(form as initialForm: GenreFormT) {
 export default (hydrate<React.PropsOf<GenreEditForm>>(
   'div.genre-edit-form',
   GenreEditForm,
-): React.AbstractComponent<React.PropsOf<GenreEditForm>, void>);
+): component(...React.PropsOf<GenreEditForm>));

--- a/root/static/scripts/main/components/ConfirmSeedButtons.js
+++ b/root/static/scripts/main/components/ConfirmSeedButtons.js
@@ -47,4 +47,4 @@ component ConfirmSeedButtons(autoSubmit: boolean) {
 export default (hydrate(
   'span.buttons.confirm-seed',
   ConfirmSeedButtons,
-): React.AbstractComponent<React.PropsOf<ConfirmSeedButtons>, void>);
+): component(...React.PropsOf<ConfirmSeedButtons>));

--- a/root/static/scripts/recording/RecordingName.js
+++ b/root/static/scripts/recording/RecordingName.js
@@ -59,4 +59,4 @@ export component RecordingName(
 export default (hydrate<React.PropsOf<RecordingName>>(
   'div.recording-name',
   RecordingName,
-): React.AbstractComponent<React.PropsOf<RecordingName>, void>);
+): component(...React.PropsOf<RecordingName>));

--- a/root/static/scripts/relationship-editor/components/DialogAttribute/BooleanAttribute.js
+++ b/root/static/scripts/relationship-editor/components/DialogAttribute/BooleanAttribute.js
@@ -64,8 +64,8 @@ component _BooleanAttribute(
   );
 }
 
-const BooleanAttribute: React.AbstractComponent<
-  React.PropsOf<_BooleanAttribute>
-> = React.memo(_BooleanAttribute);
+const BooleanAttribute:
+  component(...React.PropsOf<_BooleanAttribute>) =
+  React.memo(_BooleanAttribute);
 
 export default BooleanAttribute;

--- a/root/static/scripts/relationship-editor/components/DialogAttribute/MultiselectAttribute.js
+++ b/root/static/scripts/relationship-editor/components/DialogAttribute/MultiselectAttribute.js
@@ -23,7 +23,6 @@ import localizeLinkAttributeTypeName
   from '../../../common/i18n/localizeLinkAttributeTypeName.js';
 import {uniqueId} from '../../../common/utility/numbers.js';
 import Multiselect, {
-  type MultiselectPropsT,
   runReducer as runMultiselectReducer,
   updateValue as updateMultiselectValue,
 } from '../../../edit/components/Multiselect.js';
@@ -219,23 +218,8 @@ component MultiselectAttributeComponent(
     state.type.creditable,
   ]);
 
-  // XXX: https://github.com/facebook/flow/issues/7672
-  const LinkAttrTypeMultiselect = (
-    // eslint-disable-next-line ft-flow/enforce-suppression-code
-    // $FlowIgnore
-    Multiselect:
-      React.AbstractComponent<
-        MultiselectPropsT<
-          LinkAttrTypeT,
-          DialogMultiselectAttributeValueStateT,
-          DialogMultiselectAttributeStateT,
-        >,
-        mixed,
-      >
-  );
-
   return (
-    <LinkAttrTypeMultiselect
+    <Multiselect
       addLabel={addLabel}
       buildExtraValueChildren={buildExtraValueChildren}
       dispatch={multiselectDispatch}
@@ -245,7 +229,7 @@ component MultiselectAttributeComponent(
 }
 
 type MultiselectAttributeMemoT =
-  React.AbstractComponent<React.PropsOf<MultiselectAttributeComponent>>;
+  component(...React.PropsOf<MultiselectAttributeComponent>);
 
 const MultiselectAttribute: MultiselectAttributeMemoT =
   React.memo(MultiselectAttributeComponent);

--- a/root/static/scripts/relationship-editor/components/DialogAttribute/TextAttribute.js
+++ b/root/static/scripts/relationship-editor/components/DialogAttribute/TextAttribute.js
@@ -59,8 +59,8 @@ component _TextAttribute(
   );
 }
 
-const TextAttribute: React.AbstractComponent<
-  React.PropsOf<_TextAttribute>
-> = React.memo(_TextAttribute);
+const TextAttribute:
+  component(...React.PropsOf<_TextAttribute>) =
+  React.memo(_TextAttribute);
 
 export default TextAttribute;

--- a/root/static/scripts/relationship-editor/components/DialogAttributes.js
+++ b/root/static/scripts/relationship-editor/components/DialogAttributes.js
@@ -476,8 +476,8 @@ component _DialogAttributes(
   );
 }
 
-const DialogAttributes: React.AbstractComponent<
-  React.PropsOf<_DialogAttributes>
-> = React.memo(_DialogAttributes);
+const DialogAttributes:
+  component(...React.PropsOf<_DialogAttributes>) =
+  React.memo(_DialogAttributes);
 
 export default DialogAttributes;

--- a/root/static/scripts/relationship-editor/components/DialogButtons.js
+++ b/root/static/scripts/relationship-editor/components/DialogButtons.js
@@ -36,8 +36,8 @@ component _DialogButtons(
   );
 }
 
-const DialogButtons: React.AbstractComponent<
-  React.PropsOf<_DialogButtons>
-> = React.memo(_DialogButtons);
+const DialogButtons:
+  component(...React.PropsOf<_DialogButtons>) =
+  React.memo(_DialogButtons);
 
 export default DialogButtons;

--- a/root/static/scripts/relationship-editor/components/DialogDatePeriod.js
+++ b/root/static/scripts/relationship-editor/components/DialogDatePeriod.js
@@ -228,8 +228,8 @@ component _DialogDatePeriod(
   );
 }
 
-const DialogDatePeriod: React.AbstractComponent<
-  React.PropsOf<_DialogDatePeriod>
-> = React.memo(_DialogDatePeriod);
+const DialogDatePeriod:
+  component(...React.PropsOf<_DialogDatePeriod>) =
+  React.memo(_DialogDatePeriod);
 
 export default DialogDatePeriod;

--- a/root/static/scripts/relationship-editor/components/DialogEntityCredit.js
+++ b/root/static/scripts/relationship-editor/components/DialogEntityCredit.js
@@ -215,8 +215,8 @@ component _DialogEntityCredit(
   );
 }
 
-const DialogEntityCredit: React.AbstractComponent<
-  React.PropsOf<_DialogEntityCredit>
-> = React.memo(_DialogEntityCredit);
+const DialogEntityCredit:
+  component(...React.PropsOf<_DialogEntityCredit>) =
+  React.memo(_DialogEntityCredit);
 
 export default DialogEntityCredit;

--- a/root/static/scripts/relationship-editor/components/DialogLinkOrder.js
+++ b/root/static/scripts/relationship-editor/components/DialogLinkOrder.js
@@ -58,8 +58,8 @@ component _DialogLinkOrder(
   );
 }
 
-const DialogLinkOrder: React.AbstractComponent<
-  React.PropsOf<_DialogLinkOrder>
-> = React.memo(_DialogLinkOrder);
+const DialogLinkOrder:
+  component(...React.PropsOf<_DialogLinkOrder>) =
+  React.memo(_DialogLinkOrder);
 
 export default DialogLinkOrder;

--- a/root/static/scripts/relationship-editor/components/DialogLinkType.js
+++ b/root/static/scripts/relationship-editor/components/DialogLinkType.js
@@ -261,7 +261,7 @@ function accumulateDialogAttributeByRootId(
 }
 
 const LinkTypeAutocomplete:
-  React.AbstractComponent<AutocompletePropsT<LinkTypeT>> =
+  component(...AutocompletePropsT<LinkTypeT>) =
   Autocomplete2;
 
 component _DialogLinkType(
@@ -335,8 +335,8 @@ component _DialogLinkType(
   );
 }
 
-const DialogLinkType: React.AbstractComponent<
-  React.PropsOf<_DialogLinkType>
-> = React.memo(_DialogLinkType);
+const DialogLinkType:
+  component(...React.PropsOf<_DialogLinkType>) =
+  React.memo(_DialogLinkType);
 
 export default DialogLinkType;

--- a/root/static/scripts/relationship-editor/components/DialogPreview.js
+++ b/root/static/scripts/relationship-editor/components/DialogPreview.js
@@ -236,8 +236,8 @@ component _DialogPreview(
   );
 }
 
-const DialogPreview: React.AbstractComponent<
-  React.PropsOf<_DialogPreview>
-> = React.memo(_DialogPreview);
+const DialogPreview:
+  component(...React.PropsOf<_DialogPreview>) =
+  React.memo(_DialogPreview);
 
 export default DialogPreview;

--- a/root/static/scripts/relationship-editor/components/DialogSourceEntity.js
+++ b/root/static/scripts/relationship-editor/components/DialogSourceEntity.js
@@ -132,8 +132,8 @@ component _DialogSourceEntity(
   );
 }
 
-const DialogSourceEntity: React.AbstractComponent<
-  React.PropsOf<_DialogSourceEntity>
-> = React.memo(_DialogSourceEntity);
+const DialogSourceEntity:
+  component(...React.PropsOf<_DialogSourceEntity>) =
+  React.memo(_DialogSourceEntity);
 
 export default DialogSourceEntity;

--- a/root/static/scripts/relationship-editor/components/DialogTargetEntity.js
+++ b/root/static/scripts/relationship-editor/components/DialogTargetEntity.js
@@ -17,7 +17,6 @@ import {default as autocompleteReducer}
 import type {
   ActionT as AutocompleteActionT,
   OptionItemT,
-  PropsT as AutocompletePropsT,
   StateT as AutocompleteStateT,
 } from '../../common/components/Autocomplete2/types.js';
 import {
@@ -297,12 +296,6 @@ export function reducer(
   }
 }
 
-// XXX Until Flow supports https://github.com/facebook/flow/issues/7672
-const TargetAutocomplete:
-  React.AbstractComponent<AutocompletePropsT<NonUrlRelatableEntityT>> =
-  // $FlowIgnore[incompatible-type]
-  Autocomplete2;
-
 component _DialogTargetEntity(
   backward: boolean,
   dispatch: (DialogTargetEntityActionT) => void,
@@ -361,7 +354,7 @@ component _DialogTargetEntity(
             value={state.target.name}
           />
         ) : autocomplete ? (
-          <TargetAutocomplete
+          <Autocomplete2
             dispatch={autocompleteDispatch}
             state={autocomplete}
           />
@@ -387,8 +380,8 @@ component _DialogTargetEntity(
   );
 }
 
-const DialogTargetEntity: React.AbstractComponent<
-  React.PropsOf<_DialogTargetEntity>
-> = React.memo(_DialogTargetEntity);
+const DialogTargetEntity:
+  component(...React.PropsOf<_DialogTargetEntity>) =
+  React.memo(_DialogTargetEntity);
 
 export default DialogTargetEntity;

--- a/root/static/scripts/relationship-editor/components/DialogTargetType.js
+++ b/root/static/scripts/relationship-editor/components/DialogTargetType.js
@@ -59,8 +59,8 @@ component _DialogTargetType(
   );
 }
 
-const DialogTargetType: React.AbstractComponent<
-  React.PropsOf<_DialogTargetType>
-> = React.memo(_DialogTargetType);
+const DialogTargetType:
+  component(...React.PropsOf<_DialogTargetType>) =
+  React.memo(_DialogTargetType);
 
 export default DialogTargetType;

--- a/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
@@ -1013,9 +1013,9 @@ component _RelationshipDialogContent(...props: PropsT) {
   );
 }
 
-const RelationshipDialogContent: React.AbstractComponent<
-  React.PropsOf<_RelationshipDialogContent>
-> = React.memo(_RelationshipDialogContent);
+const RelationshipDialogContent:
+  component(...React.PropsOf<_RelationshipDialogContent>) =
+  React.memo(_RelationshipDialogContent);
 
 function getBatchSelectionMessage(sourceType: RelatableEntityTypeT) {
   switch (sourceType) {

--- a/root/static/scripts/relationship-editor/components/RelationshipEditor.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipEditor.js
@@ -556,7 +556,7 @@ type ErrorMessagePropsT = {
 };
 
 export const ErrorMessage:
-  React.AbstractComponent<ErrorMessagePropsT, mixed> =
+  component(ref: React.RefSetter<mixed>, ...ErrorMessagePropsT) =
   React.memo<ErrorMessagePropsT>(({
     error,
   }: ErrorMessagePropsT): React.MixedElement => (

--- a/root/static/scripts/relationship-editor/components/RelationshipEditorWrapper.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipEditorWrapper.js
@@ -57,7 +57,7 @@ component _RelationshipEditorWrapper(...props: PropsT) {
 }
 
 export const NonHydratedRelationshipEditorWrapper:
-  React.AbstractComponent<PropsT> =
+  component(ref: React.RefSetter<mixed>, ...PropsT) =
   withLoadedTypeInfoForRelationshipEditor<PropsT>(
     _RelationshipEditorWrapper,
   );
@@ -65,6 +65,6 @@ export const NonHydratedRelationshipEditorWrapper:
 const RelationshipEditorWrapper = (hydrate<PropsT>(
   'div.relationship-editor',
   NonHydratedRelationshipEditorWrapper,
-): React.AbstractComponent<PropsT>);
+): component(...PropsT));
 
 export default RelationshipEditorWrapper;

--- a/root/static/scripts/relationship-editor/components/RelationshipItem.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipItem.js
@@ -281,9 +281,9 @@ component _RelationshipItem(
   );
 }
 
-const RelationshipItem: React.AbstractComponent<
-  React.PropsOf<_RelationshipItem>
-> = React.memo(_RelationshipItem);
+const RelationshipItem:
+  component(...React.PropsOf<_RelationshipItem>) =
+  React.memo(_RelationshipItem);
 
 function getRelationshipStyling(relationship: RelationshipStateT) {
   return 'rel-' + getRelationshipStatusName(relationship);

--- a/root/static/scripts/relationship-editor/components/RelationshipLinkTypeGroup.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipLinkTypeGroup.js
@@ -52,8 +52,8 @@ component _RelationshipLinkTypeGroup(
   return elements;
 }
 
-const RelationshipLinkTypeGroup: React.AbstractComponent<
-  React.PropsOf<_RelationshipLinkTypeGroup>
-> = React.memo(_RelationshipLinkTypeGroup);
+const RelationshipLinkTypeGroup:
+  component(...React.PropsOf<_RelationshipLinkTypeGroup>) =
+  React.memo(_RelationshipLinkTypeGroup);
 
 export default RelationshipLinkTypeGroup;

--- a/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
@@ -302,8 +302,8 @@ component _RelationshipPhraseGroup(
   ) : null;
 }
 
-const RelationshipPhraseGroup: React.AbstractComponent<
-  React.PropsOf<_RelationshipPhraseGroup>
-> = React.memo(_RelationshipPhraseGroup);
+const RelationshipPhraseGroup:
+  component(...React.PropsOf<_RelationshipPhraseGroup>) =
+  React.memo(_RelationshipPhraseGroup);
 
 export default RelationshipPhraseGroup;

--- a/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroup.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroup.js
@@ -55,8 +55,8 @@ component _RelationshipTargetTypeGroup(
   return elements;
 }
 
-const RelationshipTargetTypeGroup: React.AbstractComponent<
-  React.PropsOf<_RelationshipTargetTypeGroup>
-> = React.memo(_RelationshipTargetTypeGroup);
+const RelationshipTargetTypeGroup:
+  component(...React.PropsOf<_RelationshipTargetTypeGroup>) =
+  React.memo(_RelationshipTargetTypeGroup);
 
 export default RelationshipTargetTypeGroup;

--- a/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroups.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroups.js
@@ -113,8 +113,8 @@ component _RelationshipTargetTypeGroups(
   );
 }
 
-const RelationshipTargetTypeGroups: React.AbstractComponent<
-  React.PropsOf<_RelationshipTargetTypeGroups>
-> = React.memo(_RelationshipTargetTypeGroups);
+const RelationshipTargetTypeGroups:
+  component(...React.PropsOf<_RelationshipTargetTypeGroups>) =
+  React.memo(_RelationshipTargetTypeGroups);
 
 export default RelationshipTargetTypeGroups;

--- a/root/static/scripts/release/components/BatchCreateWorksDialog.js
+++ b/root/static/scripts/release/components/BatchCreateWorksDialog.js
@@ -334,6 +334,6 @@ component _BatchCreateWorksButtonPopover(
   );
 }
 
-export const BatchCreateWorksButtonPopover: React.AbstractComponent<
-  React.PropsOf<_BatchCreateWorksButtonPopover>
-> = React.memo(_BatchCreateWorksButtonPopover);
+export const BatchCreateWorksButtonPopover:
+  component(...React.PropsOf<_BatchCreateWorksButtonPopover>) =
+  React.memo(_BatchCreateWorksButtonPopover);

--- a/root/static/scripts/release/components/EditWorkDialog.js
+++ b/root/static/scripts/release/components/EditWorkDialog.js
@@ -187,8 +187,8 @@ component _EditWorkDialog(
   );
 }
 
-const EditWorkDialog: React.AbstractComponent<
-  React.PropsOf<_EditWorkDialog>
-> = React.memo(_EditWorkDialog);
+const EditWorkDialog:
+  component(...React.PropsOf<_EditWorkDialog>) =
+  React.memo(_EditWorkDialog);
 
 export default EditWorkDialog;

--- a/root/static/scripts/release/components/MediumRelationshipEditor.js
+++ b/root/static/scripts/release/components/MediumRelationshipEditor.js
@@ -188,8 +188,8 @@ component _MediumRelationshipEditor(
   );
 }
 
-const MediumRelationshipEditor: React.AbstractComponent<
-  React.PropsOf<_MediumRelationshipEditor>
-> = React.memo(_MediumRelationshipEditor);
+const MediumRelationshipEditor:
+  component(...React.PropsOf<_MediumRelationshipEditor>) =
+  React.memo(_MediumRelationshipEditor);
 
 export default MediumRelationshipEditor;

--- a/root/static/scripts/release/components/MediumTable.js
+++ b/root/static/scripts/release/components/MediumTable.js
@@ -137,8 +137,8 @@ component _MediumTable(
   );
 }
 
-const MediumTable: React.AbstractComponent<
-  React.PropsOf<_MediumTable>
-> = React.memo(_MediumTable);
+const MediumTable:
+  component(...React.PropsOf<_MediumTable>) =
+  React.memo(_MediumTable);
 
 export default MediumTable;

--- a/root/static/scripts/release/components/MediumToolbox.js
+++ b/root/static/scripts/release/components/MediumToolbox.js
@@ -54,9 +54,9 @@ component _ToggleAllMediumsButtons(
   );
 }
 
-export const ToggleAllMediumsButtons: React.AbstractComponent<
-  React.PropsOf<_ToggleAllMediumsButtons>
-> = React.memo(_ToggleAllMediumsButtons);
+export const ToggleAllMediumsButtons:
+  component(...React.PropsOf<_ToggleAllMediumsButtons>) =
+  React.memo(_ToggleAllMediumsButtons);
 
 component _MediumToolbox(
   creditsMode: CreditsModeT,
@@ -90,8 +90,8 @@ component _MediumToolbox(
   );
 }
 
-const MediumToolbox: React.AbstractComponent<
-  React.PropsOf<_MediumToolbox>
-> = React.memo(_MediumToolbox);
+const MediumToolbox:
+  component(...React.PropsOf<_MediumToolbox>) =
+  React.memo(_MediumToolbox);
 
 export default MediumToolbox;

--- a/root/static/scripts/release/components/MediumTrackRow.js
+++ b/root/static/scripts/release/components/MediumTrackRow.js
@@ -101,8 +101,8 @@ component _MediumTrackRow(
   );
 }
 
-const MediumTrackRow: React.AbstractComponent<
-  React.PropsOf<_MediumTrackRow>
-> = React.memo(_MediumTrackRow);
+const MediumTrackRow:
+  component(...React.PropsOf<_MediumTrackRow>) =
+  React.memo(_MediumTrackRow);
 
 export default MediumTrackRow;

--- a/root/static/scripts/release/components/RelationshipEditorBatchTools.js
+++ b/root/static/scripts/release/components/RelationshipEditorBatchTools.js
@@ -165,8 +165,8 @@ component _RelationshipEditorBatchTools(
   );
 }
 
-const RelationshipEditorBatchTools: React.AbstractComponent<
-  React.PropsOf<_RelationshipEditorBatchTools>
-> = React.memo(_RelationshipEditorBatchTools);
+const RelationshipEditorBatchTools:
+  component(...React.PropsOf<_RelationshipEditorBatchTools>) =
+  React.memo(_RelationshipEditorBatchTools);
 
 export default RelationshipEditorBatchTools;

--- a/root/static/scripts/release/components/ReleaseRelationshipEditor.js
+++ b/root/static/scripts/release/components/ReleaseRelationshipEditor.js
@@ -1861,7 +1861,7 @@ component _ReleaseRelationshipEditor() {
   );
 }
 
-const NonHydratedReleaseRelationshipEditor: React.AbstractComponent<{}> =
+const NonHydratedReleaseRelationshipEditor =
   withLoadedTypeInfoForRelationshipEditor<{}>(
     _ReleaseRelationshipEditor,
     ['language', 'work_type'],
@@ -1870,6 +1870,6 @@ const NonHydratedReleaseRelationshipEditor: React.AbstractComponent<{}> =
 const ReleaseRelationshipEditor = (hydrate<{}>(
   'div.release-relationship-editor',
   NonHydratedReleaseRelationshipEditor,
-): React.AbstractComponent<{}, void>);
+): component());
 
 export default ReleaseRelationshipEditor;

--- a/root/static/scripts/release/components/TrackRelationshipEditor.js
+++ b/root/static/scripts/release/components/TrackRelationshipEditor.js
@@ -495,9 +495,9 @@ component _TrackRelationshipEditor(
   );
 }
 
-const TrackRelationshipEditor: React.AbstractComponent<
-  React.PropsOf<_TrackRelationshipEditor>
-> = React.memo(_TrackRelationshipEditor);
+const TrackRelationshipEditor:
+  component(...React.PropsOf<_TrackRelationshipEditor>) =
+  React.memo(_TrackRelationshipEditor);
 
 TrackRelationshipEditor.displayName = 'TrackRelationshipEditor';
 

--- a/root/static/scripts/release/components/TracklistAndCredits.js
+++ b/root/static/scripts/release/components/TracklistAndCredits.js
@@ -411,11 +411,11 @@ component _TracklistAndCredits(
   );
 }
 
-const TracklistAndCredits: React.AbstractComponent<
-  React.PropsOf<_TracklistAndCredits>
-> = React.memo(_TracklistAndCredits);
+const TracklistAndCredits:
+  component(...React.PropsOf<_TracklistAndCredits>) =
+  React.memo(_TracklistAndCredits);
 
 export default (hydrate<React.PropsOf<_TracklistAndCredits>>(
   'div.tracklist-and-credits',
   TracklistAndCredits,
-): React.AbstractComponent<React.PropsOf<_TracklistAndCredits>, void>);
+): component(...React.PropsOf<_TracklistAndCredits>));

--- a/root/static/scripts/release/components/WorkLanguageMultiselect.js
+++ b/root/static/scripts/release/components/WorkLanguageMultiselect.js
@@ -24,7 +24,6 @@ import linkedEntities from '../../common/linkedEntities.mjs';
 import {uniqueId} from '../../common/utility/numbers.js';
 import Multiselect, {
   type MultiselectActionT,
-  type MultiselectPropsT,
   runReducer as runMultiselectReducer,
 } from '../../edit/components/Multiselect.js';
 import type {
@@ -110,47 +109,28 @@ export function runReducer(
   );
 }
 
-type WorkLanguageMultiselectPropsT = {
-  +dispatch: (MultiselectActionT<LanguageT>) => void,
-  +state: MultiselectLanguageStateT,
-};
+component _WorkLanguageMultiselect(
+  dispatch: (MultiselectActionT<LanguageT>) => void,
+  state: MultiselectLanguageStateT,
+) {
+  return (
+    <tr>
+      <td className="section">
+        {addColonText(l('Lyrics languages'))}
+      </td>
+      <td className="lyrics-languages">
+        <Multiselect
+          addLabel={l('Add lyrics language')}
+          dispatch={dispatch}
+          state={state}
+        />
+      </td>
+    </tr>
+  );
+}
 
-// XXX: https://github.com/facebook/flow/issues/7672
-const LanguageMultiselect = (
-  // eslint-disable-next-line ft-flow/enforce-suppression-code
-  // $FlowIgnore
-  Multiselect:
-    React.AbstractComponent<
-      MultiselectPropsT<
-        LanguageT,
-        MultiselectLanguageValueStateT,
-        MultiselectLanguageStateT,
-      >,
-      mixed,
-    >
-);
-
-const WorkLanguageMultiselect: React.AbstractComponent<
-  WorkLanguageMultiselectPropsT,
-  mixed,
-> = React.memo<
-  WorkLanguageMultiselectPropsT,
->(({
-  dispatch,
-  state,
-}: WorkLanguageMultiselectPropsT): React.MixedElement => (
-  <tr>
-    <td className="section">
-      {addColonText(l('Lyrics languages'))}
-    </td>
-    <td className="lyrics-languages">
-      <LanguageMultiselect
-        addLabel={l('Add lyrics language')}
-        dispatch={dispatch}
-        state={state}
-      />
-    </td>
-  </tr>
-));
+const WorkLanguageMultiselect: typeof _WorkLanguageMultiselect =
+  // $FlowIssue[incompatible-type]
+  React.memo(_WorkLanguageMultiselect);
 
 export default WorkLanguageMultiselect;

--- a/root/static/scripts/release/components/WorkTypeSelect.js
+++ b/root/static/scripts/release/components/WorkTypeSelect.js
@@ -68,8 +68,8 @@ component _WorkTypeSelect(
   );
 }
 
-const WorkTypeSelect: React.AbstractComponent<
-  React.PropsOf<_WorkTypeSelect>
-> = React.memo(_WorkTypeSelect);
+const WorkTypeSelect:
+  component(...React.PropsOf<_WorkTypeSelect>) =
+  React.memo(_WorkTypeSelect);
 
 export default WorkTypeSelect;

--- a/root/static/scripts/series/components/SeriesRelationshipEditor.js
+++ b/root/static/scripts/series/components/SeriesRelationshipEditor.js
@@ -179,7 +179,8 @@ component _SeriesRelationshipEditor(...props: PropsT) {
   );
 }
 
-const NonHydratedSeriesRelationshipEditor: React.AbstractComponent<PropsT> =
+const NonHydratedSeriesRelationshipEditor:
+  component(ref: React.RefSetter<mixed>, ...PropsT) =
   withLoadedTypeInfoForRelationshipEditor<PropsT>(
     _SeriesRelationshipEditor,
   );
@@ -187,6 +188,6 @@ const NonHydratedSeriesRelationshipEditor: React.AbstractComponent<PropsT> =
 const SeriesRelationshipEditor = (hydrate<PropsT>(
   'div.relationship-editor',
   NonHydratedSeriesRelationshipEditor,
-): React.AbstractComponent<PropsT>);
+): component(...PropsT));
 
 export default SeriesRelationshipEditor;

--- a/root/static/scripts/tests/examples/todo-list/Todo.js
+++ b/root/static/scripts/tests/examples/todo-list/Todo.js
@@ -50,7 +50,7 @@ export function reducer(
   }
 }
 
-type TodoComponentT = React.AbstractComponent<PropsT, mixed>;
+type TodoComponentT = component(ref: React.RefSetter<mixed>, ...PropsT);
 
 const Todo: TodoComponentT = React.memo<PropsT>(({
   dispatch,

--- a/root/static/scripts/tests/fixtures/autocomplete2.js
+++ b/root/static/scripts/tests/fixtures/autocomplete2.js
@@ -170,7 +170,7 @@ $(function () {
     );
 
     const entityAutocompleteDispatch = React.useCallback((
-      action: AutocompleteActionT<NonUrlRelatableEntityT>,
+      action: AutocompleteActionT<NonUrlRelatableEntityT | EditorT>,
     ) => {
       dispatch({
         action,

--- a/root/static/scripts/url/components/UrlRelationshipEditor.js
+++ b/root/static/scripts/url/components/UrlRelationshipEditor.js
@@ -61,7 +61,8 @@ component _UrlRelationshipEditor(...props: PropsT) {
   );
 }
 
-const NonHydratedUrlRelationshipEditor: React.AbstractComponent<PropsT> =
+const NonHydratedUrlRelationshipEditor:
+  component(ref: React.RefSetter<mixed>, ...PropsT) =
   withLoadedTypeInfoForRelationshipEditor<PropsT>(
     _UrlRelationshipEditor,
   );
@@ -69,6 +70,6 @@ const NonHydratedUrlRelationshipEditor: React.AbstractComponent<PropsT> =
 const UrlRelationshipEditor = (hydrate<PropsT>(
   'div.relationship-editor',
   NonHydratedUrlRelationshipEditor,
-): React.AbstractComponent<PropsT>);
+): component(...PropsT));
 
 export default UrlRelationshipEditor;

--- a/root/utility/hydrate.js
+++ b/root/utility/hydrate.js
@@ -98,9 +98,9 @@ export default function hydrate<
   SanitizedConfig = Config,
 >(
   containerSelector: string,
-  Component: React.AbstractComponent<Config | SanitizedConfig>,
+  Component: React.ComponentType<Config | SanitizedConfig>,
   mungeProps?: (Config) => SanitizedConfig,
-): React.AbstractComponent<Config, void> {
+): component(...Config) {
   const [ContainerTag, ...classes] = containerSelector.split('.');
   if (typeof document !== 'undefined') {
     // This should only run on the client.

--- a/root/vars.js
+++ b/root/vars.js
@@ -30,9 +30,9 @@ declare var hydrate: (
     SanitizedConfig = Config,
   >(
     containerSelector: string,
-    Component: React.AbstractComponent<Config | SanitizedConfig, mixed>,
+    Component: React.ComponentType<Config | SanitizedConfig>,
     mungeProps?: (Config) => SanitizedConfig,
-  ) => React.AbstractComponent<Config, void>
+  ) => component(...Config)
 );
 declare var hyphenateTitle: (title: string, subtitle: string) => string;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4596,12 +4596,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.255.0":
-  version: 0.255.0
-  resolution: "flow-bin@npm:0.255.0"
+"flow-bin@npm:0.256.0":
+  version: 0.256.0
+  resolution: "flow-bin@npm:0.256.0"
   bin:
     flow: cli.js
-  checksum: 10c0/1f1e90cfbcc3b5cbb0159e7c5b9ac79b3fbcfc7600c65e1ab8a32cff9046b52319b6c81b62d2376a36176f1b126a742742760c69630f10ed64ed631509d60e28
+  checksum: 10c0/700fce13ab27a083552f16c8e41fe07d0bca7946c7b9daf2014bc457cf9dde82f8c063d3fafe9c191b7704a40b61444dfdbd42b28fe924d3e30c20b5c224c644
   languageName: node
   linkType: hard
 
@@ -6572,7 +6572,7 @@ __metadata:
     eslint-plugin-simple-import-sort: "npm:^7.0.0"
     fast-diff: "npm:1.3.0"
     filesize: "npm:10.1.4"
-    flow-bin: "npm:0.255.0"
+    flow-bin: "npm:0.256.0"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:4.2.0"
     globals: "npm:15.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4596,12 +4596,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.251.1":
-  version: 0.251.1
-  resolution: "flow-bin@npm:0.251.1"
+"flow-bin@npm:0.252.0":
+  version: 0.252.0
+  resolution: "flow-bin@npm:0.252.0"
   bin:
     flow: cli.js
-  checksum: 10c0/eff0a30bc9330a1b101ae280590160f6817ec39c68dc7db133ff0dbd226072582aab0b86737da56d50b6b785a5efa629deca8af86bae9a39775988fabc69082f
+  checksum: 10c0/a2e912fd4cb1f8da97e7d7ba87d37c209b4503cbb7707fa27fb2870fa2681dad154d0fbf14482e922e15d9569761874fe255d7dab7d079b7f4597d12c0b8e250
   languageName: node
   linkType: hard
 
@@ -6572,7 +6572,7 @@ __metadata:
     eslint-plugin-simple-import-sort: "npm:^7.0.0"
     fast-diff: "npm:1.3.0"
     filesize: "npm:10.1.4"
-    flow-bin: "npm:0.251.1"
+    flow-bin: "npm:0.252.0"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:4.2.0"
     globals: "npm:15.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4596,12 +4596,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.254.2":
-  version: 0.254.2
-  resolution: "flow-bin@npm:0.254.2"
+"flow-bin@npm:0.255.0":
+  version: 0.255.0
+  resolution: "flow-bin@npm:0.255.0"
   bin:
     flow: cli.js
-  checksum: 10c0/1fca11eacdb313819dc139ea656706db793cfcbbf74dd5a0d484732adc0fa778a2b609ac6e8d1bb1849a9b88d85083d5ec874acce62618010bd0e66d0f4fadf4
+  checksum: 10c0/1f1e90cfbcc3b5cbb0159e7c5b9ac79b3fbcfc7600c65e1ab8a32cff9046b52319b6c81b62d2376a36176f1b126a742742760c69630f10ed64ed631509d60e28
   languageName: node
   linkType: hard
 
@@ -6572,7 +6572,7 @@ __metadata:
     eslint-plugin-simple-import-sort: "npm:^7.0.0"
     fast-diff: "npm:1.3.0"
     filesize: "npm:10.1.4"
-    flow-bin: "npm:0.254.2"
+    flow-bin: "npm:0.255.0"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:4.2.0"
     globals: "npm:15.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4596,12 +4596,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.253.0":
-  version: 0.253.0
-  resolution: "flow-bin@npm:0.253.0"
+"flow-bin@npm:0.254.2":
+  version: 0.254.2
+  resolution: "flow-bin@npm:0.254.2"
   bin:
     flow: cli.js
-  checksum: 10c0/fe152556aa539deda2b821870e6d20d59b760e80e64a1de999c84d94ecff5846923c4658d5c0260b326830ced85cb474052cf29b68e07a76c4b0909c52a028ab
+  checksum: 10c0/1fca11eacdb313819dc139ea656706db793cfcbbf74dd5a0d484732adc0fa778a2b609ac6e8d1bb1849a9b88d85083d5ec874acce62618010bd0e66d0f4fadf4
   languageName: node
   linkType: hard
 
@@ -6572,7 +6572,7 @@ __metadata:
     eslint-plugin-simple-import-sort: "npm:^7.0.0"
     fast-diff: "npm:1.3.0"
     filesize: "npm:10.1.4"
-    flow-bin: "npm:0.253.0"
+    flow-bin: "npm:0.254.2"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:4.2.0"
     globals: "npm:15.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4596,12 +4596,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.250.0":
-  version: 0.250.0
-  resolution: "flow-bin@npm:0.250.0"
+"flow-bin@npm:0.251.1":
+  version: 0.251.1
+  resolution: "flow-bin@npm:0.251.1"
   bin:
     flow: cli.js
-  checksum: 10c0/9ca0e669945594ba60b0583ce1d88abdc9c731410b9906ed61bcc254beaa6df0905578284318696a2a562eb82d94db1756b567848693a4af6660ac386aac142a
+  checksum: 10c0/eff0a30bc9330a1b101ae280590160f6817ec39c68dc7db133ff0dbd226072582aab0b86737da56d50b6b785a5efa629deca8af86bae9a39775988fabc69082f
   languageName: node
   linkType: hard
 
@@ -6572,7 +6572,7 @@ __metadata:
     eslint-plugin-simple-import-sort: "npm:^7.0.0"
     fast-diff: "npm:1.3.0"
     filesize: "npm:10.1.4"
-    flow-bin: "npm:0.250.0"
+    flow-bin: "npm:0.251.1"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:4.2.0"
     globals: "npm:15.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4596,12 +4596,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.252.0":
-  version: 0.252.0
-  resolution: "flow-bin@npm:0.252.0"
+"flow-bin@npm:0.253.0":
+  version: 0.253.0
+  resolution: "flow-bin@npm:0.253.0"
   bin:
     flow: cli.js
-  checksum: 10c0/a2e912fd4cb1f8da97e7d7ba87d37c209b4503cbb7707fa27fb2870fa2681dad154d0fbf14482e922e15d9569761874fe255d7dab7d079b7f4597d12c0b8e250
+  checksum: 10c0/fe152556aa539deda2b821870e6d20d59b760e80e64a1de999c84d94ecff5846923c4658d5c0260b326830ced85cb474052cf29b68e07a76c4b0909c52a028ab
   languageName: node
   linkType: hard
 
@@ -6572,7 +6572,7 @@ __metadata:
     eslint-plugin-simple-import-sort: "npm:^7.0.0"
     fast-diff: "npm:1.3.0"
     filesize: "npm:10.1.4"
-    flow-bin: "npm:0.252.0"
+    flow-bin: "npm:0.253.0"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:4.2.0"
     globals: "npm:15.9.0"


### PR DESCRIPTION
https://github.com/facebook/flow/releases/tag/v0.251.0
https://github.com/facebook/flow/releases/tag/v0.251.1

Most changes are due to the deprecation of `React.AbstractComponent` which needs to be replaced with component types.