### PR TITLE
MBS-13806: Avoid uppercasing "mi" and "mix" as Roman numerals

### DIFF
--- a/root/static/scripts/guess-case/modes.js
+++ b/root/static/scripts/guess-case/modes.js
@@ -49,6 +49,12 @@ const LOWER_CASE_WORDS_TURKISH = /^(ve|ile|ya|veya|yahut|ki|mı|mi|mu|mü|mısı
 const UPPER_CASE_WORDS = /^(dj|mc|tv|mtv|ep|lp|ymca|nyc|ny|ussr|usa|r&b|bbc|fm|bc|ac|dc|uk|bpm|ok|nba|rza|gza|odb|dmx|2xlc)$/;
 const ROMAN_NUMERALS = /^m{0,4}(cm|cd|d?c{0,3})(xc|xl|l?x{0,3})(ix|iv|v?i{0,3})$/;
 
+/*
+ * Roman numerals which should not be uppercased since they're also
+ * frequently-used words.
+ */
+const EXCLUDED_ROMAN_NUMERALS = /^(?:mi|mix)$/;
+
 /* eslint-disable @stylistic/js/no-multi-spaces */
 const PREPROCESS_FIXLIST = [
   // trim spaces from brackets.
@@ -184,7 +190,9 @@ const DefaultMode: GuessCaseModeT = {
   },
 
   isRomanNumber(word) {
-    return getBooleanCookie('guesscase_roman') && ROMAN_NUMERALS.test(word);
+    return getBooleanCookie('guesscase_roman') &&
+      ROMAN_NUMERALS.test(word) &&
+      !EXCLUDED_ROMAN_NUMERALS.test(word);
   },
 
   isSentenceCaps() {

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -223,7 +223,7 @@ test('Release', function (t) {
 });
 
 test('Work', function (t) {
-  t.plan(26);
+  t.plan(27);
 
   const tests = [
     {
@@ -409,8 +409,16 @@ test('Work', function (t) {
       keepuppercase: false,
     },
     {
-      input: 'cmxcix + x = mix',
-      expected: 'CMXCIX + X = MIX',
+      input: 'mi amor',
+      expected: 'Mi amor',
+      bug: 'MBS-13806',
+      mode: 'Sentence',
+      roman: true,
+      keepuppercase: false,
+    },
+    {
+      input: 'cmxcix + v = miv',
+      expected: 'CMXCIX + V = MIV',
       bug: 'MBS-12523',
       mode: 'English',
       roman: true,


### PR DESCRIPTION
# MBS-13806

Introduce a regular expression matching common words to exclude from "Guess case" when "Uppercase Roman numerals" is checked.

# Problem

"Mi" is a common word in Spanish (and likely other languages) but also an uncommon (in album and song titles) number in Roman numerals. When "Guess case" is used while the "Uppercase Roman numerals" option is checked, titles like "Mi amor" are changed to "MI amor".

# Solution

Add a regular expression matching common words that are also matched by the expression for matching Roman numerals. It currently matches "mi" and "mix" (the latter of which was already excluded from uppercasing when used in ETI).

# Testing

Added a unit test case and manually tested in the edit-release form.