### PR TITLE
Convert Wikimedia classes to components

### DIFF
--- a/root/static/scripts/common/components/WikipediaExtract.js
+++ b/root/static/scripts/common/components/WikipediaExtract.js
@@ -7,6 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import * as Sentry from '@sentry/browser';
 import * as React from 'react';
 
 import {minimalEntity} from '../../../../utility/hydrate.js';
@@ -31,59 +32,62 @@ type MinimalEntityWithWikipediaExtractT = {
   +gid: string,
 };
 
-type Props = {
-  +cachedWikipediaExtract: WikipediaExtractT | null,
-  +entity:
-    | EntityWithWikipediaExtractT
-    | MinimalEntityWithWikipediaExtractT,
-};
+type WikipediaExtractRequestCallbackT = (WikipediaExtractT | null) => void;
 
-type State = {
-  wikipediaExtract: WikipediaExtractT | null,
-};
+function loadWikipediaExtract(
+  entity: EntityWithWikipediaExtractT | MinimalEntityWithWikipediaExtractT,
+  callback: WikipediaExtractRequestCallbackT,
+): void {
+  const url = entityHref(entity, '/wikipedia-extract');
 
-class WikipediaExtract extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {wikipediaExtract: props.cachedWikipediaExtract};
-  }
-
-  componentDidMount() {
-    if (!this.state.wikipediaExtract) {
-      const $ = require('jquery');
-      $.get(entityHref(this.props.entity, '/wikipedia-extract'), data => {
-        this.setState(data);
-      });
-    }
-  }
-
-  render(): React.MixedElement | null {
-    const {wikipediaExtract} = this.state;
-    return wikipediaExtract ? (
-      <>
-        <h2 className="wikipedia">{l('Wikipedia')}</h2>
-        <Collapsible
-          className="wikipedia-extract"
-          html={wikipediaExtract.content}
-        />
-        <a href={wikipediaExtract.url}>
-          {l('Continue reading at Wikipedia...')}
-        </a>
-        {' '}
-        <small>
-          {exp.l(
-            `Wikipedia content provided under the terms of the
-             {license_link|Creative Commons BY-SA license}`,
-            {license_link: 'https://creativecommons.org/licenses/by-sa/3.0/'},
-          )}
-        </small>
-      </>
-    ) : null;
-  }
+  fetch(url)
+    .then(resp => resp.json())
+    .then((reqData) => {
+      callback(reqData.wikipediaExtract);
+    })
+    .catch((error) => {
+      console.error(error);
+      Sentry.captureException(error);
+    });
 }
 
-export default (hydrate<Props>(
+component WikipediaExtract(
+  cachedWikipediaExtract: WikipediaExtractT | null,
+  entity: EntityWithWikipediaExtractT | MinimalEntityWithWikipediaExtractT,
+) {
+  const [wikipediaExtract, setWikipediaExtract] =
+    React.useState(cachedWikipediaExtract);
+
+  React.useEffect(() => {
+    if (cachedWikipediaExtract == null) {
+      loadWikipediaExtract(entity, setWikipediaExtract);
+    }
+  }, [entity]);
+
+  return wikipediaExtract ? (
+    <>
+      <h2 className="wikipedia">{l('Wikipedia')}</h2>
+      <Collapsible
+        className="wikipedia-extract"
+        html={wikipediaExtract.content}
+      />
+      <a href={wikipediaExtract.url}>
+        {l('Continue reading at Wikipedia...')}
+      </a>
+      {' '}
+      <small>
+        {exp.l(
+          `Wikipedia content provided under the terms of the
+            {license_link|Creative Commons BY-SA license}`,
+          {license_link: 'https://creativecommons.org/licenses/by-sa/3.0/'},
+        )}
+      </small>
+    </>
+  ) : null;
+}
+
+export default (hydrate<React.PropsOf<WikipediaExtract>>(
   'div.wikipedia-extract',
   WikipediaExtract,
   minimalEntity,
-): React.AbstractComponent<Props, void>);
+): component(...React.PropsOf<WikipediaExtract>));


### PR DESCRIPTION
# Description
This turns the `WikipediaExtract` file (and the mostly deprecated `CommonsImage` one) from classes to React components, and moves from jQuery to `useCallback`/`useEffect` hooks.

# Testing
Manually, by loading some files with both in a dev setup, such as `/artist/ae0b2424-d4c5-4c54-82ac-fe3be5453270`