### PR TITLE
MBS-13561 / MBS-13571 / MBS-13818 / MBS-13580 / MBS-13825: Show primary aliases in more places

### DIFF
--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -336,6 +336,12 @@ sub handle_unicode_encoding_exception {
     $self->res->status(HTTP_BAD_REQUEST);
 }
 
+has current_language => (
+    is => 'rw',
+    isa => 'Str',
+    default => 'en',
+);
+
 # Set and unset translation language
 sub with_translations {
     my ($c, $code) = @_;
@@ -355,6 +361,8 @@ sub with_translations {
     my $cookie_lang = Translation->instance->language_from_cookie($c->request->cookies->{lang});
     $c->set_language_cookie($c->request->cookies->{lang}->value) if defined $c->request->cookies->{lang};
     my $lang = Translation->instance->set_language($cookie_lang);
+    $c->current_language($lang);
+    $c->model('MB')->context->current_language($lang);
     my $html_lang = $lang =~ s/_([A-Z0-9]{2,})/-\L$1/r;
 
     $c->stash(

--- a/lib/MusicBrainz/Server/Context.pm
+++ b/lib/MusicBrainz/Server/Context.pm
@@ -208,6 +208,12 @@ has 'max_request_time' => (
     isa => 'Maybe[Int]',
 );
 
+has current_language => (
+    is => 'rw',
+    isa => 'Str',
+    default => 'en',
+);
+
 has 'catalyst_context' => (
     is => 'rw',
     isa => 'Maybe[MusicBrainz::Server]',

--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -81,6 +81,7 @@ after 'load' => sub {
     my $area = $c->stash->{area};
 
     $c->model('AreaType')->load($area);
+    $c->model('Area')->load_aliases($area);
     $c->model('Area')->load_containment($area);
 };
 
@@ -409,6 +410,7 @@ before qw( create edit ) => sub {
 sub _merge_load_entities
 {
     my ($self, $c, @areas) = @_;
+    $c->model('Area')->load_aliases(@areas);
     $c->model('Area')->load_containment(@areas);
     $c->model('AreaType')->load(@areas);
 }

--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -158,6 +158,7 @@ sub events : Chained('load')
     $c->model('Area')->load(map { $_->{entity} } map { $_->all_places } @$events);
     $c->model('Area')->load_containment(map { (map { $_->{entity} } $_->all_areas),
                                               (map { $_->{entity}->area } $_->all_places) } @$events);
+    $c->model('Event')->load_aliases(@$events);
     $c->model('Event')->load_meta(@$events);
     $c->model('Event')->rating->load_user_ratings($c->user->id, @$events) if $c->user_exists;
 

--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -264,6 +264,7 @@ sub places : Chained('load')
     $c->model('PlaceType')->load(@$places);
     $c->model('Area')->load(@$places);
     $c->model('Area')->load_containment(map { $_->area } @$places);
+    $c->model('Place')->load_aliases(@$places);
     $c->model('Place')->load_meta(@$places);
     $c->model('Place')->rating->load_user_ratings($c->user->id, @$places) if $c->user_exists;
 

--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -189,6 +189,7 @@ sub labels : Chained('load')
     $c->model('LabelType')->load(@$labels);
     $c->model('Area')->load(@$labels);
     $c->model('Area')->load_containment(map { $_->{area} } @$labels);
+    $c->model('Label')->load_aliases(@$labels);
     $c->model('Label')->load_meta(@$labels);
     if ($c->user_exists) {
         $c->model('Label')->rating->load_user_ratings($c->user->id, @$labels);

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -146,8 +146,7 @@ after 'load' => sub
         }
     }
 
-    my $lang = $c->stash->{current_language} // 'en';
-    $c->model('Artist')->load_related_info([$artist], $lang);
+    $c->model('Artist')->load_related_info($artist);
     $c->model('ArtistType')->load(map { $_->target } @{ $artist->relationships_by_type('artist') });
     $c->model('Area')->load_containment($artist->area, $artist->begin_area, $artist->end_area);
 };

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -134,6 +134,7 @@ after 'load' => sub
     my $artist_model = $c->model('Artist');
 
     unless ($returning_jsonld) {
+        $artist_model->load_aliases($artist);
         $artist_model->load_meta($artist);
 
         if ($c->user_exists) {

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -254,6 +254,7 @@ sub show : PathPart('') Chained('load')
             );
         });
         $c->model('ArtistCredit')->load(@$recordings);
+        $c->model('Recording')->load_aliases(@$recordings);
         $c->model('Recording')->load_meta(@$recordings);
         $c->model('ISRC')->load_for_recordings(@$recordings);
         if ($c->user_exists) {
@@ -476,6 +477,7 @@ sub recordings : Chained('load')
         });
     }
 
+    $c->model('Recording')->load_aliases(@$recordings);
     $c->model('Recording')->load_meta(@$recordings);
 
     my $release_group_appearances = $c->model('Recording')->appears_on($recordings, 10, 1);

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -599,6 +599,7 @@ sub releases : Chained('load')
 
     $c->model('ArtistCredit')->load(@$releases);
     $c->model('Release')->load_related_info(@$releases);
+    $c->model('Release')->load_aliases(@$releases);
     $c->model('Release')->load_meta(@$releases);
     $c->stash(
         current_view => 'Node',

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -533,6 +533,7 @@ sub events : Chained('load')
     });
     $c->model('Event')->load_related_info(@$events);
     $c->model('Event')->load_areas(@$events);
+    $c->model('Event')->load_aliases(@$events);
     $c->model('Event')->load_meta(@$events);
     $c->model('Event')->rating->load_user_ratings($c->user->id, @$events) if $c->user_exists;
 

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -146,7 +146,7 @@ after 'load' => sub
         }
     }
 
-    $c->model('Artist')->load_related_info($artist);
+    $artist_model->load_related_info($artist);
     $c->model('ArtistType')->load(map { $_->target } @{ $artist->relationships_by_type('artist') });
     $c->model('Area')->load_containment($artist->area, $artist->begin_area, $artist->end_area);
 };

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -409,6 +409,7 @@ sub works : Chained('load')
         );
     });
     $c->model('Work')->load_related_info(@$works);
+    $c->model('Work')->load_aliases(@$works);
     $c->model('Work')->load_meta(@$works);
     $c->model('Work')->rating->load_user_ratings($c->user->id, @$works) if $c->user_exists;
 

--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -125,12 +125,7 @@ sub show : Chained('load') PathPart('') {
     });
 
     if ($model->can('load_related_info')) {
-        if ($entity_type eq 'artist') {
-            my $lang = $c->stash->{current_language} // 'en';
-            $model->load_related_info($entities, $lang);
-        } else {
-            $model->load_related_info(@$entities);
-        }
+        $model->load_related_info(@$entities);
     }
 
     if ($model->can('load_meta')) {

--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -128,6 +128,10 @@ sub show : Chained('load') PathPart('') {
         $model->load_related_info(@$entities);
     }
 
+    if ($model->can('load_aliases')) {
+        $model->load_aliases(@$entities);
+    }
+
     if ($model->can('load_meta')) {
         $model->load_meta(@$entities);
     }

--- a/lib/MusicBrainz/Server/Controller/Event.pm
+++ b/lib/MusicBrainz/Server/Controller/Event.pm
@@ -61,6 +61,7 @@ after 'load' => sub {
     my $event = $c->stash->{event};
 
     my $event_model = $c->model('Event');
+    $event_model->load_aliases($event);
     $event_model->load_meta($event);
     if ($c->user_exists) {
         $event_model->rating->load_user_ratings($c->user->id, $event);
@@ -114,6 +115,7 @@ sub show : PathPart('') Chained('load') {
 
 sub _merge_load_entities {
     my ($self, $c, @events) = @_;
+    $c->model('Event')->load_aliases(@events);
     $c->model('Event')->load_related_info(@events);
 }
 

--- a/lib/MusicBrainz/Server/Controller/Genre.pm
+++ b/lib/MusicBrainz/Server/Controller/Genre.pm
@@ -39,6 +39,8 @@ after 'load' => sub {
     my ($self, $c) = @_;
     my $entity_name = $self->{entity_name};
     my $entity = $c->stash->{ $entity_name };
+    $c->model('Genre')->load_aliases($entity);
+
     $c->stash(
         can_delete => $c->model('Genre')->can_delete($entity->id),
     );
@@ -102,6 +104,7 @@ sub list : Path('/genres') Args(0) {
     my ($self, $c) = @_;
 
     my @genres = $c->model('Genre')->get_all;
+    $c->model('Genre')->load_aliases(@genres);
     my $coll = $c->get_collator();
     my @sorted_genres = sort_by { $coll->getSortKey($_->name) } @genres;
 

--- a/lib/MusicBrainz/Server/Controller/Instrument.pm
+++ b/lib/MusicBrainz/Server/Controller/Instrument.pm
@@ -154,6 +154,7 @@ sub releases : Chained('load') {
     }
 
     $c->model('ArtistCredit')->load(@releases);
+    $c->model('Release')->load_aliases(@releases);
     $c->model('Release')->load_related_info(@releases);
 
     my %props = (

--- a/lib/MusicBrainz/Server/Controller/Instrument.pm
+++ b/lib/MusicBrainz/Server/Controller/Instrument.pm
@@ -113,6 +113,7 @@ sub recordings : Chained('load') {
         $instrument_credits_and_rel_types{$item->{recording}->gid} = \@credits_and_rel_types if @credits_and_rel_types;
     }
 
+    $c->model('Recording')->load_aliases(@recordings);
     $c->model('Recording')->load_meta(@recordings);
 
     if ($c->user_exists) {

--- a/lib/MusicBrainz/Server/Controller/Instrument.pm
+++ b/lib/MusicBrainz/Server/Controller/Instrument.pm
@@ -73,6 +73,7 @@ sub artists : Chained('load') {
         $instrument_credits_and_rel_types{$item->{artist}->gid} = \@credits_and_rel_types if @credits_and_rel_types;
     }
 
+    $c->model('Artist')->load_aliases(@artists);
     $c->model('Artist')->load_meta(@artists);
     $c->model('ArtistType')->load(@artists);
     $c->model('Gender')->load(@artists);

--- a/lib/MusicBrainz/Server/Controller/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/Label.pm
@@ -130,6 +130,7 @@ sub show : PathPart('') Chained('load')
 
     $c->model('ArtistCredit')->load(@$releases);
     $c->model('Release')->load_release_events(@$releases);
+    $c->model('Release')->load_aliases(@$releases);
     $c->model('Release')->load_meta(@$releases);
     $c->model('Medium')->load_for_releases(@$releases);
     $c->model('MediumFormat')->load(map { $_->all_mediums } @$releases);

--- a/lib/MusicBrainz/Server/Controller/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/Label.pm
@@ -93,6 +93,7 @@ after 'load' => sub
     my $label_model = $c->model('Label');
 
     unless ($returning_jsonld) {
+        $label_model->load_aliases($label);
         $label_model->load_meta($label);
 
         if ($c->user_exists) {
@@ -197,6 +198,7 @@ after [qw( show collections details tags ratings aliases subscribers relationshi
 sub _merge_load_entities
 {
     my ($self, $c, @labels) = @_;
+    $c->model('Label')->load_aliases(@labels);
     $c->model('LabelType')->load(@labels);
     $c->model('Area')->load(@labels);
 }

--- a/lib/MusicBrainz/Server/Controller/Place.pm
+++ b/lib/MusicBrainz/Server/Controller/Place.pm
@@ -82,6 +82,7 @@ after 'load' => sub {
     my $returning_jsonld = $self->should_return_jsonld($c);
 
     unless ($returning_jsonld) {
+        $c->model('Place')->load_aliases($place);
         $c->model('Place')->load_meta($place);
 
         if ($c->user_exists) {
@@ -248,6 +249,7 @@ before qw( create edit ) => sub {
 sub _merge_load_entities
 {
     my ($self, $c, @places) = @_;
+    $c->model('Place')->load_aliases(@places);
     $c->model('PlaceType')->load(@places);
     $c->model('Area')->load(@places);
     $c->model('Area')->load_containment(map { $_->area } @places);

--- a/lib/MusicBrainz/Server/Controller/Place.pm
+++ b/lib/MusicBrainz/Server/Controller/Place.pm
@@ -129,6 +129,7 @@ sub events : Chained('load')
         $c->model('Event')->find_by_place($c->stash->{place}->id, shift, shift);
     });
     $c->model('Event')->load_related_info(@$events);
+    $c->model('Event')->load_aliases(@$events);
     $c->model('Event')->load_meta(@$events);
     $c->model('Event')->rating->load_user_ratings($c->user->id, @$events) if $c->user_exists;
 

--- a/lib/MusicBrainz/Server/Controller/Recording.pm
+++ b/lib/MusicBrainz/Server/Controller/Recording.pm
@@ -73,6 +73,7 @@ after 'load' => sub
     my $returning_jsonld = $self->should_return_jsonld($c);
 
     unless ($returning_jsonld) {
+        $c->model('Recording')->load_aliases($recording);
         $c->model('Recording')->load_meta($recording);
         $c->model('Recording')->load_first_release_date($recording);
 
@@ -203,6 +204,7 @@ with 'MusicBrainz::Server::Controller::Role::Create' => {
 
 sub _merge_load_entities {
     my ($self, $c, @recordings) = @_;
+    $c->model('Recording')->load_aliases(@recordings);
     $c->model('ArtistCredit')->load(@recordings);
     $c->model('ISRC')->load_for_recordings(@recordings);
 

--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -84,14 +84,13 @@ after 'load' => sub {
     my $release = $c->stash->{release};
     my $returning_jsonld = $self->should_return_jsonld($c);
 
-    $c->model('Release')->load_meta($release)
-        unless $returning_jsonld;
-
     # Load release group
     $c->model('ReleaseGroup')->load($release);
     $c->model('ReleaseGroupType')->load($release->release_group);
 
     unless ($returning_jsonld) {
+        $c->model('Release')->load_aliases($release);
+        $c->model('Release')->load_meta($release);
         $c->model('ReleaseGroup')->load_meta($release->release_group);
         $c->model('Relationship')->load($release->release_group);
         $c->model('ArtistType')->load(map { $_->target } @{ $release->relationships_by_type('artist') }, @{ $release->release_group->relationships_by_type('artist') });
@@ -493,6 +492,7 @@ around _validate_merge => sub {
 sub _merge_load_entities {
     my ($self, $c, @releases) = @_;
     $c->model('ArtistCredit')->load(@releases);
+    $c->model('Release')->load_aliases(@releases);
     $c->model('Release')->load_related_info(@releases);
 }
 
@@ -505,6 +505,7 @@ sub edit_relationships : Chained('load') PathPart('edit-relationships') Edit {
     my ($self, $c) = @_;
 
     my $release = $c->stash->{release};
+    $c->model('Release')->load_aliases($release);
     $c->model('Release')->load_meta($release);
     $c->model('ArtistCredit')->load($release);
     $c->model('ReleaseGroup')->load($release);

--- a/lib/MusicBrainz/Server/Controller/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/ReleaseGroup.pm
@@ -79,6 +79,7 @@ sub show : Chained('load') PathPart('') {
     });
 
     $c->model('Release')->load_related_info(@$releases);
+    $c->model('Release')->load_aliases(@$releases);
     $c->model('Release')->load_meta(@$releases);
     $c->model('ArtistCredit')->load(@$releases);
     $c->model('ReleaseStatus')->load(@$releases);
@@ -165,6 +166,7 @@ sub set_cover_art : Chained('load') PathPart('set-cover-art') Args(0) Edit
     my ($releases, undef) = $c->model('Release')->find_by_release_group(
         $entity->id);
     $c->model('Release')->load_related_info(@$releases);
+    $c->model('Release')->load_aliases(@$releases);
     $c->model('Release')->load_meta(@$releases);
     $c->model('ArtistCredit')->load(@$releases);
 

--- a/lib/MusicBrainz/Server/Controller/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/ReleaseGroup.pm
@@ -55,6 +55,7 @@ after 'load' => sub {
     my $returning_jsonld = $self->should_return_jsonld($c);
 
     unless ($returning_jsonld) {
+        $c->model('ReleaseGroup')->load_aliases($rg);
         $c->model('ReleaseGroup')->load_meta($rg);
 
         if ($c->user_exists) {
@@ -152,6 +153,7 @@ sub _merge_load_entities
     my ($self, $c, @rgs) = @_;
 
     $c->model('ArtistCredit')->load(@rgs);
+    $c->model('ReleaseGroup')->load_aliases(@rgs);
     $c->model('ReleaseGroup')->load_meta(@rgs);
     $c->model('ReleaseGroupType')->load(@rgs);
 }

--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -457,6 +457,7 @@ sub begin : Private
         my @merge = values %{
             $model->get_by_ids($merger->all_entities);
         };
+        $model->load_aliases(@merge) if $model->can('load_aliases');
         $c->model('ArtistCredit')->load(@merge)
             if $entity_properties->{artist_credits};
 

--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -124,6 +124,12 @@ sub direct : Private
 
     my @entities = map { $_->entity } @$results;
 
+    my $model = $c->model(type_to_model($type));
+
+    if ($model->can('load_aliases')) {
+        $model->load_aliases(@entities);
+    }
+
     if ($type eq 'artist') {
         $c->model('Artist')->load_related_info(@entities);
     }

--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -200,6 +200,7 @@ sub direct : Private
     }
     elsif ($type eq 'tag') {
         $c->model('Genre')->load(@entities);
+        $c->model('Genre')->load_aliases(map { $_->{genre} // () } @entities);
     }
 
     if ($type =~ /(recording|release|release_group)/)

--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -125,8 +125,7 @@ sub direct : Private
     my @entities = map { $_->entity } @$results;
 
     if ($type eq 'artist') {
-        my $lang = $c->stash->{current_language} // 'en';
-        $c->model('Artist')->load_related_info(\@entities, $lang);
+        $c->model('Artist')->load_related_info(@entities);
     }
     elsif ($type eq 'editor') {
         $c->model('Editor')->load_preferences(@entities);
@@ -245,15 +244,12 @@ sub do_external_search {
     my $query = $opts{query};
     my $type  = $opts{type};
 
-    my $lang = $c->stash->{current_language} // 'en';
-
     my $search = $c->model('Search');
     my $ret = $search->external_search($type,
                                        $query,
                                        $limit,
                                        $page,
-                                       $advanced,
-                                       $lang);
+                                       $advanced);
 
     if (exists $ret->{error})
     {

--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -46,6 +46,7 @@ after load => sub {
 
     my $series = $c->stash->{series};
 
+    $c->model('Series')->load_aliases($series);
     $c->model('SeriesType')->load($series);
     $c->model('SeriesOrderingType')->load($series);
 
@@ -150,6 +151,7 @@ sub _merge_load_entities {
     my ($self, $c, @series) = @_;
 
     $c->model('Relationship')->load(@series);
+    $c->model('Series')->load_aliases(@series);
     $c->model('SeriesType')->load(@series);
     $c->model('SeriesOrderingType')->load(@series);
 }

--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -72,7 +72,7 @@ sub show : PathPart('') Chained('load') {
     }
 
     if ($series->type->item_entity_type eq 'artist') {
-        $c->model('Artist')->load_related_info(\@entities);
+        $c->model('Artist')->load_related_info(@entities);
         $c->model('Artist')->load_meta(@entities);
         $c->model('Artist')->rating->load_user_ratings($c->user->id, @entities) if $c->user_exists;
     }

--- a/lib/MusicBrainz/Server/Controller/Tag.pm
+++ b/lib/MusicBrainz/Server/Controller/Tag.pm
@@ -92,13 +92,13 @@ sub show : Chained('load') PathPart('')
                 map {
 
                     my $model = $c->model(type_to_model($_));
-                    my $lang = $c->stash->{current_language} // 'en';
 
                     my ($entity_tags, $total) = $model->tags->find_entities(
                         $tag->id, 10, 0);
 
                     my @entities = map { $_->entity } @$entity_tags;
-                    $model->load_aliases(\@entities, $lang) if $model->can('load_aliases');
+                    $model->load_aliases(@entities)
+                        if $model->can('load_aliases');
                     $c->model('ArtistCredit')->load(@entities);
 
                     ("$_" => {
@@ -124,13 +124,12 @@ for my $entity_type (entities_with('tags')) {
         my ($self, $c) = @_;
 
         my $model = $c->model($entity_properties->{model});
-        my $lang = $c->stash->{current_language} // 'en';
         my $entity_tags = $self->_load_paged($c, sub {
             $model->tags->find_entities($c->stash->{tag}->id, shift, shift);
         });
         my @entities = map { $_->entity } @$entity_tags;
 
-        $model->load_aliases(\@entities, $lang) if $model->can('load_aliases');
+        $model->load_aliases(@entities) if $model->can('load_aliases');
         $c->model('ArtistCredit')->load(@entities) if $entity_properties->{artist_credits};
         $c->stash(
             current_view => 'Node',

--- a/lib/MusicBrainz/Server/Controller/Tag.pm
+++ b/lib/MusicBrainz/Server/Controller/Tag.pm
@@ -6,7 +6,7 @@ use HTTP::Status qw( :constants );
 
 extends 'MusicBrainz::Server::Controller';
 
-use MusicBrainz::Server::Data::Utils qw( boolean_to_json type_to_model );
+use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Constants qw( %ENTITIES entities_with );
 use MusicBrainz::Server::ControllerUtils::JSON qw( serialize_pager );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
@@ -90,8 +90,8 @@ sub show : Chained('load') PathPart('')
             tag => $tag->TO_JSON,
             taggedEntities => {
                 map {
-
-                    my $model = $c->model(type_to_model($_));
+                    my $entity_properties = $ENTITIES{$_};
+                    my $model = $c->model($entity_properties->{model});
 
                     my ($entity_tags, $total) = $model->tags->find_entities(
                         $tag->id, 10, 0);
@@ -99,7 +99,8 @@ sub show : Chained('load') PathPart('')
                     my @entities = map { $_->entity } @$entity_tags;
                     $model->load_aliases(@entities)
                         if $model->can('load_aliases');
-                    $c->model('ArtistCredit')->load(@entities);
+                    $c->model('ArtistCredit')->load(@entities)
+                        if $entity_properties->{artist_credits};
 
                     ("$_" => {
                         count => $total,

--- a/lib/MusicBrainz/Server/Controller/User/SubscriptionsRole.pm
+++ b/lib/MusicBrainz/Server/Controller/User/SubscriptionsRole.pm
@@ -38,9 +38,13 @@ role {
                 unless $user->preferences->public_subscriptions;
         }
 
+        my $model = $c->model(type_to_model($type));
+        my $lang = $c->stash->{current_language} // 'en';
         my $entities = $self->_load_paged($c, sub {
-            $c->model(type_to_model($type))->find_by_subscribed_editor($user->id, shift, shift);
+            $model->find_by_subscribed_editor($user->id, shift, shift);
         });
+        $model->load_aliases($entities, $lang) if $model->can('load_aliases');
+
         my %extra_props;
 
         if ($type eq 'collection') {

--- a/lib/MusicBrainz/Server/Controller/User/SubscriptionsRole.pm
+++ b/lib/MusicBrainz/Server/Controller/User/SubscriptionsRole.pm
@@ -39,11 +39,10 @@ role {
         }
 
         my $model = $c->model(type_to_model($type));
-        my $lang = $c->stash->{current_language} // 'en';
         my $entities = $self->_load_paged($c, sub {
             $model->find_by_subscribed_editor($user->id, shift, shift);
         });
-        $model->load_aliases($entities, $lang) if $model->can('load_aliases');
+        $model->load_aliases(@$entities) if $model->can('load_aliases');
 
         my %extra_props;
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Role/Autocompletion/PrimaryAlias.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Role/Autocompletion/PrimaryAlias.pm
@@ -21,7 +21,7 @@ role {
         return map +{
             entity => $_,
             aliases => $aliases->{$_->id},
-            current_language => $c->stash->{current_language} // 'en',
+            current_language => $c->current_language,
         }, $self->$orig($c, @entities);
     };
 };

--- a/lib/MusicBrainz/Server/Controller/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/Work.pm
@@ -67,6 +67,7 @@ after 'load' => sub
     my $returning_jsonld = $self->should_return_jsonld($c);
 
     unless ($returning_jsonld) {
+        $c->model('Work')->load_aliases($work);
         $c->model('Work')->load_meta($work);
 
         if ($c->user_exists) {
@@ -173,6 +174,7 @@ sub stash_work_form_json {
 sub _merge_load_entities
 {
     my ($self, $c, @works) = @_;
+    $c->model('Work')->load_aliases(@works);
     $c->model('Work')->load_meta(@works);
     $c->model('WorkType')->load(@works);
     $c->model('Work')->load_writers(@works);

--- a/lib/MusicBrainz/Server/Data/Area.pm
+++ b/lib/MusicBrainz/Server/Data/Area.pm
@@ -85,7 +85,8 @@ sub _column_mapping
 sub load
 {
     my ($self, @objs) = @_;
-    load_subobjects($self, ['area', 'begin_area', 'end_area', 'country'], @objs);
+    my @areas = load_subobjects($self, ['area', 'begin_area', 'end_area', 'country'], @objs);
+    $self->c->model('Area')->load_aliases(@areas);
 }
 
 sub load_containment {
@@ -111,6 +112,8 @@ sub load_containment {
     my $parent_areas = $self->get_by_ids(
         map { $_->{parent} } @results,
     );
+
+    $self->c->model('Area')->load_aliases(values %$parent_areas);
 
     for my $area (@areas) {
         my @parent_ids = map {

--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -487,11 +487,10 @@ sub _hash_to_row
 }
 
 sub load_related_info {
-    my ($self, $artists_ref, $user_lang) = @_;
+    my ($self, @artists) = @_;
 
     my $c = $self->c;
-    my @artists = @{$artists_ref};
-    $self->load_aliases($artists_ref, $user_lang);
+    $self->load_aliases(@artists);
     $c->model('ArtistType')->load(@artists);
     $c->model('Gender')->load(@artists);
     $c->model('Area')->load(@artists);

--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -490,7 +490,6 @@ sub load_related_info {
     my ($self, @artists) = @_;
 
     my $c = $self->c;
-    $self->load_aliases(@artists);
     $c->model('ArtistType')->load(@artists);
     $c->model('Gender')->load(@artists);
     $c->model('Area')->load(@artists);

--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -14,7 +14,6 @@ use MusicBrainz::Server::Data::Utils qw(
     add_partial_date_to_row
     conditional_merge_column_query
     contains_string
-    find_best_primary_alias
     hash_to_row
     load_subobjects
     merge_table_attributes
@@ -492,24 +491,10 @@ sub load_related_info {
 
     my $c = $self->c;
     my @artists = @{$artists_ref};
+    $self->load_aliases($artists_ref, $user_lang);
     $c->model('ArtistType')->load(@artists);
     $c->model('Gender')->load(@artists);
     $c->model('Area')->load(@artists);
-
-    # Load and save aliases so Controller::Artist::show can use them later.
-    my $artist_aliases = $c->model('Artist')->alias->find_by_entity_ids(
-        map { $_->id } @artists,
-    );
-    my @all_aliases = map { @$_ } values %$artist_aliases;
-    $c->model('Artist')->alias_type->load(@all_aliases);
-    for my $artist (@artists) {
-        my @aliases = @{ $artist_aliases->{$artist->id} };
-        $artist->aliases(\@aliases);
-        if (defined $user_lang) {
-            my $best_alias = find_best_primary_alias(\@aliases, $user_lang);
-            $artist->primary_alias($best_alias->name) if defined $best_alias;
-        }
-    }
 }
 
 sub load_meta

--- a/lib/MusicBrainz/Server/Data/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Data/ArtistCredit.pm
@@ -79,7 +79,9 @@ sub get_by_ids
 sub load
 {
     my ($self, @objs) = @_;
-    load_subobjects($self, 'artist_credit', @objs);
+    my @artist_credits = load_subobjects($self, 'artist_credit', @objs);
+    my @artists = map { map { $_->artist } $_->all_names } @artist_credits;
+    $self->c->model('Artist')->load_aliases(@artists);
 }
 
 sub find_by_ids

--- a/lib/MusicBrainz/Server/Data/Edit.pm
+++ b/lib/MusicBrainz/Server/Data/Edit.pm
@@ -687,7 +687,9 @@ sub load_all
     my $load_arguments = {};
     while (my ($model, $ids) = each %$objects_to_load) {
         my $m = ref $model ? $model : $self->c->model($model);
-        $loaded->{$model} = $m->get_by_any_ids(@$ids);
+        my $loaded_for_model = $m->get_by_any_ids(@$ids);
+        $m->load_aliases(values %$loaded_for_model) if $m->can('load_aliases');
+        $loaded->{$model} = $loaded_for_model;
 
         # Now we need to load any extra information about each object
         for my $id (@$ids) {

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -20,14 +20,18 @@ use MusicBrainz::Server::Data::Utils qw(
     load_subobjects
     placeholders
     sanitize
-    type_to_model
 );
-use MusicBrainz::Server::Constants qw( :edit_status :privileges );
-use MusicBrainz::Server::Constants qw( $PASSPHRASE_BCRYPT_COST );
-use MusicBrainz::Server::Constants qw( :create_entity $EDIT_HISTORIC_ADD_RELEASE );
-use MusicBrainz::Server::Constants qw( $EDIT_RELEASE_ADD_COVER_ART );
-use MusicBrainz::Server::Constants qw( $EDIT_EVENT_ADD_EVENT_ART );
-use MusicBrainz::Server::Constants qw( :vote );
+use MusicBrainz::Server::Constants qw(
+    :create_entity
+    :edit_status
+    :privileges
+    :vote
+    %ENTITIES
+    $EDIT_HISTORIC_ADD_RELEASE
+    $EDIT_RELEASE_ADD_COVER_ART
+    $EDIT_EVENT_ADD_EVENT_ART
+    $PASSPHRASE_BCRYPT_COST
+);
 
 extends 'MusicBrainz::Server::Data::Entity';
 
@@ -117,10 +121,12 @@ sub summarize_ratings
 
     return {
         map {
-            my ($entities) = $self->c->model(type_to_model($_))->rating
+            my $entity_properties = $ENTITIES{$_};
+            my ($entities) = $self->c->model($entity_properties->{model})->rating
                 ->find_editor_ratings($user->id, $me, 10, 0);
 
-            $self->c->model('ArtistCredit')->load(@$entities);
+            $self->c->model('ArtistCredit')->load(@$entities)
+                if $entity_properties->{artist_credits};
 
             ($_ => to_json_array($entities));
         } entities_with('ratings'),

--- a/lib/MusicBrainz/Server/Data/Event.pm
+++ b/lib/MusicBrainz/Server/Data/Event.pm
@@ -536,6 +536,7 @@ sub _find_areas
 
     my @area_ids = map { $_->[1] } @$rows;
     my $areas = $self->c->model('Area')->get_by_ids(@area_ids);
+    $self->c->model('Area')->load_aliases(values %$areas);
 
     for my $row (@$rows) {
         my ($event_id, $area_id, $credit) = @$row;

--- a/lib/MusicBrainz/Server/Data/Medium.pm
+++ b/lib/MusicBrainz/Server/Data/Medium.pm
@@ -251,7 +251,6 @@ sub set_lengths_to_cdtoc
         or die 'Could not load tracklist';
 
     $self->c->model('Track')->load_for_mediums($medium);
-    $self->c->model('ArtistCredit')->load($medium->all_tracks);
 
     my @recording_ids;
     my @info = @{ $cdtoc->track_details };

--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -439,6 +439,13 @@ sub load_entities
 
     my @series = values %{$data_by_type{'series'}};
     $self->c->model('SeriesType')->load(@series);
+
+    for my $type (keys %data_by_type) {
+        my $model = $self->c->model(type_to_model($type));
+        next unless $model->can('load_aliases');
+        my @entities = values %{$data_by_type{$type}};
+        $model->load_aliases(@entities);
+    }
 }
 
 sub _load_subset {

--- a/lib/MusicBrainz/Server/Data/Role/Alias.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Alias.pm
@@ -86,9 +86,8 @@ role
     };
 
     method 'load_aliases' => sub {
-        my ($self, $entities_ref, $user_lang) = @_;
+        my ($self, @entities) = @_;
 
-        my @entities = @{$entities_ref};
         my $entity_aliases = $self->alias->find_by_entity_ids(
             map { $_->id } @entities,
         );
@@ -97,10 +96,11 @@ role
         for my $entity (@entities) {
             my @aliases = @{ $entity_aliases->{$entity->id} };
             $entity->aliases(\@aliases);
-            if (defined $user_lang) {
-                my $best_alias = find_best_primary_alias(\@aliases, $user_lang);
-                $entity->primary_alias($best_alias->name) if defined $best_alias;
-            }
+            my $best_alias = find_best_primary_alias(
+                \@aliases,
+                $self->c->current_language,
+            );
+            $entity->primary_alias($best_alias->name) if defined $best_alias;
         }
     };
 };

--- a/lib/MusicBrainz/Server/Data/Role/Attribute.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Attribute.pm
@@ -34,6 +34,14 @@ sub _column_mapping {
     };
 }
 
+sub find_by_name {
+    my ($self, $name) = @_;
+    my $row = $self->sql->select_single_row_hash(
+        'SELECT ' . $self->_columns . ' FROM ' . $self->_table . '
+        WHERE lower(name) = lower(?)', $name);
+    return $row ? $self->_new_from_row($row) : undef;
+}
+
 sub has_children {
     my ($self, $id) = @_;
     return $self->sql->select_single_value(

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -424,7 +424,7 @@ sub schema_fixup_type {
 # matches up with the data returned from the DB for easy object creation
 sub schema_fixup
 {
-    my ($self, $data, $type, $user_lang) = @_;
+    my ($self, $data, $type) = @_;
 
     return unless (ref($data) eq 'HASH');
 
@@ -690,7 +690,7 @@ sub schema_fixup
 
             my %entity = %{ $rel->{$entity_type} };
 
-            $self->schema_fixup(\%entity, $entity_type, $user_lang);
+            $self->schema_fixup(\%entity, $entity_type);
 
             # The search server returns the MBID in the 'id' attribute, so we
             # need to delete that. (`schema_fixup` copies it to gid.)
@@ -721,13 +721,13 @@ sub schema_fixup
         next if $k eq '_extra';
         if (ref($data->{$k}) eq 'HASH')
         {
-            $self->schema_fixup($data->{$k}, $type, $user_lang);
+            $self->schema_fixup($data->{$k}, $type);
         }
         if (ref($data->{$k}) eq 'ARRAY')
         {
             foreach my $item (@{$data->{$k}})
             {
-                $self->schema_fixup($item, $type, $user_lang);
+                $self->schema_fixup($item, $type);
             }
         }
     }
@@ -754,10 +754,11 @@ sub schema_fixup
                 primary_for_locale => $_->{primary},
             )
         } @{ $data->{aliases} };
-        if (defined $user_lang) {
-            my $best_alias = find_best_primary_alias(\@aliases, $user_lang);
-            $data->{primary_alias} = $best_alias->{name} if defined $best_alias;
-        }
+        my $best_alias = find_best_primary_alias(
+            \@aliases,
+            $self->c->current_language,
+        );
+        $data->{primary_alias} = $best_alias->{name} if defined $best_alias;
 
         # Save the new objects so validation will pass, but note that the search
         # API doesn't include all attributes that are present in Entity::Alias,
@@ -847,7 +848,7 @@ sub escape_query
 
 sub external_search
 {
-    my ($self, $type, $query, $limit, $page, $adv, $user_lang) = @_;
+    my ($self, $type, $query, $limit, $page, $adv) = @_;
 
     my $entity_model = $self->c->model( type_to_model($type) )->_entity_class;
     load_class($entity_model);
@@ -931,7 +932,7 @@ sub external_search
 
         foreach my $t (@{$data->{$xmltype}})
         {
-            $self->schema_fixup($t, $type, $user_lang);
+            $self->schema_fixup($t, $type);
             push @results, MusicBrainz::Server::Entity::SearchResult->new(
                     position => $pos++,
                     score  => $t->{score},

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -414,8 +414,9 @@ Readonly our @ENTITIES_WITH_SIMPLE_TYPES => entities_with(['type', 'simple']);
 sub schema_fixup_type {
     my ($self, $data, $type) = @_;
     if (defined $data->{type} && contains_string(\@ENTITIES_WITH_SIMPLE_TYPES, $type)) {
-        my $model = 'MusicBrainz::Server::Entity::' . type_to_model($type) . 'Type';
-        $data->{type} = $model->new( name => $data->{type} );
+        my $model = $self->c->model( type_to_model($type) . 'Type' );
+        $data->{type} = $model->find_by_name($data->{type});
+        $data->{type_id} = $data->{type}->{id};
     }
     return $data;
 }

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -771,13 +771,18 @@ sub schema_fixup
             my %relationship_map = partition_by { $_->entity1->gid }
                 @{ $data->{relationships} };
 
+            my $artist_model = $self->c->model('Artist');
             $data->{writers} = [
                 map {
                     my @relationships = @{ $relationship_map{$_} };
+
+                    my $artist = $artist_model->get_by_gid($relationships[0]->{entity1}->{gid});
+                    $artist_model->load_aliases($artist);
+
                     {
                         # TODO: Pass the actual credit when SEARCH-585 is fixed
                         credit => '',
-                        entity => $relationships[0]->entity1,
+                        entity => $artist,
                         roles  => [ map { $_->link->type->name } grep { $_->link->type->entity1_type eq 'artist' } @relationships ],
                     }
                 } grep {

--- a/lib/MusicBrainz/Server/Data/Track.pm
+++ b/lib/MusicBrainz/Server/Data/Track.pm
@@ -91,6 +91,7 @@ sub load_related_info {
 
     my @recordings = $self->c->model('Recording')->load(@tracks);
     $self->c->model('ArtistCredit')->load(@tracks, @recordings);
+    $self->c->model('Recording')->load_aliases(@recordings);
     $self->c->model('Recording')->load_meta(@recordings);
     $self->c->model('Recording')->load_gid_redirects(@recordings);
     $self->c->model('Recording')->rating->load_user_ratings($user_id, @recordings) if $user_id;

--- a/lib/MusicBrainz/Server/Data/Work.pm
+++ b/lib/MusicBrainz/Server/Data/Work.pm
@@ -448,6 +448,7 @@ sub _find_writers
 
     my @artist_ids = map { $_->[1] } @$rows;
     my $artists = $self->c->model('Artist')->get_by_ids(@artist_ids);
+    $self->c->model('Artist')->load_aliases(values %$artists);
 
     for my $row (@$rows) {
         my ($work_id, $artist_id, $credit, $roles) = @$row;

--- a/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
@@ -15,6 +15,7 @@ with 'MusicBrainz::Server::Edit::Relationship',
 use MooseX::Types::Moose qw( Bool Int Str );
 use MooseX::Types::Structured qw( Dict Optional );
 use MusicBrainz::Server::Constants qw(
+    %ENTITIES
     $AMAZON_ASIN_LINK_TYPE_ID
     $EDIT_RELATIONSHIP_CREATE
 );
@@ -161,11 +162,29 @@ sub foreign_keys
     my $entity0_id = gid_or_id($self->data->{entity0});
     my $entity1_id = gid_or_id($self->data->{entity1});
 
-    $load{ type_to_model($type0) } = { $entity0_id => ['ArtistCredit'] } if $entity0_id;
+    my $entity0_properties = $ENTITIES{$type0};
+    my $entity0_model = $entity0_properties->{model};
+
+    if ($entity0_id) {
+        if ($entity0_properties->{artist_credits}) {
+            $load{ $entity0_model } = { $entity0_id => ['ArtistCredit'] };
+        } else {
+            $load{ $entity0_model } = [ $entity0_id ];
+        }
+    }
 
     # Type 1 my be equal to type 0, so we need to be careful
-    $load{ type_to_model($type1) } ||= {};
-    $load{ type_to_model($type1) }{$entity1_id} = [ 'ArtistCredit' ] if $entity1_id;
+    my $entity1_properties = $ENTITIES{$type1};
+    my $entity1_model = $entity1_properties->{model};
+
+    $load{ $entity1_model } ||= {};
+    if ($entity1_id) {
+        if ($entity1_properties->{artist_credits}) {
+            $load{ $entity1_model } = { $entity1_id => ['ArtistCredit'] };
+        } else {
+            $load{ $entity1_model } = [ $entity1_id ];
+        }
+    }
 
     return \%load;
 }

--- a/lib/MusicBrainz/Server/Edit/Relationship/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Delete.pm
@@ -4,6 +4,7 @@ use Try::Tiny;
 
 use List::AllUtils qw( any );
 use MusicBrainz::Server::Constants qw(
+    %ENTITIES
     $AMAZON_ASIN_LINK_TYPE_ID
     $CONTACT_URL
     $EDIT_RELATIONSHIP_DELETE
@@ -97,8 +98,20 @@ sub foreign_keys
     my $entity0 = $self->data->{relationship}{entity0};
     my $entity1 = $self->data->{relationship}{entity1};
 
-    $ids{$self->model0}->{gid_or_id($entity0)} = [ 'ArtistCredit' ];
-    $ids{$self->model1}->{gid_or_id($entity1)} = [ 'ArtistCredit' ];
+    my $entity0_properties = $ENTITIES{$self->data->{relationship}{link}{type}{entity0_type}};
+    my $entity1_properties = $ENTITIES{$self->data->{relationship}{link}{type}{entity1_type}};
+
+    if ($entity0_properties->{artist_credits}) {
+        $ids{$self->model0} = { gid_or_id($entity0) => [ 'ArtistCredit' ] };
+    } else {
+        $ids{$self->model0} = [ gid_or_id($entity0) ];
+    }
+
+    if ($entity1_properties->{artist_credits}) {
+        $ids{$self->model1} = { gid_or_id($entity1) => [ 'ArtistCredit' ] };
+    } else {
+        $ids{$self->model1} = [ gid_or_id($entity1) ];
+    }
 
     $ids{LinkType} = [$self->data->{link}{type}{id}];
     $ids{LinkAttributeType} = { map { $_->{type}{id} => ['LinkAttributeType'] } @{ $self->data->{relationship}{link}{attributes} // [] } };

--- a/lib/MusicBrainz/Server/Entity/Area.pm
+++ b/lib/MusicBrainz/Server/Entity/Area.pm
@@ -8,7 +8,8 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 use List::AllUtils qw( first );
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Annotation',
+with 'MusicBrainz::Server::Entity::Role::Alias',
+     'MusicBrainz::Server::Entity::Role::Annotation',
      'MusicBrainz::Server::Entity::Role::Comment',
      'MusicBrainz::Server::Entity::Role::DatePeriod',
      'MusicBrainz::Server::Entity::Role::Relatable',

--- a/lib/MusicBrainz/Server/Entity/Artist.pm
+++ b/lib/MusicBrainz/Server/Entity/Artist.pm
@@ -7,7 +7,8 @@ use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Annotation',
+with 'MusicBrainz::Server::Entity::Role::Alias',
+     'MusicBrainz::Server::Entity::Role::Annotation',
      'MusicBrainz::Server::Entity::Role::Area',
      'MusicBrainz::Server::Entity::Role::Comment',
      'MusicBrainz::Server::Entity::Role::DatePeriod',
@@ -22,17 +23,6 @@ with 'MusicBrainz::Server::Entity::Role::Annotation',
 sub entity_type { 'artist' }
 
 has 'sort_name' => (
-    is => 'rw',
-    isa => 'Str',
-);
-
-has 'aliases' => (
-    is => 'rw',
-    isa => 'ArrayRef[MusicBrainz::Server::Entity::Alias]',
-    default => sub { [] },
-);
-
-has 'primary_alias' => (
     is => 'rw',
     isa => 'Str',
 );
@@ -94,7 +84,6 @@ around TO_JSON => sub {
         begin_area => to_json_object($self->begin_area),
         end_area => to_json_object($self->end_area),
         gender => to_json_object($self->gender),
-        $self->primary_alias ? (primaryAlias => $self->primary_alias) : (),
         begin_area_id => defined $self->begin_area_id ? (0 + $self->begin_area_id) : undef,
         end_area_id => defined $self->end_area_id ? (0 + $self->end_area_id) : undef,
         gender_id => defined $self->gender_id ? (0 + $self->gender_id) : undef,

--- a/lib/MusicBrainz/Server/Entity/Event.pm
+++ b/lib/MusicBrainz/Server/Entity/Event.pm
@@ -5,7 +5,8 @@ use MusicBrainz::Server::Entity::PartialDate;
 use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Annotation',
+with 'MusicBrainz::Server::Entity::Role::Alias',
+     'MusicBrainz::Server::Entity::Role::Annotation',
      'MusicBrainz::Server::Entity::Role::Comment',
      'MusicBrainz::Server::Entity::Role::DatePeriod',
      'MusicBrainz::Server::Entity::Role::Rating',

--- a/lib/MusicBrainz/Server/Entity/Genre.pm
+++ b/lib/MusicBrainz/Server/Entity/Genre.pm
@@ -4,7 +4,8 @@ use Moose;
 use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Annotation',
+with 'MusicBrainz::Server::Entity::Role::Alias',
+     'MusicBrainz::Server::Entity::Role::Annotation',
      'MusicBrainz::Server::Entity::Role::Comment',
      'MusicBrainz::Server::Entity::Role::Relatable';
 

--- a/lib/MusicBrainz/Server/Entity/Instrument.pm
+++ b/lib/MusicBrainz/Server/Entity/Instrument.pm
@@ -6,7 +6,8 @@ use MusicBrainz::Server::Translation::Instruments;
 use MusicBrainz::Server::Translation::InstrumentDescriptions;
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Annotation',
+with 'MusicBrainz::Server::Entity::Role::Alias',
+     'MusicBrainz::Server::Entity::Role::Annotation',
      'MusicBrainz::Server::Entity::Role::Comment',
      'MusicBrainz::Server::Entity::Role::Relatable',
      'MusicBrainz::Server::Entity::Role::Taggable',

--- a/lib/MusicBrainz/Server/Entity/Label.pm
+++ b/lib/MusicBrainz/Server/Entity/Label.pm
@@ -6,7 +6,8 @@ use MusicBrainz::Server::Entity::PartialDate;
 use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Annotation',
+with 'MusicBrainz::Server::Entity::Role::Alias',
+     'MusicBrainz::Server::Entity::Role::Annotation',
      'MusicBrainz::Server::Entity::Role::Area',
      'MusicBrainz::Server::Entity::Role::Comment',
      'MusicBrainz::Server::Entity::Role::DatePeriod',

--- a/lib/MusicBrainz/Server/Entity/Place.pm
+++ b/lib/MusicBrainz/Server/Entity/Place.pm
@@ -5,7 +5,8 @@ use MusicBrainz::Server::Entity::PartialDate;
 use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Annotation',
+with 'MusicBrainz::Server::Entity::Role::Alias',
+     'MusicBrainz::Server::Entity::Role::Annotation',
      'MusicBrainz::Server::Entity::Role::Area',
      'MusicBrainz::Server::Entity::Role::Comment',
      'MusicBrainz::Server::Entity::Role::DatePeriod',

--- a/lib/MusicBrainz/Server/Entity/Recording.pm
+++ b/lib/MusicBrainz/Server/Entity/Recording.pm
@@ -11,7 +11,8 @@ use MusicBrainz::Server::Entity::Util::JSON qw(
 use List::AllUtils qw( uniq_by );
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Annotation',
+with 'MusicBrainz::Server::Entity::Role::Alias',
+     'MusicBrainz::Server::Entity::Role::Annotation',
      'MusicBrainz::Server::Entity::Role::ArtistCredit',
      'MusicBrainz::Server::Entity::Role::Comment',
      'MusicBrainz::Server::Entity::Role::Rating',

--- a/lib/MusicBrainz/Server/Entity/Release.pm
+++ b/lib/MusicBrainz/Server/Entity/Release.pm
@@ -11,7 +11,8 @@ use MusicBrainz::Server::Entity::Util::MediumFormat qw( combined_medium_format_n
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Annotation',
+with 'MusicBrainz::Server::Entity::Role::Alias',
+     'MusicBrainz::Server::Entity::Role::Annotation',
      'MusicBrainz::Server::Entity::Role::ArtistCredit',
      'MusicBrainz::Server::Entity::Role::Comment',
      'MusicBrainz::Server::Entity::Role::Relatable',

--- a/lib/MusicBrainz/Server/Entity/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Entity/ReleaseGroup.pm
@@ -10,7 +10,8 @@ use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Annotation',
+with 'MusicBrainz::Server::Entity::Role::Alias',
+     'MusicBrainz::Server::Entity::Role::Annotation',
      'MusicBrainz::Server::Entity::Role::ArtistCredit',
      'MusicBrainz::Server::Entity::Role::Comment',
      'MusicBrainz::Server::Entity::Role::Rating',

--- a/lib/MusicBrainz/Server/Entity/Role/Alias.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/Alias.pm
@@ -1,0 +1,42 @@
+package MusicBrainz::Server::Entity::Role::Alias;
+use Moose::Role;
+
+use MusicBrainz::Server::Entity::Types;
+
+has 'aliases' => (
+    is => 'rw',
+    isa => 'ArrayRef[MusicBrainz::Server::Entity::Alias]',
+    default => sub { [] },
+);
+
+has 'primary_alias' => (
+    is => 'rw',
+    isa => 'Str',
+);
+
+around TO_JSON => sub {
+    my ($orig, $self) = @_;
+
+    my $json = $self->$orig;
+    my $primary_alias = $self->primary_alias;
+
+    if (defined $primary_alias) {
+        $json->{primaryAlias} = $primary_alias;
+    }
+
+    return $json;
+};
+
+no Moose::Role;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2024 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut
+

--- a/lib/MusicBrainz/Server/Entity/Series.pm
+++ b/lib/MusicBrainz/Server/Entity/Series.pm
@@ -4,7 +4,8 @@ use Moose;
 use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Annotation',
+with 'MusicBrainz::Server::Entity::Role::Alias',
+     'MusicBrainz::Server::Entity::Role::Annotation',
      'MusicBrainz::Server::Entity::Role::Comment',
      'MusicBrainz::Server::Entity::Role::Relatable',
      'MusicBrainz::Server::Entity::Role::Taggable',

--- a/lib/MusicBrainz/Server/Entity/Work.pm
+++ b/lib/MusicBrainz/Server/Entity/Work.pm
@@ -7,7 +7,8 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
 use aliased 'MusicBrainz::Server::Entity::WorkAttribute';
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Annotation',
+with 'MusicBrainz::Server::Entity::Role::Alias',
+     'MusicBrainz::Server::Entity::Role::Annotation',
      'MusicBrainz::Server::Entity::Role::Comment',
      'MusicBrainz::Server::Entity::Role::Rating',
      'MusicBrainz::Server::Entity::Role::Relatable',

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -483,7 +483,8 @@ component EntityLink(
       );
     }
     const primaryAlias =
-      (entity.entityType !== 'track' &&
+      (entity.entityType !== 'instrument' &&
+        entity.entityType !== 'track' &&
         nonEmpty(entity.primaryAlias) &&
         entity.primaryAlias !== entityName)
         ? entity.primaryAlias

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -187,6 +187,14 @@ component EntityLink(
   const hasSubPath = nonEmpty(subPath);
   // $FlowIgnore[prop-missing]
   const comment = nonEmpty(entity.comment) ? ko.unwrap(entity.comment) : '';
+  const entityName = ko.unwrap(entity.name);
+  const primaryAlias = (entity.entityType !== 'instrument' &&
+                        entity.entityType !== 'track' &&
+                        nonEmpty(entity.primaryAlias) &&
+                        entity.primaryAlias !== entityName)
+    ? entity.primaryAlias
+    : '';
+
 
   let content = passedContent;
   let hover = '';
@@ -212,14 +220,13 @@ component EntityLink(
 
   if (showDisambiguation === 'hover' || entity.entityType === 'artist') {
     const sortName = entity.entityType === 'artist' ? entity.sort_name : '';
-    hover = nonEmpty(sortName) ? (
+    const additionalName = nonEmpty(primaryAlias) ? primaryAlias : sortName;
+    hover = nonEmpty(additionalName) ? (
       nonEmpty(comment) ? (
-        sortName + ' ' + bracketedText(comment)
-      ) : sortName
+        additionalName + ' ' + bracketedText(comment)
+      ) : additionalName
     ) : comment;
   }
-
-  const entityName = ko.unwrap(entity.name);
 
   /*
    * If we were asked to display the credited-as text explicitly,
@@ -480,13 +487,6 @@ component EntityLink(
         />,
       );
     }
-    const primaryAlias =
-      (entity.entityType !== 'instrument' &&
-        entity.entityType !== 'track' &&
-        nonEmpty(entity.primaryAlias) &&
-        entity.primaryAlias !== entityName)
-        ? entity.primaryAlias
-        : '';
     if (nonEmpty(comment) || nonEmpty(primaryAlias)) {
       parts.push(
         <Comment

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -165,7 +165,6 @@ component EntityLink(
     | LinkTypeT
     | TrackT
     | ReleaseEditorTrackT,
-  hover as passedHover?: string,
   nameVariation as passedNameVariation?: boolean,
   showArtworkPresence: boolean = false,
   showCreditedAs: boolean = false,
@@ -190,7 +189,7 @@ component EntityLink(
   const comment = nonEmpty(entity.comment) ? ko.unwrap(entity.comment) : '';
 
   let content = passedContent;
-  let hover = passedHover;
+  let hover = '';
   let nameVariation = passedNameVariation;
   let showDisambiguation = passedShowDisambiguation;
   let showIcon = passedShowIcon;
@@ -211,14 +210,13 @@ component EntityLink(
     showDisambiguation = !hasCustomContent;
   }
 
-  if (entity.entityType === 'artist' && empty(hover)) {
-    hover = entity.sort_name + (comment ? ' ' + bracketedText(comment) : '');
-  }
-
-  if (showDisambiguation === 'hover') {
-    hover = empty(hover)
-      ? comment
-      : hover + ' ' + bracketedText(comment);
+  if (showDisambiguation === 'hover' || entity.entityType === 'artist') {
+    const sortName = entity.entityType === 'artist' ? entity.sort_name : '';
+    hover = nonEmpty(sortName) ? (
+      nonEmpty(comment) ? (
+        sortName + ' ' + bracketedText(comment)
+      ) : sortName
+    ) : comment;
   }
 
   const entityName = ko.unwrap(entity.name);

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -13,6 +13,7 @@ import * as React from 'react';
 
 import type {ReleaseEditorTrackT} from '../../release-editor/types.js';
 import isGreyedOut from '../../url/utility/isGreyedOut.js';
+import {AREA_TYPE_COUNTRY} from '../constants.js';
 import commaOnlyList from '../i18n/commaOnlyList.js';
 import localizeAreaName from '../i18n/localizeAreaName.js';
 import localizeInstrumentName from '../i18n/localizeInstrumentName.js';
@@ -188,7 +189,10 @@ component EntityLink(
   // $FlowIgnore[prop-missing]
   const comment = nonEmpty(entity.comment) ? ko.unwrap(entity.comment) : '';
   const entityName = ko.unwrap(entity.name);
-  const primaryAlias = (entity.entityType !== 'instrument' &&
+  const isCountryArea = entity.entityType === 'area' &&
+                        entity.typeID === AREA_TYPE_COUNTRY;
+  const primaryAlias = (!isCountryArea &&
+                        entity.entityType !== 'instrument' &&
                         entity.entityType !== 'track' &&
                         nonEmpty(entity.primaryAlias) &&
                         entity.primaryAlias !== entityName)

--- a/root/static/scripts/release/components/MediumTrackRow.js
+++ b/root/static/scripts/release/components/MediumTrackRow.js
@@ -29,6 +29,7 @@ component _MediumTrackRow(
 ) {
   const $c = React.useContext(SanitizedCatalystContext);
   const recordingAC = track.recording?.artistCredit;
+  const recordingAlias = track.recording?.primaryAlias;
 
   return (
     <tr
@@ -44,6 +45,22 @@ component _MediumTrackRow(
           content={track.name}
           entity={track.recording}
         />
+
+        {/* Show recording primary alias only to logged in users to avoid
+          * confusing visitors with recordings.
+          */}
+        {(
+          $c.user &&
+          nonEmpty(recordingAlias) &&
+          track.name !== recordingAlias
+        ) ? (
+          <div className="small">
+            {texp.l(
+              'Recording alias: {alias}',
+              {alias: recordingAlias},
+            )}
+          </div>
+          ) : null}
 
         {/* Show recording artist only to logged in users to avoid confusing
           * visitors with recordings.


### PR DESCRIPTION
### Implement MBS-13561 / MBS-13571 / MBS-13818 / MBS-13580 / MBS-13825

# Description
Extends the code @derat added in MBS-7646 to show primary aliases in a lot more places (when they differ from the entity name). See commits and tickets for details.

There's two cases where this intentionally skips showing primary aliases: instruments and country areas (which we translate separately, so in most cases this would just cause unwanted redundancy otherwise).

# Testing
Manually, navigating all around the site and trying to see what places need to separately load the aliases.

Places where this is known to do nothing yet: TT-based places, mostly, plus I didn't implement any way to show recording primary aliases in the release relationship editor.

Places where I tested things should work fine (but it's not impossible I missed some edge cases for some entities, which I expect beta testers would let me know about): 
* Every aliasable entity's header
* Tag pages
* Rating pages
* Entities in a series
* Entities in a collection
* Entities related to the one being shown
* Artist credits everywhere I checked (showing on hover, as with sort name and disambiguation)
* Search results (both direct and indexed)
* Writers in work lists (including search)
* Per-entity lists in artist pages, area pages, instrument pages, event pages
* Merge queue on footer
* Merge pages
* Edit displays
* Genre list
* Under each track in the release page (when logged in, if the recording primary alias does not match the track name)

I'm going to put this up on test and let people have a go at finding places I forgot (and let @Aerozol critique it), but it seems trivial to add more places later, so I don't think we need to be super careful with it right now (more important is to test nothing broke while adding the aliases).