### PR TITLE
MBS-13820: Added links to Mastodon and Bluesky in the footer

### DIFF
--- a/root/account/Register.js
+++ b/root/account/Register.js
@@ -77,14 +77,15 @@ component Register(
 
       <p>
         {exp.l(
-          `Follow our {blog_link|blog} or {twitterx_link|twitter account}!
-           To talk to other users,
+          `Follow our {blog_link|blog} or our {bluesky_link|Bluesky}
+           or {mastodon_link|Mastodon} accounts! To talk to other users,
            try the {forum_link|forums} or the {chat_link|chat}.`,
           {
             blog_link: 'http://blog.metabrainz.org/',
+            bluesky_link: 'https://bsky.app/profile/musicbrainz.org',
             chat_link: '/doc/Communication/ChatBrainz',
             forum_link: 'https://community.metabrainz.org/',
-            twitterx_link: 'https://twitter.com/MusicBrainz',
+            mastodon_link: 'https://mastodon.social/@MusicBrainz',
           },
         )}
       </p>

--- a/root/layout.tt
+++ b/root/layout.tt
@@ -115,7 +115,8 @@
                 <a href="/doc/Communication/ChatBrainz" class="internal">[% l('Chat') %]</a>
                 <a href="https://tickets.metabrainz.org/" class="internal">[% l('Bug tracker') %]</a>
                 <a href="https://blog.metabrainz.org/" class="internal">[% l('Blog') %]</a>
-                <a href="https://twitter.com/MusicBrainz" class="internal">[% l('Twitter') %]</a>
+                <a href="https://mastodon.social/@MusicBrainz" class="internal">[% l('Mastodon') %]</a>
+                <a href="https://bsky.app/profile/musicbrainz.org" class="internal">[% l('Bluesky') %]</a>
                 [%- IF server_details.beta_redirect %]
                 <a href="[% c.uri_for('/set-beta-preference', {returnto => c.relative_uri}) %]" class="internal">[% server_details.is_beta ? l('Stop using beta site') : l('Use beta site') %]</a>
                 [%- END -%]

--- a/root/layout/components/Footer.js
+++ b/root/layout/components/Footer.js
@@ -31,7 +31,8 @@ component Footer() {
         </a>
         <a className="internal" href="http://tickets.metabrainz.org/">{l('Bug tracker')}</a>
         <a className="internal" href="https://blog.metabrainz.org/">{l('Blog')}</a>
-        <a className="internal" href="https://twitter.com/MusicBrainz">{l('Twitter')}</a>
+        <a className="internal" href="https://mastodon.social/@MusicBrainz">{l('Mastodon')}</a>
+        <a className="internal" href="https://bsky.app/profile/musicbrainz.org">{l('Bluesky')}</a>
 
         {DBDefs.BETA_REDIRECT_HOSTNAME ? (
           <a


### PR DESCRIPTION
# Problem
[MBS-13820](https://tickets.metabrainz.org/browse/MBS-13820)


# Solution
- Removed the Twitter URL from the footer
- Added links to Mastodon and Bluesky in the footer


# Testing
These were just minor cosmetic changes and they work fine on my test environment.
