### PR TITLE
MBS-13828: Add report for empty release groups

### DIFF
--- a/lib/MusicBrainz/Server/Report/EmptyReleaseGroups.pm
+++ b/lib/MusicBrainz/Server/Report/EmptyReleaseGroups.pm
@@ -1,0 +1,35 @@
+package MusicBrainz::Server::Report::EmptyReleaseGroups;
+use Moose;
+use utf8;
+
+with 'MusicBrainz::Server::Report::ReleaseGroupReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseGroupID';
+
+sub query {<<~'SQL'}
+    SELECT rg.id AS release_group_id,
+           row_number() OVER (ORDER BY ac.name COLLATE musicbrainz, rg.name COLLATE musicbrainz)
+      FROM release_group rg
+      JOIN artist_credit ac ON rg.artist_credit = ac.id
+      JOIN release_group_meta rm ON rg.id = rm.id
+     WHERE NOT EXISTS (
+        SELECT 1
+          FROM release r
+         WHERE r.release_group = rg.id
+         LIMIT 1
+     )
+    SQL
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2024 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut
+

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -52,6 +52,7 @@ my @all = qw(
     DuplicateRelationshipsWorks
     DuplicateRelationshipsLabels
     DuplicateReleaseGroups
+    EmptyReleaseGroups
     EventSequenceNotInSeries
     FeaturingRecordings
     FeaturingReleaseGroups
@@ -155,6 +156,7 @@ use MusicBrainz::Server::Report::DuplicateRelationshipsRecordings;
 use MusicBrainz::Server::Report::DuplicateRelationshipsWorks;
 use MusicBrainz::Server::Report::DuplicateRelationshipsLabels;
 use MusicBrainz::Server::Report::DuplicateReleaseGroups;
+use MusicBrainz::Server::Report::EmptyReleaseGroups;
 use MusicBrainz::Server::Report::EventSequenceNotInSeries;
 use MusicBrainz::Server::Report::FeaturingRecordings;
 use MusicBrainz::Server::Report::FeaturingReleaseGroups;

--- a/root/report/EmptyReleaseGroups.js
+++ b/root/report/EmptyReleaseGroups.js
@@ -1,0 +1,115 @@
+/*
+ * @flow strict
+ * Copyright (C) 2024 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import PaginatedResults from '../components/PaginatedResults.js';
+import ArtistCreditLink
+  from '../static/scripts/common/components/ArtistCreditLink.js';
+import EntityLink from '../static/scripts/common/components/EntityLink.js';
+import loopParity from '../utility/loopParity.js';
+
+import ReportLayout from './components/ReportLayout.js';
+import type {ReportDataT, ReportReleaseGroupT} from './types.js';
+
+type ReportReleaseGroupWithKeyT = $ReadOnly<{
+  ...ReportReleaseGroupT,
+  +key: string,
+}>;
+
+component EmptyReleaseGroups(...{
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportReleaseGroupWithKeyT>) {
+  let currentKey = '';
+  let lastKey = '';
+
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists release groups which do not contain any releases.
+         There are two main reasons that could lead to this, both
+         of which usually mean the data can be improved. One is that the
+         release group used to have releases, but they were moved or merged
+         without merging the group itself (in which case the group should
+         be merged). The other is that the release group was added to hold
+         links (such as reviews) but a release was not added at the time;
+         in most cases, a release can be added with some research, although
+         this might not be possible for underdocumented or not yet released
+         music.`,
+      )}
+      entityType="release_group"
+      filtered={filtered}
+      generated={generated}
+      title={l('Release groups without any releases')}
+      totalEntries={pager.total_entries}
+    >
+      <PaginatedResults pager={pager}>
+        <table className="tbl">
+          <thead>
+            <tr>
+              <th>{l('Artist')}</th>
+              <th>{l('Release group')}</th>
+              <th>{l('Type')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item, index) => {
+              lastKey = currentKey;
+              currentKey = item.key;
+
+              return (
+                <>
+                  {lastKey === item.key ? null : (
+                    <tr className="subh">
+                      <td colSpan="4" />
+                    </tr>
+                  )}
+                  <tr
+                    className={loopParity(index)}
+                    key={item.release_group_id}
+                  >
+                    {item.release_group ? (
+                      <>
+                        <td>
+                          <ArtistCreditLink
+                            artistCredit={item.release_group.artistCredit}
+                          />
+                        </td>
+                        <td>
+                          <EntityLink entity={item.release_group} />
+                        </td>
+                        <td>
+                          {nonEmpty(item.release_group.l_type_name)
+                            ? item.release_group.l_type_name
+                            : lp('Unknown', 'type')}
+                        </td>
+                      </>
+                    ) : (
+                      <>
+                        <td />
+                        <td colSpan="2">
+                          {l('This release group no longer exists.')}
+                        </td>
+                      </>
+                    )}
+                  </tr>
+                </>
+              );
+            })}
+          </tbody>
+        </table>
+      </PaginatedResults>
+    </ReportLayout>
+  );
+}
+
+export default EmptyReleaseGroups;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -217,6 +217,10 @@ component ReportsIndex() {
             reportName="DeprecatedRelationshipReleaseGroups"
           />
           <ReportsIndexEntry
+            content={l('Release groups without any releases')}
+            reportName="EmptyReleaseGroups"
+          />
+          <ReportsIndexEntry
             content={l('Possible duplicate release groups')}
             reportName="DuplicateReleaseGroups"
           />

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -256,6 +256,7 @@ export default {
   'report/DuplicateRelationshipsReleases': (): Promise<mixed> => import('../report/DuplicateRelationshipsReleases.js'),
   'report/DuplicateRelationshipsWorks': (): Promise<mixed> => import('../report/DuplicateRelationshipsWorks.js'),
   'report/DuplicateReleaseGroups': (): Promise<mixed> => import('../report/DuplicateReleaseGroups.js'),
+  'report/EmptyReleaseGroups': (): Promise<mixed> => import('../report/EmptyReleaseGroups.js'),
   'report/EventSequenceNotInSeries': (): Promise<mixed> => import('../report/EventSequenceNotInSeries.js'),
   'report/FeaturingRecordings': (): Promise<mixed> => import('../report/FeaturingRecordings.js'),
   'report/FeaturingReleaseGroups': (): Promise<mixed> => import('../report/FeaturingReleaseGroups.js'),


### PR DESCRIPTION
### Implement MBS-13828

# Description
Empty release groups are low quality data that is usually actionable. This adds a report that gives users a good way to find them for some often relatively simple data improvement.

# Testing
I ran the report with the sample data, and found 677 results (a lot more than I expected, but I checked a bunch and they did seem genuinely empty).