### PR TITLE
MBS-13830: Use username in From header on user contact email

### DIFF
--- a/lib/MusicBrainz/Server/Email.pm
+++ b/lib/MusicBrainz/Server/Email.pm
@@ -400,7 +400,8 @@ sub send_message_to_editor
     my $body = {
         template_id => 'editor-message',
         to          => _user_address($to),
-        from        => $EMAIL_NOREPLY_ADDRESS,
+        from        => _user_address($from, 1),
+        sender      => $EMAIL_NOREPLY_ADDRESS,
         # TODO: send the user's language preference here. (This preference is not yet stored on the server)
         # Which language should we use, as this email is going to a different user?
         # 'lang'

--- a/t/lib/t/MusicBrainz/Server/Email.pm
+++ b/t/lib/t/MusicBrainz/Server/Email.pm
@@ -65,12 +65,13 @@ test all => sub {
         is($mail_service_req->method, 'POST', 'mail service request method is POST');
         is($mail_service_req->uri, 'http://localhost:3000/send_single', 'mail service request uri is send_single');
         is($mail_service_req->header('Accept'), 'application/json', 'client accepts application/json');
-        is($mail_service_req->header('Content-Length'), '527', 'mail service content-length is correct');
+        is($mail_service_req->header('Content-Length'), '577', 'mail service content-length is correct');
         is($mail_service_req->header('Content-Type'), 'application/json', 'mail service content-type is application/json');
         cmp_deeply($mail_service_req_content, {
             template_id => 'editor-message',
             to => '"Editor 2" <bar@example.com>',
-            from => 'MusicBrainz Server <noreply@musicbrainz.org>',
+            from => '"Editor 1" <noreply@musicbrainz.org>',
+            sender => 'MusicBrainz Server <noreply@musicbrainz.org>',
             message_id => re(qr/^<correspondence-4444-8888-[0-9]+\@localhost>$/),
             references => ['<correspondence-4444-8888@localhost>'],
             in_reply_to => ['<correspondence-4444-8888@localhost>'],
@@ -101,12 +102,13 @@ test all => sub {
         is($mail_service_req->method, 'POST', 'mail service request method is POST');
         is($mail_service_req->uri, 'http://localhost:3000/send_single', 'mail service request uri is send_single');
         is($mail_service_req->header('Accept'), 'application/json', 'client accepts application/json');
-        is($mail_service_req->header('Content-Length'), '512', 'mail service content-length is correct');
+        is($mail_service_req->header('Content-Length'), '562', 'mail service content-length is correct');
         is($mail_service_req->header('Content-Type'), 'application/json', 'mail service content-type is application/json');
         cmp_deeply($mail_service_req_content, {
             template_id => 'editor-message',
             to => '"Editor 2" <bar@example.com>',
-            from => 'MusicBrainz Server <noreply@musicbrainz.org>',
+            from => '"Editor 1" <noreply@musicbrainz.org>',
+            sender => 'MusicBrainz Server <noreply@musicbrainz.org>',
             message_id => re(qr/^<correspondence-4444-8888-[0-9]+\@localhost>$/),
             references => ['<correspondence-4444-8888@localhost>'],
             in_reply_to => ['<correspondence-4444-8888@localhost>'],
@@ -127,12 +129,13 @@ test all => sub {
         is($mail_service_req->method, 'POST', 'mail service request method is POST');
         is($mail_service_req->uri, 'http://localhost:3000/send_single', 'mail service request uri is send_single');
         is($mail_service_req->header('Accept'), 'application/json', 'client accepts application/json');
-        is($mail_service_req->header('Content-Length'), '532', 'mail service content-length is correct');
+        is($mail_service_req->header('Content-Length'), '582', 'mail service content-length is correct');
         is($mail_service_req->header('Content-Type'), 'application/json', 'mail service content-type is application/json');
         cmp_deeply($mail_service_req_content, {
             template_id => 'editor-message',
             to => '"Editor 1" <foo@example.com>',
-            from => 'MusicBrainz Server <noreply@musicbrainz.org>',
+            from => '"Editor 1" <noreply@musicbrainz.org>',
+            sender => 'MusicBrainz Server <noreply@musicbrainz.org>',
             message_id => re(qr/^<correspondence-4444-8888-[0-9]+\@localhost>$/),
             references => ['<correspondence-4444-8888@localhost>'],
             in_reply_to => ['<correspondence-4444-8888@localhost>'],


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

[MBS-13830](https://tickets.metabrainz.org/browse/MBS-13830)

Originally reported by chaban at https://community.metabrainz.org/t/email-redesign/700833/9:

>    I also noticed some other changes, like the From header always saying “MusicBrainz Server” rather than the username. And not using Sender anymore.
> 
>    Now one will have to search the entire subject to find and sort messages by a certain user.


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

We now set the `from` parameter using the `_user_address` function with `$hidden` set, which produces the no-reply email with the username as the address name (phrase?).

We also set the `sender` parameter to `$EMAIL_NOREPLY_ADDRESS`, matching the original behaviour. This requires mb-mail-service v0.4.0 to take effect (https://github.com/metabrainz/mb-mail-service/commit/da4ce0d31b8ad56cd50b10ad92ac2b1b9105c338)

