### PR TITLE
MBS-13834: Load l() in Role::Art

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Art.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Art.pm
@@ -11,6 +11,7 @@ use DBDefs;
 use MusicBrainz::Server::Constants qw( %ENTITIES );
 use MusicBrainz::Server::ControllerUtils::Delete qw( cancel_or_action );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
+use MusicBrainz::Server::Translation qw( l );
 
 parameter 'art_archive_name' => (
     isa => 'Str',


### PR DESCRIPTION
### Fix MBS-13834

# Problem
We forgot to import `l` before using it in `Controller::Role::Art`. This was unsurprisingly causing an ISE.

# Solution
Import `l`