### PR TITLE
MBS-13829: Also support Audiomack "song" for releases

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1035,7 +1035,7 @@ const CLEANUPS: CleanupEntries = {
             };
           case LINK_TYPES.streamingfree.release:
             return {
-              result: prefix === 'album',
+              result: prefix === 'album' || prefix === 'song',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.streamingfree.recording:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -746,7 +746,7 @@ limited_link_type_combinations: [
              input_entity_type: 'recording',
     expected_relationship_type: 'streamingfree',
             expected_clean_url: 'https://audiomack.com/dablixx-osha/song/they-cant-understand',
-       only_valid_entity_types: ['recording'],
+       only_valid_entity_types: ['recording', 'release'],
   },
   {
                      input_url: 'https://audiomack.com/dablixx-osha/album/country-boy#testy',


### PR DESCRIPTION
### Implement MBS-13829

# Problem
For single releases, it seems Audiomack uses `/song` URLs, but these are only allowed at the recording level at the moment.

# Solution
Allow `/song` for releases as well as recordings.

# Testing
Changed the existing test to make sure both options are supported.
