### PR TITLE
MBS-13416: Link to entity pages from LB buttons

### DIFF
--- a/root/layout/components/sidebar/ArtistSidebar.js
+++ b/root/layout/components/sidebar/ArtistSidebar.js
@@ -33,6 +33,7 @@ import CollectionLinks from './CollectionLinks.js';
 import EditLinks from './EditLinks.js';
 import LastUpdated from './LastUpdated.js';
 import MergeLink from './MergeLink.js';
+import PlayOnListenBrainzButton from './PlayOnListenBrainzButton.js';
 import SidebarBeginDate from './SidebarBeginDate.js';
 import SidebarEndDate from './SidebarEndDate.js';
 import SidebarIpis from './SidebarIpis.js';
@@ -61,6 +62,11 @@ component ArtistSidebar(artist: ArtistT) {
       <CommonsImage
         cachedImage={$c.stash.commons_image}
         entity={artist}
+      />
+
+      <PlayOnListenBrainzButton
+        entityType="artist"
+        mbids={artist.gid}
       />
 
       <h2 className="artist-information">

--- a/root/layout/components/sidebar/PlayOnListenBrainzButton.js
+++ b/root/layout/components/sidebar/PlayOnListenBrainzButton.js
@@ -11,19 +11,28 @@ import listenBrainzIconUrl
   from '../../../static/images/icons/listenbrainz.png';
 
 function getListenBrainzLink(
-  entityType: 'release' | 'recording',
+  entityType: 'album' | 'artist' | 'recording',
   mbids: string | $ReadOnlyArray<string>,
 ): string | null {
   let formattedMbids;
 
   if (Array.isArray(mbids)) {
-    formattedMbids = mbids.join(',');
+    if (entityType === 'recording') {
+      formattedMbids = encodeURIComponent(mbids.join(','));
+    } else {
+      // Multiple MBIDs are only supported for recordings
+      return null;
+    }
   } else {
-    formattedMbids = mbids;
+    formattedMbids = encodeURIComponent(mbids);
   }
 
-  if (entityType === 'release') {
-    return `//listenbrainz.org/player/release/${formattedMbids}`;
+  if (entityType === 'artist') {
+    return `//listenbrainz.org/artist/${formattedMbids}`;
+  }
+
+  if (entityType === 'album') {
+    return `//listenbrainz.org/album/${formattedMbids}`;
   }
 
   if (entityType === 'recording') {
@@ -34,7 +43,7 @@ function getListenBrainzLink(
 }
 
 component PlayOnListenBrainzButton(
-  entityType: 'release' | 'recording',
+  entityType: 'album' | 'artist' | 'recording',
   mbids: string | $ReadOnlyArray<string>,
 ) {
   const link = getListenBrainzLink(entityType, mbids);

--- a/root/layout/components/sidebar/ReleaseGroupSidebar.js
+++ b/root/layout/components/sidebar/ReleaseGroupSidebar.js
@@ -26,7 +26,7 @@ import SidebarRating from './SidebarRating.js';
 import SidebarTags from './SidebarTags.js';
 
 component ReleaseGroupSidebar(
-  firstReleaseGid?: string | null,
+  hasReleases: boolean,
   releaseGroup: ReleaseGroupT,
 ) {
   const gid = encodeURIComponent(releaseGroup.gid);
@@ -40,10 +40,10 @@ component ReleaseGroupSidebar(
         </div>
       ) : null}
 
-      {nonEmpty(firstReleaseGid) ? (
+      {hasReleases ? (
         <PlayOnListenBrainzButton
-          entityType="release"
-          mbids={firstReleaseGid}
+          entityType="album"
+          mbids={gid}
         />
       ) : null}
 

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -110,8 +110,8 @@ component ReleaseSidebar(release: ReleaseT) {
 
       {isEmpty ? null : (
         <PlayOnListenBrainzButton
-          entityType="release"
-          mbids={release.gid}
+          entityType="album"
+          mbids={releaseGroup.gid}
         />
       )}
 

--- a/root/release_group/ReleaseGroupIndex.js
+++ b/root/release_group/ReleaseGroupIndex.js
@@ -120,9 +120,7 @@ component ReleaseGroupIndex(
   wikipediaExtract: WikipediaExtractT | null,
 ) {
   const $c = React.useContext(CatalystContext);
-  const firstReleaseGid = releases.length
-    ? releases[0][0].gid
-    : null;
+  const hasReleases = releases.length > 0;
   const
     showArtworkPresence = releases.some(
       (sub) => sub.some(
@@ -133,7 +131,7 @@ component ReleaseGroupIndex(
   return (
     <ReleaseGroupLayout
       entity={releaseGroup}
-      firstReleaseGid={firstReleaseGid}
+      hasReleases={hasReleases}
       page="index"
     >
       {eligibleForCleanup ? (
@@ -149,7 +147,7 @@ component ReleaseGroupIndex(
         cachedWikipediaExtract={wikipediaExtract}
         entity={releaseGroup}
       />
-      {releases.length ? (
+      {hasReleases ? (
         <>
           <h2>{releaseGroupType(releaseGroup)}</h2>
           <form

--- a/root/release_group/ReleaseGroupLayout.js
+++ b/root/release_group/ReleaseGroupLayout.js
@@ -18,7 +18,7 @@ import ReleaseGroupHeader from './ReleaseGroupHeader.js';
 component ReleaseGroupLayout(
   children: React.Node,
   entity as releaseGroup: ReleaseGroupT,
-  firstReleaseGid?: string | null,
+  hasReleases: boolean,
   fullWidth: boolean = false,
   page: string,
   title?: string,
@@ -37,7 +37,7 @@ component ReleaseGroupLayout(
       </div>
       {fullWidth ? null : (
         <ReleaseGroupSidebar
-          firstReleaseGid={firstReleaseGid}
+          hasReleases={hasReleases}
           releaseGroup={releaseGroup}
         />
       )}


### PR DESCRIPTION
### Implement MBS-13416

# Problem
We now have entity pages for artists and RGs ("albums") in ListenBrainz, but we still link only to BrainzPlayer playlists.

# Solution
This changes the LB buttons to link to entity pages when possible.

Release links redirect to release groups, so the LB team advised to just link to RGs directly. Since the pages cannot be played if empty, we don't change the existing behaviour where we hide the buttons if no releases exist in an RG
or no tracks exist on a release. We no longer care about the first release's MBID for RGs, just that it exists, so this simplifies that parameter to be boolean.

Also adding links for artists since those are now available. I did not skip "empty" artists (with no releases nor recordings) because we only have this data from the artist index but we want the buttons to appear on all tabs, and it doesn't seem worth passing a boolean up from the Perl layer just for this.

Recording pages do not yet exist, so we keep linking to the player for recordings (and recording collections). Since recordings are the only case where an array of MBIDs is actually supported, I changed the code to just return nothing when passed an array in any other case.

#  Testing
Manually, with sample data, particularly `/artist/ae0b2424-d4c5-4c54-82ac-fe3be5453270` and `/release-group/863ca853-cc83-47dd-8106-1284399c44f5`