### PR TITLE
MBS-13839: Also sort by ID in cancel_edits_and_votes

### DIFF
--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -641,7 +641,7 @@ sub cancel_edits_and_votes {
     # no conflicts happen that make some cancelling fail and all
     # entities that should be autoremoved do get removed
     my $own_edit_ids = $self->sql->select_single_column_array(
-            'SELECT id FROM edit WHERE editor = ? AND status = ? ORDER BY open_time DESC',
+            'SELECT id FROM edit WHERE editor = ? AND status = ? ORDER BY open_time DESC, id DESC',
             $editor->id, $STATUS_OPEN);
     my $own_edits = $self->c->model('Edit')->get_by_ids(@$own_edit_ids);
 


### PR DESCRIPTION
### Fix MBS-13839

# Problem
Canceling edits in `cancel_edits_and_votes` is supposed to happen in the opposite order as the edits were entered but sorting by `open_time` alone does not consistently work - edits 118415049 (Add series) and 118415050 (Add rel to the series) have the exact same open time since they were opened as a set, and the code tries to close the series first causing an ISE. This only breaks for series AFAICT, since for other stuff we actually remove the entity even if it has relationships.

# Solution
Just sorting by ID would probably be enough, but just to play it extra safe, this keeps the sort by time first, then ID if time is the same.

# Testing
Changed the spammer test to specifically test for this case.
