### PR TITLE
MBS-13854: Reword release label edit failure message

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
@@ -265,7 +265,7 @@ sub accept {
     my $release_label = $self->release_label;
 
     MusicBrainz::Server::Edit::Exceptions::FailedDependency->throw(
-        'This release label no longer exists.',
+        'This label is no longer associated with the release.',
     ) unless defined $release_label;
 
     my %args = %{ $self->merge_changes };


### PR DESCRIPTION
# MBS-13854

Change EditReleaseLabel's "This release label no longer exists." failure message to "This label is no longer associated with the release." to make it clearer that the issue is that the release-to-label association no longer exists, and not necessarily that the label entity itself has been deleted.

# Problem

When an "Edit release label" edit fails due to the original label no longer being associated with the release, the ModBot failure message can be misinterpreted as saying that the label entity itself no longer exists.

# Solution

Reword the message in an attempt to make it clearer that it's just the release-to-label association that doesn't exist.

# Testing

Checked the new message locally:

1. Created votable edits to add a new release with a label.
2. Created a votable edit to change the release to use a different label.
3. Canceled the original "Add release label" edit.

![image](https://github.com/user-attachments/assets/f7590af5-bc8b-4d93-a558-246d2f255101)