### PR TITLE
MBS-13858: Make email Message-Id unique

### DIFF
--- a/lib/MusicBrainz/Server/Email.pm
+++ b/lib/MusicBrainz/Server/Email.pm
@@ -24,6 +24,7 @@ use MusicBrainz::Server::Constants qw(
     $EDITOR_MODBOT
     $MINIMUM_RESPONSE_PERIOD
 );
+use MusicBrainz::Server::Data::Utils qw( generate_gid );
 use MusicBrainz::Server::Email::AutoEditorElection::Nomination;
 use MusicBrainz::Server::Email::AutoEditorElection::VotingOpen;
 use MusicBrainz::Server::Email::AutoEditorElection::Timeout;
@@ -75,7 +76,7 @@ sub _create_email
 
     # Add a Message-Id header if there isn't one.
     if ( !(any { "$_" eq 'Message-Id' } @$headers) ) {
-        push @$headers, 'Message-Id', _message_id('uncategorized-email-%d', time());
+        push @$headers, 'Message-Id', _message_id('uncategorized-email-%s', generate_gid());
     }
     return Email::MIME->create(
         header => $headers,
@@ -95,7 +96,7 @@ sub _create_email_verification_email
         'To'         => $opts{email},
         'From'       => $EMAIL_NOREPLY_ADDRESS,
         'Reply-To'   => $EMAIL_SUPPORT_ADDRESS,
-        'Message-Id' => _message_id('verify-email-%d', time()),
+        'Message-Id' => _message_id('verify-email-%s', generate_gid()),
         'Subject'    => 'Please verify your email address',
     );
 
@@ -132,7 +133,7 @@ sub _create_email_in_use_email
         'To'         => $opts{email},
         'From'       => $EMAIL_NOREPLY_ADDRESS,
         'Reply-To'   => $EMAIL_SUPPORT_ADDRESS,
-        'Message-Id' => _message_id('email-in-use-%d', time()),
+        'Message-Id' => _message_id('email-in-use-%s', generate_gid()),
         'Subject'    => 'Email address already in use',
     );
 
@@ -186,7 +187,7 @@ sub _create_lost_username_email
         'To'         => _user_address($opts{user}),
         'From'       => $EMAIL_NOREPLY_ADDRESS,
         'Reply-To'   => $EMAIL_SUPPORT_ADDRESS,
-        'Message-Id' => _message_id('lost-username-%d', time()),
+        'Message-Id' => _message_id('lost-username-%s', generate_gid()),
         'Subject'    => 'Lost username',
     );
 
@@ -224,7 +225,7 @@ sub _create_no_vote_email
         'To'          => _user_address($opts{editor}),
         'From'        => $EMAIL_NOREPLY_ADDRESS,
         'Reply-To'    => $EMAIL_SUPPORT_ADDRESS,
-        'Message-Id'  => _message_id('edit-%d-%d-no-vote-%d', $edit_id, $voter->id, time()),
+        'Message-Id'  => _message_id('edit-%d-%d-no-vote-%s', $edit_id, $voter->id, generate_gid()),
         'References'  => _message_id('edit-%d', $edit_id),
         'In-Reply-To' => _message_id('edit-%d', $edit_id),
         'Subject'     => "Someone has voted against your edit #$edit_id",
@@ -274,7 +275,7 @@ sub _create_password_reset_request_email
         'To'         => _user_address($opts{user}),
         'From'       => $EMAIL_NOREPLY_ADDRESS,
         'Reply-To'   => $EMAIL_SUPPORT_ADDRESS,
-        'Message-Id' => _message_id('password-reset-%d', time()),
+        'Message-Id' => _message_id('password-reset-%s', generate_gid()),
         'Subject'    => 'Password reset request',
     );
 
@@ -335,7 +336,7 @@ sub _create_edit_note_email
         'To'          => _user_address($editor),
         'From'        => _user_address($from_editor, 1),
         'Sender'      => $EMAIL_NOREPLY_ADDRESS,
-        'Message-Id'  => _message_id('edit-%d-%s-edit-note-%d', $edit_id, $from_editor->id, time()),
+        'Message-Id'  => _message_id('edit-%d-%s-edit-note-%s', $edit_id, $from_editor->id, generate_gid()),
         'References'  => _message_id('edit-%d', $edit_id),
         'In-Reply-To' => _message_id('edit-%d', $edit_id),
     );
@@ -405,7 +406,7 @@ sub send_message_to_editor
         # TODO: send the user's language preference here. (This preference is not yet stored on the server)
         # Which language should we use, as this email is going to a different user?
         # 'lang'
-        message_id  => _message_id('correspondence-%s-%s-%d', $correspondents[0]->id, $correspondents[1]->id, time()),
+        message_id  => _message_id('correspondence-%s-%s-%s', $correspondents[0]->id, $correspondents[1]->id, generate_gid()),
         references  => [_message_id('correspondence-%s-%s', $correspondents[0]->id, $correspondents[1]->id)],
         in_reply_to => [_message_id('correspondence-%s-%s', $correspondents[0]->id, $correspondents[1]->id)],
         params      => {
@@ -591,7 +592,7 @@ sub send_editor_report {
         'To'          => $EMAIL_ACCOUNT_ADMINS_ADDRESS,
         'Sender'      => $EMAIL_NOREPLY_ADDRESS,
         'Subject'     => _encode_header($subject),
-        'Message-Id'  => _message_id('editor-report-%s-%d', $reported_user->id, time),
+        'Message-Id'  => _message_id('editor-report-%s-%s', $reported_user->id, generate_gid()),
     );
 
     push @headers, 'From', _user_address($reporter, 1);
@@ -611,7 +612,7 @@ sub send_editor_report {
             'To'          => _user_address($reporter),
             'Sender'      => $EMAIL_NOREPLY_ADDRESS,
             'Subject'     => _encode_header($copy_subject),
-            'Message-Id'  => _message_id('editor-report-copy-%s-%d', $reported_user->id, time),
+            'Message-Id'  => _message_id('editor-report-copy-%s-%s', $reported_user->id, generate_gid()),
         );
 
         push @copy_headers, 'From', _user_address($reporter, 1);

--- a/t/lib/t/MusicBrainz/Server/Email.pm
+++ b/t/lib/t/MusicBrainz/Server/Email.pm
@@ -65,14 +65,14 @@ test all => sub {
         is($mail_service_req->method, 'POST', 'mail service request method is POST');
         is($mail_service_req->uri, 'http://localhost:3000/send_single', 'mail service request uri is send_single');
         is($mail_service_req->header('Accept'), 'application/json', 'client accepts application/json');
-        is($mail_service_req->header('Content-Length'), '577', 'mail service content-length is correct');
+        is($mail_service_req->header('Content-Length'), '603', 'mail service content-length is correct');
         is($mail_service_req->header('Content-Type'), 'application/json', 'mail service content-type is application/json');
         cmp_deeply($mail_service_req_content, {
             template_id => 'editor-message',
             to => '"Editor 2" <bar@example.com>',
             from => '"Editor 1" <noreply@musicbrainz.org>',
             sender => 'MusicBrainz Server <noreply@musicbrainz.org>',
-            message_id => re(qr/^<correspondence-4444-8888-[0-9]+\@localhost>$/),
+            message_id => re(qr/^<correspondence-4444-8888-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\@localhost>$/),
             references => ['<correspondence-4444-8888@localhost>'],
             in_reply_to => ['<correspondence-4444-8888@localhost>'],
             reply_to => 'MusicBrainz Server <noreply@musicbrainz.org>',
@@ -102,14 +102,14 @@ test all => sub {
         is($mail_service_req->method, 'POST', 'mail service request method is POST');
         is($mail_service_req->uri, 'http://localhost:3000/send_single', 'mail service request uri is send_single');
         is($mail_service_req->header('Accept'), 'application/json', 'client accepts application/json');
-        is($mail_service_req->header('Content-Length'), '562', 'mail service content-length is correct');
+        is($mail_service_req->header('Content-Length'), '588', 'mail service content-length is correct');
         is($mail_service_req->header('Content-Type'), 'application/json', 'mail service content-type is application/json');
         cmp_deeply($mail_service_req_content, {
             template_id => 'editor-message',
             to => '"Editor 2" <bar@example.com>',
             from => '"Editor 1" <noreply@musicbrainz.org>',
             sender => 'MusicBrainz Server <noreply@musicbrainz.org>',
-            message_id => re(qr/^<correspondence-4444-8888-[0-9]+\@localhost>$/),
+            message_id => re(qr/^<correspondence-4444-8888-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\@localhost>$/),
             references => ['<correspondence-4444-8888@localhost>'],
             in_reply_to => ['<correspondence-4444-8888@localhost>'],
             reply_to => '"Editor 1" <foo@example.com>',
@@ -129,14 +129,14 @@ test all => sub {
         is($mail_service_req->method, 'POST', 'mail service request method is POST');
         is($mail_service_req->uri, 'http://localhost:3000/send_single', 'mail service request uri is send_single');
         is($mail_service_req->header('Accept'), 'application/json', 'client accepts application/json');
-        is($mail_service_req->header('Content-Length'), '582', 'mail service content-length is correct');
+        is($mail_service_req->header('Content-Length'), '608', 'mail service content-length is correct');
         is($mail_service_req->header('Content-Type'), 'application/json', 'mail service content-type is application/json');
         cmp_deeply($mail_service_req_content, {
             template_id => 'editor-message',
             to => '"Editor 1" <foo@example.com>',
             from => '"Editor 1" <noreply@musicbrainz.org>',
             sender => 'MusicBrainz Server <noreply@musicbrainz.org>',
-            message_id => re(qr/^<correspondence-4444-8888-[0-9]+\@localhost>$/),
+            message_id => re(qr/^<correspondence-4444-8888-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\@localhost>$/),
             references => ['<correspondence-4444-8888@localhost>'],
             in_reply_to => ['<correspondence-4444-8888@localhost>'],
             reply_to => '"Editor 1" <foo@example.com>',
@@ -169,7 +169,7 @@ test all => sub {
     is($e->get_header('From'), 'MusicBrainz Server <noreply@musicbrainz.org>', 'From is noreply@...');
     is($e->get_header('To'), 'user@example.com', 'To is user@example.com');
     is($e->get_header('Subject'), 'Please verify your email address', 'Subject is Please verify your email address');
-    like($e->get_header('Message-Id'), qr{<verify-email-\d+@.*>}, 'Message-Id has right format');
+    like($e->get_header('Message-Id'), qr{<verify-email-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}@.*>}, 'Message-Id has right format');
     compare_body($e->object->body_str,
                  "Hello Editor 1,\n".
                  "\n".
@@ -202,7 +202,7 @@ test all => sub {
     is($e->get_header('From'), 'MusicBrainz Server <noreply@musicbrainz.org>', 'From is noreply@...');
     is($e->get_header('To'), '"Editor 1" <foo@example.com>', 'To is Editor 1, foo@example.com');
     is($e->get_header('Subject'), 'Lost username', 'Subject is Lost username');
-    like($e->get_header('Message-Id'), qr{<lost-username-\d+@.*>}, 'Message-Id has right format');
+    like($e->get_header('Message-Id'), qr{<lost-username-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}@.*>}, 'Message-Id has right format');
     compare_body($e->object->body_str,
                  "Someone, probably you, asked to look up the username of the\n".
                  "MusicBrainz account associated with this email address.\n".
@@ -235,7 +235,7 @@ test all => sub {
     is($e->get_header('From'), 'MusicBrainz Server <noreply@musicbrainz.org>', 'From is noreply@...');
     is($e->get_header('To'), '"Editor 1" <foo@example.com>', 'To is Editor 1, foo@example.com');
     is($e->get_header('Subject'), 'Password reset request', 'Subject is Password reset request');
-    like($e->get_header('Message-Id'), qr{<password-reset-\d+@.*>}, 'Message-Id has right format');
+    like($e->get_header('Message-Id'), qr{<password-reset-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}@.*>}, 'Message-Id has right format');
     compare_body($e->object->body_str,
                  "Someone, probably you, asked that your MusicBrainz password be reset.\n".
                  "\n".
@@ -274,7 +274,8 @@ test all => sub {
     is($e->get_header('To'), '"Editor 1" <foo@example.com>', 'To is Editor 1, foo@example.com');
     is($e->get_header('Reply-To'), 'MusicBrainz <support@musicbrainz.org>', 'Reply-To is support@...');
     is($e->get_header('References'), sprintf('<edit-1234@%s>', DBDefs->WEB_SERVER_USED_IN_EMAIL) , 'References edit-1234');
-    like($e->get_header('Message-Id'), qr{<edit-1234-8888-no-vote-\d+@.*>} , 'Message ID has right format');
+    like($e->get_header('Message-Id'), qr{<edit-1234-8888-no-vote-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}@.*>} , '
+     has right format');
     is($e->get_header('Subject'), 'Someone has voted against your edit #1234', 'Subject is Someone has voted against...');
     my $close_time = DateTime->now()->add_duration($MINIMUM_RESPONSE_PERIOD)->truncate( to => 'hour' )->add( hours => 1 );
     $close_time = $close_time->strftime('%F %H:%M %Z');
@@ -323,7 +324,7 @@ EOS
     is($e->get_header('To'), '"Editor 1" <foo@example.com>', 'To is Editor 1, foo@example.com');
     is($e->get_header('Subject'), 'Note added to edit #1234', 'Subject is Note added to edit #1234');
     is($e->get_header('References'), sprintf('<edit-1234@%s>', DBDefs->WEB_SERVER_USED_IN_EMAIL) , 'References edit-1234');
-    like($e->get_header('Message-Id'), qr{<edit-1234-8888-edit-note-\d+@.*>} , 'Message ID has right format');
+    like($e->get_header('Message-Id'), qr{<edit-1234-8888-edit-note-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}@.*>} , 'Message ID has right format');
     is($e->get_header('Sender'), 'MusicBrainz Server <noreply@musicbrainz.org>', 'Sender is noreply@...');
     compare_body($e->object->body_str,
                  "'Editor 2' has added the following note to edit #1234:\n".
@@ -383,7 +384,7 @@ EOS
     is($e->get_header('From'), '"Editor 1" <noreply@musicbrainz.org>', 'Header from is "Editor 1" <noreply@musicbrainz.org>');
     is($e->get_header('To'), '"Editor 2" <bar@example.com>', 'To is Editor 2, bar@example.com');
     is($e->get_header('Subject'), 'Note added to your edit #9000', 'Subject is Note added to your edit #9000');
-    like($e->get_header('Message-Id'), qr{<edit-9000-4444-edit-note-\d+@.*>} , 'Message ID has right format');
+    like($e->get_header('Message-Id'), qr{<edit-9000-4444-edit-note-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}@.*>} , 'Message ID has right format');
     is($e->get_header('Sender'), 'MusicBrainz Server <noreply@musicbrainz.org>', 'Sender is noreply@...');
     compare_body($e->object->body_str,
                  "'Editor 1' has added the following note to your edit #9000:\n".


### PR DESCRIPTION
### Fix MBS-13858

# Problem
Right now emails sent the same second are getting the same Message-Id, which does not sound ideal. 

# Solution
This replaces the time() call with generate_gid(), which generates UUID v 4 and should effectively guarantee uniqueness.

# Testing
Changed the email tests to expect an UUID instead and made sure they pass.