### PR TITLE
MBS-13862: Unbreak rel foreign keys for entities of same type

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
@@ -15,7 +15,6 @@ with 'MusicBrainz::Server::Edit::Relationship',
 use MooseX::Types::Moose qw( Bool Int Str );
 use MooseX::Types::Structured qw( Dict Optional );
 use MusicBrainz::Server::Constants qw(
-    %ENTITIES
     $AMAZON_ASIN_LINK_TYPE_ID
     $EDIT_RELATIONSHIP_CREATE
 );
@@ -162,29 +161,11 @@ sub foreign_keys
     my $entity0_id = gid_or_id($self->data->{entity0});
     my $entity1_id = gid_or_id($self->data->{entity1});
 
-    my $entity0_properties = $ENTITIES{$type0};
-    my $entity0_model = $entity0_properties->{model};
-
-    if ($entity0_id) {
-        if ($entity0_properties->{artist_credits}) {
-            $load{ $entity0_model } = { $entity0_id => ['ArtistCredit'] };
-        } else {
-            $load{ $entity0_model } = [ $entity0_id ];
-        }
-    }
+    $load{ type_to_model($type0) } = { $entity0_id => ['ArtistCredit'] } if $entity0_id;
 
     # Type 1 my be equal to type 0, so we need to be careful
-    my $entity1_properties = $ENTITIES{$type1};
-    my $entity1_model = $entity1_properties->{model};
-
-    $load{ $entity1_model } ||= {};
-    if ($entity1_id) {
-        if ($entity1_properties->{artist_credits}) {
-            $load{ $entity1_model } = { $entity1_id => ['ArtistCredit'] };
-        } else {
-            $load{ $entity1_model } = [ $entity1_id ];
-        }
-    }
+    $load{ type_to_model($type1) } ||= {};
+    $load{ type_to_model($type1) }{$entity1_id} = [ 'ArtistCredit' ] if $entity1_id;
 
     return \%load;
 }

--- a/lib/MusicBrainz/Server/Edit/Relationship/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Delete.pm
@@ -4,7 +4,6 @@ use Try::Tiny;
 
 use List::AllUtils qw( any );
 use MusicBrainz::Server::Constants qw(
-    %ENTITIES
     $AMAZON_ASIN_LINK_TYPE_ID
     $CONTACT_URL
     $EDIT_RELATIONSHIP_DELETE
@@ -98,20 +97,8 @@ sub foreign_keys
     my $entity0 = $self->data->{relationship}{entity0};
     my $entity1 = $self->data->{relationship}{entity1};
 
-    my $entity0_properties = $ENTITIES{$self->data->{relationship}{link}{type}{entity0_type}};
-    my $entity1_properties = $ENTITIES{$self->data->{relationship}{link}{type}{entity1_type}};
-
-    if ($entity0_properties->{artist_credits}) {
-        $ids{$self->model0} = { gid_or_id($entity0) => [ 'ArtistCredit' ] };
-    } else {
-        $ids{$self->model0} = [ gid_or_id($entity0) ];
-    }
-
-    if ($entity1_properties->{artist_credits}) {
-        $ids{$self->model1} = { gid_or_id($entity1) => [ 'ArtistCredit' ] };
-    } else {
-        $ids{$self->model1} = [ gid_or_id($entity1) ];
-    }
+    $ids{$self->model0}->{gid_or_id($entity0)} = [ 'ArtistCredit' ];
+    $ids{$self->model1}->{gid_or_id($entity1)} = [ 'ArtistCredit' ];
 
     $ids{LinkType} = [$self->data->{link}{type}{id}];
     $ids{LinkAttributeType} = { map { $_->{type}{id} => ['LinkAttributeType'] } @{ $self->data->{relationship}{link}{attributes} // [] } };

--- a/lib/MusicBrainz/Server/Edit/Relationship/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Edit.pm
@@ -9,7 +9,6 @@ use Moose::Util::TypeConstraints qw( as subtype find_type_constraint );
 use MooseX::Types::Moose qw( Bool Int Str );
 use MooseX::Types::Structured qw( Dict Optional );
 use MusicBrainz::Server::Constants qw(
-    %ENTITIES
     $AMAZON_ASIN_LINK_TYPE_ID
     $EDIT_RELATIONSHIP_EDIT
 );
@@ -119,11 +118,8 @@ sub foreign_keys
 {
     my ($self) = @_;
 
-    my $entity0_properties = $ENTITIES{$self->data->{type0}};
-    my $entity1_properties = $ENTITIES{$self->data->{type1}};
-
-    my $model0 = $entity0_properties->{model};
-    my $model1 = $entity1_properties->{model};
+    my $model0 = type_to_model($self->data->{type0});
+    my $model1 = type_to_model($self->data->{type1});
 
     my %load;
     my $old = $self->data->{old};
@@ -146,35 +142,15 @@ sub foreign_keys
     $load{$model0} = {};
     $load{$model1} = {};
 
-    # Autovivification can create subtle bugs elsewhere if the change data is modified,
-    # so guard old and new to where the properties exist.
-    if ($entity0_properties->{artist_credits}) {
-        $load{$model0} = { gid_or_id($link->{entity0}) => [ 'ArtistCredit' ] };
-        $load{$model0} = { gid_or_id($old->{entity0}) => [ 'ArtistCredit' ] }
-            if defined $old->{entity0};
-        $load{$model0} = { gid_or_id($new->{entity0}) => [ 'ArtistCredit' ] }
-            if defined $new->{entity0};
-    } else {
-        $load{$model0} = [ gid_or_id($link->{entity0}) ];
-        $load{$model0} = [ gid_or_id($old->{entity0}) ]
-            if defined $old->{entity0};
-        $load{$model0} = [ gid_or_id($new->{entity0}) ]
-            if defined $new->{entity0};
-    }
+    $load{$model0}->{gid_or_id($link->{entity0})} = ['ArtistCredit'];
+    $load{$model1}->{gid_or_id($link->{entity1})} = ['ArtistCredit'];
 
-    if ($entity1_properties->{artist_credits}) {
-        $load{$model1} = { gid_or_id($link->{entity1}) => [ 'ArtistCredit' ] };
-        $load{$model1} = { gid_or_id($old->{entity1}) => [ 'ArtistCredit' ] }
-            if defined $old->{entity1};
-        $load{$model1} = { gid_or_id($new->{entity1}) => [ 'ArtistCredit' ] }
-            if defined $new->{entity1};
-    } else {
-        $load{$model1} = [ gid_or_id($link->{entity1}) ];
-        $load{$model1} = [ gid_or_id($old->{entity1}) ]
-            if defined $old->{entity1};
-        $load{$model1} = [ gid_or_id($new->{entity1}) ]
-            if defined $new->{entity1};
-    }
+    # Autovivification can create subtle bugs elsewhere if the change data is modified,
+    # so guard these to where the properties exist.
+    $load{$model0}->{gid_or_id($old->{entity0})} = ['ArtistCredit'] if defined $old->{entity0};
+    $load{$model1}->{gid_or_id($old->{entity1})} = ['ArtistCredit'] if defined $old->{entity1};
+    $load{$model0}->{gid_or_id($new->{entity0})} = ['ArtistCredit'] if defined $new->{entity0};
+    $load{$model1}->{gid_or_id($new->{entity1})} = ['ArtistCredit'] if defined $new->{entity1};
 
     return \%load;
 }

--- a/lib/MusicBrainz/Server/Entity/Relationship.pm
+++ b/lib/MusicBrainz/Server/Entity/Relationship.pm
@@ -295,14 +295,6 @@ around TO_JSON => sub {
 
     my $link = $self->link;
 
-    if (defined $self->source) {
-        $self->link_entity(
-            $self->source_type,
-            $self->source->id,
-            $self->source,
-        );
-    }
-
     my $json = {
         attributes      => [map {
             my $type = $_->type;


### PR DESCRIPTION
### Fix MBS-13862

# Problem
Some `entity0` are not being loaded for add/edit/delete relationship edits in beta, leading to the entity being shown greyed out as if it had been removed.

# Solution
When both entities had the same type, I was overwriting the keys for entity 0 instead of adding the entity 1 ones alongside them.
    
This could be avoided, but since we don't actually need to be careful with this anymore since I figured out how to use `load_subobjects` to only try to look at ACs where they exist, the easiest way to avoid the issue is to revert the changes to the edit files.

# Testing
Manually by checking the reported edits (`/edit/119271964` and `/edit/119174960`) and edit searches for artist-artist and recording-recording relationship types such as [this one](http://reolappy:5000/search/edits?auto_edit_filter=&order=desc&negation=0&combinator=and&conditions.0.field=link_type&conditions.0.operator=%3D&conditions.0.args=230&conditions.1.field=type&conditions.1.operator=%3D&conditions.1.args=91%2C234&field=Veuillez+choisir+une+condition).