### PR TITLE
MBS-13863: Compare alias with content, not entity name

### DIFF
--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -191,14 +191,6 @@ component EntityLink(
   const entityName = ko.unwrap(entity.name);
   const isCountryArea = entity.entityType === 'area' &&
                         entity.typeID === AREA_TYPE_COUNTRY;
-  const primaryAlias = (!isCountryArea &&
-                        entity.entityType !== 'instrument' &&
-                        entity.entityType !== 'track' &&
-                        nonEmpty(entity.primaryAlias) &&
-                        entity.primaryAlias !== entityName)
-    ? entity.primaryAlias
-    : '';
-
 
   let content = passedContent;
   let hover = '';
@@ -216,20 +208,6 @@ component EntityLink(
       invariant(false, errorMessage);
     }
     Sentry.captureException(new Error(errorMessage));
-  }
-
-  if (showDisambiguation === undefined) {
-    showDisambiguation = !hasCustomContent;
-  }
-
-  if (showDisambiguation === 'hover' || entity.entityType === 'artist') {
-    const sortName = entity.entityType === 'artist' ? entity.sort_name : '';
-    const additionalName = nonEmpty(primaryAlias) ? primaryAlias : sortName;
-    hover = nonEmpty(additionalName) ? (
-      nonEmpty(comment) ? (
-        additionalName + ' ' + bracketedText(comment)
-      ) : additionalName
-    ) : comment;
   }
 
   /*
@@ -251,6 +229,29 @@ component EntityLink(
   }
 
   content = empty(content) ? entityName : content;
+
+  const primaryAlias = (!isCountryArea &&
+                        entity.entityType !== 'instrument' &&
+                        entity.entityType !== 'track' &&
+                        nonEmpty(entity.primaryAlias) &&
+                        entity.primaryAlias !== content)
+    ? entity.primaryAlias
+    : '';
+
+
+  if (showDisambiguation === undefined) {
+    showDisambiguation = !hasCustomContent;
+  }
+
+  if (showDisambiguation === 'hover' || entity.entityType === 'artist') {
+    const sortName = entity.entityType === 'artist' ? entity.sort_name : '';
+    const additionalName = nonEmpty(primaryAlias) ? primaryAlias : sortName;
+    hover = nonEmpty(additionalName) ? (
+      nonEmpty(comment) ? (
+        additionalName + ' ' + bracketedText(comment)
+      ) : additionalName
+    ) : comment;
+  }
 
   if (!ko.unwrap(entity.gid)) {
     if (entity.entityType === 'url') {


### PR DESCRIPTION
### Implement MBS-13863

# Problem
In beta, the new code showing the primary alias looks a bit dumb for relationships where the relationship credit is itself already the same as the alias, such as "Lan Shui (_Lan Shui_)" in [this recording](https://beta.musicbrainz.org/recording/905b6a88-7303-4020-a501-19cf5f930347).


# Solution
In cases where we have a relationship credit, for example, it doesn't make sense to repeat the alias if it matches the credit. On the other hand, it actually *does* seem to make sense to show the alias if it doesn't match the credit even if it does match the name - an editor checking a Japanese or Russian release might appreciate knowing who a Western artist shown under a local credit is. This changes the name === alias check to check the actual content to be displayed rather than the entity name. If we feel this becomes problematic when artists have shortened credits or the like we can always compare with both name *and* credit, but that would lose us the "credit in other language" helpful case.

# Testing
Manually, checking that the alias is not shown in this case but is still shown for Rachmaninov on the same page.