### PR TITLE
MBS-13867: Display RG primary alias in artist overview

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -271,6 +271,7 @@ sub show : PathPart('') Chained('load')
     $c->model('ArtistCredit')->load(@$release_groups);
     $c->model('ArtistType')->load(map { map { $_->artist } $_->artist_credit->all_names} @$release_groups);
     $c->model('ReleaseGroupType')->load(@$release_groups);
+    $c->model('ReleaseGroup')->load_aliases(@$release_groups);
     $c->stash(
         recordings => $recordings,
         recordings_jsonld => {items => $recordings},


### PR DESCRIPTION
### Fix MBS-13867

# Problem
I forgot to load primary aliases for RGs on artist pages.

# Solution
To load primary aliases for RGs on artist pages.

# Testing
Manually, with the artist from the ticket (`/artist/5837fcae-b639-41db-ae1d-87fa9141509c`) using a full data tunnel.