### PR TITLE
MBS-13872: Show primary alias in user tags and ratings

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -726,6 +726,7 @@ sub _merge_load_entities {
     my ($self, $c, @artists) = @_;
 
     $c->model('ArtistType')->load(@artists);
+    $c->model('Artist')->load_aliases(@artists);
     $c->model('Gender')->load(@artists);
     $c->model('Area')->load(@artists);
     $c->model('Area')->load_containment(map { $_->{area} } @artists);

--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -457,7 +457,7 @@ sub begin : Private
         my @merge = values %{
             $model->get_by_ids($merger->all_entities);
         };
-        $model->load_aliases(@merge) if $model->can('load_aliases');
+        $model->load_aliases(@merge) if $entity_properties->{aliases};
         $c->model('ArtistCredit')->load(@merge)
             if $entity_properties->{artist_credits};
 

--- a/lib/MusicBrainz/Server/Controller/Tag.pm
+++ b/lib/MusicBrainz/Server/Controller/Tag.pm
@@ -98,7 +98,7 @@ sub show : Chained('load') PathPart('')
 
                     my @entities = map { $_->entity } @$entity_tags;
                     $model->load_aliases(@entities)
-                        if $model->can('load_aliases');
+                        if $entity_properties->{aliases};
                     $c->model('ArtistCredit')->load(@entities)
                         if $entity_properties->{artist_credits};
 

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -574,7 +574,7 @@ sub ratings : Chained('load') PathPart('ratings') Args(1) HiddenOnMirrors
     $c->model('ArtistCredit')->load(@$ratings)
         if $entity_properties->{artist_credits};
     $c->model($model)->load_aliases(@$ratings)
-        if $c->model($model)->can('load_aliases');
+        if $entity_properties->{aliases};
 
     my %props = (
         entityType => $type,
@@ -665,7 +665,7 @@ sub tag : Chained('load_tag') PathPart('')
             $c->model('ArtistCredit')->load(@entity_entries)
                 if $entity_properties->{artist_credits};
             $model->load_aliases(@entity_entries)
-                if $model->can('load_aliases');
+                if $entity_properties->{aliases};
 
             ("$_" => {
                 count => $total,
@@ -722,7 +722,7 @@ for my $entity_type (entities_with('tags')) {
         $c->model('ArtistCredit')->load(@entity_entries)
             if $entity_properties->{artist_credits};
         $model->load_aliases(@entity_entries)
-            if $model->can('load_aliases');
+            if $entity_properties->{aliases};
 
         $c->stash(
             current_view => 'Node',

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -573,6 +573,8 @@ sub ratings : Chained('load') PathPart('ratings') Args(1) HiddenOnMirrors
     }, limit => 100);
     $c->model('ArtistCredit')->load(@$ratings)
         if $entity_properties->{artist_credits};
+    $c->model($model)->load_aliases(@$ratings)
+        if $c->model($model)->can('load_aliases');
 
     my %props = (
         entityType => $type,
@@ -655,11 +657,15 @@ sub tag : Chained('load_tag') PathPart('')
     if ($tag) {
         %tagged_entities = map {
             my $entity_properties = $ENTITIES{$_};
+            my $model = $c->model($entity_properties->{model});
 
-            my ($entities, $total) = $c->model($entity_properties->{model})->tags->find_editor_entities(
+            my ($entities, $total) = $model->tags->find_editor_entities(
                 $user->id, $tag->id, $show_downvoted, 10, 0);
-            $c->model('ArtistCredit')->load(map { $_->entity } @$entities)
+            my @entity_entries = map { $_->entity } @$entities;
+            $c->model('ArtistCredit')->load(@entity_entries)
                 if $entity_properties->{artist_credits};
+            $model->load_aliases(@entity_entries)
+                if $model->can('load_aliases');
 
             ("$_" => {
                 count => $total,
@@ -694,6 +700,7 @@ for my $entity_type (entities_with('tags')) {
     my $method = sub {
         my ($self, $c) = @_;
 
+        my $model = $c->model($entity_properties->{model});
         my $user = $c->stash->{user};
         my $tag = $c->stash->{tag};
         my $show_downvoted = $c->req->params->{show_downvoted} ? 1 : 0;
@@ -708,10 +715,14 @@ for my $entity_type (entities_with('tags')) {
 
         my $entity_tags = $self->_load_paged($c, sub {
             return ([], 0) unless $tag;
-            return $c->model($entity_properties->{model})->tags->find_editor_entities(
+            return $model->tags->find_editor_entities(
                 $user->id, $c->stash->{tag}->id, $show_downvoted, shift, shift);
         });
-        $c->model('ArtistCredit')->load(map { $_->entity } @$entity_tags) if $entity_properties->{artist_credits};
+        my @entity_entries = map { $_->entity } @$entity_tags;
+        $c->model('ArtistCredit')->load(@entity_entries)
+            if $entity_properties->{artist_credits};
+        $model->load_aliases(@entity_entries)
+            if $model->can('load_aliases');
 
         $c->stash(
             current_view => 'Node',

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -130,7 +130,7 @@ sub summarize_ratings
                 if $entity_properties->{artist_credits};
 
             $model->load_aliases(@$entities)
-                if $model->can('load_aliases');
+                if $entity_properties->{aliases};
 
             ($_ => to_json_array($entities));
         } entities_with('ratings'),

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -122,11 +122,15 @@ sub summarize_ratings
     return {
         map {
             my $entity_properties = $ENTITIES{$_};
-            my ($entities) = $self->c->model($entity_properties->{model})->rating
+            my $model = $self->c->model($entity_properties->{model});
+            my ($entities) = $model->rating
                 ->find_editor_ratings($user->id, $me, 10, 0);
 
             $self->c->model('ArtistCredit')->load(@$entities)
                 if $entity_properties->{artist_credits};
+
+            $model->load_aliases(@$entities)
+                if $model->can('load_aliases');
 
             ($_ => to_json_array($entities));
         } entities_with('ratings'),


### PR DESCRIPTION
### Implement MBS-13872

I had loaded aliases here for some cases, but not most - this should now cover all pages (user tag and user tag by entity, and user rating and user rating by entity).

I also noticed while testing that I wasn't loading aliases on artist merge pages, so a separate commit does that now.

# Testing
Manually, with `/user/reosarevok/tag/nyū%20myūjikku` / `/user/reosarevok/tag/nyū%20myūjikku/artist` and `/user/dragonzeron/ratings` / `/user/dragonzeron/ratings/artist` - and by merging some artists with aliases.