### PR TITLE
MBS-13886: Don't crash on wrong link_type for paged rels

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Load.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Load.pm
@@ -7,6 +7,7 @@ use namespace::autoclean;
 use MusicBrainz::Server::Data::Utils qw( contains_string model_to_type );
 use MusicBrainz::Server::Validation qw( is_guid is_positive_integer );
 use MusicBrainz::Server::Constants qw( :direction %ENTITIES );
+use MusicBrainz::Server::Translation qw( l );
 use Readonly;
 use aliased 'MusicBrainz::Server::Entity::RelationshipLinkTypeGroup';
 
@@ -89,6 +90,13 @@ role
                 my %opts;
 
                 if (is_positive_integer($link_type_id)) {
+                    my $link_type = $c->model('LinkType')->get_by_id($link_type_id);
+                    unless ($link_type) {
+                        $c->stash(
+                            message  => l('The provided relationship type ID is not valid.'),
+                        );
+                        $c->detach('/error_400');
+                    }
                     $opts{link_type_id} = $link_type_id;
                     $opts{limit} = $RELATIONSHIP_PAGE_SIZE;
 

--- a/root/components/RelationshipsTable.js
+++ b/root/components/RelationshipsTable.js
@@ -347,9 +347,7 @@ component RelationshipsTable(
     } else {
       pageContent = (
         <p>
-          {linkPhrase
-            ? l('No relationships of the selected type were found.')
-            : l('The provided relationship type ID is not valid.')}
+          {l('No relationships of the selected type were found.')}
         </p>
       );
     }


### PR DESCRIPTION
### Fix MBS-13886

# Problem
Trying to access a paged relationships list with a non-existing link type, such as `/work/8dcffe3f-cb5c-3459-b6d7-0558a2174808?direction=2&link_type_id=277&page=1`, causes a JS `TypeError`. Found in Sentry.

# Solution
I assume someone was just playing around with the URL params and I cannot think of any other way of getting here than the user fiddling like that. As such, it seems to make sense to block this at the controller level and a 400 BAD REQUEST seems like a good fit.

# Testing
Manually, on the URL above.