### PR TITLE
MBS-13855 / MBS-13887: Threads handling improvements

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5497,10 +5497,15 @@ const CLEANUPS: CleanupEntries = {
     match: [/^(https?:\/\/)?([^/]+\.)?threads\.net\//i],
     restrict: [{...LINK_TYPES.streamingfree, ...LINK_TYPES.socialnetwork}],
     clean(url) {
-      return url.replace(
+      url = url.replace(
         /^(?:https?:\/\/)?(?:www\.)?threads\.net(?:\/#!)?\/([^#?]+).*$/,
         'https://www.threads.net/$1',
       );
+      url = url.replace(
+        /^https:\/\/www\.threads\.net\/@[^/]+\/post\/([^/]+)/,
+        'https://www.threads.net/t/$1',
+      );
+      return url;
     },
     validate(url, id) {
       const isAProfile = /^https:\/\/www\.threads\.net\/@[^/]+$/.test(url);

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5498,8 +5498,8 @@ const CLEANUPS: CleanupEntries = {
     restrict: [{...LINK_TYPES.streamingfree, ...LINK_TYPES.socialnetwork}],
     clean(url) {
       return url.replace(
-        /^(?:https?:\/\/)?(?:www\.)?threads\.net(?:\/#!)?\//,
-        'https://www.threads.net/',
+        /^(?:https?:\/\/)?(?:www\.)?threads\.net(?:\/#!)?\/([^#?]+).*$/,
+        'https://www.threads.net/$1',
       );
     },
     validate(url, id) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5712,6 +5712,13 @@ limited_link_type_combinations: ['downloadpurchase', 'mailorder'],
        only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
   },
   {
+                     input_url: 'https://www.threads.net/@pijusmusic?xmt=AQGzAol_Hx_F7AhixuRL9azxH4P2AYJKBOasDrM7Y2yyf6Y',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'socialnetwork',
+            expected_clean_url: 'https://www.threads.net/@pijusmusic',
+       only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
+  },
+  {
                      input_url: 'https://threads.net/t/CucwR6erBPo',
              input_entity_type: 'recording',
     expected_relationship_type: 'streamingfree',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5725,6 +5725,13 @@ limited_link_type_combinations: ['downloadpurchase', 'mailorder'],
             expected_clean_url: 'https://www.threads.net/t/CucwR6erBPo',
        only_valid_entity_types: ['recording'],
   },
+  {
+                     input_url: 'https://www.threads.net/@pijusmusic/post/DESGn_BsdiQ',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'streamingfree',
+            expected_clean_url: 'https://www.threads.net/t/DESGn_BsdiQ',
+       only_valid_entity_types: ['recording'],
+  },
   // Ticketmaster
   {
                      input_url: 'http://ticketmaster.com/depeche-mode-tickets/artist/734907#about',


### PR DESCRIPTION
### Implement MBS-13855 / MBS-13887

# Problem
Threads links are not cleaned of useless parameters, and the new format for posts is unsupported.

# Solution
Dropping the useless URL params, and accepting and cleaning the new threads/posts format. I'm still cleaning to the `/t/post_id` format (which still works) since it seems like it might be more persistent since it doesn't depend on the name not changing

# Testing
Added cleanup tests.