### PR TITLE
MBS-13749: Wrap artist credit links in bdi

### DIFF
--- a/root/static/scripts/common/components/ArtistCreditLink.js
+++ b/root/static/scripts/common/components/ArtistCreditLink.js
@@ -9,6 +9,7 @@
 
 import informationIconUrl from '../../../images/icons/information.png';
 import Tooltip from '../../edit/components/Tooltip.js';
+import isolateText from '../utility/isolateText.js';
 
 import EntityLink, {DeletedLink} from './EntityLink.js';
 
@@ -69,6 +70,7 @@ component ArtistCreditLink(
           content={credit.name}
           entity={artist}
           key={`${artist.id}-${i}`}
+          shouldIsolate={false}
           showDeleted={showDeleted}
           showDisambiguation={showDisambiguation}
           showEditsPending={showEditsPending && !artistCredit.editsPending}
@@ -82,6 +84,7 @@ component ArtistCreditLink(
           allowNew={false}
           key={`deleted-${i}`}
           name={credit.name}
+          shouldIsolate={false}
         />,
       );
     }
@@ -95,7 +98,7 @@ component ArtistCreditLink(
       </span>
     );
   }
-  return parts;
+  return isolateText(parts);
 }
 
 export default ArtistCreditLink;

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -22,11 +22,16 @@ import entityHref from '../utility/entityHref.js';
 import formatDatePeriod from '../utility/formatDatePeriod.js';
 import isolateText from '../utility/isolateText.js';
 
+function maybeIsolated(shouldIsolate: boolean, content: ?React.Node) {
+  return shouldIsolate ? isolateText(content) : content;
+}
+
 export component DeletedLink(
   allowNew: boolean,
   className?: string,
   deletedCaption?: string,
   name: ?Expand2ReactOutput,
+  shouldIsolate: boolean = true,
 ) {
   const caption = nonEmpty(deletedCaption) ? deletedCaption : (allowNew
     ? l('This entity will be added by this edit.')
@@ -41,7 +46,7 @@ export component DeletedLink(
       }
       title={caption}
     >
-      {isolateText(nonEmpty(name)
+      {maybeIsolated(shouldIsolate, nonEmpty(name)
         ? name
         : lp('[removed]', 'generic entity'))}
     </span>
@@ -175,6 +180,7 @@ component EntityLink(
   showEventDate: boolean = true,
   showIcon as passedShowIcon?: boolean = false,
   subPath?: string,
+  shouldIsolate: boolean = true,
   ...passedAnchorProps: {
     className?: string,
     href?: string,
@@ -314,9 +320,13 @@ component EntityLink(
           ? disabledLinkText()
           : null}
       >
-        {isolateText(content)}
+        {maybeIsolated(shouldIsolate, content)}
       </span>
-    ) : <a key="link" {...anchorProps}>{isolateText(content)}</a>;
+    ) : (
+      <a key="link" {...anchorProps}>
+        {maybeIsolated(shouldIsolate, content)}
+      </a>
+    );
 
   if (nameVariation === true) {
     content = (

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -113,7 +113,7 @@ test 'previewing/creating/editing a release group and release' => sub {
 
     $html = $response->{previews}->[0]->{preview};
 
-    like($html, qr{<bdi>Boredoms</bdi></a> plus <a href=".*" title="a fake artist"><bdi>a fake artist</bdi></a> and a trailing join phrase}, 'preview has artist name');
+    like($html, qr{<bdi><a href=".*" title="Boredoms">Boredoms</a> plus <a href=".*" title="a fake artist">a fake artist</a> and a trailing join phrase</bdi>}, 'preview has artist name');
     like($html, qr/0798d15b-64e2-499f-9969-70167b1d8617/, 'preview has artist gid');
     like($html, qr/Vision Creation Newsun/, 'preview has release name');
     like($html, qr/limited edition/, 'preview has release comment');


### PR DESCRIPTION
This shows multiple right-to-left artist credits correctly

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

This fixes MBS-13749, where multiple right-to-left artist credits are not rendered correctly


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Wrap the entire `ArtistCreditLink` in `<bdi>` tags.
Had to remove `<bdi>` tags from the `EntityLink` parts so that the entire credit text will be taken into account when calculating the directionality of the text, instead of just the join phrase.

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

- Tested release [81d3646a-c1d4-4807-80b7-25d0380ffb0a](https://beta.musicbrainz.org/release/81d3646a-c1d4-4807-80b7-25d0380ffb0a) which has multiple such credits on a dev server. 
- Verified that left-to-right credits are not affected.
- ran JavaScript unit tests
