### PR TITLE
MBS-13888: Also convert relative wiki links to /doc

### DIFF
--- a/lib/MusicBrainz/Server/Data/WikiDoc.pm
+++ b/lib/MusicBrainz/Server/Data/WikiDoc.pm
@@ -50,10 +50,11 @@ sub _fix_html_links
             $node->replace_with($node->content_list);
         }
     }
-    # if this is not a link to the wikidocs server, don't mess with it.
-    elsif ($href =~ m,^(?:https?:)?//$wiki_server,)
+    # If this is not a link to the wikidocs server, don't mess with it.
+    # Relative links inside the wiki should be wiki links, so convert them too.
+    elsif ($href =~ m,^(?:\/|(?:https?:)?//$wiki_server),)
     {
-        $href =~ s,^(?:https?:)?//$wiki_server/?,/doc/,;
+        $href =~ s,^(?:\/|(?:https?:)?//$wiki_server/?),/doc/,;
         $node->attr('href', $href);
     }
     elsif ($href =~ m,^$WIKI_IMAGE_PREFIX,) {

--- a/lib/MusicBrainz/Server/Data/WikiDoc.pm
+++ b/lib/MusicBrainz/Server/Data/WikiDoc.pm
@@ -54,7 +54,7 @@ sub _fix_html_links
     # Relative links inside the wiki should be wiki links, so convert them too.
     elsif ($href =~ m,^(?:\/|(?:https?:)?//$wiki_server),)
     {
-        $href =~ s,^(?:\/|(?:https?:)?//$wiki_server/?),/doc/,;
+        $href =~ s,^(?:/|(?:https?:)?//$wiki_server/?),/doc/,;
         $node->attr('href', $href);
     }
     elsif ($href =~ m,^$WIKI_IMAGE_PREFIX,) {

--- a/t/lib/t/MusicBrainz/Server/Data/WikiDoc.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/WikiDoc.pm
@@ -25,12 +25,21 @@ my $wd = $test->c->model('WikiDoc');
 
 my $page = $wd->_create_page('Artist_Name', 123, '
 <h3><span class="editsection">[<a href="http://wiki.musicbrainz.org/?title=Artist_Name&amp;action=edit&amp;section=6" title="Edit section: Section">edit</a>]</span> Section</h3>
-<p>Foo</p>
+<p><a href="/Foo" title="Foo">Foo</a></p>
 ');
 
-is($page->title, 'Artist Name');
-is($page->version, 123);
-like($page->content, qr{<h3> Section</h3>});
+is($page->title, 'Artist Name', 'The doc page has the right title');
+is($page->version, 123, 'The doc page has the right version');
+like(
+    $page->content,
+    qr{<h3> Section</h3>},
+    'The doc page contains the section header',
+);
+like(
+    $page->content,
+    qr{/doc/Foo},
+    'The relative wiki link was converted to use /doc',
+);
 
 $wd = $test->c->model('WikiDoc');
 $page = $wd->get_page('XML_Webservice');


### PR DESCRIPTION
### Fix MBS-13888

# Problem
Wiki links that are returned as relative links (such as pages listed inside a category in `Category:X` links) are not being detected as such, and not being turned into `/doc/` links, leading to broken links to `mb.org/DocPage`. See https://musicbrainz.org/doc/Category:How_To for an example.

# Solution
Also recognize relative links as wiki links and turn them into `/doc/` links as part of `_fix_html_links`

# Testing
Manually (by disabling the cache and checking the new version did have working links), plus I extended the existing Data::WikiDoc to have a relative link for the test to check.