### PR TITLE
MBS-13591: Show error when blocking Bandcamp user page

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1142,7 +1142,10 @@ const CLEANUPS: CleanupEntries = {
               target: ERROR_TARGETS.ENTITY,
             };
           }
-          return {result: /^https:\/\/[^/]+\.bandcamp\.com\/$/.test(url)};
+          return {
+            result: /^https:\/\/[^/]+\.bandcamp\.com\/$/.test(url),
+            target: ERROR_TARGETS.ENTITY,
+          };
         case LINK_TYPES.bandcamp.genre:
           return {
             result: /^https:\/\/bandcamp\.com\/discover\/[\w-]+$/.test(url),

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -951,6 +951,13 @@ limited_link_type_combinations: [
                                   target: 'url',
                                 },
   },
+  {
+                     input_url: 'https://bandcamp.com/slowmouth',
+             input_entity_type: 'artist',
+    expected_relationship_type: undefined,
+       input_relationship_type: 'bandcamp',
+       only_valid_entity_types: [],
+  },
   // Bandsintown
   {
                      input_url: "https://m.bandsintown.com/MattDobberteen's50thBirthday?came_from=178",


### PR DESCRIPTION
### Fix MBS-13591

# Problem
We currently blocking edit submission when a Bandcamp user link is added, but nothing is shown to the user - the submit button is just greyed out. MBS-12408 asks to allow these (separate from artist links) but in any case as long as we keep blocking them we should show the error so it is clear what's going on.

# Solution
The reason no error message was displayed is simply that no target was given, so this adds a target (`ENTITY` since that's what we already used for the equivalent label check).

# Testing
Added a test to make it clear that this blocking is (currently) intentional, at least.