### PR TITLE
MBS-13891: dribbble.com URLs are wrongly blocked

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2471,12 +2471,18 @@ const CLEANUPS: CleanupEntries = {
           };
         }
         const hardcodedPaths = [
+          'designers',
           'directories',
           'for-designers',
           'hiring',
+          'jobs',
           'learn',
           'pro',
+          'session',
           'shots',
+          'signup',
+          'stories',
+          'submit-brief',
           'tags',
         ];
         if (hardcodedPaths.includes(userName)) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2460,7 +2460,7 @@ const CLEANUPS: CleanupEntries = {
       return url;
     },
     validate(url) {
-      const m = /^https:\/\/www\.artstation\.com\/([^/]+)$/.exec(url);
+      const m = /^https:\/\/dribbble\.com\/([^/]+)$/.exec(url);
       if (m) {
         const userName = m[1];
         if (userName === 'search') {


### PR DESCRIPTION
### Fix MBS-13891

# Problem
Valid dribbble.com links are being rejected.

# Solution
We were validating with `artstation.com`... clearly nobody has tried to use this in years. Just change it to `dribbble.com`.

# Testing
Manually. We don't currently have a way to automate-test that a link is *not* blocked, I think, other than checking what entities are accepted - I guess we could set the valid entities to all relevant ones on all cases where we don't actually close any options when validating?