### PR TITLE
MBS-13857 / MBS-13893: Block invisible characters from usernames

### DIFF
--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -19,7 +19,7 @@ use MusicBrainz::Server::Data::Utils qw(
     hash_to_row
     load_subobjects
     placeholders
-    sanitize
+    sanitize_username
 );
 use MusicBrainz::Server::Constants qw(
     :create_entity
@@ -282,7 +282,7 @@ sub find_subscribers
 
 sub _die_if_username_invalid {
     my $name = shift;
-    my $sanitized_name = sanitize($name);
+    my $sanitized_name = sanitize_username($name);
 
     die 'Invalid user name' if (
         $name ne $sanitized_name ||

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -73,6 +73,7 @@ our @EXPORT_OK = qw(
     remove_equal
     remove_invisible_characters
     sanitize
+    sanitize_username
     take_while
     trim
     trim_comment
@@ -345,6 +346,17 @@ sub sanitize {
     $t = remove_direction_marks($t);
     # Collapse spaces again, since characters may have been removed.
     $t = collapse_whitespace($t);
+
+    return $t;
+}
+
+sub sanitize_username {
+    my $t = shift;
+
+    return '' unless non_empty($t);
+
+    $t = sanitize($t);
+    $t = remove_invisible_characters($t);
 
     return $t;
 }

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -357,6 +357,7 @@ sub sanitize_username {
 
     $t = sanitize($t);
     $t = remove_invisible_characters($t);
+    $t = remove_tag_characters($t);
 
     return $t;
 }
@@ -480,6 +481,16 @@ sub remove_lineformatting_characters {
     # - shy
     # - Other, control (including TAB \x09, LF \x0A, and CR \x0D)
     =~ s/[\N{ZERO WIDTH SPACE}\N{SOFT HYPHEN}\p{Cc}]//gr;
+}
+
+sub remove_tag_characters {
+    my $string = shift;
+
+    # https://en.wikipedia.org/wiki/Tags_(Unicode_block)
+    # Can be used for flag emojis but also as invisible chars
+    $string =~ s/[\x{E0000}-\x{E007F}]//g;
+
+    return $string;
 }
 
 sub type_to_model

--- a/lib/MusicBrainz/Server/Form/Utils.pm
+++ b/lib/MusicBrainz/Server/Form/Utils.pm
@@ -3,7 +3,7 @@ package MusicBrainz::Server::Form::Utils;
 use strict;
 use warnings;
 
-use MusicBrainz::Server::Data::Utils qw( sanitize );
+use MusicBrainz::Server::Data::Utils qw( sanitize_username );
 use MusicBrainz::Server::Translation qw( l lp );
 use List::AllUtils qw( sort_by );
 
@@ -212,7 +212,7 @@ sub validate_username {
 
     if (defined $username) {
         unless (defined $previous_username && $editor_model->are_names_equivalent($previous_username, $username)) {
-            my $sanitized_name = sanitize($username);
+            my $sanitized_name = sanitize_username($username);
             if (
                 $username ne $sanitized_name ||
                 $sanitized_name =~ qr{://}

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Register.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Register.pm
@@ -107,6 +107,15 @@ test 'Trying to register with an invalid name' => sub {
     $mech->content_contains('username contains invalid characters', 'form has error message for invisible characters in username');
 
     $mech->submit_form( with_fields => {
+        'register.username' => "test\N{TAG LATIN CAPITAL LETTER T}\N{TAG LATIN CAPITAL LETTER E}\N{TAG LATIN CAPITAL LETTER S}\N{TAG LATIN CAPITAL LETTER T}",
+        'register.password' => 'foo',
+        'register.confirm_password' => 'foo',
+        'register.email' => 'foobar@example.org',
+    });
+    like($mech->uri, qr{/register}, 'stays on registration page');
+    $mech->content_contains('username contains invalid characters', 'form has error message for tag characters in username');
+
+    $mech->submit_form( with_fields => {
         'register.username' => 'looks://like_a_url_to_me',
         'register.password' => 'foo',
         'register.confirm_password' => 'foo',

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Register.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Register.pm
@@ -98,6 +98,15 @@ test 'Trying to register with an invalid name' => sub {
     $mech->content_contains('username contains invalid characters', 'form has error message for consecutive spaces in username');
 
     $mech->submit_form( with_fields => {
+        'register.username' => "test\N{HANGUL FILLER}\N{HALFWIDTH HANGUL FILLER}\N{BRAILLE PATTERN BLANK}\N{HANGUL CHOSEONG FILLER}\N{HANGUL JUNGSEONG FILLER}",
+        'register.password' => 'foo',
+        'register.confirm_password' => 'foo',
+        'register.email' => 'foobar@example.org',
+    });
+    like($mech->uri, qr{/register}, 'stays on registration page');
+    $mech->content_contains('username contains invalid characters', 'form has error message for invisible characters in username');
+
+    $mech->submit_form( with_fields => {
         'register.username' => 'looks://like_a_url_to_me',
         'register.password' => 'foo',
         'register.confirm_password' => 'foo',


### PR DESCRIPTION
### Implement MBS-13857 / MBS-13893

# Problem
There's recently been a bunch of abusive character creation involving the use of unicode tag characters to create multiple accounts with visually the same name. Additionally, we have blocked some other invisible characters from edit notes, but we still allow them in usernames - these can have the same effect.

# Solution
This moves from simply using `sanitize` to block invalid characters in names to a new `sanitize_username` method, that also runs the pre-existing method `remove_invisible_characters` and a new `remove_tag_characters` method on the username on top of `sanitize`.

# Testing
Two tests (one per commit / set of characters) have been added to the `User::Register` test.