### PR TITLE
MBS-13895: Allow Crew United links as otherdbs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2036,6 +2036,24 @@ const CLEANUPS: CleanupEntries = {
       return url.replace(/^(?:https?:\/\/)?(?:www[0-9]?\.)?cpdl\.org/, 'http://cpdl.org');
     },
   },
+  'crewunited': {
+    match: [/^(https?:\/\/)?(www\.)?crew-united\.com\//i],
+    restrict: [LINK_TYPES.otherdatabases],
+    clean(url) {
+      return url.replace(/^(?:https?:\/\/)?(?:www\.)?crew-united\.com\/(?:[a-z]+\/)?([\w-]+_[\d]+\.html).*?$/, 'https://www.crew-united.com/en/$1');
+    },
+    validate(url, id) {
+      if (/^https:\/\/www\.crew-united\.com\/en\/[\w-]+_[\d]+\.html$/.test(url)) {
+        if (id === LINK_TYPES.otherdatabases.artist ||
+            id === LINK_TYPES.otherdatabases.label ||
+            id === LINK_TYPES.otherdatabases.recording) {
+          return {result: true};
+        }
+        return {result: false, target: ERROR_TARGETS.ENTITY};
+      }
+      return {result: false, target: ERROR_TARGETS.URL};
+    },
+  },
   'dahr': {
     match: [
       /^(https?:\/\/)?adp\.library\.ucsb\.edu\/index\.php\/(mastertalent|matrix|objects|talent)/i,

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1913,6 +1913,28 @@ limited_link_type_combinations: [
     expected_relationship_type: 'license',
             expected_clean_url: 'https://creativecommons.org/publicdomain/zero/1.0/',
   },
+  // Crew United
+  {
+                     input_url: 'http://www.crew-united.com/Jaques-Linon_89709.html',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.crew-united.com/en/Jaques-Linon_89709.html',
+       only_valid_entity_types: ['artist', 'label', 'recording'],
+  },
+  {
+                     input_url: 'https://crew-united.com/ro/Hell-Raisa-Records_147592.html',
+             input_entity_type: 'label',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.crew-united.com/en/Hell-Raisa-Records_147592.html',
+       only_valid_entity_types: ['artist', 'label', 'recording'],
+  },
+  {
+                     input_url: 'https://www.crew-united.com/en/Kaisa-Den-Schlechten-geht-es-gut__143909.html#!&tabctl_15249142_activeTab=1189721449',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.crew-united.com/en/Kaisa-Den-Schlechten-geht-es-gut__143909.html',
+       only_valid_entity_types: ['artist', 'label', 'recording'],
+  },
   // DAHR
   {
                      input_url: 'https://adp.library.ucsb.edu/index.php/talent/detail/800/Louis_Armstrong_All-Stars_Musical_group',


### PR DESCRIPTION
### Implement MBS-13895

# Description
This is a database of audiovisual work, including music videos. They have entries for artists, companies (labels) and videos (recordings). Sadly, we cannot determine the entity type from the URL. All languages seem equivalent, so this standardizes to `/en` to avoid duplicates.

Removing the entity name and leaving the numeric ID, tempting as it is, does not work.

# Testing
Added some tests checking the language standardization, dropping extra crap, and the usual http/www.