### PR TITLE
MBS-13896 / MBS-13897: User type link improvements

### DIFF
--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -77,7 +77,11 @@ function generateUserTypesList(
     );
   }
   if (isBot(user)) {
-    typesList.push(lp('Internal/Bot', 'user type'));
+    typesList.push(
+      <a href="/doc/Editor#Bot" key="bot">
+        {lp('Internal/Bot', 'user type')}
+      </a>,
+    );
   }
   if (isRelationshipEditor(user)) {
     typesList.push(

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -71,7 +71,7 @@ function generateUserTypesList(
   }
   if (isAutoEditor(user)) {
     typesList.push(
-      <a href="/doc/Editor#Auto-editors" key="auto-editor">
+      <a href="/doc/Editor#Auto-editor" key="auto-editor">
         {lp('Auto-editor', 'user type')}
       </a>,
     );
@@ -81,21 +81,21 @@ function generateUserTypesList(
   }
   if (isRelationshipEditor(user)) {
     typesList.push(
-      <a href="/doc/Editor#Relationship_editors" key="relationship-editor">
+      <a href="/doc/Editor#Relationship_editor" key="relationship-editor">
         {lp('Relationship editor', 'user type')}
       </a>,
     );
   }
   if (isWikiTranscluder(user)) {
     typesList.push(
-      <a href="/doc/Editor#Transclusion_editors" key="transclusion-editor">
+      <a href="/doc/Editor#Transclusion_editor" key="transclusion-editor">
         {lp('Transclusion editor', 'user type')}
       </a>,
     );
   }
   if (isLocationEditor(user)) {
     typesList.push(
-      <a href="/doc/Editor#Location_editors" key="location-editor">
+      <a href="/doc/Editor#Location_editor" key="location-editor">
         {lp('Location editor', 'user type')}
       </a>,
     );

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -83,6 +83,13 @@ function generateUserTypesList(
       </a>,
     );
   }
+  if (isAccountAdmin(user)) {
+    typesList.push(
+      <a href="/doc/Editor#Account_admin" key="account-admin">
+        {lp('Account admin', 'user type')}
+      </a>,
+    );
+  }
   if (isRelationshipEditor(user)) {
     typesList.push(
       <a href="/doc/Editor#Relationship_editor" key="relationship-editor">

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -102,13 +102,14 @@ function generateUserTypesList(
   }
   if (isBeginner(user)) {
     typesList.push(
-      <span
+      <a
         className="tooltip"
+        href="/doc/Editor#Beginner_editor"
         key="beginner"
         title={l('This user is new to MusicBrainz.')}
       >
         {lp('Beginner', 'user type')}
-      </span>,
+      </a>,
     );
   }
   // If no other types apply, then this is a normal user


### PR DESCRIPTION
### Fix MBS-13896 / Implement MBS-13897

# Description
This fixes anchor links to editor types from editor pages (such as `/user/reosarevok`), which had broken when @Aerozol changed the headers on the doc from plural to singular. It also adds links to missing (now documented) types, "Bot", "Beginner" and "Account admin" (the last of which wasn't even indicated on the page yet for some reason, but really should be).

# Testing
Manually, by checking my own page (all privs except beginner and bot) and creating a new account locally (beginner) and setting it as a bot.