### PR TITLE
MBS-13866: Show translated RG types on search results

### DIFF
--- a/root/search/components/ReleaseGroupResults.js
+++ b/root/search/components/ReleaseGroupResults.js
@@ -42,10 +42,8 @@ function getResultBuilder(showArtworkPresence: boolean) {
           <ArtistCreditLink artistCredit={releaseGroup.artistCredit} />
         </td>
         <td>
-          {nonEmpty(releaseGroup.typeName)
-            ? lp_attributes(
-              releaseGroup.typeName, 'release_group_primary_type',
-            )
+          {nonEmpty(releaseGroup.l_type_name)
+            ? releaseGroup.l_type_name
             : null}
         </td>
       </tr>

--- a/root/search/components/ReleaseResults.js
+++ b/root/search/components/ReleaseResults.js
@@ -42,7 +42,7 @@ function getResultBuilder(showArtworkPresence: boolean) {
   ) {
     const release = result.entity;
     const score = result.score;
-    const typeName = release.releaseGroup?.typeName;
+    const typeName = release.releaseGroup?.l_type_name;
 
     return (
       <tr className={loopParity(index)} data-score={score} key={release.id}>
@@ -80,9 +80,7 @@ function getResultBuilder(showArtworkPresence: boolean) {
           <ReleaseLanguageScript release={release} />
         </td>
         <td>
-          {nonEmpty(typeName)
-            ? lp_attributes(typeName, 'release_group_primary_type')
-            : null}
+          {nonEmpty(typeName) ? typeName : null}
         </td>
         <td>
           {release.status


### PR DESCRIPTION
### Fix MBS-13866

# Problem
Any combined release group types (such as "Album + Live") show untranslated on release and release group search result pages.

# Solution
We were only translating expecting primary types, but these are actually combined types. This just uses `l_type_name`, which is what we already use on sidebars to display translations for the same combined types.

# Testing
Manually, with `/search?query=ticheli&type=release_group&method=indexed` (and the same search for releases).