### PR TITLE
MBS-13902: Add test for persistent (did:plc) Bluesky links

### DIFF
--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1315,6 +1315,12 @@ limited_link_type_combinations: [
     expected_relationship_type: 'socialnetwork',
             expected_clean_url: 'https://bsky.app/profile/thecure.com',
   },
+  {
+                     input_url: 'https://bsky.app/profile/did:plc:vqm2zcwhku3u7schrnrh74hb/followers',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'socialnetwork',
+            expected_clean_url: 'https://bsky.app/profile/did:plc:vqm2zcwhku3u7schrnrh74hb',
+  },
   // BnF (Bibliothèque nationale de France) Catalogue
   {
                      input_url: 'http://ark.bnf.fr/ark:/12148/cb11923342r',


### PR DESCRIPTION
### Implement MBS-13902

# Description
Bluesky has a second type of more permanent, but also more hidden, links. See https://docs.bsky.app/docs/advanced-guides/resolving-identities

Our implementation already supports these (by accident) but this adds a test so that we don't later accidentally break support. These could cause an artist to get duplicate Bluesky links, but given how non-trivial these are to find, the most likely source is something like Wikidata rather than user action. It doesn't feel good to outright block them either since they are more permanent than the default links, so this "sure, I guess you can add them" implementation seems fine enough to me.

# Testing
The whole point is to add a test