### PR TITLE
Beta: Don't show admin approval buttons on edit lists

### DIFF
--- a/root/edit/components/EditSummary.js
+++ b/root/edit/components/EditSummary.js
@@ -18,8 +18,6 @@ import {
   DB_READ_ONLY,
   DB_STAGING_TESTING_FEATURES,
 } from '../../static/scripts/common/DBDefs.mjs';
-import {isAccountAdmin}
-  from '../../static/scripts/common/utility/privileges.js';
 import {
   editorMayAddNote,
   editorMayApprove,
@@ -36,11 +34,9 @@ component EditSummary(
 ) {
   const $c = React.useContext(CatalystContext);
   const user = $c.user;
-  const isAdmin = isAccountAdmin(user);
   const mayAddNote = editorMayAddNote(edit, user);
   const mayApprove = editorMayApprove(edit, user);
   const mayCancel = editorMayCancel(edit, user);
-  const showAcceptReject = DB_STAGING_TESTING_FEATURES || isAdmin;
 
   return (
     <>
@@ -81,23 +77,8 @@ component EditSummary(
             </a>
           ) : null}
 
-          {edit.status === EDIT_STATUS_OPEN && showAcceptReject ? (
-            isAdmin ? (
-              <>
-                <a
-                  className="positive"
-                  href={`/admin/accept-edit/${edit.id}`}
-                >
-                  {l('Accept edit')}
-                </a>
-                <a
-                  className="negative"
-                  href={`/admin/reject-edit/${edit.id}`}
-                >
-                  {l('Reject edit')}
-                </a>
-              </>
-            ) : (
+          {edit.status === EDIT_STATUS_OPEN &&
+            DB_STAGING_TESTING_FEATURES ? (
               <>
                 <a
                   className="positive"
@@ -112,8 +93,7 @@ component EditSummary(
                   {l('Reject edit')}
                 </a>
               </>
-            )
-          ) : null}
+            ) : null}
         </div>) : null}
     </>
   );


### PR DESCRIPTION
### Amends MBS-13770

# Description
From very quick personal experience, it's way too easy to misclick the new approval / rejection buttons on edit lists while trying to do a normal approve (or probably even when adding a note). For the cases where this is needed, it's fine to spend the few extra seconds to go into the edit page(s) and apply or reject from there.

Partially reverts https://github.com/metabrainz/musicbrainz-server/pull/3392 

# Testing
Manually, by checking that the approve/reject buttons that still show locally are no longer the admin ones, but the default test ones that won't show outside test servers.