### PR TITLE
MBS-13597: Add release filter to label index pages 

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Ajax.pm
+++ b/lib/MusicBrainz/Server/Controller/Ajax.pm
@@ -12,6 +12,7 @@ use MusicBrainz::Server::FilterUtils qw(
     create_artist_releases_form
     create_artist_recordings_form
     create_artist_works_form
+    create_label_releases_form
 );
 
 sub filter_artist_events_form : Local {
@@ -59,6 +60,16 @@ sub filter_artist_works_form : Local {
 
     my $artist_id = $c->req->query_params->{artist_id};
     my $form = create_artist_works_form($c, $artist_id);
+
+    $c->res->body(encode_json($form->TO_JSON));
+    $c->res->content_type('application/json; charset=utf-8');
+}
+
+sub filter_label_releases_form : Local {
+    my ($self, $c) = @_;
+
+    my $label_id = $c->req->query_params->{label_id};
+    my $form = create_label_releases_form($c, $label_id);
 
     $c->res->body(encode_json($form->TO_JSON));
     $c->res->content_type('application/json; charset=utf-8');

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -27,6 +27,7 @@ with 'MusicBrainz::Server::Controller::Role::Annotation';
 with 'MusicBrainz::Server::Controller::Role::Alias';
 with 'MusicBrainz::Server::Controller::Role::Details';
 with 'MusicBrainz::Server::Controller::Role::EditListing';
+with 'MusicBrainz::Server::Controller::Role::Filter';
 with 'MusicBrainz::Server::Controller::Role::IPI';
 with 'MusicBrainz::Server::Controller::Role::ISNI';
 with 'MusicBrainz::Server::Controller::Role::Rating';
@@ -889,41 +890,6 @@ sub edit_credit : Chained('credit') PathPart('edit') Edit {
                 $c->uri_for_action('/artist/aliases', [ $artist->gid ]));
         },
     );
-}
-
-=head2 process_filter
-
-Utility function for dynamically loading the filter form.
-
-=cut
-
-sub process_filter
-{
-    my ($self, $c, $create_form) = @_;
-
-    my %filter;
-    unless (exists $c->req->params->{'filter.cancel'}) {
-        my $cookie = $c->req->cookies->{filter};
-        my $has_filter_params = grep { /^filter\./ } keys %{ $c->req->params };
-        if ($has_filter_params || ($cookie && defined($cookie->value) && $cookie->value eq '1')) {
-            my $filter_form = $create_form->();
-            if ($c->form_submitted_and_valid($filter_form)) {
-                for my $name ($filter_form->filter_field_names) {
-                    my $value = $filter_form->field($name)->value;
-                    if ($value) {
-                        $filter{$name} = $value;
-                    }
-
-                }
-                $c->res->cookies->{filter} = { value => '1', path => '/' };
-            }
-        }
-    }
-    else {
-        $c->res->cookies->{filter} = { value => '', path => '/' };
-    }
-
-    return \%filter;
 }
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/Controller/Role/Filter.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Filter.pm
@@ -1,0 +1,51 @@
+package MusicBrainz::Server::Controller::Role::Filter;
+use Moose::Role;
+use namespace::autoclean;
+
+=head2 process_filter
+
+Utility function for dynamically loading the filter form.
+
+=cut
+
+sub process_filter
+{
+    my ($self, $c, $create_form) = @_;
+
+    my %filter;
+    unless (exists $c->req->params->{'filter.cancel'}) {
+        my $cookie = $c->req->cookies->{filter};
+        my $has_filter_params = grep { /^filter\./ } keys %{ $c->req->params };
+        if ($has_filter_params || ($cookie && defined($cookie->value) && $cookie->value eq '1')) {
+            my $filter_form = $create_form->();
+            if ($c->form_submitted_and_valid($filter_form)) {
+                for my $name ($filter_form->filter_field_names) {
+                    my $value = $filter_form->field($name)->value;
+                    if ($value) {
+                        $filter{$name} = $value;
+                    }
+
+                }
+                $c->res->cookies->{filter} = { value => '1', path => '/' };
+            }
+        }
+    }
+    else {
+        $c->res->cookies->{filter} = { value => '', path => '/' };
+    }
+
+    return \%filter;
+}
+
+no Moose::Role;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Data/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Data/ArtistCredit.pm
@@ -102,6 +102,45 @@ sub find_by_artist_id
     return $self->find_by_ids($ids);
 }
 
+sub find_by_recording_artist
+{
+    my ($self, $artist_id) = @_;
+
+    my $query = 'SELECT DISTINCT rec.artist_credit
+                 FROM recording rec
+                 JOIN artist_credit_name acn
+                     ON acn.artist_credit = rec.artist_credit
+                 WHERE acn.artist = ?';
+    my $ids = $self->sql->select_single_column_array($query, $artist_id);
+    return $self->find_by_ids($ids);
+}
+
+sub find_by_release_artist
+{
+    my ($self, $artist_id) = @_;
+
+    my $query = 'SELECT DISTINCT rel.artist_credit
+                 FROM release rel
+                 JOIN artist_credit_name acn
+                     ON acn.artist_credit = rel.artist_credit
+                 WHERE acn.artist = ?';
+    my $ids = $self->sql->select_single_column_array($query, $artist_id);
+    return $self->find_by_ids($ids);
+}
+
+sub find_by_release_label
+{
+    my ($self, $label_id) = @_;
+
+    my $query = 'SELECT DISTINCT rel.artist_credit
+                 FROM release rel
+                 JOIN release_label rl
+                     ON rl.release = rel.id
+                 WHERE rl.label = ?';
+    my $ids = $self->sql->select_single_column_array($query, $label_id);
+    return $self->find_by_ids($ids);
+}
+
 sub uncache_for_artist_ids
 {
     my ($self, @artist_ids) = @_;

--- a/lib/MusicBrainz/Server/Data/Recording.pm
+++ b/lib/MusicBrainz/Server/Data/Recording.pm
@@ -81,19 +81,6 @@ sub _id_column
     return 'recording.id';
 }
 
-sub find_artist_credits_by_artist
-{
-    my ($self, $artist_id) = @_;
-
-    my $query = 'SELECT DISTINCT rec.artist_credit
-                 FROM recording rec
-                 JOIN artist_credit_name acn
-                     ON acn.artist_credit = rec.artist_credit
-                 WHERE acn.artist = ?';
-    my $ids = $self->sql->select_single_column_array($query, $artist_id);
-    return $self->c->model('ArtistCredit')->find_by_ids($ids);
-}
-
 sub find_by_artist
 {
     my ($self, $artist_id, $limit, $offset, %args) = @_;

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -226,65 +226,6 @@ sub load
     return load_subobjects($self, 'release', @objs);
 }
 
-sub find_artist_credits_by_artist
-{
-    my ($self, $artist_id) = @_;
-
-    my $query = 'SELECT DISTINCT rel.artist_credit
-                 FROM release rel
-                 JOIN artist_credit_name acn
-                     ON acn.artist_credit = rel.artist_credit
-                 WHERE acn.artist = ?';
-    my $ids = $self->sql->select_single_column_array($query, $artist_id);
-    return $self->c->model('ArtistCredit')->find_by_ids($ids);
-}
-
-sub find_artist_credits_by_label
-{
-    my ($self, $label_id) = @_;
-
-    my $query = 'SELECT DISTINCT rel.artist_credit
-                 FROM release rel
-                 JOIN release_label rl
-                     ON rl.release = rel.id
-                 WHERE rl.label = ?';
-    my $ids = $self->sql->select_single_column_array($query, $label_id);
-    return $self->c->model('ArtistCredit')->find_by_ids($ids);
-}
-
-sub find_labels_by_artist
-{
-    my ($self, $artist_id) = @_;
-
-    my $query = 'SELECT DISTINCT rl.label
-                 FROM release_label rl
-                 JOIN release rel ON rl.release = rel.id
-                 JOIN artist_credit_name acn
-                     ON acn.artist_credit = rel.artist_credit
-                 WHERE acn.artist = ?';
-    my $ids = $self->sql->select_single_column_array($query, $artist_id);
-    return $self->c->model('Label')->get_by_ids_sorted_by_name(@$ids);
-}
-
-# This might seem stupid, but it helps filtering multi-label releases
-sub find_labels_by_label
-{
-    my ($self, $label_id) = @_;
-
-    my $query = <<~'SQL';
-        SELECT DISTINCT rl.label
-          FROM release_label rl
-         WHERE rl.release IN (
-            SELECT rl2.release
-              FROM release_label rl2
-             WHERE rl2.label = ?
-         )
-        SQL
-
-    my $ids = $self->sql->select_single_column_array($query, $label_id);
-    return $self->c->model('Label')->get_by_ids_sorted_by_name(@$ids);
-}
-
 sub find_by_area {
     my ($self, $area_id, $limit, $offset) = @_;
     my $query = 'SELECT ' . $self->_columns . '

--- a/lib/MusicBrainz/Server/FilterUtils.pm
+++ b/lib/MusicBrainz/Server/FilterUtils.pm
@@ -88,10 +88,12 @@ sub preserve_selected_artist_credit {
     # to preserve the intent of the filter (showing no results until the AC
     # is possibly used again).
     my $selected_artist_credit_id = $c->req->query_params->{'filter.artist_credit_id'};
-    unless (any { $_->id == $selected_artist_credit_id } @$artist_credits) {
-        my $artist_credit = $c->model('ArtistCredit')->get_by_id($selected_artist_credit_id);
-        if ($artist_credit) {
-            unshift @$artist_credits, $artist_credit;
+    if ($selected_artist_credit_id) {
+        unless (any { $_->id == $selected_artist_credit_id } @$artist_credits) {
+            my $artist_credit = $c->model('ArtistCredit')->get_by_id($selected_artist_credit_id);
+            if ($artist_credit) {
+                unshift @$artist_credits, $artist_credit;
+            }
         }
     }
 }

--- a/lib/MusicBrainz/Server/FilterUtils.pm
+++ b/lib/MusicBrainz/Server/FilterUtils.pm
@@ -47,11 +47,11 @@ sub create_artist_releases_form {
     my %form_args = (entity_type => 'release');
 
     $form_args{artist_credits} =
-        $c->model('Release')->find_artist_credits_by_artist($artist_id);
+        $c->model('ArtistCredit')->find_by_release_artist($artist_id);
     preserve_selected_artist_credit($c, $form_args{artist_credits});
     $form_args{countries} = [$c->model('CountryArea')->get_all];
     $form_args{labels} =
-        $c->model('Release')->find_labels_by_artist($artist_id);
+        [$c->model('Label')->find_by_release_artist($artist_id)];
     $form_args{statuses} = [$c->model('ReleaseStatus')->get_all];
 
     return $c->form(filter_form => 'Filter::ReleaseForArtist', %form_args);
@@ -63,7 +63,7 @@ sub create_artist_recordings_form {
     my %form_args = (entity_type => 'recording');
 
     $form_args{artist_credits} =
-        $c->model('Recording')->find_artist_credits_by_artist($artist_id);
+        $c->model('ArtistCredit')->find_by_recording_artist($artist_id);
     preserve_selected_artist_credit($c, $form_args{artist_credits});
 
     return $c->form(filter_form => 'Filter::Recording', %form_args);
@@ -87,11 +87,11 @@ sub create_label_releases_form {
     my %form_args = (entity_type => 'release');
 
     $form_args{artist_credits} =
-        $c->model('Release')->find_artist_credits_by_label($label_id);
+        $c->model('ArtistCredit')->find_by_release_label($label_id);
     preserve_selected_artist_credit($c, $form_args{artist_credits});
     $form_args{countries} = [$c->model('CountryArea')->get_all];
     $form_args{labels} =
-        $c->model('Release')->find_labels_by_label($label_id);
+        [$c->model('Label')->find_by_release_label($label_id)];
     $form_args{statuses} = [$c->model('ReleaseStatus')->get_all];
 
     return $c->form(filter_form => 'Filter::ReleaseForLabel', %form_args);

--- a/lib/MusicBrainz/Server/FilterUtils.pm
+++ b/lib/MusicBrainz/Server/FilterUtils.pm
@@ -11,6 +11,7 @@ our @EXPORT_OK = qw(
     create_artist_releases_form
     create_artist_recordings_form
     create_artist_works_form
+    create_label_releases_form
 );
 
 sub create_artist_events_form {
@@ -53,7 +54,7 @@ sub create_artist_releases_form {
         $c->model('Release')->find_labels_by_artist($artist_id);
     $form_args{statuses} = [$c->model('ReleaseStatus')->get_all];
 
-    return $c->form(filter_form => 'Filter::Release', %form_args);
+    return $c->form(filter_form => 'Filter::ReleaseForArtist', %form_args);
 }
 
 sub create_artist_recordings_form {
@@ -78,6 +79,22 @@ sub create_artist_works_form {
     );
 
     return $c->form(filter_form => 'Filter::Work', %form_args);
+}
+
+sub create_label_releases_form {
+    my ($c, $label_id) = @_;
+
+    my %form_args = (entity_type => 'release');
+
+    $form_args{artist_credits} =
+        $c->model('Release')->find_artist_credits_by_label($label_id);
+    preserve_selected_artist_credit($c, $form_args{artist_credits});
+    $form_args{countries} = [$c->model('CountryArea')->get_all];
+    $form_args{labels} =
+        $c->model('Release')->find_labels_by_label($label_id);
+    $form_args{statuses} = [$c->model('ReleaseStatus')->get_all];
+
+    return $c->form(filter_form => 'Filter::ReleaseForLabel', %form_args);
 }
 
 sub preserve_selected_artist_credit {

--- a/lib/MusicBrainz/Server/Form/Filter/Release.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Release.pm
@@ -74,15 +74,6 @@ sub options_country_id {
     ];
 }
 
-sub options_label_id {
-    my ($self, $field) = @_;
-    return [
-        { value => '-1', label => lp('[none]', 'release label') },
-        map +{ value => $_->id, label => $_->name },
-        @{ $self->labels },
-    ];
-}
-
 sub options_status_id {
     my ($self, $field) = @_;
     return [
@@ -105,7 +96,6 @@ around TO_JSON => sub {
     my $json = $self->$orig;
     $json->{options_artist_credit_id} = $self->options_artist_credit_id;
     $json->{options_country_id} = $self->options_country_id;
-    $json->{options_label_id} = $self->options_label_id;
     $json->{options_status_id} = $self->options_status_id;
     return $json;
 };

--- a/lib/MusicBrainz/Server/Form/Filter/ReleaseForArtist.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/ReleaseForArtist.pm
@@ -1,0 +1,37 @@
+package MusicBrainz::Server::Form::Filter::ReleaseForArtist;
+use strict;
+use warnings;
+
+use HTML::FormHandler::Moose;
+use MusicBrainz::Server::Translation qw( lp );
+
+extends 'MusicBrainz::Server::Form::Filter::Release';
+
+sub options_label_id {
+    my ($self, $field) = @_;
+    return [
+        { value => '-1', label => lp('[none]', 'release label') },
+        map +{ value => $_->id, label => $_->name },
+        @{ $self->labels },
+    ];
+}
+
+around TO_JSON => sub {
+    my ($orig, $self) = @_;
+
+    my $json = $self->$orig;
+    $json->{options_label_id} = $self->options_label_id;
+    return $json;
+};
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Form/Filter/ReleaseForLabel.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/ReleaseForLabel.pm
@@ -1,0 +1,35 @@
+package MusicBrainz::Server::Form::Filter::ReleaseForLabel;
+use strict;
+use warnings;
+
+use HTML::FormHandler::Moose;
+
+extends 'MusicBrainz::Server::Form::Filter::Release';
+
+sub options_label_id {
+    my ($self, $field) = @_;
+    return [
+        map +{ value => $_->id, label => $_->name },
+        @{ $self->labels },
+    ];
+}
+
+around TO_JSON => sub {
+    my ($orig, $self) = @_;
+
+    my $json = $self->$orig;
+    $json->{options_label_id} = $self->options_label_id;
+    return $json;
+};
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/root/label/LabelIndex.js
+++ b/root/label/LabelIndex.js
@@ -18,6 +18,9 @@ import manifest from '../static/manifest.mjs';
 import Annotation from '../static/scripts/common/components/Annotation.js';
 import DescriptiveLink
   from '../static/scripts/common/components/DescriptiveLink.js';
+import Filter from '../static/scripts/common/components/Filter.js';
+import {type ReleaseFilterT}
+  from '../static/scripts/common/components/FilterForm.js';
 import WikipediaExtract
   from '../static/scripts/common/components/WikipediaExtract.js';
 import commaOnlyList from '../static/scripts/common/i18n/commaOnlyList.js';
@@ -28,7 +31,10 @@ import {returnToCurrentPage} from '../utility/returnUri.js';
 import LabelLayout from './LabelLayout.js';
 
 component LabelIndex(
+  ajaxFilterFormUrl: string,
   eligibleForCleanup: boolean,
+  filterForm: ?ReleaseFilterT,
+  hasFilter: boolean,
   label: LabelT,
   numberOfRevisions: number,
   pager: PagerT,
@@ -68,6 +74,12 @@ component LabelIndex(
         entity={label}
       />
       <h2 className="releases">{l('Releases')}</h2>
+
+      <Filter
+        ajaxFormUrl={ajaxFilterFormUrl}
+        initialFilterForm={filterForm}
+      />
+
       {releases?.length ? (
         <form
           action={'/release/merge_queue?' + returnToCurrentPage($c)}
@@ -87,7 +99,11 @@ component LabelIndex(
           ) : null}
         </form>
       ) : (
-        <p>{l('This label does not have any releases.')}</p>
+        <p>
+          {hasFilter
+            ? l('No releases found that match this search.')
+            : l('This label does not have any releases.')}
+        </p>
       )}
       {manifest('label/index', {async: 'async'})}
     </LabelLayout>

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Filtering.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Filtering.pm
@@ -1,0 +1,201 @@
+package t::MusicBrainz::Server::Controller::Label::Filtering;
+use utf8;
+use strict;
+use warnings;
+
+use Test::Routine;
+use MusicBrainz::Server::Test qw( test_xpath_html );
+
+with 't::Mechanize', 't::Context';
+
+=head1 DESCRIPTION
+
+This test checks whether filtering works for release lists
+in label pages.
+
+=cut
+
+test 'Release page filtering' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+filtering');
+
+    $mech->get_ok(
+        '/label/5a584032-dcef-41bb-9f8b-19540116fb1c',
+        'Fetched label page',
+    );
+
+    my $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '3',
+        'There are three entries in the unfiltered release table',
+    );
+
+    $mech->get_ok(
+        '/label/5a584032-dcef-41bb-9f8b-19540116fb1c?filter.name=Symphony',
+        'Fetched label releases page with name filter "Symphony"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '1',
+        'There is one entry in the release table after filtering by name',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[1]',
+        'Piano Concerto / Symphony no. 2',
+        'The entry is named "Piano Concerto / Symphony no. 2"',
+    );
+
+    $mech->get_ok(
+        '/label/5a584032-dcef-41bb-9f8b-19540116fb1c?filter.artist_credit_id=3400',
+        'Fetched label releases page with artist credit filter',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '2',
+        'There are two entries in the release table after filtering by credit',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[1]',
+        'Symphonies / Concertos / Choral and Vocal Works',
+        'The first entry is named "Symphonies / Concertos / Choral and Vocal Works"',
+    );
+
+    $mech->get_ok(
+        '/label/5a584032-dcef-41bb-9f8b-19540116fb1c?filter.status_id=1',
+        'Fetched label releases page with status filter "Official"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '2',
+        'There are two entries in the release table after filtering by "Official" status',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[1]',
+        'Symphonies / Concertos / Choral and Vocal Works',
+        'The first entry is named "Symphonies / Concertos / Choral and Vocal Works"',
+    );
+
+    $mech->get_ok(
+        '/label/5a584032-dcef-41bb-9f8b-19540116fb1c?filter.status_id=-1',
+        'Fetched label releases page with status filter "[none]"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '1',
+        'There is one entry in the release table after filtering by no status',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[1]',
+        'String Quartet',
+        'The entry is named "String Quartet"',
+    );
+
+    $mech->get_ok(
+        '/label/5a584032-dcef-41bb-9f8b-19540116fb1c?filter.date=2010',
+        'Fetched label releases page with date filter',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '2',
+        'There are two entries in the release table after filtering by date',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[1]',
+        'Piano Concerto / Symphony no. 2',
+        'The first entry is named "Piano Concerto / Symphony no. 2"',
+    );
+
+    $mech->get_ok(
+        '/label/5a584032-dcef-41bb-9f8b-19540116fb1c?filter.label_id=3402',
+        'Fetched label releases page with label filter (for a second label)',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '1',
+        'There is one entry in the release table after filtering by label',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[1]',
+        'Symphonies / Concertos / Choral and Vocal Works',
+        'The entry is named "Symphonies / Concertos / Choral and Vocal Works"',
+    );
+
+    $mech->get_ok(
+        '/label/5a584032-dcef-41bb-9f8b-19540116fb1c?filter.country_id=221',
+        'Fetched label releases page with country filter',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '1',
+        'There is one entry in the release table after filtering by country',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[1]',
+        'Piano Concerto / Symphony no. 2',
+        'The entry is named "Piano Concerto / Symphony no. 2"',
+    );
+
+    $mech->get_ok(
+        '/label/5a584032-dcef-41bb-9f8b-19540116fb1c?filter.country_id=-1',
+        'Fetched label releases page with country filter "[none]"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '2',
+        'There are two entries in the release table after filtering by no country',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[1]',
+        'Symphonies / Concertos / Choral and Vocal Works',
+        'The entry is named "Symphonies / Concertos / Choral and Vocal Works"',
+    );
+
+    $mech->get_ok(
+        '/label/5a584032-dcef-41bb-9f8b-19540116fb1c?filter.country_id=-1&filter.date=2010',
+        'Fetched label releases page with both date filter and country filter "[none]"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '1',
+        'There is one entry in the release table after filtering by no country + date 2010',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[1]',
+        'String Quartet',
+        'The entry is named "String Quartet"',
+    );
+};
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -99,6 +99,7 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   'Controller::Ajax::filter_artist_release_groups_form',
   'Controller::Ajax::filter_artist_releases_form',
   'Controller::Ajax::filter_artist_works_form',
+  'Controller::Ajax::filter_label_releases_form',
   'Controller::Area::alias',
   'Controller::Area::aliases',
   'Controller::Area::annotation_diff',

--- a/t/sql/filtering.sql
+++ b/t/sql/filtering.sql
@@ -57,6 +57,7 @@ INSERT INTO label (id, gid, name)
 INSERT INTO release_label (release, label, catalog_number)
     VALUES (3400, NULL, '4509-91711-2'),
            (3401, 3401, '0289 479 4518'),
+           (3402, 3401, '123456'),
            (3402, 3402, '8.501066'),
            (3403, 3403, NULL),
            (3404, 3401, NULL),


### PR DESCRIPTION
### Implement MBS-13597

# Problem
We have very useful filter tools for all sort of artist pages that have long and unwieldy tables. Another thing that is long and unwieldy: label pages with sometimes thousands of releases. And we cannot filter those.

# Solution
This extends the release filter from the artist releases page to label index pages, which have very similar lists. Most of the code can be reused, so I moved some into roles.

The only real difference with the artist forms are that ACs are taken for all the releases in the label and that "no label exists" is not a filter option for labels, for obvious reasons.

# Testing
Tests added, with very small changes from the artist release ones.

While testing this locally I saw we were getting a warning due to the new code to keep ACs when moving around in filters, so I deal with that in the small first commit.