### PR TITLE
MBS-13903: Fix "CDTOC is already attached" error

### DIFF
--- a/lib/MusicBrainz/Server/Controller/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Controller/CDTOC.pm
@@ -376,6 +376,7 @@ sub _attach_list {
                     : ''
             } @$releases];
 
+            my $medium_has_cdtoc = $c->stash->{medium_has_cdtoc};
             my %props = (
                 action      => 'add',
                 form        => $search_release->TO_JSON,
@@ -384,6 +385,7 @@ sub _attach_list {
                 results     => to_json_array($sorted_releases),
                 tocString   => $c->stash->{toc},
                 wasMbidSearch => boolean_to_json($was_mbid_search),
+                associatedMedium => defined $medium_has_cdtoc ? (0 + $medium_has_cdtoc) : undef,
             );
 
             $c->stash(


### PR DESCRIPTION
# Problem

Prior to #2642, the presence of `medium_has_cdtoc` in the stash was used to show this error message. In the new React template, this variable is named `associatedMedium`, but it wasn't being set anywhere.

# Testing

Tested a real CD lookup on my local development server.