### PR TITLE
MBS-13907: Support Discogs label URLs for events

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -95,6 +95,7 @@ export const LINK_TYPES: LinkTypeMap = {
   },
   discogs: {
     artist: '04a5b104-a4c2-4bac-99a1-7b837c37d9e4',
+    event: '73713a50-1377-44cd-b429-4a2c0c612bf1',
     genre: '4c8510c9-1dc2-49b9-9693-27bdc5cc8311',
     label: '5b987f87-25bc-4a2d-b3f1-3618795b8207',
     place: '1c140ac8-8dc2-449e-92cb-52c90d525640',
@@ -2260,6 +2261,11 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.discogs.artist:
             return {
               result: prefix === 'artist' || prefix === 'user',
+              target: ERROR_TARGETS.ENTITY,
+            };
+          case LINK_TYPES.discogs.event:
+            return {
+              result: prefix === 'label',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.discogs.genre:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2118,12 +2118,20 @@ limited_link_type_combinations: [
              input_entity_type: 'label',
     expected_relationship_type: 'discogs',
             expected_clean_url: 'https://www.discogs.com/label/2262',
+       only_valid_entity_types: ['event', 'label', 'place', 'series'],
   },
   {                             // old-style URL without numerical ID
                      input_url: 'http://www.discogs.com/label/Demonic',
              input_entity_type: 'label',
     expected_relationship_type: 'discogs',
        only_valid_entity_types: [],
+  },
+  {
+                     input_url: 'https://www.discogs.com/label/418444-Monterey-Pop-Festival?page=1',
+             input_entity_type: 'label',
+    expected_relationship_type: 'discogs',
+            expected_clean_url: 'https://www.discogs.com/label/418444',
+       only_valid_entity_types: ['event', 'label', 'place', 'series'],
   },
   {
                      input_url: 'http://www.discogs.com/release/12130',


### PR DESCRIPTION
### Implement MBS-13907

# Description
Apparently Discogs *also* uses labels for events, on top of places and series. And I thought we did too many things with labels!

Added a Discogs event relationship, and this adds support for it and validates it as needed.

# Testing
Added an event example as a test, and made sure label links are valid only for the four label-ish entities.