### PR TITLE
MBS-8500: Add "not by me" filter for collection edit lists

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -212,10 +212,15 @@ sub _list_edits {
 
     $self->collection_collaborator($c) if !$collection->public;
 
+    my $hide_own = 0;
+    if (($c->req->query_params->{hide_own} // '') eq '1') {
+        $hide_own = 1;
+    }
+
     my $status = $show_open_only ? $STATUS_OPEN : undef;
     my $edits  = $self->_load_paged($c, sub {
         my ($limit, $offset) = @_;
-        $c->model('Edit')->find_by_collection($collection->id, $limit, $offset, $status);
+        $c->model('Edit')->find_by_collection($collection->id, $limit, $offset, $status, $hide_own, $c->user->id);
     });
 
     $c->stash(edits => $edits); # stash early in case an ISE occurs while loading the edits

--- a/lib/MusicBrainz/Server/Data/Edit.pm
+++ b/lib/MusicBrainz/Server/Data/Edit.pm
@@ -192,16 +192,27 @@ sub find
 
 sub find_by_collection
 {
-    my ($self, $collection_id, $limit, $offset, $status) = @_;
+    my ($self, $collection_id, $limit, $offset, $status, $hide_own, $editor_id) = @_;
 
-    my $status_cond = '';
+    my @conditions;
+    my $query_conditions = '';
 
-    $status_cond = 'WHERE status = ' . $status if defined $status;
+    if (defined $status) {
+        push @conditions, 'status = ' . $status;
+    }
+
+    if ($hide_own) {
+        push @conditions, 'editor != ' . $editor_id;
+    }
+
+    if (@conditions) {
+        $query_conditions = ' WHERE ' . (join ' AND ', @conditions);
+    }
 
     my $query = 'SELECT ' . $self->_columns . ' FROM ' . $self->_table . "
                       JOIN ($EDIT_IDS_FOR_COLLECTION_SQL) relevant_edits
                         ON relevant_edits.edit = edit.id
-                  $status_cond
+                  $query_conditions
                   ORDER BY edit.id DESC
                   LIMIT $LIMIT_FOR_EDIT_LISTING";
         # XXX Do not rewrite this query without extensive performance tests

--- a/root/edit/components/ListHeader.js
+++ b/root/edit/components/ListHeader.js
@@ -25,6 +25,7 @@ component QuickLinks(
   const isSecureConnection = $c.req.secure;
   const protocol = isSecureConnection ? 'https://' : 'http://';
   const openParam = $c.req.query_params.open;
+  const hideOwnParam = $c.req.query_params.hide_own;
   const entityUrlFragment = entity
     ? ENTITIES[entity.entityType].url
     : undefined;
@@ -55,14 +56,15 @@ component QuickLinks(
     }
   }
   if (entity && entityUrlFragment) {
+    const isCollection = entity.entityType === 'collection';
+    const allPage = `/${entityUrlFragment}/${entity.gid}/edits`;
+    const openPage = `/${entityUrlFragment}/${entity.gid}/open_edits`;
+
     if (isEntityAllPage) {
       quickLinks.push(
-        <a
-          href={`/${entityUrlFragment}/${entity.gid}/open_edits`}
-          key="entity-open"
-        >
+        <a href={openPage} key="entity-open">
           <strong>
-            {entity.entityType === 'collection'
+            {isCollection
               ? l('Open edits for this collection')
               : l('Open edits for this entity')}
           </strong>
@@ -71,17 +73,39 @@ component QuickLinks(
     }
     if (isEntityOpenPage) {
       quickLinks.push(
-        <a
-          href={`/${entityUrlFragment}/${entity.gid}/edits`}
-          key="entity-all"
-        >
+        <a href={allPage} key="entity-all">
           <strong>
-            {entity.entityType === 'collection'
+            {isCollection
               ? l('All edits for this collection')
               : l('All edits for this entity')}
           </strong>
         </a>,
       );
+    }
+    if (isCollection) {
+      if (hideOwnParam === '1') {
+        quickLinks.push(
+          <a
+            href={(isEntityAllPage ? allPage : openPage) + '?hide_own=0'}
+            key="show-all-collection-edits"
+          >
+            <strong>
+              {l('Everyone’s edits for this collection')}
+            </strong>
+          </a>,
+        );
+      } else {
+        quickLinks.push(
+          <a
+            href={(isEntityAllPage ? allPage : openPage) + '?hide_own=1'}
+            key="hide-own-collection-edits"
+          >
+            <strong>
+              {l('Others’ edits for this collection')}
+            </strong>
+          </a>,
+        );
+      }
     }
   }
   if (page === 'subscribed') {


### PR DESCRIPTION
### Implement MBS-8500

# Problem
Collection edit lists cannot be filtered, and it can be very hard to find others' edits to review on a collection where you are fairly active yourself as an editor.

# Solution
This could ideally be eventually solved by edit searches, but we are not really near to having collection filters for edit searches.

At least for now, having an extra "hide own edits" condition for collections seems like by far the easiest choice, and combines well with the status condition we already have in `find_by_collection`.

# Testing
Manually, with my own private collection I happen to have a lot of edits in. You can always make some edits locally to test though :) 