### PR TITLE
MBS-13908: isolate artist credentials in edit diff

### DIFF
--- a/root/static/scripts/edit/utility/diffArtistCredits.js
+++ b/root/static/scripts/edit/utility/diffArtistCredits.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import EntityLink from '../../common/components/EntityLink.js';
+import isolateText from '../../common/utility/isolateText.js';
 import DiffSide from '../components/edit/DiffSide.js';
 
 import editDiff, {
@@ -161,7 +162,7 @@ export default function diffArtistCredits(
   }
 
   return {
-    new: newNames,
-    old: oldNames,
+    new: isolateText(newNames),
+    old: isolateText(oldNames),
   };
 }


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem

MBS-13908: Right-to-left credit rendering still broken in medium edits


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

call `isolateText` on each side of the diff


# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

- edited multiple artists release, see ticket
- ran JS tests