### PR TITLE
add --no-same-owner option to tar

### DIFF
--- a/admin/MBImport.pl
+++ b/admin/MBImport.pl
@@ -125,8 +125,8 @@ for my $arg (@ARGV)
 for (@tar_to_extract)
 {
     my ($tar, $dir, $decompress) = @$_;
-    print localtime() . " : tar -C $dir $decompress -xvf $tar\n";
-    system "tar -C $dir $decompress -xvf $tar";
+    print localtime() . " : tar -C $dir $decompress --no-same-owner -xvf $tar\n";
+    system "tar -C $dir $decompress --no-same-owner -xvf $tar";
     exit($CHILD_ERROR >> 8) if $CHILD_ERROR;
 }
 


### PR DESCRIPTION
# Problem
I'm running a setup to deploy the server docker using helm and using the previous Ubuntu version. I currently get the error when running the createdb.sh 
`mbdump/artist_alias_type
tar: mbdump/artist_alias_type: Cannot change ownership to uid 1000, gid 1000: Operation not permitted`.
More on the issue [here](https://superuser.com/questions/1435437/how-to-get-around-this-error-when-untarring-an-archive-tar-cannot-change-owner)

# Solution
Added the `--no-same-owner` option to the tar command


# Testing
I tested this by running the the createdb.sh again and the import tar command was successful.