### PR TITLE
MBS-13912: Show just "Bluesky" on sidebar for did:plc links

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/Bluesky.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Bluesky.pm
@@ -8,7 +8,7 @@ with 'MusicBrainz::Server::Entity::URL::Sidebar';
 sub sidebar_name {
     my $self = shift;
 
-    if ($self->url =~ m{^https?://(?:www\.)?bsky\.app/profile/([^/]+)/?$}i) {
+    if ($self->url =~ m{^https?://(?:www\.)?bsky\.app/profile/((?!did:plc)[^/]+)/?$}i) {
         return '@' . $1;
     }
     else {


### PR DESCRIPTION
### Implement MBS-13912

# Description
Since `did:plc` links are just a code, such as "`@did:plc:vqm2zcwhku3u7schrnrh74hb`", it isn't super useful to show it on the sidebar. Just showing "Bluesky" is also more consistent with persistent YouTube channel links, which are shown as just "YouTube" (as opposed to channel names, which are shown by name).

# Testing
Manually, on `artist/ec972f65-58d5-4d2b-bfff-4011316ec742` (who has a `did:plc` link)