### PR TITLE
MBS-13918: Link to docs from primary alias checkbox label

### DIFF
--- a/root/static/scripts/alias/AliasEditForm.js
+++ b/root/static/scripts/alias/AliasEditForm.js
@@ -323,7 +323,15 @@ const AliasEditForm = ({
                   state.isTypeSearchHint || !state.form.field.locale.value
                 }
                 field={state.form.field.primary_for_locale}
-                label={l('This is the primary alias for this locale')}
+                label={exp.l(
+                  'This is the {alias_doc|primary alias} for this locale',
+                  {
+                    alias_doc: {
+                      href: '/doc/Style/Aliases#Localised_names',
+                      target: '_blank',
+                    },
+                  },
+                )}
                 onChange={setPrimaryForLocale}
               />
             </div>


### PR DESCRIPTION
### Implement MBS-13918

# Problem
Some users seem to just check primary for every alias they add, whether it makes sense or not. It doesn't seem they understand what the field is for. This was always bad, now it's more visible since the wrong aliases end up displayed by the entity name.

# Solution
This adds a link to the [specific guidelines for when to mark an alias as primary](https://musicbrainz.org/doc/Style/Aliases#Localised_names) to the "This is the primary alias for this locale" checkbox label, in the hopes that it will make users check before using the checkbox. At the very least it will be easier to point out that they should have read them before doing the wrong thing...

# Testing
Manually visited the alias form and clicked through.