### PR TITLE
MBS-13922: Add URL cleanup and validation for Naver Vibe

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -6206,10 +6206,10 @@ const CLEANUPS: CleanupEntries = {
       return false;
     },
     clean(url) {
-      url = url.replace(/^(?:https?:\/\/)?music\.naver\.com\/album\/index\.nhn\?albumId=(\d+)(?:&.+)/, 'https://vibe.naver.com/album/$1');
-      url = url.replace(/^(?:https?:\/\/)?music\.naver\.com\/artist\/(?:\w+)\.nhn\?artistId=(\d+)(?:&.+)/, 'https://vibe.naver.com/artist/$1');
-      url = url.replace(/^(?:https?:\/\/)?music\.naver\.com\/video\/(?:\w+)\.nhn\?videoId=(\d+)(?:&.+)/, 'https://vibe.naver.com/video/$1');
-      url = url.replace(/^(?:https?:\/\/)?vibe\.naver\.com\/(album|artist|track|video)\/(\d+)(?:\/\w+)/, 'https://vibe.naver.com/$1/$2');
+      url = url.replace(/^(?:https?:\/\/)?music\.naver\.com\/album\/index\.nhn\?albumId=(\d+).*$/, 'https://vibe.naver.com/album/$1');
+      url = url.replace(/^(?:https?:\/\/)?music\.naver\.com\/artist\/(?:\w+)\.nhn\?artistId=(\d+).*$/, 'https://vibe.naver.com/artist/$1');
+      url = url.replace(/^(?:https?:\/\/)?music\.naver\.com\/video\/(?:\w+)\.nhn\?videoId=(\d+).*$/, 'https://vibe.naver.com/video/$1');
+      url = url.replace(/^(?:https?:\/\/)?vibe\.naver\.com\/(album|artist|track|video)\/(\d+).*$/, 'https://vibe.naver.com/$1/$2');
       return url;
     },
     validate(url, id) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -6156,6 +6156,98 @@ const CLEANUPS: CleanupEntries = {
       };
     },
   },
+  'vibe': {
+    match: [
+      /^(https?:\/\/)?vibe\.naver\.com\//i,
+      /^(https?:\/\/)?music\.naver\.com\//i, // legacy URL
+    ],
+    restrict: [
+      multiple(LINK_TYPES.downloadpurchase, LINK_TYPES.streamingpaid),
+      LINK_TYPES.streamingpaid,
+    ],
+    select(url, sourceType) {
+      const m = /^https:\/\/vibe\.naver\.com\/(album|artist|track|video)/.exec(url);
+      if (m) {
+        const prefix = m[1];
+        switch (prefix) {
+          case 'album':
+            if (sourceType === 'release') {
+              return [
+                LINK_TYPES.downloadpurchase.release,
+                LINK_TYPES.streamingpaid.release,
+              ];
+            }
+            break;
+          case 'artist':
+            if (sourceType === 'artist') {
+              return [
+                LINK_TYPES.downloadpurchase.artist,
+                LINK_TYPES.streamingpaid.artist,
+              ];
+            }
+            break;
+          case 'track':
+            if (sourceType === 'recording') {
+              return [
+                LINK_TYPES.downloadpurchase.recording,
+                LINK_TYPES.streamingpaid.recording,
+              ];
+            }
+            break;
+          default: // video
+            if (sourceType === 'release') {
+              return LINK_TYPES.streamingpaid.release;
+            } else if (sourceType === 'recording') {
+              return LINK_TYPES.streamingpaid.recording;
+            }
+            break;
+        }
+      }
+      return false;
+    },
+    clean(url) {
+      url = url.replace(/^(?:https?:\/\/)?music\.naver\.com\/album\/index\.nhn\?albumId=(\d+)(?:&.+)/, 'https://vibe.naver.com/album/$1');
+      url = url.replace(/^(?:https?:\/\/)?music\.naver\.com\/artist\/(?:\w+)\.nhn\?artistId=(\d+)(?:&.+)/, 'https://vibe.naver.com/artist/$1');
+      url = url.replace(/^(?:https?:\/\/)?music\.naver\.com\/video\/(?:\w+)\.nhn\?videoId=(\d+)(?:&.+)/, 'https://vibe.naver.com/video/$1');
+      url = url.replace(/^(?:https?:\/\/)?vibe\.naver\.com\/(album|artist|track|video)\/(\d+)(?:\/\w+)/, 'https://vibe.naver.com/$1/$2');
+      return url;
+    },
+    validate(url, id) {
+      if (/https:\/\/vibe\.naver\.com\/search/.test(url)) {
+        return {
+          error: noLinkToSearchMsg(),
+          result: false,
+          target: ERROR_TARGETS.URL,
+        };
+      }
+      const m = /^https?:\/\/vibe\.naver\.com\/(album|artist|track|video)\/(\d+)/.exec(url);
+      if (m) {
+        const prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.downloadpurchase.release:
+          case LINK_TYPES.streamingpaid.release:
+            return {
+              result: prefix === 'album' || prefix === 'video',
+              target: ERROR_TARGETS.ENTITY,
+            };
+          case LINK_TYPES.downloadpurchase.artist:
+          case LINK_TYPES.streamingpaid.artist:
+            return {
+              result: prefix === 'artist',
+              target: ERROR_TARGETS.ENTITY,
+            };
+          case LINK_TYPES.downloadpurchase.recording:
+          case LINK_TYPES.streamingpaid.recording:
+            return {
+              result: prefix === 'track' || prefix === 'video',
+              target: ERROR_TARGETS.ENTITY,
+            };
+        }
+        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+      }
+      return {result: false, target: ERROR_TARGETS.URL};
+    },
+  },
   'vimeo': {
     match: [/^(https?:\/\/)?([^/]+\.)?vimeo\.com\/(?!(?:ondemand|store\/ondemand))/i],
     restrict: [{...LINK_TYPES.streamingfree, ...LINK_TYPES.videochannel}],

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -6451,6 +6451,66 @@ limited_link_type_combinations: ['downloadpurchase', 'mailorder'],
                      input_url: 'www.viaf.org/viaf/16766997/',
             expected_clean_url: 'http://viaf.org/viaf/16766997',
   },
+  // Naver Vibe
+  {
+                     input_url: 'https://vibe.naver.com/album/32004180',
+             input_entity_type: 'release',
+    expected_relationship_type: ['downloadpurchase', 'streamingpaid'],
+limited_link_type_combinations: [
+                                  ['downloadpurchase', 'streamingpaid'],
+                                  'streamingpaid',
+                                ],
+            expected_clean_url: 'https://vibe.naver.com/album/32004180',
+  },
+  {
+                     input_url: 'https://vibe.naver.com/artist/5176052',
+             input_entity_type: 'artist',
+    expected_relationship_type: ['downloadpurchase', 'streamingpaid'],
+limited_link_type_combinations: [
+                                  ['downloadpurchase', 'streamingpaid'],
+                                  'streamingpaid',
+                                ],
+            expected_clean_url: 'https://vibe.naver.com/artist/5176052',
+  },
+  {
+                     input_url: 'https://vibe.naver.com/artist/5176052/albums',
+             input_entity_type: 'artist',
+    expected_relationship_type: ['downloadpurchase', 'streamingpaid'],
+limited_link_type_combinations: [
+                                  ['downloadpurchase', 'streamingpaid'],
+                                  'streamingpaid',
+                                ],
+            expected_clean_url: 'https://vibe.naver.com/artist/5176052',
+  },
+  {
+                     input_url: 'https://vibe.naver.com/video/406927',
+             input_entity_type: 'release',
+    expected_relationship_type: 'streamingpaid',
+            expected_clean_url: 'https://vibe.naver.com/video/406927',
+       only_valid_entity_types: ['release', 'recording'],
+  },
+  {
+                     input_url: 'https://vibe.naver.com/search?query=NMIXX',
+             input_entity_type: 'artist',
+       input_relationship_type: 'streamingpaid',
+    expected_relationship_type: undefined,
+            expected_clean_url: 'https://vibe.naver.com/search?query=NMIXX',
+                expected_error: {
+                                  error: 'a link to a search result',
+                                  target: 'url',
+                                },
+       only_valid_entity_types: [],
+  },
+  {
+                     input_url: 'http://music.naver.com/album/index.nhn?albumId=307278',
+             input_entity_type: 'release',
+    expected_relationship_type: ['downloadpurchase', 'streamingpaid'],
+limited_link_type_combinations: [
+                                   ['downloadpurchase', 'streamingpaid'],
+                                   'streamingpaid',
+                                ],
+            expected_clean_url: 'https://vibe.naver.com/album/307278',
+  },
   // Videogam.in
   {
                      input_url: 'http://videogam.in/music/?id=PCCG-00486',


### PR DESCRIPTION
### Problem
Currently, URL relationships for [Naver Vibe](https://vibe.naver.com) aren't validated nor cleaned up to a standard format.

### Solution
Implement URL cleanup code for Naver Vibe, ensure that links are only added to their respective allowed entities, and rewrite legacy Naver Music links to the new Vibe format.

### Testing
Tested locally by adding various types of Naver Vibe links to artists and releases. Additionally, unit tests have been written.Currently, the unit tests fail due to a timeout, I'm not sure what is causing that, since it also says that all tests passed.