### PR TITLE
MBS-13914: Validate vote arguments for voter edit search

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate/Voter.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/Voter.pm
@@ -4,6 +4,7 @@ use namespace::autoclean;
 use Scalar::Util qw( looks_like_number );
 
 use MusicBrainz::Server::Constants qw( :vote );
+use MusicBrainz::Server::Types qw( VoteOption );
 use MusicBrainz::Server::Validation qw( is_database_row_id );
 
 with 'MusicBrainz::Server::EditSearch::Predicate';
@@ -37,6 +38,9 @@ sub operator_cardinality_map {
 sub valid {
     my ($self) = @_;
     return unless $self->arguments > 0;
+    for my $argument ($self->arguments) {
+        return unless VoteOption->check($argument) || $argument eq 'no';
+    }
     return $self->operator ne '=' && $self->operator ne '!=' || is_database_row_id($self->voter_id);
 }
 


### PR DESCRIPTION
### Fix MBS-13914

# Problem
A link such as `/search/edits?conditions.0.args=&conditions.0.field=voter&conditions.0.name=aerozol&conditions.0.operator=%3D&conditions.0.voter_id=463559` causes an ISE when logged in - it seems to be caused by the empty `conditions.0.args=` leading to an empty `WHERE ()` in the query. It seems this can probably only be hit by manually editing the URL (since just deselecting all the vote options removes `args` entirely and was already being caught as invalid).

# Solution
It seems any argument that is not a valid vote option or "no" (which we use for searching for lack of votes) should just be deemed invalid and reject the search, so this checks the arguments against the valid list and rejects any that don't match.

# Testing
Manually.