### PR TITLE
MBS-13763: Add past year stats to the editors statistic page

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Statistics.pm
+++ b/lib/MusicBrainz/Server/Controller/Statistics.pm
@@ -354,18 +354,28 @@ sub editors : Path('editors') {
     my $top_recently_active_editors =
         _editor_data_points($stats, 'editor.top_recently_active.rank',
                             'count.edit.top_recently_active.rank');
+    my $top_yearly_active_editors =
+        _editor_data_points($stats, 'editor.top_yearly_active.rank',
+                            'count.edit.top_yearly_active.rank');
     my $top_active_editors =
         _editor_data_points($stats, 'editor.top_active.rank',
                             'count.edit.top_active.rank');
     my $top_recently_active_voters =
         _editor_data_points($stats, 'editor.top_recently_active_voters.rank',
                             'count.vote.top_recently_active_voters.rank');
+    my $top_yearly_active_voters =
+        _editor_data_points($stats, 'editor.top_yearly_active_voters.rank',
+                            'count.vote.top_yearly_active_voters.rank');
     my $top_active_voters =
         _editor_data_points($stats, 'editor.top_active_voters.rank',
                             'count.vote.top_active_voters.rank');
 
-    my @data_points = ( @$top_recently_active_editors, @$top_active_editors,
-                        @$top_recently_active_voters, @$top_active_voters );
+    my @data_points = ( @$top_recently_active_editors,
+                        @$top_yearly_active_editors,
+                        @$top_active_editors,
+                        @$top_recently_active_voters,
+                        @$top_yearly_active_voters,
+                        @$top_active_voters );
 
     my $editors = $c->model('Editor')->get_by_ids(map { $_->{editor_id} } @data_points);
     for my $data_point (@data_points) {
@@ -375,8 +385,10 @@ sub editors : Path('editors') {
     my %props = (
         dateCollected => $stats->{date_collected},
         topRecentlyActiveEditors => $top_recently_active_editors,
+        topYearlyEditors => $top_yearly_active_editors,
         topEditors => $top_active_editors,
         topRecentlyActiveVoters => $top_recently_active_voters,
+        topYearlyVoters => $top_yearly_active_voters,
         topVoters => $top_active_voters,
     );
 

--- a/root/statistics/Editors.js
+++ b/root/statistics/Editors.js
@@ -80,6 +80,8 @@ component Editors(
   topRecentlyActiveEditors: $ReadOnlyArray<EditorStatT>,
   topRecentlyActiveVoters: $ReadOnlyArray<EditorStatT>,
   topVoters: $ReadOnlyArray<EditorStatT>,
+  topYearlyEditors: $ReadOnlyArray<EditorStatT>,
+  topYearlyVoters: $ReadOnlyArray<EditorStatT>,
 ) {
   return (
     <StatisticsLayout
@@ -105,6 +107,12 @@ component Editors(
           tableLabel={l_statistics('Most active editors in the past week')}
         />
         <EditorStatsTable
+          countLabel={l_statistics('Applied edits in past year')}
+          dataPoints={topYearlyEditors}
+          editorLabel={l_mb_server('Editor')}
+          tableLabel={l_statistics('Most active editors in the past year')}
+        />
+        <EditorStatsTable
           countLabel={l_statistics('Total applied edits')}
           dataPoints={topEditors}
           editorLabel={l_mb_server('Editor')}
@@ -120,6 +128,12 @@ component Editors(
           dataPoints={topRecentlyActiveVoters}
           editorLabel={l_statistics('Voter')}
           tableLabel={l_statistics('Most active voters in the past week')}
+        />
+        <EditorStatsTable
+          countLabel={l_statistics('Votes in past year')}
+          dataPoints={topYearlyVoters}
+          editorLabel={l_mb_server('Editor')}
+          tableLabel={l_statistics('Most active voters in the past year')}
         />
         <EditorStatsTable
           countLabel={l_statistics('Total votes')}

--- a/t/lib/t/MusicBrainz/Server/Data/Statistics.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Statistics.pm
@@ -85,6 +85,43 @@ test 'top_recently_active_editors' => sub {
     is($stats->statistic('count.edit.top_recently_active.rank.2'), 1);
 };
 
+test 'top_yearly_active_editors' => sub {
+    my $test = shift;
+    $test->c->sql->do(<<~'SQL');
+        INSERT INTO editor (id, name, password, ha1, email, email_confirm_date)
+            SELECT x, 'Editor ' || x, '{CLEARTEXT}pass', md5('Editor ' || x || ':musicbrainz:pass'), '', now() FROM generate_series(11, 14) s(x);
+
+        INSERT INTO edit (id, status, type, open_time, expire_time, editor)
+            VALUES
+              -- Edits that should count
+                (1, 2, 1, now(), now(), 11),
+                (2, 2, 1, now(), now(), 11),
+                (3, 2, 1, now() - '1 month'::interval, now(), 12),
+
+              -- Open edits don't count
+                (4, 1, 1, now(), now(), 11),
+
+              -- Failed edits don't count
+                (5, 4, 1, now(), now(), 13),
+
+              -- Old edits don't count
+                (6, 2, 1, '1970-01-01', now(), 14);
+
+        INSERT INTO edit_data (edit, data) SELECT generate_series(1, 4), '{}';
+        SQL
+
+    ok !exception { $test->c->model('Statistics')->recalculate_all };
+    my $stats = $test->c->model('Statistics::ByDate')->get_latest_statistics();
+
+    ok(defined $stats);
+    is($stats->statistic('editor.top_yearly_active.rank.1'), 11);
+    is($stats->statistic('editor.top_yearly_active.rank.2'), 12);
+    is($stats->statistic('editor.top_yearly_active.rank.3'), undef);
+
+    is($stats->statistic('count.edit.top_yearly_active.rank.1'), 2);
+    is($stats->statistic('count.edit.top_yearly_active.rank.2'), 1);
+};
+
 test 'top_editors' => sub {
     my $test = shift;
     $test->c->sql->do(<<~'SQL');
@@ -157,6 +194,45 @@ test 'top_recently_active_voters' => sub {
 
     is($stats->statistic('count.vote.top_recently_active_voters.rank.1'), 2);
     is($stats->statistic('count.vote.top_recently_active_voters.rank.2'), 1);
+};
+
+test 'top_yearly_active_voters' => sub {
+    my $test = shift;
+    $test->c->sql->do(<<~'SQL');
+        INSERT INTO editor (id, name, password, ha1, email, email_confirm_date)
+            SELECT x, 'Editor ' || x, '{CLEARTEXT}pass', md5('Editor ' || x || ':musicbrainz:pass'), '', now() FROM generate_series(11, 15) s(x);
+        INSERT INTO edit (id, status, type, open_time, expire_time, editor)
+            SELECT x, 2, 1, now(), now(), 11 FROM generate_series(1, 4) s(x);
+        INSERT INTO edit_data (edit, data) SELECT generate_series(1, 4), '{}';
+
+        INSERT INTO vote (id, edit, vote, vote_time, editor, superseded)
+        VALUES
+            -- Votes that should count
+              (1, 1, 0, now(), 11, FALSE),
+              (2, 2, 1, now(), 11, FALSE),
+              (3, 1, 2, now() - '8 day'::interval, 12, FALSE),
+
+            -- Abstains don't count
+              (4, 1, -1, now(), 13, FALSE),
+
+            -- Old votes don't count
+              (5, 1, 1, now() - '3 year'::interval, 14, FALSE),
+
+            -- Superseded votes don't count
+              (6, 1,  1, now(), 15, TRUE),
+              (7, 1, -1, now(), 15, FALSE);
+        SQL
+
+    ok !exception { $test->c->model('Statistics')->recalculate_all };
+    my $stats = $test->c->model('Statistics::ByDate')->get_latest_statistics();
+
+    ok(defined $stats);
+    is($stats->statistic('editor.top_yearly_active_voters.rank.1'), 11);
+    is($stats->statistic('editor.top_yearly_active_voters.rank.2'), 12);
+    is($stats->statistic('editor.top_yearly_active_voters.rank.3'), undef);
+
+    is($stats->statistic('count.vote.top_yearly_active_voters.rank.1'), 2);
+    is($stats->statistic('count.vote.top_yearly_active_voters.rank.2'), 1);
 };
 
 test 'top_voters' => sub {


### PR DESCRIPTION
### Implement MBS-13763

# Description

We've gotten requests for "top for last year" editor stats and it seems sensible; one week is for big editing spurts only, and top of all time is basically impossible for anyone who hasn't been editing for 15 years and/or is kinda crazy in the coconut to get a good position on.

This adds `top_yearly` for both editing and voting. For editing, this counts only applied edits (same as yearly and unlike weekly) since a year is a long enough period that the open edits should not make that much of a difference (and if they do, they won't a week later).

# Testing
Manually, plus I added a test for each to `Data::Statistics` (basically copying the existing ones and fiddling a bit with the edit dates/values).