### PR TITLE
MBS-13920 (I): Make feat. artist errors block submission

### DIFF
--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -1179,6 +1179,9 @@ class Release extends mbEntity.Release {
     this.hasUnconfirmedVariousArtists = errorField(
       this.mediums.any('hasUnconfirmedVariousArtists'),
     );
+    this.hasUnconfirmedFeatOnTrackTitles = errorField(
+      this.mediums.any('hasUnconfirmedFeatOnTrackTitles'),
+    );
     this.needsMediums = errorField(function () {
       return !(self.mediums().length || self.hasUnknownTracklist());
     });


### PR DESCRIPTION
# MBS-13920

Add an errorField() call to the release editor to block edit submission if the user didn't click the checkbox to confirm that the appearance of featured artists in track titles was intentional. I think that this was accidentally omitted from ca19708d61a47b29d53991801632db3f6df73dd4.

# Problem

An error is displayed if the user doesn't confirm that they meant to list a featured artist in a track title, but unlike all of the other errors in the tracklist editor, it doesn't block edit submission.

# Solution

Add an `errorField` call to register an error if any of the mediums contain unconfirmed appearances of featured artists in track titles.

# Testing

Checked locally that the "Enter edit" button is now disabled before I check the checkbox (but still enabled after).