### PR TITLE
MBS-13920 (II): Detect feat. artists in titles when seeding

### DIFF
--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -28,6 +28,7 @@ import {debounceComputed} from '../common/utility/debounce.js';
 import escapeRegExp from '../common/utility/escapeRegExp.mjs';
 import formatTrackLength from '../common/utility/formatTrackLength.js';
 import isBlank from '../common/utility/isBlank.js';
+import isDatabaseRowId from '../common/utility/isDatabaseRowId.js';
 import releaseLabelKey from '../common/utility/releaseLabelKey.js';
 import request from '../common/utility/request.js';
 import {fixedWidthInteger, uniqueId} from '../common/utility/strings.js';
@@ -67,9 +68,13 @@ class Track {
     this.name.original = data.name;
     this.name.subscribe(this.nameChanged, this);
 
-    this.hasFeatOnOrigTitle = featRegex.test(
-      data.name.replace(bracketRegex, ' '),
-    );
+    /*
+     * Check that the track has a valid ID to avoid treating a newly-added
+     * title as original when seeding a new release (see MBS-13920).
+     */
+    this.hasFeatOnOrigTitle =
+      isDatabaseRowId(this.id) &&
+      featRegex.test(data.name.replace(bracketRegex, ' '));
 
     this.previewName = ko.observable(null);
     this.previewNameDiffers = ko.computed(() => {
@@ -497,9 +502,7 @@ class Medium {
       return !self.tracksUnknownToUser() &&
              self.tracks().some(t => t.hasVariousArtists());
     });
-    this.confirmedVariousArtists = ko.observable(
-      this.hasVariousArtistTracks(),
-    );
+    this.confirmedVariousArtists = ko.observable(false);
     this.hasFeatOnTrackTitles = ko.computed(function () {
       return !self.tracksUnknownToUser() &&
              self.tracks().some(t => t.hasFeatOnTitle());
@@ -510,9 +513,7 @@ class Medium {
                t => !t.hasFeatOnOrigTitle && t.hasFeatOnTitle(),
              );
     });
-    this.confirmedFeatOnTrackTitles = ko.observable(
-      this.hasFeatOnTrackTitles.peek(),
-    );
+    this.confirmedFeatOnTrackTitles = ko.observable(false);
     this.hasTooEarlyFormat = ko.computed(function () {
       const mediumFormatDate = MB.mediumFormatDates[self.formatID()];
       return Boolean(mediumFormatDate && self.release.earliestYear() &&


### PR DESCRIPTION
# MBS-13920

Make the release editor display an error (and checkbox to bypass) when featured artists appear in seeded track titles. Previously, the error and checkbox were only displayed for manually-entered titles.

# Problem

The release editor incorrectly treats featured artists as already having been present in seeded track titles. As a result, editors can skip the warning without needing to confirm that the titles are deliberate when seeding releases.

# Solution

Update `Track`'s constructor to first check that the track already has an ID before treating the supplied title as original for the purposes of initializing the `hasFeatOnOrigTitle` field. Also update `Medium`'s constructor to use `hasOrigFeatOnTitle` rather than `hasFeatOnTitle()` when choosing the initial state for `confirmedFeatOnTrackTitles`.

# Testing

Manually checked that I now see an error and checkbox when seeding a release with a featured artist in the title (I used https://volaband.bandcamp.com/album/friend-of-a-phantom). If I edit a release that already has featured artists in titles, I see only a warning (as before).