### PR TITLE
MBS-13929: Add Spotify songwriter pages to otherdbs whitelist

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/Spotify.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Spotify.pm
@@ -14,6 +14,8 @@ sub sidebar_name {
         return l('Playlists at Spotify');
     } elsif ($self->url =~ m{^(?:https?:)?//shop\.spotify\.com/[^/?#]+/?}i) {
         return l('Purchase at Spotify');
+    } elsif ($self->url =~ m{^(?:https?:)?//artists\.spotify\.com/songwriter/[^/?#]+/?}i) {
+        return l('Songwriter info at Spotify');
     } else {
         return l('Stream at Spotify');
     }

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5363,7 +5363,7 @@ const CLEANUPS: CleanupEntries = {
     },
   },
   'spotify': {
-    match: [/^(https?:\/\/)?(((?!shop)[^/])+\.)?(spotify\.(?:com|link))\/(?!(?:intl-[a-z]+\/)?user)/i],
+    match: [/^(https?:\/\/)?(((?!(?:artists|shop))[^/])+\.)?(spotify\.(?:com|link))\/(?!(?:intl-[a-z]+\/)?user)/i],
     restrict: [LINK_TYPES.streamingfree],
     clean(url) {
       url = url.replace(/^(?:https?:\/\/)?embed\.spotify\.com\/\?uri=spotify:([a-z]+):([a-zA-Z0-9_-]+)$/, 'https://open.spotify.com/$1/$2');
@@ -5428,6 +5428,24 @@ const CLEANUPS: CleanupEntries = {
         case LINK_TYPES.mailorder.release:
           return {
             result: /^https:\/\/shop\.spotify\.com\/[^?#]+$/.test(url),
+            target: ERROR_TARGETS.URL,
+          };
+      }
+      return {result: false, target: ERROR_TARGETS.ENTITY};
+    },
+  },
+  'spotifysongwriter': {
+    match: [/^(https?:\/\/)?artists\.spotify\.com\//i],
+    restrict: [LINK_TYPES.otherdatabases],
+    clean(url) {
+      url = url.replace(/^(?:https?:\/\/)?artists\.spotify\.com\/songwriter\/(\w+).*$/, 'https://artists.spotify.com/songwriter/$1');
+      return url;
+    },
+    validate(url, id) {
+      switch (id) {
+        case LINK_TYPES.otherdatabases.artist:
+          return {
+            result: /^https:\/\/artists\.spotify\.com\/songwriter\/\w+$/.test(url),
             target: ERROR_TARGETS.URL,
           };
       }

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5663,6 +5663,13 @@ limited_link_type_combinations: ['downloadpurchase', 'mailorder'],
                                   target: 'url',
                                 },
   },
+  {
+                     input_url: 'http://artists.spotify.com/songwriter/4wmgHQAAzg3gbnQWSyoMZp',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://artists.spotify.com/songwriter/4wmgHQAAzg3gbnQWSyoMZp',
+       only_valid_entity_types: ['artist'],
+  },
   // SteamDB
   {
                      input_url: 'http://www.steamdb.info/app/331230/info/',


### PR DESCRIPTION
### Implement MBS-13929

# Description
We've got several requests to support Spotify songwriter links such as https://artists.spotify.com/songwriter/4wmgHQAAzg3gbnQWSyoMZp

These seem useful but belong separately from usual Spotify links. Other databases seems like the best fit, so using that. Wasn't sure what to use for the sidebar, settled on "Songwriter info at Spotify" but improvements welcome.

# Testing
Manually (for sidebar text testing) plus added an automated test.

# Tasks
When releasing, transclude the [doc change](https://wiki.musicbrainz.org/index.php?title=Other_Databases_Relationship_Type%2FWhitelist&type=revision&diff=78241&oldid=78211).