### PR TITLE
Avoid spreading `key` props in `useTable` hook

### DIFF
--- a/flow-typed/npm/react-table_v7.x.x.js
+++ b/flow-typed/npm/react-table_v7.x.x.js
@@ -38,8 +38,8 @@ declare module 'react-table' {
 
   declare export type ColumnInstance = {
     +cellProps?: {[attribute: string]: string},
-    +getCellProps: (props?: {...}) => {...},
-    +getHeaderProps: (props?: {...}) => {...},
+    +getCellProps: (props?: {...}) => {+key: string, ...},
+    +getHeaderProps: (props?: {...}) => {+key: string, ...},
     // Not actually part of react-table but our own expansion of it
     +headerProps?: {[attribute: string]: string},
     +render: (type: 'Header' | string, props?: {...}) => React.Node,
@@ -47,20 +47,20 @@ declare module 'react-table' {
 
   declare export type HeaderGroup = $ReadOnly<{
     ...$ReadOnly<ColumnInstance>,
-    +getHeaderGroupProps: (props?: {...}) => {...},
+    +getHeaderGroupProps: (props?: {...}) => {+key: string, ...},
     +headers: $ReadOnlyArray<ColumnInstance>,
   }>;
 
   declare export type Cell<+V> = {
     +column: ColumnInstance,
-    +getCellProps: (props?: {...}) => {...},
+    +getCellProps: (props?: {...}) => {+key: string, ...},
     +render: (type: 'Cell' | string, userProps?: {...}) => React.Node,
     +value: V,
   };
 
   declare export type Row<+D> = {
     +cells: $ReadOnlyArray<Cell<mixed>>,
-    +getRowProps: (props?: {...}) => {...},
+    +getRowProps: (props?: {...}) => {+key: string, ...},
     +index: number,
     +original: D,
   };

--- a/root/hooks/useTable.js
+++ b/root/hooks/useTable.js
@@ -18,31 +18,41 @@ import {
 
 import loopParity from '../utility/loopParity.js';
 
-const renderTableHeaderCell = (column: ColumnInstance) => (
-  <th
-    {...column.getHeaderProps(column.headerProps)}
-  >
-    {column.render('Header')}
-  </th>
-);
+const renderTableHeaderCell = (column: ColumnInstance) => {
+  const {key, ...headerProps} = column.getHeaderProps(column.headerProps);
+  return (
+    <th {...headerProps} key={key}>
+      {column.render('Header')}
+    </th>
+  );
+};
 
-const renderTableHeaderRow = (headerGroup: HeaderGroup) => (
-  <tr {...headerGroup.getHeaderGroupProps()}>
-    {headerGroup.headers.map(renderTableHeaderCell)}
-  </tr>
-);
+const renderTableHeaderRow = (headerGroup: HeaderGroup) => {
+  const {key, ...headerGroupProps} = headerGroup.getHeaderGroupProps();
+  return (
+    <tr {...headerGroupProps} key={key}>
+      {headerGroup.headers.map(renderTableHeaderCell)}
+    </tr>
+  );
+};
 
-const renderTableCell = (cell: Cell<mixed>) => (
-  <td {...cell.getCellProps(cell.column.cellProps)}>
-    {cell.render('Cell')}
-  </td>
-);
+const renderTableCell = (cell: Cell<mixed>) => {
+  const {key, ...cellProps} = cell.getCellProps(cell.column.cellProps);
+  return (
+    <td {...cellProps} key={key}>
+      {cell.render('Cell')}
+    </td>
+  );
+};
 
-const renderTableRow = <D>(row: Row<D>, i: number): React.MixedElement => (
-  <tr {...row.getRowProps({className: loopParity(i)})}>
-    {row.cells.map(renderTableCell)}
-  </tr>
-);
+const renderTableRow = <D>(row: Row<D>, i: number): React.MixedElement => {
+  const {key, ...rowProps} = row.getRowProps({className: loopParity(i)});
+  return (
+    <tr {...rowProps} key={key}>
+      {row.cells.map(renderTableCell)}
+    </tr>
+  );
+};
 
 type Props<D> = {
   className?: string,


### PR DESCRIPTION
Fixes the following kinds of warnings on pages using `useTable`:

```
Warning: A props object containing a "key" prop is being spread into JSX:
  let props = {key: someKey, role: ..., children: ...};
  <td {...props} />
React keys must be passed directly to JSX without using spread:
  let props = {role: ..., children: ...};
  <td key={someKey} {...props} />
```

I did check that react-table assigns its own keys in all of these cases on `/report/KaraokePlusInstrumentalRecordings`.