### PR TITLE
MBS-13939: Don't reject BnF links with language code

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1608,7 +1608,7 @@ const CLEANUPS: CleanupEntries = {
     ],
     restrict: [LINK_TYPES.otherdatabases],
     clean(url) {
-      let m = /^(?:https?:\/\/)?data\.bnf\.fr\/(?:[a-z-]+\/)?([1-4][0-9]{7})(?:[0-9b-z])?(?:[./?#].*)?$/.exec(url);
+      let m = /^(?:https?:\/\/)?data\.bnf\.fr\/(?:[a-z]{2}\/)?(?:[a-z-]+\/)?([1-4][0-9]{7})(?:[0-9b-z])?(?:[./?#].*)?$/.exec(url);
       if (m) {
         const frBnF = m[1];
         const phbt = '0123456789bcdfghjkmnpqrstvwxz';
@@ -1617,7 +1617,7 @@ const CLEANUPS: CleanupEntries = {
         }, 2) % 29];
         url = 'https://catalogue.bnf.fr/ark:/12148/cb' + frBnF + controlChar;
       } else {
-        m = /^(?:https?:\/\/)?(?:n2t\.net|(?:ark|catalogue|data)\.bnf\.fr)\/(ark:\/12148\/cb[1-4][0-9]{7}[0-9b-z])(?:[./?#].*)?$/.exec(url);
+        m = /^(?:https?:\/\/)?(?:n2t\.net|(?:ark|catalogue|data)\.bnf\.fr)\/(?:[a-z]{2}\/)?(ark:\/12148\/cb[1-4][0-9]{7}[0-9b-z])(?:[./?#].*)?$/.exec(url);
         if (m) {
           const persistentARK = m[1];
           url = 'https://catalogue.bnf.fr/' + persistentARK;

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1337,7 +1337,7 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist', 'instrument', 'label', 'place', 'series', 'work'],
   },
   {
-                     input_url: 'http://data.bnf.fr/ark:/12148/cb11923342r',
+                     input_url: 'https://data.bnf.fr/en/ark:/12148/cb11923342r',
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://catalogue.bnf.fr/ark:/12148/cb11923342r',
@@ -1351,7 +1351,7 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist', 'instrument', 'label', 'place', 'series', 'work'],
   },
   {
-                     input_url: 'http://data.bnf.fr/linked-authors/11923342/r/220',
+                     input_url: 'https://data.bnf.fr/fr/linked-authors/11923342/r/220/page1',
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://catalogue.bnf.fr/ark:/12148/cb11923342r',


### PR DESCRIPTION
### Implement MBS-13939

# Description
BNF seems to now support language codes for their data URLs. We should not reject them as we do now, but clean them up into the same permalinks we are already using; language is irrelevant for the URI.

# Testing
Updated two of the existing testing URLs to include language codes - one for each kind of URL in the `clean` method.