### PR TITLE
MBS-13938: Don't reject VIAF links with language code

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -6162,7 +6162,7 @@ const CLEANUPS: CleanupEntries = {
     match: [/^(https?:\/\/)?([^/]+\.)?viaf\.org/i],
     restrict: [LINK_TYPES.viaf],
     clean(url) {
-      url = url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?viaf\.org\/viaf\/([0-9]+).*$/,
+      url = url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?viaf\.org\/(?:[a-z]{2}\/)?viaf\/([0-9]+).*$/,
                         'http://viaf.org/viaf/$1');
       return url;
     },

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -6444,7 +6444,7 @@ limited_link_type_combinations: ['downloadpurchase', 'mailorder'],
             expected_clean_url: 'http://viaf.org/viaf/16766997',
   },
   {
-                     input_url: 'http://viaf.org/viaf/32197206/#Mozart,_Wolfgang_Amadeus,_1756-1791',
+                     input_url: 'http://viaf.org/en/viaf/32197206/#Mozart,_Wolfgang_Amadeus,_1756-1791',
             expected_clean_url: 'http://viaf.org/viaf/32197206',
   },
   {
@@ -6452,7 +6452,7 @@ limited_link_type_combinations: ['downloadpurchase', 'mailorder'],
             expected_clean_url: 'http://viaf.org/viaf/16766997',
   },
   {
-                     input_url: 'viaf.org/viaf/16766997/',
+                     input_url: 'viaf.org/fr/viaf/16766997/',
             expected_clean_url: 'http://viaf.org/viaf/16766997',
   },
   {


### PR DESCRIPTION
### Implement MBS-13938

# Description
VIAF seems to now support language codes for their data URLs. We should not reject them as we do now, but clean them up into the same permalinks we are already using; language is irrelevant for the URI.

# Testing
Changed a couple of the URLs in the existing tests to include language codes.