### PR TITLE
MBS-13917: Add new properties to avoid crashes

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Work.pm
+++ b/lib/MusicBrainz/Server/Entity/Work.pm
@@ -42,6 +42,7 @@ has 'artists' => (
     },
 );
 
+# TODO: Remove this after the next MBS release
 has 'writers' => (
     traits => [ 'Array' ],
     is => 'ro',
@@ -56,6 +57,40 @@ has 'writers' => (
     handles => {
         add_writer => 'push',
         all_writers => 'elements',
+    },
+);
+
+has 'authors' => (
+    traits => [ 'Array' ],
+    is => 'ro',
+    isa => ArrayRef[
+        Dict[
+            credit => Str,
+            roles => ArrayRef[Str],
+            entity => Object,
+        ],
+    ],
+    default => sub { [] },
+    handles => {
+        add_author => 'push',
+        all_authors => 'elements',
+    },
+);
+
+has 'other_artists' => (
+    traits => [ 'Array' ],
+    is => 'ro',
+    isa => ArrayRef[
+        Dict[
+            credit => Str,
+            roles => ArrayRef[Str],
+            entity => Object,
+        ],
+    ],
+    default => sub { [] },
+    handles => {
+        add_other_artist => 'push',
+        all_other_artists => 'elements',
     },
 );
 


### PR DESCRIPTION
# Description

We need the production server to support the same fields than beta will be adding for works, in order to avoid clashing redis entries causing crashes (this caused issues while releasing beta that meant I had to revert it).

https://github.com/metabrainz/musicbrainz-server/pull/1171