### PR TITLE
MBS-13917: Add new properties to avoid crashes

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Work.pm
+++ b/lib/MusicBrainz/Server/Entity/Work.pm
@@ -42,6 +42,24 @@ has 'artists' => (
     },
 );
 
+# TODO: Remove this after the next MBS release
+has 'writers' => (
+    traits => [ 'Array' ],
+    is => 'ro',
+    isa => ArrayRef[
+        Dict[
+            credit => Str,
+            roles => ArrayRef[Str],
+            entity => Object,
+        ],
+    ],
+    default => sub { [] },
+    handles => {
+        add_writer => 'push',
+        all_writers => 'elements',
+    },
+);
+
 has 'authors' => (
     traits => [ 'Array' ],
     is => 'ro',


### PR DESCRIPTION
# Description

We need the beta server to support the same fields than production will be adding for works, in order to avoid clashing redis entries causing crashes (this caused issues while releasing beta that meant I had to revert it).

https://github.com/metabrainz/musicbrainz-server/pull/1171