### PR TITLE
MBS-13771: Filter edit search by entity type

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -296,6 +296,7 @@ sub search : Path('/search/edits')
         quality => [ [$QUALITY_LOW => N_l('Low')], [$QUALITY_NORMAL => N_l('Normal')], [$QUALITY_HIGH => N_l('High')], [$QUALITY_UNKNOWN => N_l('Default')] ],
         languages => [ grep { $_->frequency > 0 } $c->model('Language')->get_all ],
         countries => [ $c->model('CountryArea')->get_all ],
+        rg_types => [ $c->model('ReleaseGroupType')->get_all ],
         relationship_type => [ $c->model('LinkType')->get_full_tree(get_deprecated_and_empty => 1) ],
     );
     return unless %{ $c->req->query_params };

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -300,6 +300,7 @@ sub search : Path('/search/edits')
         relationship_type => [ $c->model('LinkType')->get_full_tree(get_deprecated_and_empty => 1) ],
         area_types => [ $c->model('AreaType')->get_all ],
         artist_types => [ $c->model('ArtistType')->get_all ],
+        event_types => [ $c->model('EventType')->get_all ],
         work_types => [ $c->model('WorkType')->get_all ],
     );
     return unless %{ $c->req->query_params };

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -303,6 +303,7 @@ sub search : Path('/search/edits')
         event_types => [ $c->model('EventType')->get_all ],
         instrument_types => [ $c->model('InstrumentType')->get_all ],
         label_types => [ $c->model('LabelType')->get_all ],
+        place_types => [ $c->model('PlaceType')->get_all ],
         work_types => [ $c->model('WorkType')->get_all ],
     );
     return unless %{ $c->req->query_params };

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -297,6 +297,7 @@ sub search : Path('/search/edits')
         languages => [ grep { $_->frequency > 0 } $c->model('Language')->get_all ],
         countries => [ $c->model('CountryArea')->get_all ],
         rg_types => [ $c->model('ReleaseGroupType')->get_all ],
+        rg_secondary_types => [ $c->model('ReleaseGroupSecondaryType')->get_all ],
         relationship_type => [ $c->model('LinkType')->get_full_tree(get_deprecated_and_empty => 1) ],
         area_types => [ $c->model('AreaType')->get_all ],
         artist_types => [ $c->model('ArtistType')->get_all ],

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -298,6 +298,7 @@ sub search : Path('/search/edits')
         countries => [ $c->model('CountryArea')->get_all ],
         rg_types => [ $c->model('ReleaseGroupType')->get_all ],
         relationship_type => [ $c->model('LinkType')->get_full_tree(get_deprecated_and_empty => 1) ],
+        area_types => [ $c->model('AreaType')->get_all ],
         work_types => [ $c->model('WorkType')->get_all ],
     );
     return unless %{ $c->req->query_params };

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -299,6 +299,7 @@ sub search : Path('/search/edits')
         rg_types => [ $c->model('ReleaseGroupType')->get_all ],
         relationship_type => [ $c->model('LinkType')->get_full_tree(get_deprecated_and_empty => 1) ],
         area_types => [ $c->model('AreaType')->get_all ],
+        artist_types => [ $c->model('ArtistType')->get_all ],
         work_types => [ $c->model('WorkType')->get_all ],
     );
     return unless %{ $c->req->query_params };

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -302,6 +302,7 @@ sub search : Path('/search/edits')
         artist_types => [ $c->model('ArtistType')->get_all ],
         event_types => [ $c->model('EventType')->get_all ],
         instrument_types => [ $c->model('InstrumentType')->get_all ],
+        label_types => [ $c->model('LabelType')->get_all ],
         work_types => [ $c->model('WorkType')->get_all ],
     );
     return unless %{ $c->req->query_params };

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -304,6 +304,7 @@ sub search : Path('/search/edits')
         instrument_types => [ $c->model('InstrumentType')->get_all ],
         label_types => [ $c->model('LabelType')->get_all ],
         place_types => [ $c->model('PlaceType')->get_all ],
+        series_types => [ $c->model('SeriesType')->get_all ],
         work_types => [ $c->model('WorkType')->get_all ],
     );
     return unless %{ $c->req->query_params };

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -296,8 +296,6 @@ sub search : Path('/search/edits')
         quality => [ [$QUALITY_LOW => N_l('Low')], [$QUALITY_NORMAL => N_l('Normal')], [$QUALITY_HIGH => N_l('High')], [$QUALITY_UNKNOWN => N_l('Default')] ],
         languages => [ grep { $_->frequency > 0 } $c->model('Language')->get_all ],
         countries => [ $c->model('CountryArea')->get_all ],
-        rg_types => [ $c->model('ReleaseGroupType')->get_all ],
-        rg_secondary_types => [ $c->model('ReleaseGroupSecondaryType')->get_all ],
         relationship_type => [ $c->model('LinkType')->get_full_tree(get_deprecated_and_empty => 1) ],
         area_types => [ $c->model('AreaType')->get_all ],
         artist_types => [ $c->model('ArtistType')->get_all ],
@@ -305,6 +303,8 @@ sub search : Path('/search/edits')
         instrument_types => [ $c->model('InstrumentType')->get_all ],
         label_types => [ $c->model('LabelType')->get_all ],
         place_types => [ $c->model('PlaceType')->get_all ],
+        rg_types => [ $c->model('ReleaseGroupType')->get_all ],
+        rg_secondary_types => [ $c->model('ReleaseGroupSecondaryType')->get_all ],
         series_types => [ $c->model('SeriesType')->get_all ],
         work_types => [ $c->model('WorkType')->get_all ],
     );

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -298,6 +298,7 @@ sub search : Path('/search/edits')
         countries => [ $c->model('CountryArea')->get_all ],
         rg_types => [ $c->model('ReleaseGroupType')->get_all ],
         relationship_type => [ $c->model('LinkType')->get_full_tree(get_deprecated_and_empty => 1) ],
+        work_types => [ $c->model('WorkType')->get_all ],
     );
     return unless %{ $c->req->query_params };
 

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -301,6 +301,7 @@ sub search : Path('/search/edits')
         area_types => [ $c->model('AreaType')->get_all ],
         artist_types => [ $c->model('ArtistType')->get_all ],
         event_types => [ $c->model('EventType')->get_all ],
+        instrument_types => [ $c->model('InstrumentType')->get_all ],
         work_types => [ $c->model('WorkType')->get_all ],
     );
     return unless %{ $c->req->query_params };

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/AreaType.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/AreaType.pm
@@ -1,0 +1,18 @@
+package MusicBrainz::Server::EditSearch::Predicate::AreaType;
+use Moose;
+use namespace::autoclean;
+
+extends 'MusicBrainz::Server::EditSearch::Predicate::Set';
+with 'MusicBrainz::Server::EditSearch::Predicate::Role::EntityType' => { type => 'area' };
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/ArtistType.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/ArtistType.pm
@@ -1,0 +1,18 @@
+package MusicBrainz::Server::EditSearch::Predicate::ArtistType;
+use Moose;
+use namespace::autoclean;
+
+extends 'MusicBrainz::Server::EditSearch::Predicate::Set';
+with 'MusicBrainz::Server::EditSearch::Predicate::Role::EntityType' => { type => 'artist' };
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/EventType.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/EventType.pm
@@ -1,0 +1,18 @@
+package MusicBrainz::Server::EditSearch::Predicate::EventType;
+use Moose;
+use namespace::autoclean;
+
+extends 'MusicBrainz::Server::EditSearch::Predicate::Set';
+with 'MusicBrainz::Server::EditSearch::Predicate::Role::EntityType' => { type => 'event' };
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/InstrumentType.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/InstrumentType.pm
@@ -1,0 +1,18 @@
+package MusicBrainz::Server::EditSearch::Predicate::InstrumentType;
+use Moose;
+use namespace::autoclean;
+
+extends 'MusicBrainz::Server::EditSearch::Predicate::Set';
+with 'MusicBrainz::Server::EditSearch::Predicate::Role::EntityType' => { type => 'instrument' };
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/LabelType.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/LabelType.pm
@@ -1,0 +1,18 @@
+package MusicBrainz::Server::EditSearch::Predicate::LabelType;
+use Moose;
+use namespace::autoclean;
+
+extends 'MusicBrainz::Server::EditSearch::Predicate::Set';
+with 'MusicBrainz::Server::EditSearch::Predicate::Role::EntityType' => { type => 'label' };
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/PlaceType.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/PlaceType.pm
@@ -1,0 +1,18 @@
+package MusicBrainz::Server::EditSearch::Predicate::PlaceType;
+use Moose;
+use namespace::autoclean;
+
+extends 'MusicBrainz::Server::EditSearch::Predicate::Set';
+with 'MusicBrainz::Server::EditSearch::Predicate::Role::EntityType' => { type => 'place' };
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/ReleaseGroupPrimaryType.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/ReleaseGroupPrimaryType.pm
@@ -1,0 +1,18 @@
+package MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType;
+use Moose;
+use namespace::autoclean;
+
+extends 'MusicBrainz::Server::EditSearch::Predicate::Set';
+with 'MusicBrainz::Server::EditSearch::Predicate::Role::EntityType' => { type => 'release_group' };
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/ReleaseGroupSecondaryType.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/ReleaseGroupSecondaryType.pm
@@ -1,0 +1,35 @@
+package MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupSecondaryType;
+use Moose;
+use namespace::autoclean;
+
+extends 'MusicBrainz::Server::EditSearch::Predicate::Set';
+
+sub combine_with_query {
+    my ($self, $query) = @_;
+    return unless $self->arguments;
+
+    $query->add_where([
+        'EXISTS (
+            SELECT 1
+              FROM edit_release_group A
+              JOIN release_group B ON A.release_group = B.id
+              JOIN release_group_secondary_type_join C on C.release_group = B.id
+             WHERE A.edit = edit.id AND ' .
+        join(' ', 'C.secondary_type', $self->operator,
+             $self->operator eq '='  ? 'any(?)' :
+             $self->operator eq '!=' ? 'all(?)' : die q(Shouldn't get here)) . ')',
+        $self->sql_arguments,
+    ]) if $self->arguments > 0;
+}
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/Role/EntityType.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/Role/EntityType.pm
@@ -1,0 +1,42 @@
+package MusicBrainz::Server::EditSearch::Predicate::Role::EntityType;
+use MooseX::Role::Parameterized;
+use namespace::autoclean;
+
+parameter 'type' => (
+    isa => 'Str',
+    required => 1,
+);
+
+role {
+    my $params = shift;
+    my $type = $params->type;
+
+    requires 'arguments';
+
+    method 'combine_with_query' => sub
+    {
+        my ($self, $query) = @_;
+        return unless $self->arguments;
+
+        $query->add_where([
+            "EXISTS (SELECT 1 FROM edit_$type A JOIN $type B ON A.$type = B.id WHERE A.edit = edit.id AND " .
+            join(' ', 'B.type', $self->operator,
+                $self->operator eq '='  ? 'any(?)' :
+                $self->operator eq '!=' ? 'all(?)' : die q(Shouldn't get here)) . ')',
+            $self->sql_arguments,
+        ]) if $self->arguments > 0;
+   };
+
+};
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/SeriesType.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/SeriesType.pm
@@ -1,0 +1,18 @@
+package MusicBrainz::Server::EditSearch::Predicate::SeriesType;
+use Moose;
+use namespace::autoclean;
+
+extends 'MusicBrainz::Server::EditSearch::Predicate::Set';
+with 'MusicBrainz::Server::EditSearch::Predicate::Role::EntityType' => { type => 'series' };
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/WorkType.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/WorkType.pm
@@ -1,0 +1,18 @@
+package MusicBrainz::Server::EditSearch::Predicate::WorkType;
+use Moose;
+use namespace::autoclean;
+
+extends 'MusicBrainz::Server::EditSearch::Predicate::Set';
+with 'MusicBrainz::Server::EditSearch::Predicate::Role::EntityType' => { type => 'work' };
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -24,6 +24,7 @@ use MusicBrainz::Server::EditSearch::Predicate::AreaType;
 use MusicBrainz::Server::EditSearch::Predicate::ArtistType;
 use MusicBrainz::Server::EditSearch::Predicate::EventType;
 use MusicBrainz::Server::EditSearch::Predicate::InstrumentType;
+use MusicBrainz::Server::EditSearch::Predicate::LabelType;
 use MusicBrainz::Server::EditSearch::Predicate::WorkType;
 use MusicBrainz::Server::EditSearch::Predicate::ArtistArea;
 use MusicBrainz::Server::EditSearch::Predicate::LabelArea;
@@ -53,6 +54,7 @@ my %field_map = (
     artist_type => 'MusicBrainz::Server::EditSearch::Predicate::ArtistType',
     event_type => 'MusicBrainz::Server::EditSearch::Predicate::EventType',
     instrument_type => 'MusicBrainz::Server::EditSearch::Predicate::InstrumentType',
+    label_type => 'MusicBrainz::Server::EditSearch::Predicate::LabelType',
     work_type => 'MusicBrainz::Server::EditSearch::Predicate::WorkType',
     artist_area => 'MusicBrainz::Server::EditSearch::Predicate::ArtistArea',
     label_area => 'MusicBrainz::Server::EditSearch::Predicate::LabelArea',

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -23,6 +23,7 @@ use MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality;
 use MusicBrainz::Server::EditSearch::Predicate::AreaType;
 use MusicBrainz::Server::EditSearch::Predicate::ArtistType;
 use MusicBrainz::Server::EditSearch::Predicate::EventType;
+use MusicBrainz::Server::EditSearch::Predicate::InstrumentType;
 use MusicBrainz::Server::EditSearch::Predicate::WorkType;
 use MusicBrainz::Server::EditSearch::Predicate::ArtistArea;
 use MusicBrainz::Server::EditSearch::Predicate::LabelArea;
@@ -51,6 +52,7 @@ my %field_map = (
     area_type => 'MusicBrainz::Server::EditSearch::Predicate::AreaType',
     artist_type => 'MusicBrainz::Server::EditSearch::Predicate::ArtistType',
     event_type => 'MusicBrainz::Server::EditSearch::Predicate::EventType',
+    instrument_type => 'MusicBrainz::Server::EditSearch::Predicate::InstrumentType',
     work_type => 'MusicBrainz::Server::EditSearch::Predicate::WorkType',
     artist_area => 'MusicBrainz::Server::EditSearch::Predicate::ArtistArea',
     label_area => 'MusicBrainz::Server::EditSearch::Predicate::LabelArea',

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -21,6 +21,7 @@ use MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseLanguage;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality;
 use MusicBrainz::Server::EditSearch::Predicate::AreaType;
+use MusicBrainz::Server::EditSearch::Predicate::ArtistType;
 use MusicBrainz::Server::EditSearch::Predicate::WorkType;
 use MusicBrainz::Server::EditSearch::Predicate::ArtistArea;
 use MusicBrainz::Server::EditSearch::Predicate::LabelArea;
@@ -47,6 +48,7 @@ my %field_map = (
     release_language => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseLanguage',
     release_quality => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality',
     area_type => 'MusicBrainz::Server::EditSearch::Predicate::AreaType',
+    artist_type => 'MusicBrainz::Server::EditSearch::Predicate::ArtistType',
     work_type => 'MusicBrainz::Server::EditSearch::Predicate::WorkType',
     artist_area => 'MusicBrainz::Server::EditSearch::Predicate::ArtistArea',
     label_area => 'MusicBrainz::Server::EditSearch::Predicate::LabelArea',

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -20,6 +20,7 @@ use MusicBrainz::Server::EditSearch::Predicate::Voter;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseLanguage;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality;
+use MusicBrainz::Server::EditSearch::Predicate::WorkType;
 use MusicBrainz::Server::EditSearch::Predicate::ArtistArea;
 use MusicBrainz::Server::EditSearch::Predicate::LabelArea;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseCountry;
@@ -44,6 +45,7 @@ my %field_map = (
     release_group_primary_type => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType',
     release_language => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseLanguage',
     release_quality => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality',
+    work_type => 'MusicBrainz::Server::EditSearch::Predicate::WorkType',
     artist_area => 'MusicBrainz::Server::EditSearch::Predicate::ArtistArea',
     label_area => 'MusicBrainz::Server::EditSearch::Predicate::LabelArea',
     release_country => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseCountry',

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -25,6 +25,7 @@ use MusicBrainz::Server::EditSearch::Predicate::ArtistType;
 use MusicBrainz::Server::EditSearch::Predicate::EventType;
 use MusicBrainz::Server::EditSearch::Predicate::InstrumentType;
 use MusicBrainz::Server::EditSearch::Predicate::LabelType;
+use MusicBrainz::Server::EditSearch::Predicate::PlaceType;
 use MusicBrainz::Server::EditSearch::Predicate::WorkType;
 use MusicBrainz::Server::EditSearch::Predicate::ArtistArea;
 use MusicBrainz::Server::EditSearch::Predicate::LabelArea;
@@ -55,6 +56,7 @@ my %field_map = (
     event_type => 'MusicBrainz::Server::EditSearch::Predicate::EventType',
     instrument_type => 'MusicBrainz::Server::EditSearch::Predicate::InstrumentType',
     label_type => 'MusicBrainz::Server::EditSearch::Predicate::LabelType',
+    place_type => 'MusicBrainz::Server::EditSearch::Predicate::PlaceType',
     work_type => 'MusicBrainz::Server::EditSearch::Predicate::WorkType',
     artist_area => 'MusicBrainz::Server::EditSearch::Predicate::ArtistArea',
     label_area => 'MusicBrainz::Server::EditSearch::Predicate::LabelArea',

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -17,6 +17,7 @@ use MusicBrainz::Server::EditSearch::Predicate::EditorFlag;
 use MusicBrainz::Server::EditSearch::Predicate::VoteCount;
 use MusicBrainz::Server::EditSearch::Predicate::AppliedEdits;
 use MusicBrainz::Server::EditSearch::Predicate::Voter;
+use MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseLanguage;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality;
 use MusicBrainz::Server::EditSearch::Predicate::ArtistArea;
@@ -40,6 +41,7 @@ my %field_map = (
     vote_count => 'MusicBrainz::Server::EditSearch::Predicate::VoteCount',
     editor => 'MusicBrainz::Server::EditSearch::Predicate::Editor',
     voter => 'MusicBrainz::Server::EditSearch::Predicate::Voter',
+    release_group_primary_type => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType',
     release_language => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseLanguage',
     release_quality => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality',
     artist_area => 'MusicBrainz::Server::EditSearch::Predicate::ArtistArea',

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -22,6 +22,7 @@ use MusicBrainz::Server::EditSearch::Predicate::ReleaseLanguage;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality;
 use MusicBrainz::Server::EditSearch::Predicate::AreaType;
 use MusicBrainz::Server::EditSearch::Predicate::ArtistType;
+use MusicBrainz::Server::EditSearch::Predicate::EventType;
 use MusicBrainz::Server::EditSearch::Predicate::WorkType;
 use MusicBrainz::Server::EditSearch::Predicate::ArtistArea;
 use MusicBrainz::Server::EditSearch::Predicate::LabelArea;
@@ -49,6 +50,7 @@ my %field_map = (
     release_quality => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality',
     area_type => 'MusicBrainz::Server::EditSearch::Predicate::AreaType',
     artist_type => 'MusicBrainz::Server::EditSearch::Predicate::ArtistType',
+    event_type => 'MusicBrainz::Server::EditSearch::Predicate::EventType',
     work_type => 'MusicBrainz::Server::EditSearch::Predicate::WorkType',
     artist_area => 'MusicBrainz::Server::EditSearch::Predicate::ArtistArea',
     label_area => 'MusicBrainz::Server::EditSearch::Predicate::LabelArea',

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -20,6 +20,7 @@ use MusicBrainz::Server::EditSearch::Predicate::Voter;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseLanguage;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality;
+use MusicBrainz::Server::EditSearch::Predicate::AreaType;
 use MusicBrainz::Server::EditSearch::Predicate::WorkType;
 use MusicBrainz::Server::EditSearch::Predicate::ArtistArea;
 use MusicBrainz::Server::EditSearch::Predicate::LabelArea;
@@ -45,6 +46,7 @@ my %field_map = (
     release_group_primary_type => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType',
     release_language => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseLanguage',
     release_quality => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality',
+    area_type => 'MusicBrainz::Server::EditSearch::Predicate::AreaType',
     work_type => 'MusicBrainz::Server::EditSearch::Predicate::WorkType',
     artist_area => 'MusicBrainz::Server::EditSearch::Predicate::ArtistArea',
     label_area => 'MusicBrainz::Server::EditSearch::Predicate::LabelArea',

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -17,8 +17,6 @@ use MusicBrainz::Server::EditSearch::Predicate::EditorFlag;
 use MusicBrainz::Server::EditSearch::Predicate::VoteCount;
 use MusicBrainz::Server::EditSearch::Predicate::AppliedEdits;
 use MusicBrainz::Server::EditSearch::Predicate::Voter;
-use MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType;
-use MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupSecondaryType;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseLanguage;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality;
 use MusicBrainz::Server::EditSearch::Predicate::AreaType;
@@ -27,6 +25,8 @@ use MusicBrainz::Server::EditSearch::Predicate::EventType;
 use MusicBrainz::Server::EditSearch::Predicate::InstrumentType;
 use MusicBrainz::Server::EditSearch::Predicate::LabelType;
 use MusicBrainz::Server::EditSearch::Predicate::PlaceType;
+use MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType;
+use MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupSecondaryType;
 use MusicBrainz::Server::EditSearch::Predicate::SeriesType;
 use MusicBrainz::Server::EditSearch::Predicate::WorkType;
 use MusicBrainz::Server::EditSearch::Predicate::ArtistArea;
@@ -50,8 +50,6 @@ my %field_map = (
     vote_count => 'MusicBrainz::Server::EditSearch::Predicate::VoteCount',
     editor => 'MusicBrainz::Server::EditSearch::Predicate::Editor',
     voter => 'MusicBrainz::Server::EditSearch::Predicate::Voter',
-    release_group_primary_type => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType',
-    release_group_secondary_type => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupSecondaryType',
     release_language => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseLanguage',
     release_quality => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality',
     area_type => 'MusicBrainz::Server::EditSearch::Predicate::AreaType',
@@ -60,6 +58,8 @@ my %field_map = (
     instrument_type => 'MusicBrainz::Server::EditSearch::Predicate::InstrumentType',
     label_type => 'MusicBrainz::Server::EditSearch::Predicate::LabelType',
     place_type => 'MusicBrainz::Server::EditSearch::Predicate::PlaceType',
+    release_group_primary_type => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType',
+    release_group_secondary_type => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupSecondaryType',
     series_type => 'MusicBrainz::Server::EditSearch::Predicate::SeriesType',
     work_type => 'MusicBrainz::Server::EditSearch::Predicate::WorkType',
     artist_area => 'MusicBrainz::Server::EditSearch::Predicate::ArtistArea',

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -18,6 +18,7 @@ use MusicBrainz::Server::EditSearch::Predicate::VoteCount;
 use MusicBrainz::Server::EditSearch::Predicate::AppliedEdits;
 use MusicBrainz::Server::EditSearch::Predicate::Voter;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType;
+use MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupSecondaryType;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseLanguage;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality;
 use MusicBrainz::Server::EditSearch::Predicate::AreaType;
@@ -50,6 +51,7 @@ my %field_map = (
     editor => 'MusicBrainz::Server::EditSearch::Predicate::Editor',
     voter => 'MusicBrainz::Server::EditSearch::Predicate::Voter',
     release_group_primary_type => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType',
+    release_group_secondary_type => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupSecondaryType',
     release_language => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseLanguage',
     release_quality => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality',
     area_type => 'MusicBrainz::Server::EditSearch::Predicate::AreaType',

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -26,6 +26,7 @@ use MusicBrainz::Server::EditSearch::Predicate::EventType;
 use MusicBrainz::Server::EditSearch::Predicate::InstrumentType;
 use MusicBrainz::Server::EditSearch::Predicate::LabelType;
 use MusicBrainz::Server::EditSearch::Predicate::PlaceType;
+use MusicBrainz::Server::EditSearch::Predicate::SeriesType;
 use MusicBrainz::Server::EditSearch::Predicate::WorkType;
 use MusicBrainz::Server::EditSearch::Predicate::ArtistArea;
 use MusicBrainz::Server::EditSearch::Predicate::LabelArea;
@@ -57,6 +58,7 @@ my %field_map = (
     instrument_type => 'MusicBrainz::Server::EditSearch::Predicate::InstrumentType',
     label_type => 'MusicBrainz::Server::EditSearch::Predicate::LabelType',
     place_type => 'MusicBrainz::Server::EditSearch::Predicate::PlaceType',
+    series_type => 'MusicBrainz::Server::EditSearch::Predicate::SeriesType',
     work_type => 'MusicBrainz::Server::EditSearch::Predicate::WorkType',
     artist_area => 'MusicBrainz::Server::EditSearch::Predicate::ArtistArea',
     label_area => 'MusicBrainz::Server::EditSearch::Predicate::LabelArea',

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -98,6 +98,8 @@
                predicate_entity_type(field.field_name, label_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::PlaceType';
                predicate_entity_type(field.field_name, place_types, field);
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::SeriesType';
+               predicate_entity_type(field.field_name, series_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::WorkType';
                predicate_entity_type(field.field_name, work_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::EditorFlag';
@@ -494,6 +496,7 @@
                    [ 'release_group', l('Release group') ],
                    [ 'release_group_primary_type', l('Release group primary type') ],
                    [ 'series', lp('Series', 'singular') ],
+                   [ 'series_type', l('Series type') ],
                    [ 'url', l('URL') ],
                    [ 'work', l('Work') ],
                    [ 'work_type', l('Work type') ],
@@ -548,6 +551,7 @@
     [% predicate_entity_type('instrument_type', instrument_types) %]
     [% predicate_entity_type('label_type', label_types) %]
     [% predicate_entity_type('place_type', place_types) %]
+    [% predicate_entity_type('series_type', series_types) %]
     [% predicate_entity_type('work_type', work_types) %]
     [% predicate_link('artist_area', undef, 'area') %]
     [% predicate_link('label_area', undef, 'area') %]

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -86,6 +86,8 @@
                predicate_country(field.field_name, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::RelationshipType';
                predicate_link_type(field.field_name, field);
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::WorkType';
+               predicate_entity_type(field.field_name, work_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::EditorFlag';
                predicate_editor_flag(field.field_name, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::AppliedEdits';
@@ -344,7 +346,7 @@
   [% operators([ [ '=', l('is') ]
                  [ '!=', l('is not') ] ], field_contents) %]
 
-  <select name="args" multiple="multiple" size=[% set_contents.size %]>
+  <select name="args" multiple="multiple" size=[% set_contents.size < 10 ? set_contents.size : 10 %]>
     [%- FOR type=set_contents %]
     <option value="[% type.id %]"
             [%- 'selected="selected"' IF field_contents.find_argument(type.id) %]>
@@ -476,6 +478,7 @@
                    [ 'series', lp('Series', 'singular') ],
                    [ 'url', l('URL') ],
                    [ 'work', l('Work') ],
+                   [ 'work_type', l('Work type') ],
                    [ 'editor', l('Editor'), {requires_login => 1} ],
                    [ 'voter', l('Voter'), {requires_login => 1} ]
                    [ 'release_language', l('Release language') ],
@@ -521,6 +524,7 @@
     [% predicate_voter('voter') %]
     [% predicate_release_language('release_language') %]
     [% predicate_entity_type('release_group_primary_type', rg_types) %]
+    [% predicate_entity_type('work_type', work_types) %]
     [% predicate_link('artist_area', undef, 'area') %]
     [% predicate_link('label_area', undef, 'area') %]
     [% predicate_country('release_country') %]

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -80,10 +80,6 @@
                predicate_link(field.field_name, field, 'area');
              CASE 'MusicBrainz::Server::EditSearch::Predicate::LabelArea';
                predicate_link(field.field_name, field, 'area');
-             CASE 'MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType';
-               predicate_entity_type(field.field_name, rg_types, field);
-             CASE 'MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupSecondaryType';
-               predicate_entity_type(field.field_name, rg_secondary_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::ReleaseCountry';
                predicate_country(field.field_name, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::RelationshipType';
@@ -100,6 +96,10 @@
                predicate_entity_type(field.field_name, label_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::PlaceType';
                predicate_entity_type(field.field_name, place_types, field);
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType';
+               predicate_entity_type(field.field_name, rg_types, field);
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupSecondaryType';
+               predicate_entity_type(field.field_name, rg_secondary_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::SeriesType';
                predicate_entity_type(field.field_name, series_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::WorkType';
@@ -547,14 +547,14 @@
     [% predicate_user('editor') %]
     [% predicate_voter('voter') %]
     [% predicate_release_language('release_language') %]
-    [% predicate_entity_type('release_group_primary_type', rg_types) %]
-    [% predicate_entity_type('release_group_secondary_type', rg_secondary_types) %]
     [% predicate_entity_type('area_type', area_types) %]
     [% predicate_entity_type('artist_type', artist_types) %]
     [% predicate_entity_type('event_type', event_types) %]
     [% predicate_entity_type('instrument_type', instrument_types) %]
     [% predicate_entity_type('label_type', label_types) %]
     [% predicate_entity_type('place_type', place_types) %]
+    [% predicate_entity_type('release_group_primary_type', rg_types) %]
+    [% predicate_entity_type('release_group_secondary_type', rg_secondary_types) %]
     [% predicate_entity_type('series_type', series_types) %]
     [% predicate_entity_type('work_type', work_types) %]
     [% predicate_link('artist_area', undef, 'area') %]

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -86,6 +86,8 @@
                predicate_country(field.field_name, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::RelationshipType';
                predicate_link_type(field.field_name, field);
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::AreaType';
+               predicate_entity_type(field.field_name, area_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::WorkType';
                predicate_entity_type(field.field_name, work_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::EditorFlag';
@@ -465,6 +467,7 @@
                    [ 'edit_note_content', l('Edit note content'), {requires_login => 1} ],
                    [ 'edit_subscription', l('Edited entity'), {requires_login => 1} ],
                    [ 'area', l('Area') ],
+                   [ 'area_type', l('Area type') ],
                    [ 'artist', l('Artist') ],
                    [ 'event', l('Event') ],
                    [ 'genre', l('Genre') ],
@@ -524,6 +527,7 @@
     [% predicate_voter('voter') %]
     [% predicate_release_language('release_language') %]
     [% predicate_entity_type('release_group_primary_type', rg_types) %]
+    [% predicate_entity_type('area_type', area_types) %]
     [% predicate_entity_type('work_type', work_types) %]
     [% predicate_link('artist_area', undef, 'area') %]
     [% predicate_link('label_area', undef, 'area') %]

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -82,6 +82,8 @@
                predicate_link(field.field_name, field, 'area');
              CASE 'MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType';
                predicate_entity_type(field.field_name, rg_types, field);
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupSecondaryType';
+               predicate_entity_type(field.field_name, rg_secondary_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::ReleaseCountry';
                predicate_country(field.field_name, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::RelationshipType';
@@ -495,6 +497,7 @@
                    [ 'release', l('Release') ],
                    [ 'release_group', l('Release group') ],
                    [ 'release_group_primary_type', l('Release group primary type') ],
+                   [ 'release_group_secondary_type', l('Release group secondary type') ],
                    [ 'series', lp('Series', 'singular') ],
                    [ 'series_type', l('Series type') ],
                    [ 'url', l('URL') ],
@@ -545,6 +548,7 @@
     [% predicate_voter('voter') %]
     [% predicate_release_language('release_language') %]
     [% predicate_entity_type('release_group_primary_type', rg_types) %]
+    [% predicate_entity_type('release_group_secondary_type', rg_secondary_types) %]
     [% predicate_entity_type('area_type', area_types) %]
     [% predicate_entity_type('artist_type', artist_types) %]
     [% predicate_entity_type('event_type', event_types) %]

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -80,6 +80,8 @@
                predicate_link(field.field_name, field, 'area');
              CASE 'MusicBrainz::Server::EditSearch::Predicate::LabelArea';
                predicate_link(field.field_name, field, 'area');
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::ReleaseGroupPrimaryType';
+               predicate_entity_type(field.field_name, rg_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::ReleaseCountry';
                predicate_country(field.field_name, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::RelationshipType';
@@ -338,6 +340,19 @@
   </span>
 [% END %]
 
+[% MACRO predicate_entity_type(field, set_contents, field_contents) WRAPPER wfield predicate="set" %]
+  [% operators([ [ '=', l('is') ]
+                 [ '!=', l('is not') ] ], field_contents) %]
+
+  <select name="args" multiple="multiple" size=[% set_contents.size %]>
+    [%- FOR type=set_contents %]
+    <option value="[% type.id %]"
+            [%- 'selected="selected"' IF field_contents.find_argument(type.id) %]>
+        [%- html_escape(type.l_name) -%]</option>
+    [%- END %]
+  </select>
+[% END %]
+
 [% MACRO predicate_country(field, field_contents) WRAPPER wfield predicate="set" %]
   [% operators([ [ '=', l('is') ]
                  [ '!=', l('is not') ] ], field_contents) %]
@@ -457,6 +472,7 @@
                    [ 'recording', l('Recording') ],
                    [ 'release', l('Release') ],
                    [ 'release_group', l('Release group') ],
+                   [ 'release_group_primary_type', l('Release group primary type') ],
                    [ 'series', lp('Series', 'singular') ],
                    [ 'url', l('URL') ],
                    [ 'work', l('Work') ],
@@ -504,6 +520,7 @@
     [% predicate_user('editor') %]
     [% predicate_voter('voter') %]
     [% predicate_release_language('release_language') %]
+    [% predicate_entity_type('release_group_primary_type', rg_types) %]
     [% predicate_link('artist_area', undef, 'area') %]
     [% predicate_link('label_area', undef, 'area') %]
     [% predicate_country('release_country') %]

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -94,6 +94,8 @@
                predicate_entity_type(field.field_name, event_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::InstrumentType';
                predicate_entity_type(field.field_name, instrument_types, field);
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::LabelType';
+               predicate_entity_type(field.field_name, label_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::WorkType';
                predicate_entity_type(field.field_name, work_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::EditorFlag';
@@ -482,6 +484,7 @@
                    [ 'instrument', l('Instrument') ],
                    [ 'instrument_type', l('Instrument type') ],
                    [ 'label', l('Label') ],
+                   [ 'label_type', l('Label type') ],
                    [ 'place', l('Place') ],
                    [ 'recording', l('Recording') ],
                    [ 'release', l('Release') ],
@@ -540,6 +543,7 @@
     [% predicate_entity_type('artist_type', artist_types) %]
     [% predicate_entity_type('event_type', event_types) %]
     [% predicate_entity_type('instrument_type', instrument_types) %]
+    [% predicate_entity_type('label_type', label_types) %]
     [% predicate_entity_type('work_type', work_types) %]
     [% predicate_link('artist_area', undef, 'area') %]
     [% predicate_link('label_area', undef, 'area') %]

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -96,6 +96,8 @@
                predicate_entity_type(field.field_name, instrument_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::LabelType';
                predicate_entity_type(field.field_name, label_types, field);
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::PlaceType';
+               predicate_entity_type(field.field_name, place_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::WorkType';
                predicate_entity_type(field.field_name, work_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::EditorFlag';
@@ -486,6 +488,7 @@
                    [ 'label', l('Label') ],
                    [ 'label_type', l('Label type') ],
                    [ 'place', l('Place') ],
+                   [ 'place_type', l('Place type') ],
                    [ 'recording', l('Recording') ],
                    [ 'release', l('Release') ],
                    [ 'release_group', l('Release group') ],
@@ -544,6 +547,7 @@
     [% predicate_entity_type('event_type', event_types) %]
     [% predicate_entity_type('instrument_type', instrument_types) %]
     [% predicate_entity_type('label_type', label_types) %]
+    [% predicate_entity_type('place_type', place_types) %]
     [% predicate_entity_type('work_type', work_types) %]
     [% predicate_link('artist_area', undef, 'area') %]
     [% predicate_link('label_area', undef, 'area') %]

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -90,6 +90,8 @@
                predicate_entity_type(field.field_name, area_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::ArtistType';
                predicate_entity_type(field.field_name, artist_types, field);
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::EventType';
+               predicate_entity_type(field.field_name, event_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::WorkType';
                predicate_entity_type(field.field_name, work_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::EditorFlag';
@@ -473,6 +475,7 @@
                    [ 'artist', l('Artist') ],
                    [ 'artist_type', l('Artist type') ],
                    [ 'event', l('Event') ],
+                   [ 'event_type', l('Event type') ],
                    [ 'genre', l('Genre') ],
                    [ 'instrument', l('Instrument') ],
                    [ 'label', l('Label') ],
@@ -532,6 +535,7 @@
     [% predicate_entity_type('release_group_primary_type', rg_types) %]
     [% predicate_entity_type('area_type', area_types) %]
     [% predicate_entity_type('artist_type', artist_types) %]
+    [% predicate_entity_type('event_type', event_types) %]
     [% predicate_entity_type('work_type', work_types) %]
     [% predicate_link('artist_area', undef, 'area') %]
     [% predicate_link('label_area', undef, 'area') %]

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -92,6 +92,8 @@
                predicate_entity_type(field.field_name, artist_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::EventType';
                predicate_entity_type(field.field_name, event_types, field);
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::InstrumentType';
+               predicate_entity_type(field.field_name, instrument_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::WorkType';
                predicate_entity_type(field.field_name, work_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::EditorFlag';
@@ -478,6 +480,7 @@
                    [ 'event_type', l('Event type') ],
                    [ 'genre', l('Genre') ],
                    [ 'instrument', l('Instrument') ],
+                   [ 'instrument_type', l('Instrument type') ],
                    [ 'label', l('Label') ],
                    [ 'place', l('Place') ],
                    [ 'recording', l('Recording') ],
@@ -536,6 +539,7 @@
     [% predicate_entity_type('area_type', area_types) %]
     [% predicate_entity_type('artist_type', artist_types) %]
     [% predicate_entity_type('event_type', event_types) %]
+    [% predicate_entity_type('instrument_type', instrument_types) %]
     [% predicate_entity_type('work_type', work_types) %]
     [% predicate_link('artist_area', undef, 'area') %]
     [% predicate_link('label_area', undef, 'area') %]

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -88,6 +88,8 @@
                predicate_link_type(field.field_name, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::AreaType';
                predicate_entity_type(field.field_name, area_types, field);
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::ArtistType';
+               predicate_entity_type(field.field_name, artist_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::WorkType';
                predicate_entity_type(field.field_name, work_types, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::EditorFlag';
@@ -469,6 +471,7 @@
                    [ 'area', l('Area') ],
                    [ 'area_type', l('Area type') ],
                    [ 'artist', l('Artist') ],
+                   [ 'artist_type', l('Artist type') ],
                    [ 'event', l('Event') ],
                    [ 'genre', l('Genre') ],
                    [ 'instrument', l('Instrument') ],
@@ -528,6 +531,7 @@
     [% predicate_release_language('release_language') %]
     [% predicate_entity_type('release_group_primary_type', rg_types) %]
     [% predicate_entity_type('area_type', area_types) %]
+    [% predicate_entity_type('artist_type', artist_types) %]
     [% predicate_entity_type('work_type', work_types) %]
     [% predicate_link('artist_area', undef, 'area') %]
     [% predicate_link('label_area', undef, 'area') %]


### PR DESCRIPTION
### Implement MBS-13771

# Description
This adds a way to filter edit searches by entity type. I implemented this because of a request to filter by the primary type of release groups, but since it's a trivially reusable role, and this seems like a useful filter for every entity type with types, I am adding it for every entity with types. RG secondary types don't use the role (they could in a similar way to `EntityArea`, but I did not see the point of complicating the role significantly for a one-off) but other than that work the same as all other types.

# Testing
Manually, searching for edits with all kinds of type filters and making sure the results seem sensible.