### PR TITLE
MBS-13950: Support Utaite/Touhou/VocaDB tag pages for genres

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -6110,6 +6110,11 @@ const CLEANUPS: CleanupEntries = {
               result: prefix === 'Es',
               target: ERROR_TARGETS.ENTITY,
             };
+          case LINK_TYPES.otherdatabases.genre:
+            return {
+              result: prefix === 'T',
+              target: ERROR_TARGETS.ENTITY,
+            };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
       }

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -6340,6 +6340,13 @@ limited_link_type_combinations: ['downloadpurchase', 'mailorder'],
             expected_clean_url: 'https://vocadb.net/S/143473',
        only_valid_entity_types: ['recording', 'work'],
   },
+  {
+                     input_url: 'https://touhoudb.com/T/1041/pumpcore',
+             input_entity_type: 'event',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://touhoudb.com/T/1041',
+       only_valid_entity_types: ['genre'],
+  },
   // Utamap
   {
                      input_url: 'http://www.utamap.com/showkasi.php?surl=34985',


### PR DESCRIPTION
### Implement MBS-13950

# Description
We already support Utaite/Touhou/VocaDB pages for most other entities (they're closely related sites so we handle them all in the same way), but we did not support their tag (`/T`) links for genres. This just adds that support.

# Testing
Added a `/T` link to the automated test list.