### PR TITLE
MBS-13951: Allow filtering KaraokePlusInstrumentalRecordings

### DIFF
--- a/lib/MusicBrainz/Server/Report/KaraokePlusInstrumentalRecordings.pm
+++ b/lib/MusicBrainz/Server/Report/KaraokePlusInstrumentalRecordings.pm
@@ -1,7 +1,8 @@
 package MusicBrainz::Server::Report::KaraokePlusInstrumentalRecordings;
 use Moose;
 
-with 'MusicBrainz::Server::Report::RecordingReport';
+with 'MusicBrainz::Server::Report::RecordingReport',
+     'MusicBrainz::Server::Report::FilterForEditor::RecordingID';
 
 sub query {<<~'SQL'}
     SELECT


### PR DESCRIPTION
### Implement MBS-13951

# Problem
The new `KaraokePlusInstrumentalRecordings` report (https://musicbrainz.org/report/KaraokePlusInstrumentalRecordings) does not support filtering. There's no reason for this, except that I just missed adding it originally.

# Solution
Use `FilterForEditor::RecordingID` here as with all other recording reports not about Various Artists.

# Testing
Manually, by subscribing to an artist with recordings in the report and making sure the filter works normally.