### PR TITLE
Wait for renderer socket before starting plackup

### DIFF
--- a/docker/musicbrainz-website/website.service
+++ b/docker/musicbrainz-website/website.service
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+cd /home/musicbrainz/musicbrainz-server
+
+RENDERER_SOCKET="$(realpath "$(
+    sudo -E -H -u musicbrainz \
+        carton exec -- \
+        perl -Ilib -e 'use DBDefs; print DBDefs->RENDERER_SOCKET;'
+)")"
+
+if ! ss -lx | grep -Fq "$RENDERER_SOCKET"; then
+    echo "No socket ready at $RENDERER_SOCKET."
+    exit 1
+fi
+
 /usr/local/bin/dbdefs_to_js.sh
 
 exec /usr/local/bin/start_musicbrainz_server.sh

--- a/docker/templates/macros.m4
+++ b/docker/templates/macros.m4
@@ -92,11 +92,14 @@ pkg-config
 
 # postgresql-server-dev-16 provides pg_config, which is needed by InitDb.pl
 # at run-time.
+# iproute2 provides ss, which is used by
+# docker/musicbrainz-website/website.service.
 m4_define(
     `mbs_run_deps',
     `m4_dnl
 bzip2
 ca-certificates
+iproute2
 libdb5.3
 libexpat1
 libicu70


### PR DESCRIPTION
# Problem

The website service starts up and passes Consul health checks well before the template-renderer is available (as it requires compiling root/static/build/server.js on startup), which leads to service unavailability.

# Solution

This simply checks whether the renderer socket is ready first.