### PR TITLE
MBS-13957: Add a report for duplicate items in series 

### DIFF
--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -544,10 +544,10 @@ sub generate_table_list {
     @end_types = @RELATABLE_ENTITIES unless @end_types;
     foreach my $t (@end_types) {
         if ($type le $t) {
-            push @types, ["l_${type}_${t}", 'entity0', 'entity1'];
+            push @types, ["l_${type}_${t}", 'entity0', 'entity1', $t];
         }
         if ($type ge $t) {
-            push @types, ["l_${t}_${type}", 'entity1', 'entity0'];
+            push @types, ["l_${t}_${type}", 'entity1', 'entity0', $t];
         }
     }
     return @types;

--- a/lib/MusicBrainz/Server/Report/SeriesContainingDuplicates.pm
+++ b/lib/MusicBrainz/Server/Report/SeriesContainingDuplicates.pm
@@ -1,0 +1,104 @@
+package MusicBrainz::Server::Report::SeriesContainingDuplicates;
+use Moose;
+
+use MusicBrainz::Server::Constants qw( %PART_OF_SERIES );
+use MusicBrainz::Server::Data::Utils qw( type_to_model );
+use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
+
+with 'MusicBrainz::Server::Report::SeriesReport',
+     'MusicBrainz::Server::Report::FilterForEditor::SeriesID';
+
+around inflate_rows => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    my $items = $self->$orig(@_);
+
+    for my $result (@$items) {
+        my $series = $result->{series};
+        my $series_type = $self->c->model('SeriesType')->get_by_id($series->{typeID});
+        my $entity_type = $series_type->item_entity_type;
+        my $model = $self->c->model(type_to_model($entity_type));
+        my $entity = $model->get_by_id($result->{entity_id});
+        $result->{entity} = to_json_object($entity);
+    }
+
+    return $items;
+};
+
+sub query {
+    my $self = shift;
+
+    my @subqueries;
+
+    my @series_l_tables = $self->c->model('Relationship')->generate_table_list(
+        'series',
+        keys %PART_OF_SERIES,
+    );
+
+    for my $series_l_table (@series_l_tables) {
+        my (
+            $table_name,
+            $series_column,
+            $other_column,
+            $target_type,
+        ) = @$series_l_table;
+
+        my $part_of_series_gid = $self->c->sql->dbh->quote(
+            $PART_OF_SERIES{$target_type},
+        );
+
+        my $subquery = <<~"SQL";
+            SELECT
+                DISTINCT s.id AS series_id,
+                         rels_table.$other_column AS entity_id,
+                         latv.text_value as order_number,
+                         s.name AS series_name
+            FROM
+                series s
+                JOIN $table_name rels_table ON rels_table.$series_column = s.id
+                JOIN link ON link.id = rels_table.link
+                JOIN link_type lt ON lt.id = link.link_type
+                LEFT JOIN link_attribute_text_value latv ON latv.link = link.id
+            WHERE (
+                lt.gid = $part_of_series_gid -- part of series
+                AND (
+                    latv.attribute_type = 788 -- number attribute
+                OR
+                    latv.attribute_type IS NULL
+                )
+            )
+            GROUP BY s.id, rels_table.$other_column, latv.text_value, s.name
+            HAVING count(*) > 1
+        SQL
+
+        push @subqueries, $subquery;
+    }
+
+    my $inner_table = join(' UNION ', @subqueries);
+
+    my $query = <<~"SQL";
+        SELECT DISTINCT series_id,
+                        entity_id,
+                        order_number,
+                        row_number() OVER (ORDER BY series_name COLLATE musicbrainz)
+        FROM ($inner_table)
+        SQL
+
+    return $query;
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut
+

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -104,6 +104,7 @@ my @all = qw(
     ReleasesMissingDiscIDs
     ReleasesConflictingDiscIDs
     SeparateDiscs
+    SeriesContainingDuplicates
     SetInDifferentRG
     ShouldNotHaveDiscIDs
     ShowNotesButNotBroadcast
@@ -211,6 +212,7 @@ use MusicBrainz::Server::Report::ReleasesWithUnlikelyLanguageScript;
 use MusicBrainz::Server::Report::ReleasesMissingDiscIDs;
 use MusicBrainz::Server::Report::ReleasesConflictingDiscIDs;
 use MusicBrainz::Server::Report::SeparateDiscs;
+use MusicBrainz::Server::Report::SeriesContainingDuplicates;
 use MusicBrainz::Server::Report::SetInDifferentRG;
 use MusicBrainz::Server::Report::ShouldNotHaveDiscIDs;
 use MusicBrainz::Server::Report::ShowNotesButNotBroadcast;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -585,6 +585,10 @@ component ReportsIndex() {
             content={l('Series with annotations')}
             reportName="AnnotationsSeries"
           />
+          <ReportsIndexEntry
+            content={l('Series containing duplicates')}
+            reportName="SeriesContainingDuplicates"
+          />
         </ul>
 
         <h2>{l('Works')}</h2>

--- a/root/report/SeriesContainingDuplicates.js
+++ b/root/report/SeriesContainingDuplicates.js
@@ -1,0 +1,61 @@
+/*
+ * @flow strict
+ * Copyright (C) 2018 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import {
+  defineEntityColumn,
+  defineTextColumn,
+} from '../utility/tableColumns.js';
+
+import ReportLayout from './components/ReportLayout.js';
+import SeriesList from './components/SeriesList.js';
+import type {ReportDataT, ReportSeriesDuplicatesT} from './types.js';
+
+const entityColumn = defineEntityColumn<ReportSeriesDuplicatesT>({
+  columnName: 'duplicate',
+  getEntity: result => result.entity ?? null,
+  showIcon: true,
+  title: l('Duplicate entity'),
+});
+
+const numberColumn = defineTextColumn<ReportSeriesDuplicatesT>({
+  columnName: 'number',
+  getText: result => result.order_number ?? '',
+  title: l('Number'),
+});
+
+component SeriesContainingDuplicates(...{
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportSeriesDuplicatesT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists series which contain the same entity multiple
+         times with the same number attribute.`,
+      )}
+      entityType="series"
+      filtered={filtered}
+      generated={generated}
+      title={l('Series containing duplicates')}
+      totalEntries={pager.total_entries}
+    >
+      <SeriesList
+        columnsAfter={[entityColumn, numberColumn]}
+        items={items}
+        pager={pager}
+      />
+    </ReportLayout>
+  );
+}
+
+export default SeriesContainingDuplicates;

--- a/root/report/types.js
+++ b/root/report/types.js
@@ -279,6 +279,15 @@ export type ReportSeriesAnnotationT = $ReadOnly<{
   +series_id: number,
 }>;
 
+export type ReportSeriesDuplicatesT = {
+  +entity: ?EntityWithSeriesT,
+  +entity_gid: string,
+  +order_number: string,
+  +row_number: number,
+  +series: ?SeriesT,
+  +series_id: number,
+};
+
 export type ReportUrlRelationshipT = $ReadOnly<{
   ...ReportRelationshipRoleT,
   +row_number: number,

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -312,6 +312,7 @@ export default {
   'report/ReportNotAvailable': (): Promise<mixed> => import('../report/ReportNotAvailable.js'),
   'report/ReportsIndex': (): Promise<mixed> => import('../report/ReportsIndex.js'),
   'report/SeparateDiscs': (): Promise<mixed> => import('../report/SeparateDiscs.js'),
+  'report/SeriesContainingDuplicates': (): Promise<mixed> => import('../report/SeriesContainingDuplicates.js'),
   'report/SetInDifferentRg': (): Promise<mixed> => import('../report/SetInDifferentRg.js'),
   'report/ShouldNotHaveDiscIds': (): Promise<mixed> => import('../report/ShouldNotHaveDiscIds.js'),
   'report/ShowNotesButNotBroadcast': (): Promise<mixed> => import('../report/ShowNotesButNotBroadcast.js'),

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -319,11 +319,13 @@ export function defineEntityColumn<D>(
     +columnName: string,
     +descriptive?: boolean,
     +getEntity: (D) => RelatableEntityT | null,
+    +showIcon?: boolean,
     +subPath?: string,
     +title: string,
   },
 ): ColumnOptions<D, string> {
   const descriptive = props.descriptive ?? true;
+  const showIcon = props.showIcon ?? false;
   const sortable = props.sortable ?? false;
   const subPath =
     Object.hasOwn(props, 'subPath')
@@ -335,12 +337,18 @@ export function defineEntityColumn<D>(
       const entity = props.getEntity(original);
       return (entity
         ? descriptive
-          ? <DescriptiveLink entity={entity} subPath={subPath} />
-          : (
+          ? (
+            <DescriptiveLink
+              entity={entity}
+              showIcon={showIcon}
+              subPath={subPath}
+            />
+          ) : (
             <EntityLink
               entity={entity}
               // Event lists show date in its own column
               showEventDate={false}
+              showIcon={showIcon}
               subPath={subPath}
             />
           )


### PR DESCRIPTION
### Implement MBS-13957

On top of https://github.com/metabrainz/musicbrainz-server/pull/1659 

# Description
This adds a report for duplicate items inside series. In order to determine duplicates, the link order is ignored, but the number attribute is not. As such, this shows either entities which are in a series twice with the same number attribute, or without a number attribute at all.

# Testing
Manually with sample data (manipulated to add more dupe entities).