### PR TITLE
MBS-13959: Prevent submitting relationships for a different source entity

### DIFF
--- a/admin/sql/InsertTestData.sql
+++ b/admin/sql/InsertTestData.sql
@@ -242,6 +242,7 @@ INSERT INTO isrc (isrc, recording) VALUES ('DEE250800230', 2);
 INSERT INTO link (id, link_type, attribute_count) VALUES (1, 148, 1);
 INSERT INTO link (id, link_type, attribute_count) VALUES (2, 148, 2);
 INSERT INTO link (id, link_type, attribute_count, begin_date_year) VALUES (3, 183, 0, 2006);
+INSERT INTO link (id, link_type, attribute_count) VALUES (4, 108, 0);
 
 INSERT INTO link_attribute (link, attribute_type) VALUES (1, 229);
 INSERT INTO link_attribute (link, attribute_type) VALUES (2, 1);
@@ -256,6 +257,7 @@ INSERT INTO artist (id, gid, name, sort_name, comment) VALUES
 INSERT INTO event (id, gid, name, begin_date_year, begin_date_month, begin_date_day, end_date_year, end_date_month, end_date_day, time, type, cancelled, setlist, comment, ended)
     VALUES (59357, 'ca1d24c1-1999-46fd-8a95-3d4108df5cb2', 'BBC Open Music Prom', 2022, 9, 1, 2022, 9, 1, '19:30:00', 1, 'f', NULL, '2022, Prom 60', 't');
 
+INSERT INTO l_artist_artist (id, link, entity0, entity1) VALUES (1, 4, 8, 9);
 INSERT INTO l_artist_recording (id, link, entity0, entity1) VALUES (1, 1, 8, 2);
 INSERT INTO l_artist_recording (id, link, entity0, entity1, edits_pending) VALUES (2, 1, 9, 2, 1);
 INSERT INTO l_artist_recording (id, link, entity0, entity1) VALUES (3, 2, 8, 3);

--- a/lib/MusicBrainz/Server/Controller/Role/EditRelationships.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/EditRelationships.pm
@@ -392,6 +392,26 @@ role {
         my $entity_map = load_entities($c, ref_to_type($source), @field_values);
         my $link_types_by_id = {};
         my %reordered_relationships;
+        my %rel_ids_by_target_type;
+
+        for my $field (@field_values) {
+            my $relationship_id = $field->{relationship_id};
+            if (defined $relationship_id) {
+                push @{ $rel_ids_by_target_type{ $field->{target_type} } },
+                    $relationship_id;
+            }
+        }
+        my %existing_relationships = map {
+            my $key = $_->target_type . '-' . $_->id;
+            ($key => $_)
+        } $c->model('Relationship')->load_subset(
+            \%rel_ids_by_target_type,
+            $source->meta->clone_object(
+                $source,
+                relationships => [],
+                has_loaded_relationships => 0,
+            ),
+        );
 
         for my $field (@field_values) {
             my %args;
@@ -426,17 +446,13 @@ role {
 
             my $relationship;
             if ($field->{relationship_id}) {
-                $relationship = $c->model('Relationship')->get_by_id(
-                   $link_type->entity0_type, $link_type->entity1_type, $field->{relationship_id},
-                );
-
-                # MBS-7354: relationship may have been deleted after the form was created
+                $relationship = $existing_relationships{
+                    $field->{target_type} . '-' . $field->{relationship_id}
+                };
+                # The relationship may have been deleted after the form was
+                # created (MBS-7354), or it may not have belonged to the
+                # source entity to begin with (MBS-13959).
                 defined $relationship or next;
-
-                $c->model('Link')->load($relationship);
-                $c->model('LinkType')->load($relationship->link);
-                $c->model('Relationship')->load_entities($relationship);
-
                 $args{relationship} = $relationship;
             }
 

--- a/lib/MusicBrainz/Server/Controller/Role/EditRelationships.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/EditRelationships.pm
@@ -524,7 +524,7 @@ role {
             );
         }
 
-        return @edits;
+        return grep { defined } @edits;
     };
 };
 

--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -145,7 +145,7 @@ sub _load
 
         my $type0 = $t->[0];
         my $type1 = $t->[1];
-        my (@cond, @params, $target, $target_id, $source_id, $query);
+        my (@cond, @params, $target_id, $source_id, $query);
 
         if ($source_type eq $type0) {
             my $condstring = 'entity0 IN (' . placeholders(@source_ids) . ')';
@@ -154,7 +154,6 @@ sub _load
             }
             push @cond, $condstring;
             push @params, @source_ids;
-            $target = $type1;
             $target_id = 'entity1';
             $source_id = 'entity0';
         }
@@ -165,7 +164,6 @@ sub _load
             }
             push @cond, $condstring;
             push @params, @source_ids;
-            $target = $type0;
             $target_id = 'entity0';
             $source_id = 'entity1';
         }
@@ -183,16 +181,16 @@ sub _load
                      l.end_date_year,   l.end_date_month,   l.end_date_day,
                      l.ended';
 
-        if ($ENTITIES{$target}{sort_name}) {
-            $order .= ", ${target}.sort_name COLLATE musicbrainz";
-        } elsif ($target eq 'url') {
+        if ($ENTITIES{$target_type}{sort_name}) {
+            $order .= ", ${target_type}.sort_name COLLATE musicbrainz";
+        } elsif ($target_type eq 'url') {
             $order .= ', url';
         } else {
-            $order .= ", ${target}.name COLLATE musicbrainz";
+            $order .= ", ${target_type}.name COLLATE musicbrainz";
         }
 
         $query = "SELECT $select
-                    JOIN $target ON $target_id = ${target}.id
+                    JOIN $target_type ON $target_id = ${target_type}.id
                    WHERE " . join(' AND ', @cond) . "
                    ORDER BY $order";
 

--- a/root/static/scripts/common/utility/doOrLogError.js
+++ b/root/static/scripts/common/utility/doOrLogError.js
@@ -1,0 +1,25 @@
+/*
+ * @flow strict
+ * Copyright (C) 2025 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import {captureException} from '@sentry/browser';
+
+export default function doOrLogError<T>(
+  callback: () => T,
+  captureToSentry?: boolean = true,
+): T | void {
+  try {
+    return callback();
+  } catch (error) {
+    console.error(error);
+    if (captureToSentry) {
+      captureException(error);
+    }
+  }
+  return undefined;
+}

--- a/root/static/scripts/common/utility/getScriptArgs.js
+++ b/root/static/scripts/common/utility/getScriptArgs.js
@@ -1,4 +1,5 @@
 /*
+ * @flow strict
  * Copyright (C) 2017 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,
@@ -18,11 +19,11 @@ function getCurrentScript() {
   return currentScript;
 }
 
-function getScriptArgs() {
+function getScriptArgs(): mixed {
   const currentScript = getCurrentScript();
   if (currentScript) {
     const args = currentScript.getAttribute('data-args');
-    if (args) {
+    if (nonEmpty(args)) {
       return JSON.parse(args);
     }
   }

--- a/root/static/scripts/common/utility/getScriptArgs.js
+++ b/root/static/scripts/common/utility/getScriptArgs.js
@@ -7,6 +7,8 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import {captureException} from '@sentry/browser';
+
 function getCurrentScript() {
   let currentScript = document.currentScript;
 
@@ -24,7 +26,12 @@ function getScriptArgs(): mixed {
   if (currentScript) {
     const args = currentScript.getAttribute('data-args');
     if (nonEmpty(args)) {
-      return JSON.parse(args);
+      try {
+        return JSON.parse(args);
+      } catch (error) {
+        console.error(error);
+        captureException(error);
+      }
     }
   }
   return {};

--- a/root/static/scripts/common/utility/storage.js
+++ b/root/static/scripts/common/utility/storage.js
@@ -7,6 +7,8 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import doOrLogError from './doOrLogError.js';
+
 /* eslint-disable import/no-mutable-exports */
 export let hasLocalStorage: boolean = false;
 export let hasSessionStorage: boolean = false;
@@ -64,4 +66,83 @@ export function localStorage(name: string, value?: string): string | void {
     }
   }
   return store[name];
+}
+
+/*
+ * Some `sessionStorage` keys are intended to only store form data in case
+ * of an error (so that state can be preserved). But if the form submits
+ * succesfully, there's no easy way to tell the next page to delete those
+ * keys. That could technically cause large amounts of form data to
+ * accumulate if an editor is reusing the same session (tab) for editing.
+ * Since `sessionStorage` space is limited, we want to delete such keys ASAP
+ * (while still allowing access where they're needed).
+ *
+ * The current solution is to store a list of ephemeral key patterns that are
+ * deleted whenever this module is loaded. Their values are moved into an
+ * `ephemeralSessionStorageValues` map.
+ */
+const ephemeralSessionStorageKeys = [
+  /^submittedLinks_/,
+  /^relationshipEditorChanges_/,
+];
+
+const ephemeralSessionStorageValues = new Map<string, string>();
+
+/*
+ * We generally want to ignore errors such as "quota exceeded," which we
+ * can't do anything about. (Exceeding the storage quota should be much
+ * less likely now that MBS-13393 is mitigated.) Hence, all direct
+ * `sessionStorage` access is wrapped in `doOrLogError`.
+ */
+export const sessionStorageWrapper: {
+  get(key: string): ?string,
+  remove(key: string): void,
+  set(key: string, value: mixed): void,
+} = hasSessionStorage
+  ? {
+    get(key) {
+      return doOrLogError(
+        () => {
+          if (ephemeralSessionStorageValues.has(key)) {
+            return ephemeralSessionStorageValues.get(key);
+          }
+          return sessionStorage.getItem(key);
+        },
+        /* captureToSentry = */ false,
+      );
+    },
+    remove(key) {
+      return doOrLogError(
+        () => sessionStorage.removeItem(key),
+        /* captureToSentry = */ false,
+      );
+    },
+    set(key, value) {
+      return doOrLogError(
+        () => sessionStorage.setItem(key, String(value)),
+        /* captureToSentry = */ false,
+      );
+    },
+  }
+  : {
+    get() {},
+    remove() {},
+    set() {},
+  };
+
+if (hasSessionStorage) {
+  doOrLogError(
+    () => {
+      for (const key of Object.keys(sessionStorage)) {
+        if (ephemeralSessionStorageKeys.some(pattern => pattern.test(key))) {
+          ephemeralSessionStorageValues.set(
+            key,
+            String(sessionStorage.getItem(key)),
+          );
+          sessionStorage.removeItem(key);
+        }
+      }
+    },
+    /* captureToSentry = */ true,
+  );
 }

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -9,7 +9,6 @@
 
 import punycode from 'punycode';
 
-import {captureException} from '@sentry/browser';
 import $ from 'jquery';
 import ko from 'knockout';
 import * as React from 'react';
@@ -39,8 +38,12 @@ import {
 } from '../common/utility/catalyst.js';
 import {compareDatePeriods} from '../common/utility/compareDates.js';
 import formatDatePeriod from '../common/utility/formatDatePeriod.js';
+import isDatabaseRowId from '../common/utility/isDatabaseRowId.js';
 import {isDateNonEmpty} from '../common/utility/isDateEmpty.js';
-import {hasSessionStorage} from '../common/utility/storage.js';
+import {
+  hasSessionStorage,
+  sessionStorageWrapper,
+} from '../common/utility/storage.js';
 import {uniqueId} from '../common/utility/strings.js';
 import {
   appendHiddenRelationshipInputs,
@@ -199,6 +202,12 @@ export class _ExternalLinksEditor
 
   +typeOptions: $ReadOnlyArray<LinkTypeOptionT>;
 
+  +submittedLinksWrapper: {
+    get(): ?Array<LinkStateT>,
+    remove(): void,
+    set(links: $ReadOnlyArray<LinkStateT>): void,
+  };
+
   constructor(props: LinksEditorProps) {
     super(props);
 
@@ -217,6 +226,34 @@ export class _ExternalLinksEditor
       );
     });
 
+    const sourceId = isDatabaseRowId(sourceData.id) ? sourceData.id : 'new';
+    const submittedLinksKey = `submittedLinks_${sourceType}_${sourceId}`;
+    this.submittedLinksWrapper = {
+      get() {
+        if (hasSessionStorage) {
+          const submittedLinksJson =
+            sessionStorageWrapper.get(submittedLinksKey);
+          if (submittedLinksJson) {
+            return ((
+              decompactEntityJson(JSON.parse(submittedLinksJson))
+            ): any).filter(l => !isEmpty(l)).map(newLinkState);
+          }
+        }
+        return undefined;
+      },
+      remove() {
+        sessionStorageWrapper.remove(submittedLinksKey);
+      },
+      set(links) {
+        if (hasSessionStorage) {
+          sessionStorageWrapper.set(
+            submittedLinksKey,
+            JSON.stringify(compactEntityJson(links)),
+          );
+        }
+      },
+    };
+
     if (typeof window !== 'undefined') {
       const $c = getCatalystContext();
       if (
@@ -227,15 +264,10 @@ export class _ExternalLinksEditor
          */
         sourceType !== 'release'
       ) {
-        if (hasSessionStorage) {
-          const submittedLinks =
-            window.sessionStorage.getItem('submittedLinks');
-          if (submittedLinks) {
-            initialLinks = ((
-              decompactEntityJson(JSON.parse(submittedLinks))
-            ): any).filter(l => !isEmpty(l)).map(newLinkState);
-            window.sessionStorage.removeItem('submittedLinks');
-          }
+        const submittedLinks = this.submittedLinksWrapper.get();
+        if (submittedLinks) {
+          initialLinks = submittedLinks;
+          this.submittedLinksWrapper.remove();
         }
       } else {
         /*
@@ -1948,15 +1980,8 @@ export function prepareExternalLinksHtmlFormSubmission(
       externalLinksEditor.getFormData(formName + '.url', 0, pushInput);
 
       const links = externalLinksEditor.state.links;
-      if (hasSessionStorage && links.length) {
-        try {
-          window.sessionStorage.setItem(
-            'submittedLinks',
-            JSON.stringify(compactEntityJson(links)),
-          );
-        } catch (error) {
-          captureException(error);
-        }
+      if (links.length) {
+        externalLinksEditor.submittedLinksWrapper.set(links);
       }
     },
   );

--- a/root/static/scripts/relationship-editor/components/RelationshipEditor.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipEditor.js
@@ -28,7 +28,10 @@ import {
 import coerceToError from '../../common/utility/coerceToError.js';
 import isDatabaseRowId from '../../common/utility/isDatabaseRowId.js';
 import {uniqueNegativeId} from '../../common/utility/numbers.js';
-import {hasSessionStorage} from '../../common/utility/storage.js';
+import {
+  hasSessionStorage,
+  sessionStorageWrapper,
+} from '../../common/utility/storage.js';
 import reducerWithErrorHandling
   from '../../edit/utility/reducerWithErrorHandling.js';
 import {
@@ -64,8 +67,9 @@ import getRelationshipTarget from '../utility/getRelationshipTarget.js';
 import isRelationshipBackward from '../utility/isRelationshipBackward.js';
 import mergeRelationship from '../utility/mergeRelationship.js';
 import moveRelationship from '../utility/moveRelationship.js';
-import prepareHtmlFormSubmission
-  from '../utility/prepareHtmlFormSubmission.js';
+import prepareHtmlFormSubmission, {
+  getSessionStorageKey as getHtmlFormSubmissionSessionStorageKey,
+} from '../utility/prepareHtmlFormSubmission.js';
 import relationshipsAreIdentical
   from '../utility/relationshipsAreIdentical.js';
 import splitRelationshipByAttributes
@@ -222,8 +226,10 @@ export function loadOrCreateInitialState(
   const $c = getCatalystContext();
   let submittedRelationships;
   if (hasSessionStorage && $c.req.method === 'POST') {
+    const source = args.source ?? getSourceEntityDataForRelationshipEditor();
+    const sessionStorageKey = getHtmlFormSubmissionSessionStorageKey(source);
     const submittedRelationshipsJson =
-      sessionStorage.getItem('relationshipEditorChanges');
+      sessionStorageWrapper.get(sessionStorageKey);
     if (nonEmpty(submittedRelationshipsJson)) {
       try {
         submittedRelationships = ((decompactEntityJson(
@@ -238,7 +244,7 @@ export function loadOrCreateInitialState(
          * development, so delay the sessionStorage removal.
          */
         setTimeout(() => {
-          sessionStorage.removeItem('relationshipEditorChanges');
+          sessionStorageWrapper.remove(sessionStorageKey);
         }, 1000);
       }
     }

--- a/root/static/scripts/work/edit.js
+++ b/root/static/scripts/work/edit.js
@@ -32,6 +32,7 @@ import {pushCompoundField, pushField} from '../edit/utility/pushField.js';
 import subfieldErrors from '../edit/utility/subfieldErrors.js';
 import initializeGuessCase from '../guess-case/MB/Control/GuessCase.js';
 
+// eslint-disable-next-line ft-flow/no-weak-types
 const scriptArgs: any = getScriptArgs();
 
 type WorkAttributeField = CompoundFieldT<{

--- a/root/static/scripts/work/edit.js
+++ b/root/static/scripts/work/edit.js
@@ -32,7 +32,7 @@ import {pushCompoundField, pushField} from '../edit/utility/pushField.js';
 import subfieldErrors from '../edit/utility/subfieldErrors.js';
 import initializeGuessCase from '../guess-case/MB/Control/GuessCase.js';
 
-const scriptArgs = getScriptArgs();
+const scriptArgs: any = getScriptArgs();
 
 type WorkAttributeField = CompoundFieldT<{
   +type_id: FieldT<?number>,

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/EditExternalLinks.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/EditExternalLinks.pm
@@ -225,6 +225,30 @@ test 'MBS-8322: Check URL relationship dates are not removed if not specified' =
     is(@edits, 0, 'No edits were entered');
 };
 
+test 'MBS-13959: Editing a URL from another source entity is rejected' => sub {
+    my $test = shift;
+    my ($c, $mech) = ($test->c, $test->mech);
+
+    MusicBrainz::Server::Test->prepare_test_database($c);
+
+    $mech->get_ok('/login');
+    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+
+    my @edits = capture_edits {
+        $mech->post_ok('/artist/2fed031c-0e89-406e-b9f0-3d192637907a/edit', {
+            'edit-artist.name' => 'Test Alias',
+            'edit-artist.sort_name' => 'Kate Bush',
+            'edit-artist.Second' => 'Kate Bush',
+            # relationship id=1 belongs to artist e2a083a9-9942-4d6e-b4d2-8397320b95f7
+            'edit-artist.url.0.relationship_id' => '1',
+            'edit-artist.url.0.link_type_id' => '183',
+            'edit-artist.url.0.text' => 'http://musicbrainz.org/search',
+        });
+    } $c;
+
+    is(@edits, 0, 'No edits were entered');
+};
+
 sub prepare_test {
     my $test = shift;
 


### PR DESCRIPTION
# Problem

MBS-13959

The simplified cause of this issue was that all relationship/external link editor forms shared the same `sessionStorage` keys. Normally that wasn't a problem, because the keys were only read on POST and overwritten on form submission. The problem occurred when a POST happened with no form submission, while at the same time `sessionStorage` still had data from a previous form. (One way that could happen was being logged out, as the login form performs a POST to the destination endpoint.)

# Solution

This commit adds a number of mitigations for this issue on both the client and server side:

 * On the client side, we now use separate keys for each entity, and make sure to clear them whenever we can. (That's actually a bit more important now that the number of keys could otherwise grow infinitely with the number of entities one edits within the same tab.)

 * On the server side, we now check whether the source entity of each submitted link or relationship matches the entity whose edit page was submitted. That's done indirectly by changing how `Controller::Role::EditRelationships` loads relationships: instead of trusting that each relationship ID belongs to the source and blindly passing them to `get_by_id`, pass them to `load_subset` instead, which already works by restricting the source entity column.

   While it would have technically been possible to perform this check even after using `get_by_id` to load the relationship, it would require figuring out the direction of the original (unmodified) relationship, which `load_subset` does for us.

# Testing

Added some Perl tests for the server side changes, and tested the JavaScript changes manually.

The `getScriptArgs` changes were from a previous version of this branch and are not really related anymore, but I kept them anyway because they're minor.