### PR TITLE
MBS-13960: Allow rateyourmusic /video links on recordings

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4856,6 +4856,7 @@ const CLEANUPS: CleanupEntries = {
       if (m) {
         const prefix = m[1];
         const subPath = m[2];
+        const isAVideo = ['musicvideo', 'video'].includes(subPath);
         switch (id) {
           case LINK_TYPES.otherdatabases.artist:
             return {
@@ -4883,7 +4884,7 @@ const CLEANUPS: CleanupEntries = {
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.recording:
-            if (prefix === 'release' && subPath !== 'musicvideo') {
+            if (prefix === 'release' && !isAVideo) {
               return {
                 error:
                   l('Only RYM music videos can be linked to recordings.'),
@@ -4893,7 +4894,7 @@ const CLEANUPS: CleanupEntries = {
             }
             return {
               result: prefix === 'song' ||
-                      (prefix === 'release' && subPath === 'musicvideo'),
+                      (prefix === 'release' && isAVideo),
               target: ERROR_TARGETS.RELATIONSHIP,
             };
           case LINK_TYPES.otherdatabases.release:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4912,6 +4912,13 @@ limited_link_type_combinations: [
         only_valid_entity_types: ['recording', 'release', 'release_group'],
   },
   {
+                     input_url: 'https://rateyourmusic.com/release/video/ensemble-for-new-music-tallinn-arash-yazdani/in-vain/',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://rateyourmusic.com/release/video/ensemble-for-new-music-tallinn-arash-yazdani/in-vain/',
+        only_valid_entity_types: ['recording', 'release', 'release_group'],
+  },
+  {
                      input_url: 'https://rateyourmusic.com/release/single/tori_amos/a_sorta_fairytale/',
              input_entity_type: 'release_group',
     expected_relationship_type: 'otherdatabases',


### PR DESCRIPTION
### Implement MBS-13960

# Description
We only allow `/musicvideo` links from Rate Your Music on recordings because I never knew they had two different URL subpaths for videos depending, I guess, on whether it's an "official music video" sort of thing or just a video with music (`/video`, like the live example from the ticket I added to the test). Both of these make equal sense on MB recordings.

# Testing
Added one of these to the automated tests.