### PR TITLE
MBS-13958: Don't reject IMDb links including a language code

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2964,7 +2964,7 @@ const CLEANUPS: CleanupEntries = {
     match: [/^(https?:\/\/)?([^/]+\.)?imdb\./i],
     restrict: [LINK_TYPES.imdb],
     clean(url) {
-      return url.replace(/^https?:\/\/([^.]+\.)?imdb\.(com|de|it|es|fr|pt)\/([a-z]+\/[a-z0-9]+)(\/.*)*$/, 'https://www.imdb.com/$3/');
+      return url.replace(/^https?:\/\/(?:[^.]+\.)?imdb\.(?:com|de|it|es|fr|pt)\/(?:[a-z]{2}\/)?([a-z]+\/[a-z0-9]+)(?:\/.*)*$/, 'https://www.imdb.com/$1/');
     },
     validate(url, id) {
       const m = /^https:\/\/www\.imdb\.com\/(name\/nm|title\/tt|character\/ch|company\/co)[0-9]{7,}\/$/.exec(url);

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2994,9 +2994,10 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist'],
   },
   {
-                     input_url: 'https://www.imdb.com/name/nm10024808/',
+                     input_url: 'https://www.imdb.com/de/name/nm10024808/',
              input_entity_type: 'artist',
     expected_relationship_type: 'imdb',
+            expected_clean_url: 'https://www.imdb.com/name/nm10024808/',
        only_valid_entity_types: ['artist'],
   },
   {


### PR DESCRIPTION
### Implement MBS-13958

# Description
IMDB now supports language codes as part of the URL. These language codes seem to just translate the UI, so it's fine to just drop them entirely - but not to block the link.

I also made some useless capturing groups on the regex non-capturing while I changed it.

# Testing
Changed one of the current test URLs to use a language code.