### PR TITLE
MBS-12826: Speed up release series reordering

### DIFF
--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -1673,13 +1673,15 @@ sub set_release_events {
     $self->c->model('ReleaseGroup')->_delete_from_cache($release_group_id);
 }
 
+our $empty_partial_date = MusicBrainz::Server::Entity::PartialDate->new;
+
 sub series_ordering {
     my ($self, $r1, $r2) = @_;
 
     my ($a_date) = sort { $a <=> $b } map { $_->date } $r1->entity0->all_events;
     my ($b_date) = sort { $a <=> $b } map { $_->date } $r2->entity0->all_events;
-    my $empty = MusicBrainz::Server::Entity::PartialDate->new();
-    my $cmp = ($a_date // $empty) <=> ($b_date // $empty);
+
+    my $cmp = ($a_date // $empty_partial_date) <=> ($b_date // $empty_partial_date);
     return $cmp if $cmp;
 
     my ($a_catalog_number) = sort map { $_->catalog_number // '' } $r1->entity0->all_labels;

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -1676,16 +1676,12 @@ sub set_release_events {
 sub series_ordering {
     my ($self, $r1, $r2) = @_;
 
-    my @releases = ($r1->entity0, $r2->entity0);
-    $self->load_release_events(@releases);
-
     my ($a_date) = sort { $a <=> $b } map { $_->date } $r1->entity0->all_events;
     my ($b_date) = sort { $a <=> $b } map { $_->date } $r2->entity0->all_events;
     my $empty = MusicBrainz::Server::Entity::PartialDate->new();
     my $cmp = ($a_date // $empty) <=> ($b_date // $empty);
     return $cmp if $cmp;
 
-    $self->c->model('ReleaseLabel')->load(@releases);
     my ($a_catalog_number) = sort map { $_->catalog_number // '' } $r1->entity0->all_labels;
     my ($b_catalog_number) = sort map { $_->catalog_number // '' } $r2->entity0->all_labels;
     return ($a_catalog_number // '') cmp ($b_catalog_number // '');

--- a/lib/MusicBrainz/Server/Data/Series.pm
+++ b/lib/MusicBrainz/Server/Data/Series.pm
@@ -329,6 +329,12 @@ sub automatically_reorder {
     $self->c->model('LinkType')->load(map { $_->link } @relationships);
     $self->c->model('Relationship')->load_entities(@relationships);
 
+    if ($entity_type eq 'release') {
+        my @releases = map { $_->$target_prop } @relationships;
+        $self->c->model('Release')->load_release_events(@releases);
+        $self->c->model('ReleaseLabel')->load(@releases);
+    }
+
     my %relationships_by_text_value;
     my %relationships_by_link_order;
     for my $item (@$series_items) {


### PR DESCRIPTION
# Problem

MBS-12826 - Anything that would reorder large release series causes timeouts

# Solution

Moves some data loading calls out of `Data::Release::series_ordering`, which heavily contributed to the extremely poor performance here.

This patch doesn't exactly make release series reordering fast, but it should prevent timeouts.

# Testing

I wrote a script that reorders the "Apple Digital Masters" series to test this:

 * On test.mb, reordering that series dropped from 87s to 14s.

 * On prod.mb, it went from 73s to 11s.

The script:

```Perl
#!/usr/bin/env perl

use strict;
use warnings;

use FindBin;
use lib "$FindBin::Bin/lib";

use Data::Dumper;
use Time::HiRes qw( gettimeofday tv_interval );

use MusicBrainz::Server::Context;

my $c = MusicBrainz::Server::Context->create_script_context(
    database => 'READWRITE',
);
# Apple Digital Masters
my $series_id = 8438;

$c->sql->begin;

$c->sql->do('SET LOCAL statement_timeout = 0');

my $t0 = [gettimeofday];
$c->model('Series')->automatically_reorder($series_id);
my $interval = tv_interval($t0);

printf "Took %d seconds\n", $interval;

$c->sql->rollback;
```