### PR TITLE
Speed up `Data::Utils::ref_to_type`

### DIFF
--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -84,6 +84,7 @@ our @EXPORT_OK = qw(
 );
 
 Readonly my %TYPE_TO_MODEL => map { $_ => $ENTITIES{$_}{model} } grep { $ENTITIES{$_}{model} } keys %ENTITIES;
+Readonly my %MODEL_TO_TYPE => reverse %TYPE_TO_MODEL;
 
 sub ref_to_type {
     my $object = shift;
@@ -515,8 +516,7 @@ sub type_to_model
 sub model_to_type {
     my $model = shift;
     if (defined $model) {
-        my %map = reverse %TYPE_TO_MODEL;
-        return $map{$model};
+        return $MODEL_TO_TYPE{$model};
     }
     return;
 }

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -512,10 +512,13 @@ sub type_to_model
     return $TYPE_TO_MODEL{$_[0]} || die "$_[0] is not a type that has a model";
 }
 
-sub model_to_type
-{
-    my %map = reverse %TYPE_TO_MODEL;
-    return $map{$_[0]} || undef;
+sub model_to_type {
+    my $model = shift;
+    if (defined $model) {
+        my %map = reverse %TYPE_TO_MODEL;
+        return $map{$model};
+    }
+    return;
 }
 
 sub object_to_ids

--- a/t/lib/t/MusicBrainz/Server/Data/Utils.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Utils.pm
@@ -5,10 +5,21 @@ use warnings;
 use Test::Routine;
 use Test::Moose;
 use Test::More;
+use Test::Fatal;
 
 use MusicBrainz::Server::Context;
-use MusicBrainz::Server::Data::Utils qw( order_by generate_gid take_while sanitize trim );
+use MusicBrainz::Server::Data::Utils qw(
+    order_by
+    generate_gid
+    take_while
+    sanitize
+    trim
+    ref_to_type
+);
+use MusicBrainz::Server::Entity::AreaAliasType;
 use MusicBrainz::Server::Entity::PartialDate;
+use MusicBrainz::Server::Entity::Recording;
+use MusicBrainz::Server::Entity::URL::45cat;
 use MusicBrainz::Server::Test;
 
 with 't::Context';
@@ -196,6 +207,31 @@ test 'Test trim and sanitize' => sub {
            'strips BOM, removes leading/trailing whitespace',
            ' A B ',
            'strips BOM, keeps leading/trailing whitespace');
+};
+
+test 'Test ref_to_type' => sub {
+    like exception {
+        ref_to_type(undef);
+    }, qr/Can't call method "isa" on an undefined value/,
+        'ref_to_type of undef throws an exception';
+
+    like exception {
+        ref_to_type('');
+    }, qr/Can't call method "isa" without a package or object reference/,
+        'ref_to_type of "" throws an exception';
+
+    my $area_alias_type = MusicBrainz::Server::Entity::AreaAliasType->new;
+    my $recording = MusicBrainz::Server::Entity::Recording->new;
+    my $url = MusicBrainz::Server::Entity::URL::45cat->new;
+
+    is(ref_to_type($area_alias_type), 'area_alias_type',
+       'ref_to_type of Entity::AreaAliasType is "area_alias_type"');
+
+    is(ref_to_type($recording), 'recording',
+       'ref_to_type of Entity::Recording is "recording"');
+
+    is(ref_to_type($url), 'url',
+       'ref_to_type of Entity::URL::45cat is "url"');
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Data/Utils.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Utils.pm
@@ -15,6 +15,7 @@ use MusicBrainz::Server::Data::Utils qw(
     sanitize
     trim
     ref_to_type
+    model_to_type
 );
 use MusicBrainz::Server::Entity::AreaAliasType;
 use MusicBrainz::Server::Entity::PartialDate;
@@ -232,6 +233,21 @@ test 'Test ref_to_type' => sub {
 
     is(ref_to_type($url), 'url',
        'ref_to_type of Entity::URL::45cat is "url"');
+};
+
+test 'Test model_to_type' => sub {
+    is(model_to_type(undef), undef, 'model_to_type of undef is undef');
+
+    is(model_to_type(''), undef, 'model_to_type of "" is undef');
+
+    is(model_to_type('AreaAliasType'), 'area_alias_type',
+       'model_to_type of "AreaAliasType" is "area_alias_type"');
+
+    is(model_to_type('Recording'), 'recording',
+       'model_to_type of "Recording" is "recording"');
+
+    is(model_to_type('URL'), 'url',
+       'model_to_type of "URL" is "url"');
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Data/Utils.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Utils.pm
@@ -212,12 +212,12 @@ test 'Test trim and sanitize' => sub {
 test 'Test ref_to_type' => sub {
     like exception {
         ref_to_type(undef);
-    }, qr/Can't call method "isa" on an undefined value/,
+    }, qr/ref_to_type can only be called on references/,
         'ref_to_type of undef throws an exception';
 
     like exception {
         ref_to_type('');
-    }, qr/Can't call method "isa" without a package or object reference/,
+    }, qr/ref_to_type can only be called on references/,
         'ref_to_type of "" throws an exception';
 
     my $area_alias_type = MusicBrainz::Server::Entity::AreaAliasType->new;


### PR DESCRIPTION
Some low-hanging fruit I found while profiling a release index page. The current implementation of `ref_to_type` is so shockingly inefficient that I can't believe how long it's been like this, considering the impact it has (it had the highest inclusive/exclusive time of any subroutine in the profiling data).

It should be obvious why it was slow, but to show how slow it was, I wrote a script that pushes an instance of every subclass of `MusicBrainz::Server::Entity` onto a list, and then calls `ref_to_type` on all of those instances 1000x each.

Before this commit:

$ ./ref_to_type_perf.pl
14.310254 seconds

After this commit:

$ ./ref_to_type_perf.pl
0.142224 seconds

Now consider that the release page I was profiling from the sample database, dceb6a01-3431-36af-b2e1-6462193bd67c, calls `ref_to_type` 6116 times.

# Testing

I used a modified version of the script I mentioned above to actually print the results of `ref_to_type` on all of those instances, ran it on both branches, and diffed the results (which was empty).