### PR TITLE
Remove some unnecessary code from `Controller::Role::Tag`

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -29,7 +29,7 @@ with 'MusicBrainz::Server::Controller::Role::WikipediaExtract';
 with 'MusicBrainz::Server::Controller::Role::CommonsImage';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
-    endpoints => {show => {copy_stash => ['top_tags']}, aliases => {copy_stash => ['aliases']}},
+    endpoints => {show => {copy_stash => ['top_tags', 'genre_map']}, aliases => {copy_stash => ['aliases']}},
 };
 with 'MusicBrainz::Server::Controller::Role::Collection' => {
     entity_type => 'area',

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -43,7 +43,7 @@ with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
                                           {from => 'identities', to => 'identities'},
                                           {from => 'legal_name', to => 'legal_name'},
                                           {from => 'other_identities', to => 'other_identities'},
-                                          'top_tags']},
+                                          'top_tags', 'genre_map']},
                   recordings => {copy_stash => [{from => 'recordings_jsonld', to => 'recordings'}]},
                   relationships => {},
                   aliases => {copy_stash => ['aliases']}},

--- a/lib/MusicBrainz/Server/Controller/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/Label.pm
@@ -36,7 +36,7 @@ with 'MusicBrainz::Server::Controller::Role::WikipediaExtract';
 with 'MusicBrainz::Server::Controller::Role::CommonsImage';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
-    endpoints => {show => {copy_stash => [{from => 'releases_jsonld', to => 'releases'}, 'top_tags']},
+    endpoints => {show => {copy_stash => [{from => 'releases_jsonld', to => 'releases'}, 'top_tags', 'genre_map']},
                   aliases => {copy_stash => ['aliases']}},
 };
 with 'MusicBrainz::Server::Controller::Role::Collection' => {

--- a/lib/MusicBrainz/Server/Controller/Place.pm
+++ b/lib/MusicBrainz/Server/Controller/Place.pm
@@ -31,7 +31,7 @@ with 'MusicBrainz::Server::Controller::Role::WikipediaExtract';
 with 'MusicBrainz::Server::Controller::Role::CommonsImage';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
-    endpoints => {show => {copy_stash => ['top_tags']}, aliases => {copy_stash => ['aliases']}},
+    endpoints => {show => {copy_stash => ['top_tags', 'genre_map']}, aliases => {copy_stash => ['aliases']}},
 };
 with 'MusicBrainz::Server::Controller::Role::Collection' => {
     entity_type => 'place',

--- a/lib/MusicBrainz/Server/Controller/Recording.pm
+++ b/lib/MusicBrainz/Server/Controller/Recording.pm
@@ -19,7 +19,7 @@ with 'MusicBrainz::Server::Controller::Role::Tag';
 with 'MusicBrainz::Server::Controller::Role::EditListing';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
-    endpoints => {show => {copy_stash => ['top_tags']}, aliases => {copy_stash => ['aliases']}},
+    endpoints => {show => {copy_stash => ['top_tags', 'genre_map']}, aliases => {copy_stash => ['aliases']}},
 };
 with 'MusicBrainz::Server::Controller::Role::Collection' => {
     entity_type => 'recording',

--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -33,7 +33,7 @@ with 'MusicBrainz::Server::Controller::Role::EditListing';
 with 'MusicBrainz::Server::Controller::Role::Tag';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
     endpoints => {
-        show => {copy_stash => ['release_artwork', 'top_tags']},
+        show => {copy_stash => ['release_artwork', 'top_tags', 'genre_map']},
         aliases => {copy_stash => ['aliases']},
         cover_art => {copy_stash => ['cover_art']},
     },

--- a/lib/MusicBrainz/Server/Controller/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/ReleaseGroup.pm
@@ -32,7 +32,7 @@ with 'MusicBrainz::Server::Controller::Role::WikipediaExtract';
 with 'MusicBrainz::Server::Controller::Role::Cleanup';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
-    endpoints => {show => {copy_stash => [{from => 'releases_jsonld', to => 'releases'}, 'top_tags']},
+    endpoints => {show => {copy_stash => [{from => 'releases_jsonld', to => 'releases'}, 'top_tags', 'genre_map']},
                   aliases => {copy_stash => ['aliases']}},
 };
 with 'MusicBrainz::Server::Controller::Role::Collection' => {

--- a/lib/MusicBrainz/Server/Controller/Role/Tag.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Tag.pm
@@ -23,7 +23,6 @@ after load => sub {
         @user_tags = $tags_model->find_user_tags($c->user->id, $entity->id);
     }
 
-    $c->model('Genre')->load(map { $_->tag } (@tags, @user_tags));
     my %genre_map = map { $_->name => $_->TO_JSON } $c->model('Genre')->get_all;
 
     $c->stash(
@@ -31,7 +30,6 @@ after load => sub {
         top_tags => to_json_array(\@tags),
         more_tags => $count > @tags,
         user_tags => to_json_array(\@user_tags),
-        user_tags_json => $c->json->encode(\@user_tags),
     );
 };
 

--- a/lib/MusicBrainz/Server/Controller/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/Work.pm
@@ -49,7 +49,7 @@ with 'MusicBrainz::Server::Controller::Role::WikipediaExtract';
 with 'MusicBrainz::Server::Controller::Role::CommonsImage';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
-    endpoints => {show => {copy_stash => ['top_tags']}, aliases => {copy_stash => ['aliases']}},
+    endpoints => {show => {copy_stash => ['top_tags', 'genre_map']}, aliases => {copy_stash => ['aliases']}},
 };
 with 'MusicBrainz::Server::Controller::Role::Collection' => {
     entity_type => 'work',

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Role/Genre.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Role/Genre.pm
@@ -8,9 +8,11 @@ around serialize => sub {
     my ($orig, $self, $entity, $inc, $stash, $toplevel) = @_;
     my $ret = $self->$orig($entity, $inc, $stash, $toplevel);
 
-    my $tags = $stash->store($entity)->{top_tags};
+    my $store = $stash->store($entity);
+    my $tags = $store->{top_tags};
+    my $genre_map = $store->{genre_map};
     my @genres = map {
-        my $genre = $_->{tag}{genre};
+        my $genre = $genre_map->{ $_->{tag}{name} };
         $genre ? (DBDefs->JSON_LD_ID_BASE_URI . '/genre/' . $genre->{gid}) : ()
     } @$tags;
 

--- a/root/layout/components/sidebar/SidebarTags.js
+++ b/root/layout/components/sidebar/SidebarTags.js
@@ -22,12 +22,14 @@ component TagList(
   isGenreList: boolean = false,
   tags: ?$ReadOnlyArray<AggregatedTagT>,
 ) {
+  const $c = React.useContext(CatalystContext);
   const upvotedTags = tags ? tags.filter(tag => tag.count > 0) : null;
   const links = upvotedTags ? upvotedTags.reduce((
     accum: Array<React.MixedElement>,
     aggregatedTag,
   ) => {
-    if (Boolean(aggregatedTag.tag.genre) === isGenreList) {
+    const genre = $c.stash.genre_map?.[aggregatedTag.tag.name];
+    if ((genre != null) === isGenreList) {
       accum.push(
         <TagLink
           key={'tag-' + aggregatedTag.tag.name}


### PR DESCRIPTION
Another small thing I noticed while profiling the Nine Inch Nails artist page from the sample database. It saves around 16ms per request there locally, but that may vary depending on the number of tags/genres the artist has.

 1. `user_tags_json` was unused.

 2. We don't have to load genres on the tags, because we can access them via `genre_map` in the stash.

# Testing

I tested browsing various entity pages that have tags/genres in the sidebar. Also made sure the automated tests for JSON-LD still pass.