### PR TITLE
MBS-13967: Make doc_link macro pass literal path

### DIFF
--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -15,7 +15,7 @@
 ~%]
 [%- USE UserDate(c.user.preferences, current_language) # Converted to React at root/utility/formatUserDate.js
 -%]
-[%~ MACRO doc_link(to) BLOCK -%][% c.uri_for('/doc', to) %][%- END -%]
+[%~ MACRO doc_link(to) BLOCK -%][% c.uri_for('/doc/' _ to) %][%- END -%]
 [%~ MACRO va_doc_link BLOCK -%]
     [%- doc_link('Style/Unknown_and_untitled/Special_purpose_artist#List_of_official_SPAs') -%]
 [%- END -%]


### PR DESCRIPTION
# MBS-13967

Update the doc_link Template Toolkit macro to concatenate "/doc/" and the supplied argument instead of letting uri_for join them into a path.

This convinces uri_for to not perform URL-escaping, which was breaking URLs with fragments like
/doc/Style/Unknown_and_untitled/Special_purpose_artist#List_of_official_SPAs.

# Problem

Linking to a specific section of a documentation page doesn't work. The server encodes `#` as `%23`, e.g. <https://musicbrainz.org/doc/Style/Unknown_and_untitled/Special_purpose_artist%23List_of_official_SPAs>.

Surprisingly to me, the server still returns the correct wiki page, but it has a messed-up title (e.g. "Style / Unknown and untitled / **Special purpose artist#List of official SPAs**") and the browser doesn't jump to the requested section.

# Solution

Make the `doc_link` TT macro concatenate `/doc/` and the supplied argument before calling `uri_for` instead of passing them as separate arguments.

Per https://github.com/perl-catalyst/catalyst-runtime/blob/1d40b8ea5a7f4a4ae99af921b914f04e7c9a21c3/lib/Catalyst.pm#L1569:

> B\<NOTE\> If you are using this 'stringy' first argument, we skip encoding and
allow you to declare something like:
>
>     $c->uri_for('/foo/bar#baz')
> 
> Where 'baz' is a URI fragment.  We consider this first argument string to be
> 'expert' mode where you are expected to create a valid URL and we for the most
> part just pass it through without a lot of internal effort to escape and encode.

# Testing

I verified that links to the official SPA section (e.g. when a track is credited to Various Artists) work now.

I grepped for `doc_link([^)]*)` through the source and don't expect this change to cause problems with existing calls.