### PR TITLE
MBS-13711 (I): Warn about improperly-capitalized ETI

### DIFF
--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -437,6 +437,25 @@
       </div>
     <!-- /ko -->
 
+    <!-- ko if: release.shouldUseEnglishCapitalization() && hasCapitalizedETI() -->
+      <div class="capitalized-eti warning">
+        [%- warning_icon %]
+        <p>
+          <strong>[% l('Warning:') | html_entity %]</strong>
+          [% l('This medium seems to have capitalized {eti|extra title information} in track titles. Descriptive parts of extra title information like “remix” or “version” should be lowercased in most languages.', { eti => { href => doc_link('Style/Titles#Extra_title_information'), target => '_blank' } }) %]
+        </p>
+        <!-- ko if: hasAddedCapitalizedETI() && $root.isBeginner -->
+          <label>
+            <input id="confirm-eti" type="checkbox" data-bind="checked: confirmedCapitalizedETI" />
+            [% l('I confirm that this extra title information is capitalized correctly.') %]
+          </label>
+          <p class="error field-error" style="padding-left: 1em" data-bind="showErrorWhenTabIsSwitched: hasUnconfirmedCapitalizedETI">
+            [%~ l('If you’re sure the extra title information is capitalized correctly, confirm it above. Otherwise, please fix the data (the “Guess case” button might help!).') %]
+          </p>
+        <!-- /ko -->
+      </div>
+    <!-- /ko -->
+
     <div data-bind="visible: loaded() && !collapsed()">
       <!-- ko if: tracks().length === 0 -->
       <p style="margin: 1em">

--- a/root/static/scripts/common/constants.js
+++ b/root/static/scripts/common/constants.js
@@ -387,8 +387,11 @@ export const FLUENCY_NAMES:
   native: N_l('Native'),
 };
 
+export const LANGUAGE_ENG_ID = 120;
 export const LANGUAGE_MUL_ID = 284;
 export const LANGUAGE_ZXX_ID = 486;
+
+export const COUNTRY_JA_AREA_ID = 107;
 
 export const DISPLAY_NONE_STYLE = Object.freeze({display: 'none'});
 

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -16,10 +16,14 @@ import {
   hasVariousArtists,
 } from '../common/immutable-entities.js';
 import MB from '../common/MB.js';
-import {getSourceEntityData} from '../common/utility/catalyst.js';
+import {
+  getCatalystContext,
+  getSourceEntityData,
+} from '../common/utility/catalyst.js';
 import clean from '../common/utility/clean.js';
 import {cloneObjectDeep} from '../common/utility/cloneDeep.mjs';
 import {debounceComputed} from '../common/utility/debounce.js';
+import {isBeginner} from '../common/utility/privileges.js';
 import request from '../common/utility/request.js';
 import * as externalLinks from '../edit/externalLinks.js';
 import {createField} from '../edit/utility/createField.js';
@@ -52,6 +56,7 @@ releaseEditor.init = function (options) {
 
   $.extend(this, {
     action: options.action,
+    isBeginner: isBeginner(getCatalystContext().user),
     redirectURI: options.redirectURI,
     returnTo: options.returnTo,
   });


### PR DESCRIPTION
# MBS-13711

Make the tracklist editor display a warning if a track title appears to contain ETI with an incorrectly-capitalized non-title word, e.g. "Remix" or "Version". If the user is a beginner, a checkbox is displayed for them to confirm that the usage is correct.

This check is skipped for releases that are set to a language other than English and for Japan-only releases.

# Problem

Many new editors are unfamiliar with the style guidelines, creating cleanup work for other editors.

# Solution

Make the tracklist editor display a warning pointing to the [ETI guidelines](https://musicbrainz.org/doc/Style/Titles#Extra_title_information) if a track title contains ETI ending in "Instrumental", "Live", "Mix", "Remix", or "Version".

If the editor is a beginner, also display a checkbox to make sure that they at least read the message.

# Testing

Created a release with a track named "Test (Remix)" and checked that the warning is displayed, and that the checkbox and error on the edit note tab are also displayed if the editor is a beginner.