### PR TITLE
MBS-13711 (II): Warn about capitalized short words in titles

### DIFF
--- a/lib/MusicBrainz/Server/Data/Area.pm
+++ b/lib/MusicBrainz/Server/Data/Area.pm
@@ -22,6 +22,7 @@ use MusicBrainz::Server::Data::Utils::Cleanup qw( used_in_relationship );
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Relatable',
+     'MusicBrainz::Server::Data::Role::GIDRedirect',
      'MusicBrainz::Server::Data::Role::Name',
      'MusicBrainz::Server::Data::Role::Annotation' => { type => 'area' },
      'MusicBrainz::Server::Data::Role::Alias' => { type => 'area' },

--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -26,6 +26,7 @@ use Scalar::Util qw( looks_like_number );
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Relatable',
+     'MusicBrainz::Server::Data::Role::GIDRedirect',
      'MusicBrainz::Server::Data::Role::Name',
      'MusicBrainz::Server::Data::Role::Annotation' => { type => 'artist' },
      'MusicBrainz::Server::Data::Role::Alias' => { type => 'artist' },

--- a/lib/MusicBrainz/Server/Data/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Data/ArtistCredit.pm
@@ -25,6 +25,23 @@ sub _type { 'artist_credit' }
 
 sub _table { shift->_main_table }
 
+sub _build_columns {
+    return join q(, ), (
+        'artist_credit.id',
+        'artist_credit.gid',
+        'artist_credit.name COLLATE musicbrainz',
+        'artist_credit.artist_count',
+        'artist_credit.edits_pending',
+    );
+}
+
+has '_columns' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_columns',
+);
+
 sub get_by_ids
 {
     my ($self, @ids) = @_;

--- a/lib/MusicBrainz/Server/Data/Event.pm
+++ b/lib/MusicBrainz/Server/Data/Event.pm
@@ -23,6 +23,7 @@ use aliased 'MusicBrainz::Server::Entity::EventArt';
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Relatable',
+     'MusicBrainz::Server::Data::Role::GIDRedirect',
      'MusicBrainz::Server::Data::Role::Name',
      'MusicBrainz::Server::Data::Role::Annotation' => { type => 'event' },
      'MusicBrainz::Server::Data::Role::Alias' => { type => 'event' },

--- a/lib/MusicBrainz/Server/Data/Instrument.pm
+++ b/lib/MusicBrainz/Server/Data/Instrument.pm
@@ -12,6 +12,7 @@ use MusicBrainz::Server::Entity::Instrument;
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Relatable',
+     'MusicBrainz::Server::Data::Role::GIDRedirect',
      'MusicBrainz::Server::Data::Role::Name',
      'MusicBrainz::Server::Data::Role::Annotation' => {
         type => 'instrument',

--- a/lib/MusicBrainz/Server/Data/Label.pm
+++ b/lib/MusicBrainz/Server/Data/Label.pm
@@ -21,6 +21,7 @@ use MusicBrainz::Server::Data::Utils::Uniqueness qw( assert_uniqueness_conserved
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Relatable',
+     'MusicBrainz::Server::Data::Role::GIDRedirect',
      'MusicBrainz::Server::Data::Role::Name',
      'MusicBrainz::Server::Data::Role::Annotation' => { type => 'label' },
      'MusicBrainz::Server::Data::Role::Alias' => { type => 'label' },

--- a/lib/MusicBrainz/Server/Data/Place.pm
+++ b/lib/MusicBrainz/Server/Data/Place.pm
@@ -20,6 +20,7 @@ use MusicBrainz::Server::Data::Utils::Cleanup qw( used_in_relationship );
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Relatable',
+     'MusicBrainz::Server::Data::Role::GIDRedirect',
      'MusicBrainz::Server::Data::Role::Name',
      'MusicBrainz::Server::Data::Role::Annotation' => { type => 'place' },
      'MusicBrainz::Server::Data::Role::Alias' => { type => 'place' },

--- a/lib/MusicBrainz/Server/Data/Recording.pm
+++ b/lib/MusicBrainz/Server/Data/Recording.pm
@@ -19,6 +19,7 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Relatable',
+     'MusicBrainz::Server::Data::Role::GIDRedirect',
      'MusicBrainz::Server::Data::Role::Name',
      'MusicBrainz::Server::Data::Role::Annotation' => { type => 'recording' },
      'MusicBrainz::Server::Data::Role::GIDEntityCache',

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -33,6 +33,7 @@ use aliased 'MusicBrainz::Server::Entity::ReleaseArt';
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Relatable',
+     'MusicBrainz::Server::Data::Role::GIDRedirect',
      'MusicBrainz::Server::Data::Role::Name',
      'MusicBrainz::Server::Data::Role::Annotation' => { type => 'release' },
      'MusicBrainz::Server::Data::Role::GIDEntityCache',

--- a/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
@@ -18,6 +18,7 @@ use MusicBrainz::Server::Data::Utils::Cleanup qw( used_in_relationship );
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Relatable',
+     'MusicBrainz::Server::Data::Role::GIDRedirect',
      'MusicBrainz::Server::Data::Role::Name',
      'MusicBrainz::Server::Data::Role::Annotation' => {
         type => 'release_group',

--- a/lib/MusicBrainz/Server/Data/Role/GID.pm
+++ b/lib/MusicBrainz/Server/Data/Role/GID.pm
@@ -3,7 +3,7 @@ package MusicBrainz::Server::Data::Role::GID;
 use Moose::Role;
 use namespace::autoclean;
 
-use MusicBrainz::Server::Data::Utils qw( generate_gid );
+use MusicBrainz::Server::Data::Utils qw( generate_gid placeholders );
 
 requires '_hash_to_row', '_main_table';
 requires 'sql';
@@ -42,6 +42,14 @@ sub _insert_hook_make_row {
 sub _insert_hook_after_each { }
 
 sub _insert_hook_after { }
+
+sub delete_returning_gids {
+    my ($self, @ids) = @_;
+    return $self->sql->select_single_column_array('
+        DELETE FROM ' . $self->_main_table . '
+        WHERE id IN (' . placeholders(@ids) . ')
+        RETURNING gid', @ids);
+}
 
 no Moose::Role;
 1;

--- a/lib/MusicBrainz/Server/Data/Role/Relatable.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Relatable.pm
@@ -6,8 +6,7 @@ use namespace::autoclean;
 with 'MusicBrainz::Server::Data::Role::EntityModelClass',
      'MusicBrainz::Server::Data::Role::GetByGID',
      'MusicBrainz::Server::Data::Role::MainTable',
-     'MusicBrainz::Server::Data::Role::GID',
-     'MusicBrainz::Server::Data::Role::GIDRedirect';
+     'MusicBrainz::Server::Data::Role::GID';
 
 no Moose::Role;
 1;

--- a/lib/MusicBrainz/Server/Data/Series.pm
+++ b/lib/MusicBrainz/Server/Data/Series.pm
@@ -21,6 +21,7 @@ use MusicBrainz::Server::Entity::SeriesType;
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Relatable',
+     'MusicBrainz::Server::Data::Role::GIDRedirect',
      'MusicBrainz::Server::Data::Role::Name',
      'MusicBrainz::Server::Data::Role::Annotation' => { type => 'series' },
      'MusicBrainz::Server::Data::Role::Alias' => { type => 'series' },

--- a/lib/MusicBrainz/Server/Data/URL.pm
+++ b/lib/MusicBrainz/Server/Data/URL.pm
@@ -9,6 +9,7 @@ use URI;
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Relatable',
+     'MusicBrainz::Server::Data::Role::GIDRedirect',
      'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'url' },
      'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'url' },
      'MusicBrainz::Server::Data::Role::Merge';

--- a/lib/MusicBrainz/Server/Data/Work.pm
+++ b/lib/MusicBrainz/Server/Data/Work.pm
@@ -17,6 +17,7 @@ use MusicBrainz::Server::Entity::WorkAttributeType;
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Relatable',
+     'MusicBrainz::Server::Data::Role::GIDRedirect',
      'MusicBrainz::Server::Data::Role::Name',
      'MusicBrainz::Server::Data::Role::Annotation' => { type => 'work' },
      'MusicBrainz::Server::Data::Role::Alias' => { type => 'work' },

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -456,6 +456,25 @@
       </div>
     <!-- /ko -->
 
+    <!-- ko if: hasMiscapitalizedTitles() -->
+      <div class="miscapitalized-titles warning">
+        [%- warning_icon %]
+        <p>
+          <strong>[% l('Warning:') | html_entity %]</strong>
+          [% l('This medium may have incorrectly capitalized English track titles. Short articles, conjunctions, and prepositions like “and”, “of”, “or”, “to”, and “the” {guidelines|should typically be lowercased}.', { guidelines => { href => doc_link('Style/Language/English'), target => '_blank' } }) %]
+        </p>
+        <!-- ko if: hasAddedMiscapitalizedTitles() && $root.isBeginner -->
+          <label>
+            <input id="confirm-miscapitalized-titles" type="checkbox" data-bind="checked: confirmedMiscapitalizedTitles" />
+            [% l('I confirm that these titles are capitalized correctly.') %]
+          </label>
+          <p class="error field-error" style="padding-left: 1em" data-bind="showErrorWhenTabIsSwitched: hasUnconfirmedMiscapitalizedTitles">
+            [%~ l('If you’re sure the titles are capitalized correctly, confirm it above. Otherwise, please fix the data (the “Guess case” button might help!).') %]
+          </p>
+        <!-- /ko -->
+      </div>
+    <!-- /ko -->
+
     <div data-bind="visible: loaded() && !collapsed()">
       <!-- ko if: tracks().length === 0 -->
       <p style="margin: 1em">

--- a/root/static/scripts/tests/release-editor/actions.js
+++ b/root/static/scripts/tests/release-editor/actions.js
@@ -38,7 +38,7 @@ test('removing a medium should change the medium positions', function (t) {
 
   release.mediums.push(
     new fields.Medium(common.testMedium, release),
-    new fields.Medium({position: 3, release, tracks: []}),
+    new fields.Medium({position: 3, release, tracks: []}, release),
   );
 
   const mediums = release.mediums();

--- a/root/static/scripts/tests/release-editor/common.js
+++ b/root/static/scripts/tests/release-editor/common.js
@@ -30,7 +30,9 @@ export function setupReleaseEdit() {
 }
 
 export function trackParserTest(t, input, expected) {
-  const result = trackParser.parse(input);
+  const release = releaseEditor.rootField.release();
+  const medium = release.mediums()[0];
+  const result = trackParser.parse(input, medium);
 
   function getProps(track) {
     const props = {};

--- a/root/static/scripts/tests/release-editor/dialogs.js
+++ b/root/static/scripts/tests/release-editor/dialogs.js
@@ -127,7 +127,7 @@ dialogTest((
   const medium = release.mediums()[0];
 
   medium.tracks.push(
-    new fields.Track({length: 12345, name: '~fooo~', position: 1}),
+    new fields.Track({length: 12345, name: '~fooo~', position: 1}, medium),
   );
 
   t.ok(medium.hasTracks(), 'medium has tracks');

--- a/root/static/scripts/tests/release-editor/edits.js
+++ b/root/static/scripts/tests/release-editor/edits.js
@@ -285,14 +285,14 @@ test('mediumCreate edits are not given conflicting positions', function (t) {
   const newMedium1 = new fields.Medium({
     name: 'foo',
     position: 1,
-  });
+  }, release);
 
   newMedium1.tracks.push(new fields.Track({}, newMedium1));
 
   const newMedium2 = new fields.Medium({
     name: 'bar',
     position: 2,
-  });
+  }, release);
 
   newMedium2.tracks.push(new fields.Track({}, newMedium2));
   mediums.push(newMedium1, newMedium2);
@@ -358,7 +358,7 @@ test((
   releaseEditor.rootField.release(release);
 
   const mediums = release.mediums;
-  const newMedium = new fields.Medium({position: 2});
+  const newMedium = new fields.Medium({position: 2}, release);
 
   newMedium.tracks.push(new fields.Track({}, newMedium));
   mediums.push(newMedium);

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -62,12 +62,12 @@ fieldTest((
   const mediums = release.mediums;
 
   mediums([
-    new fields.Medium({tracks: []}),
-    new fields.Medium({tracks: [{}]}),
-    new fields.Medium({id: 1, tracks: []}),
-    new fields.Medium({originalID: 1, tracks: []}),
-    new fields.Medium({id: 1, tracks: [{}]}),
-    new fields.Medium({originalID: 1, tracks: [{}]}),
+    new fields.Medium({tracks: []}, release),
+    new fields.Medium({tracks: [{}]}, release),
+    new fields.Medium({id: 1, tracks: []}, release),
+    new fields.Medium({originalID: 1, tracks: []}, release),
+    new fields.Medium({id: 1, tracks: [{}]}, release),
+    new fields.Medium({originalID: 1, tracks: [{}]}, release),
   ]);
 
   t.equal(


### PR DESCRIPTION
# MBS-13711

Make the tracklist editor display a warning if an apparently-English title capitalizes a short word that should be lowercased. "and", "of", "or", "to", and "the" are checked. A confirmation checkbox is displayed for beginner editors.

# Problem

Beginner editors often import releases from Discogs (where the [First Letter Of Each Word Is Capitalized](https://support.discogs.com/hc/en-us/articles/360005006334-Database-Guidelines-1-General-Rules#Capitalization_And_Grammar)) without updating titles to follow [MusicBrainz's language-specific guidelines](https://musicbrainz.org/doc/Style#Language_specific_guidelines). This creates cleanup work for other editors.

# Solution

Use a similar approach to #3504 to display a warning pointing to the English style guidelines if any of the above words appear in the middle of a track title with their first word capitalized.

![Screenshot 2025-03-27 07 31 37](https://github.com/user-attachments/assets/8622e107-88b6-453f-ad3f-efb499b710e6)
_Verdana has ugly curly/angled double quotes. :-(_

# Testing

Entered miscapitalized titles as a beginner and non-beginner editor and with unset/English/other languages and Japan/non-Japan release events.