### PR TITLE
Make type_bubble() refer to "entity" rather than "work"

### DIFF
--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -296,7 +296,7 @@
 [%- MACRO type_bubble(form, types) BLOCK -%]
     <div class="bubble" id="type-bubble">
       <span id="type-bubble-default" [% IF form.value %] style="display:none" [% END %]>
-        [%- l('Select any type from the list to see its description. If the work
+        [%- l('Select any type from the list to see its description. If the entity
                doesn’t seem to match any type, just leave this blank.') -%]
       </span>
       [% FOREACH id IN form.options %]


### PR DESCRIPTION
Update the type_bubble TT macro to say "If the entity doesn't seem to match any type" rather than "If the work ...", since it's used for many non-work entity types.