### PR TITLE
Decrease excess vertical padding in documentation bubbles

### DIFF
--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -110,13 +110,15 @@ form div.checkbox-block div.row {
 .bubble {
     display: none;
     position: absolute;
-    min-height: 64px;
+    min-height: 54px;
     margin: 0;
     padding: @form-margin;
     background: @very-light-bg;
     border-radius: 12px;
     box-sizing: border-box;
     > svg { color: @very-light-bg; }
+    > p:first-child { margin-top: 0; }
+    > p:last-child { margin-bottom: 0; }
 }
 
 .bubble-tail {


### PR DESCRIPTION
Update the CSS for documentation bubbles to reduce min-height and remove first paragraphs' top margins and final paragraphs' bottom margins.

# Problem

There's excess blank padding at the bottom of documentation bubbles, especially when they just contain a single line of text. Some bubbles (e.g. sort name on `/artist/create`) also have excess top padding.

# Solution

Shrink bubbles' `min-height` from 64px to 54px (a minimum height is still needed to ensure the bubble extends all the way down to its arrow), and set `margin-top` to 0 for the first paragraph child in the bubble and `margin-bottom` to 0 for the final one.

**Before (single line):**
![short_before](https://github.com/user-attachments/assets/8b8217b5-a4a1-4b1b-b356-acbb1c273423)

**After (single line):**
![short_after](https://github.com/user-attachments/assets/7ff2273b-7510-4080-8c6e-f7aa47360ed2)

**Before (multiple paragraphs):**
![bottom_before](https://github.com/user-attachments/assets/d938669a-2177-4f21-a4be-98b12742ffe4)

**After (multiple paragraphs):**
![bottom_after](https://github.com/user-attachments/assets/04cd0a5c-a54b-4aa4-802c-d237ff6f91ca)

# Testing

Manually checked appearance of bubbles in the artist and release forms.