### PR TITLE
MBS-13978: Fix cover art display in the release sidebar

### DIFF
--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -91,6 +91,7 @@ component ReleaseSidebar(release: ReleaseT) {
                 {all: entityHref(release, 'cover-art')},
               ))}
             />
+            {manifest('common/loadArtwork', {async: 'async'})}
             {manifest('common/artworkViewer', {async: 'async'})}
           </>
         ) : isDarkened ? (


### PR DESCRIPTION
The loadArtwork.js script wasn't added to the `ReleaseSidebar` component in 81eb6ffc74cdd7294ed151aceab1db0b509922e8.

Tested locally. I previously had custom DBDefs settings for local artwork display, so didn't notice it before.