### PR TITLE
Separate SolrCloud 7 key

### DIFF
--- a/admin/config.search-indexes-dump.sh
+++ b/admin/config.search-indexes-dump.sh
@@ -1,4 +1,4 @@
 RSYNC_FULLEXPORT_DIR="$SEARCH_INDEXES_DUMP_DIR"
 RSYNC_FULLEXPORT_KEY='~/.ssh/rsync-data-search-index-dumps'
 RSYNC_LATEST_KEY='~/.ssh/rsync-data-search-index-dumps-latest'
-RSYNC_SOLRCLOUD_BACKUPS_KEY='~/.ssh/rsync-solrcloud-collections-backup'
+RSYNC_SOLRCLOUD_BACKUPS_KEY='~/.ssh/rsync-solrcloud7-collections-backup'


### PR DESCRIPTION
# Problem

The path for collections backup in SolrCloud is not the same for the versions 7 and 8/9/10, thus preventing to use the same key to query both versions for backup during the upcoming transition period related to SEARCH-685.

# Solution

Separate keys for each version. This is only for a transition period. Using a temporary name for the old version.

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

Manually deployed to the production `search-indexes-dump` container.

# Draft progress
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Double-check Wednesday dump

# Further action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. It goes with deployment pull requests.