### PR TITLE
MBS-13980: Add artist, label, and place doc bubbles (I)

### DIFF
--- a/root/artist/edit_form.tt
+++ b/root/artist/edit_form.tt
@@ -1,4 +1,8 @@
-<p>[%- l('For more information, check the {doc_doc|documentation} and {doc_styleguide|style guidelines}.', {doc_doc => { href => doc_link('Artist'), target => '_blank' }, doc_styleguide => { href => doc_link('Style/Artist'), target => '_blank' }}) -%]</p>
+<p>
+  [%- l('For more information, check the {doc_doc|documentation} and {doc_styleguide|style guidelines}.',
+        { doc_doc => { href => doc_link('Artist'), target => '_blank' },
+          doc_styleguide => { href => doc_link('Style/Artist'), target => '_blank' } }) -%]
+</p>
 
 <form action="[% c.req.uri %]" method="post" class="edit-artist">
     [%- USE r = FormRenderer(form) -%]
@@ -97,16 +101,117 @@
   </div>
 
   <div class="documentation">
-    [%- area_bubble() -%]
+    <div class="bubble" id="name-bubble">
+      <p>
+        [% l('The {doc|name} is the artist’s official name.',
+             { doc => { href => doc_link('Artist#Name'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('Please see the {doc|style guidelines} for more information.',
+             { doc => { href => doc_link('Style/Artist#Name'), target => '_blank' } }) %]
+      </p>
+    </div>
 
     [%- sort_name_bubble() -%]
 
+    <div class="bubble" id="comment-bubble">
+      <p>
+        [% l('The {doc|disambiguation} field helps users distinguish between artists with identical or similar names.
+              Feel free to leave it blank if it seems unlikely that there will be other artists with similar names.',
+             { doc => { href => doc_link('Disambiguation_Comment'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('This field is not a place to store general background information.
+              That kind of information should go in an {doc|annotation}.',
+             { doc => { href => doc_link('Annotation'), target => '_blank' } }) %]
+      </p>
+    </div>
+
     [%- type_bubble(form.field('type_id'), artist_types) -%]
+
+    <div class="bubble" id="gender-bubble">
+      <p>
+        [% l('The {doc|gender} field describes the gender with which a person or character identifies.',
+             { doc => { href => doc_link('Artist#Gender'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('Please see the {doc|style guidelines} for more information.',
+             { doc => { href => doc_link('Style/Artist#Gender'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="area-bubble">
+      <p>
+        [% l('The {doc|area} indicates the country the artist is primarily identified with.
+              If the artist is strongly associated with an area smaller than a country, select that instead.',
+             { doc => { href => doc_link('Artist#Area'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('Please see the {doc|style guidelines} for more information.',
+             { doc => { href => doc_link('Style/Artist#Main_area'), target => '_blank' } }) %]
+      </p>
+      [% area_bubble_selection() %]
+    </div>
 
     [%- ipi_bubble() -%]
     [%- isni_bubble() -%]
-  </div>
 
+    <div class="bubble" id="begin-end-date-bubble">
+      <p class="desc desc-1">
+        [% l('The {doc|begin and end dates} describe when the artist was born and died.',
+             { doc => { href => doc_link('Artist#Begin_and_end_dates'), target => '_blank' } }) %]
+      </p>
+      <p class="desc desc-2 desc-5 desc-6">
+        [% l('The {doc|begin and end dates} describe when the group was formed and dissolved.',
+             { doc => { href => doc_link('Artist#Begin_and_end_dates'), target => '_blank' } }) %]
+      </p>
+      <p class="desc desc-4">
+        [% l('The {doc|begin date} is the real-life date when the character concept was created.
+              The end date should not be set.',
+             { doc => { href => doc_link('Artist#Begin_and_end_dates'), target => '_blank' } }) %]
+      </p>
+      <p class="desc desc-default">
+        [% l('The {doc|begin and end dates} describe when the artist started and stopped existing.',
+             { doc => { href => doc_link('Artist#Begin_and_end_dates'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('Please see the {doc|style guidelines} for more information.',
+             { doc => { href => doc_link('Style/Artist#Begin_and_end_areas/dates'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="begin-end-area-bubble">
+      <p class="desc desc-1">
+        [% l('The begin and end areas describe where the artist was born and died.') %]
+      </p>
+      <p class="desc desc-2 desc-5 desc-6">
+        [% l('The begin and end areas describe where the group was formed and dissolved.') %]
+      </p>
+      <p class="desc desc-4">
+        [% l('The begin area is the real-life area where the character concept was created.
+              The end area should not be set.') %]
+      </p>
+      <p class="desc desc-default">
+        [% l('The begin and end areas describe where the artist was when it started and stopped existing.') %]
+      </p>
+      <p>
+        [% l('Please see the {doc|style guidelines} for more information.',
+             { doc => { href => doc_link('Style/Artist#Begin_and_end_areas/dates'), target => '_blank' } }) %]
+      </p>
+      [% area_bubble_selection() %]
+    </div>
+
+    <div class="bubble" id="external-link-bubble">
+      <p>
+        [% l('External links are URLs associated with the artist.
+              These can include the artist’s official homepage and social networking pages, streaming services,
+              and unofficial pages like Wikipedia entries, biographies, interviews, and fan sites.') %]
+      </p>
+      <p>
+        [% l('Please don’t add a Wikipedia page if a Wikidata item linking to the same article already exists.') %]
+      </p>
+    </div>
+  </div>
 </form>
 
 [%- guesscase_options() -%]

--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -242,36 +242,38 @@
 
 [%- MACRO ipi_bubble BLOCK -%]
     <div class="bubble" id="ipi-bubble">
-      <p>[% l('IPI codes are assigned by CISAC to “interested parties” in musical rights management.
-               Check {ipi_doc|the documentation} for more info.',
-            { ipi_doc => doc_link('IPI') }) %]</p>
+      <p>[% l('{doc|IPI codes} are assigned by CISAC to “interested parties” in musical rights management.',
+              { doc => doc_link('IPI') }) %]</p>
       <p>[% l('If you don’t know the code for this entity, just leave the field blank.') %]</p>
     </div>
 [%- END -%]
 
 [%- MACRO isni_bubble BLOCK -%]
     <div class="bubble" id="isni-bubble">
-      <p>[% l('ISNI codes are an ISO standard used to uniquely identify persons and organizations.
-               Check {isni_doc|the documentation} for more info.',
-            { isni_doc => doc_link('ISNI') }) %]</p>
+      <p>[% l('{doc|ISNI codes} are an ISO standard used to uniquely identify persons and organizations.',
+              { doc => doc_link('ISNI') }) %]</p>
       <p>[% l('If you don’t know the code for this entity, just leave the field blank.') %]</p>
     </div>
 [%- END -%]
 
-[%- MACRO area_bubble BLOCK -%]
-    <div class="bubble" id="area-bubble">
-      <!-- ko with: target() && target().area -->
-        <p data-bind="html: $data.selectionMessage()"></p>
-      <!-- /ko -->
-    </div>
+[%- MACRO area_bubble_selection BLOCK -%]
+    <!-- ko if: target() && target().area && target().area().gid -->
+      <p data-bind="html: target().area().selectionMessage()"></p>
+    <!-- /ko -->
 [%- END -%]
 
 [%- MACRO sort_name_bubble BLOCK -%]
     <div class="bubble" id="sort-name-bubble">
-      <p>[% l('The sort name is an artist name variant used when sorting alphabetically.
-               For usage information check the {sort_name_doc|sort name guidelines}.',
-            { sort_name_doc => doc_link('Style/Artist/Sort_Name') }) %]</p>
-      <p>[% l('“Last Name, First Name” and “Group, The” are common examples of sort names.') %]</p>
+      <p>
+        [% l('The sort name is an artist name variant used when sorting alphabetically.') %]
+      </p>
+      <p>
+        [% l('“Last Name, First Name” and “Group, The” are common examples of sort names.') %]
+      </p>
+      <p>
+        [% l('Please see the {doc|style guidelines} for more information.',
+             { doc => { href => doc_link('Style/Artist/Sort_Name'), target => '_blank' } }) %]
+      </p>
     </div>
 [%- END -%]
 

--- a/root/label/edit_form.tt
+++ b/root/label/edit_form.tt
@@ -62,10 +62,63 @@
   </div>
 
   <div class="documentation">
-    [%- area_bubble() -%]
+    <div class="bubble" id="name-bubble">
+      <p>
+        [% l('The {doc|name} is the label’s official name.',
+             { doc => { href => doc_link('Label#Name'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="comment-bubble">
+      <p>
+        [% l('The {doc|disambiguation} field helps users distinguish between labels with identical or similar names.
+              Feel free to leave it blank if you aren’t warned about possible duplicates.',
+             { doc => { href => doc_link('Disambiguation_Comment'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('This field is not a place to store general background information.
+              That kind of information should go in an {doc|annotation}.',
+             { doc => { href => doc_link('Annotation'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    [%- type_bubble(form.field('type_id'), label_types) -%]
+
+    <div class="bubble" id="area-bubble">
+      <p>
+        [% l('The {doc|area} indicates the geographical origin of the label.',
+             { doc => { href => doc_link('Label/Country'), target => '_blank' } }) %]
+      </p>
+      [% area_bubble_selection() %]
+    </div>
+
+    <div class="bubble" id="label-code-bubble">
+      <p>
+        [% l('The {doc|label code} is a 4‐ or 5‐digit number uniquely identifying the label.',
+             { doc => { href => doc_link('Label/Label_Code'), target => '_blank' } }) %]
+      </p>
+    </div>
+
     [%- ipi_bubble() -%]
     [%- isni_bubble() -%]
-    [%- type_bubble(form.field('type_id'), label_types) -%]
+
+    <div class="bubble" id="begin-end-date-bubble">
+      <p>
+        [% l('The {doc|begin and end dates} describe the period during which the label existed or was active.',
+             { doc => { href => doc_link('Label#Date_period'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="external-link-bubble">
+      <p>
+        [% l('External links are URLs associated with the label.
+              These can include the label’s official homepage and social networking pages, catalogs, order pages,
+              and unofficial pages like Wikipedia entries, histories, and fan sites.') %]
+      </p>
+      <p>
+        [% l('Please don’t add a Wikipedia page if a Wikidata item linking to the same article already exists.') %]
+      </p>
+    </div>
   </div>
 
 </form>

--- a/root/place/edit_form.tt
+++ b/root/place/edit_form.tt
@@ -1,4 +1,8 @@
-<p>[%- l('For more information, check the {doc_doc|documentation}.', {doc_doc => { href => doc_link('Place'), target => '_blank' }}) -%]</p>
+<p>
+  [%- l('For more information, check the {doc_doc|documentation} and {doc_styleguide|style guidelines}.',
+        { doc_doc => { href => doc_link('Place'), target => '_blank' },
+          doc_styleguide => { href => doc_link('Style/Place'), target => '_blank' } }) -%]
+</p>
 
 <form action="[% c.req.uri %]" method="post" class="edit-place">
     [%- USE r = FormRenderer(form) -%]
@@ -46,7 +50,47 @@
   </div>
 
   <div class="documentation">
-    [%- area_bubble() -%]
+    <div class="bubble" id="name-bubble">
+      <p>
+        [% l('The {doc|name} is the place’s official name.',
+             { doc => { href => doc_link('Place#Name'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('Please see the {doc|style guidelines} for more information.',
+             { doc => { href => doc_link('Style/Place#Name'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="comment-bubble">
+      <p>
+        [% l('The {doc|disambiguation} field helps users distinguish between places with similar names.
+              Feel to leave it blank if you aren’t warned about possible duplicates in the same area.',
+             { doc => { href => doc_link('Disambiguation_Comment'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('This field is not a place to store general background information.
+              That kind of information should go in an {doc|annotation}.',
+             { doc => { href => doc_link('Annotation'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    [%- type_bubble(form.field('type_id'), place_types) -%]
+
+    <div class="bubble" id="address-bubble">
+      <p>
+        [% l('The {doc|address} describes the place’s location using the standard addressing format for the country where it’s located.
+              It should include the ZIP/postal code but not the country name.',
+             { doc => { href => doc_link('Place#Address'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="area-bubble">
+      <p>
+        [% l('The {doc|area} is the location (such as city) where the place is located.',
+             { doc => { href => doc_link('Place#Area'), target => '_blank' } }) %]
+      </p>
+      [% area_bubble_selection() %]
+    </div>
 
     <div class="bubble" id="coordinates-bubble">
         <p>[% l('Enter coordinates manually or click the map to get coordinates from the marker. If you’re too far out, clicking will zoom instead.') %]</p>
@@ -54,7 +98,23 @@
         [% script_manifest('place/map.js', { 'data-args' => map_data_args }) %]
     </div>
 
-    [%- type_bubble(form.field('type_id'), place_types) -%]
+    <div class="bubble" id="begin-end-date-bubble">
+      <p>
+        [% l('The {doc|begin and end dates} describe when the place was founded and when it shut down.',
+             { doc => { href => doc_link('Place#Begin_and_end_dates'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="external-link-bubble">
+      <p>
+        [% l('External links are URLs associated with the place.
+              These can include the place’s official homepage and social networking pages, ticketing pages,
+              and unofficial pages like Wikipedia entries, histories, and fan sites.') %]
+      </p>
+      <p>
+        [% l('Please don’t add a Wikipedia page if a Wikidata item linking to the same article already exists.') %]
+      </p>
+    </div>
   </div>
 
 </form>

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -565,8 +565,8 @@
 
   <div class="bubble" data-bind="bubble: $root.commentBubble">
     <p>
-      [% l('The {doc|disambiguation} field is used to help users distinguish between identically-named releases.
-            It’s fine to leave it empty if other properties like artist, label, or date distinguish this release.',
+      [% l('The {doc|disambiguation} field helps users distinguish between releases in the same release group.
+            Please leave it empty if other properties like artist, format, label, or date distinguish this release.',
            { doc => { href => doc_link('Disambiguation_Comment'), target => '_blank' } }) %]
     </p>
     <p>

--- a/root/static/scripts/artist/edit.js
+++ b/root/static/scripts/artist/edit.js
@@ -33,11 +33,49 @@ $(function () {
   initializeToggleEnded('id-edit-artist');
   initializeTooShortYearChecks('artist');
 
-  initializeBubble('#sort-name-bubble', 'input[name=edit-artist\\.sort_name');
+  initializeBubble('#name-bubble', 'input[name=edit-artist\\.name]');
+  initializeBubble(
+    '#sort-name-bubble',
+    'input[name=edit-artist\\.sort_name]',
+  );
+  initializeBubble('#comment-bubble', 'input[name=edit-artist\\.comment]');
+  initializeBubble('#gender-bubble', 'select[name=edit-artist\\.gender_id]');
   initializeBubble('#ipi-bubble', 'input[name=edit-artist\\.ipi_codes\\.0]');
   initializeBubble(
     '#isni-bubble',
     'input[name=edit-artist\\.isni_codes\\.0]',
+  );
+  initializeBubble(
+    '#begin-end-date-bubble',
+    'input[name^=edit-artist\\.period\\.begin_date\\.], ' +
+      'input[name^=edit-artist\\.period\\.end_date\\.]',
+  );
+
+  // Update the begin and end documentation bubbles to match the type.
+  const updateBeginEndBubbles = () => {
+    for (const sel of ['#begin-end-date-bubble', '#begin-end-area-bubble']) {
+      $(sel + ' .desc').hide();
+      const value = $(typeIdField)[0].value;
+      const desc = $(sel + ` .desc-${value}`);
+      if (desc.length) {
+        desc.show();
+      } else {
+        $(sel + ' .desc-default').show();
+      }
+    }
+  };
+  $(typeIdField).on('change', () => updateBeginEndBubbles());
+  updateBeginEndBubbles();
+
+  /*
+   * Display documentation bubbles for external components.
+   * Area bubbles are initialized in ArtistEdit().
+   */
+  const externalLinkBubble = initializeBubble('#external-link-bubble');
+  $(document).on(
+    'focus',
+    '#external-links-editor-container .external-link-item input.value',
+    (event) => externalLinkBubble.show(event.target),
   );
 
   installFormUnloadWarning();

--- a/root/static/scripts/edit/MB/Control/Area.js
+++ b/root/static/scripts/edit/MB/Control/Area.js
@@ -13,22 +13,15 @@ import EntityAutocomplete from '../../../common/MB/Control/Autocomplete.js';
 
 import {BubbleDoc} from './Bubble.js';
 
-export default function initializeArea(...selectors) {
-  var bubble = new BubbleDoc();
+export default function initializeArea(spanSelector, bubbleSelector) {
+  const bubble = new BubbleDoc();
+  ko.applyBindingsToNode($(bubbleSelector)[0], {bubble});
 
-  bubble.canBeShown = function (viewModel) {
-    return viewModel.area().gid;
-  };
-
-  ko.applyBindingsToNode($('#area-bubble')[0], {bubble});
-
-  for (const selector of selectors) {
-    const $span = $(selector);
-    const name = $span.find('input.name')[0];
-    const ac = EntityAutocomplete({inputs: $span});
-
+  $(spanSelector).each(function () {
+    const name = $(this).find('input.name')[0];
+    const ac = EntityAutocomplete({inputs: $(this)});
     ko.applyBindingsToNode(
       name, {controlsBubble: bubble}, {area: ac.currentSelection},
     );
-  }
+  });
 }

--- a/root/static/scripts/edit/MB/Control/ArtistEdit.js
+++ b/root/static/scripts/edit/MB/Control/ArtistEdit.js
@@ -129,7 +129,8 @@ export default function ArtistEdit() {
 
   initializeGuessCase('artist', 'id-edit-artist');
 
-  initializeArea('#area', '#begin_area', '#end_area');
+  initializeArea('#area', '#area-bubble');
+  initializeArea('#begin_area, #end_area', '#begin-end-area-bubble');
 
   return self;
 }

--- a/root/static/scripts/edit/MB/Control/Bubble.js
+++ b/root/static/scripts/edit/MB/Control/Bubble.js
@@ -337,7 +337,12 @@ export default function initializeBubble(bubble, control, vm, canBeShown) {
   }
 
   ko.applyBindingsToNode($(bubble)[0], {bubble: bubbleDoc}, vm);
-  ko.applyBindingsToNode($(control)[0], {controlsBubble: bubbleDoc}, vm);
+
+  if (control) {
+    $(control).each((_, el) => {
+      ko.applyBindingsToNode(el, {controlsBubble: bubbleDoc}, vm);
+    });
+  }
 
   return bubbleDoc;
 }

--- a/root/static/scripts/label/edit.js
+++ b/root/static/scripts/label/edit.js
@@ -25,12 +25,30 @@ $(function () {
 
   initializeGuessCase('label', 'id-edit-label');
 
-  initializeArea('span.area.autocomplete');
+  initializeArea('span.area.autocomplete', '#area-bubble');
 
   initializeDuplicateChecker('label');
 
+  initializeBubble('#name-bubble', 'input[name=edit-label\\.name]');
+  initializeBubble('#comment-bubble', 'input[name=edit-label\\.comment]');
+  initializeBubble(
+    '#label-code-bubble', 'input[name=edit-label\\.label_code]',
+  );
   initializeBubble('#ipi-bubble', 'input[name=edit-label\\.ipi_codes\\.0]');
   initializeBubble('#isni-bubble', 'input[name=edit-label\\.isni_codes\\.0]');
+  initializeBubble(
+    '#begin-end-date-bubble',
+    'input[name^=edit-label\\.period\\.begin_date\\.], ' +
+      'input[name^=edit-label\\.period\\.end_date\\.]',
+  );
+
+  // Display documentation bubbles for external components.
+  const externalLinkBubble = initializeBubble('#external-link-bubble');
+  $(document).on(
+    'focus',
+    '#external-links-editor-container .external-link-item input.value',
+    (event) => externalLinkBubble.show(event.target),
+  );
 
   installFormUnloadWarning();
 

--- a/root/static/scripts/place/edit.js
+++ b/root/static/scripts/place/edit.js
@@ -23,10 +23,27 @@ import {map, marker} from './map.js';
 
 $(function () {
   initializeGuessCase('place', 'id-edit-place');
-  initializeArea('span.area.autocomplete');
+  initializeArea('span.area.autocomplete', '#area-bubble');
   initializeDuplicateChecker('place');
 
-  const bubble = initializeBubble(
+  initializeBubble('#name-bubble', 'input[name=edit-place\\.name]');
+  initializeBubble('#comment-bubble', 'input[name=edit-place\\.comment]');
+  initializeBubble('#address-bubble', 'input[name=edit-place\\.address]');
+  initializeBubble(
+    '#begin-end-date-bubble',
+    'input[name^=edit-place\\.period\\.begin_date\\.], ' +
+      'input[name^=edit-place\\.period\\.end_date\\.]',
+  );
+
+  // Display documentation bubbles for external components.
+  const externalLinkBubble = initializeBubble('#external-link-bubble');
+  $(document).on(
+    'focus',
+    '#external-links-editor-container .external-link-item input.value',
+    (event) => externalLinkBubble.show(event.target),
+  );
+
+  const coordsBubble = initializeBubble(
     '#coordinates-bubble',
     'input[name=edit-place\\.coordinates]',
   );
@@ -37,18 +54,18 @@ $(function () {
    * This tells it to update its position once it's visible.
    */
   let invalidateSizeRan = false;
-  function afterBubbleShow() {
+  function afterCoordsBubbleShow() {
     if (!invalidateSizeRan) {
       map.invalidateSize();
       invalidateSizeRan = true;
     }
   }
 
-  const bubbleShow = bubble.show;
+  const coordsBubbleShow = coordsBubble.show;
 
-  bubble.show = function (...args) {
-    bubbleShow.apply(this, args);
-    afterBubbleShow();
+  coordsBubble.show = function (...args) {
+    coordsBubbleShow.apply(this, args);
+    afterCoordsBubbleShow();
   };
 
   map.on('click', function (e) {

--- a/t/selenium/MBS-9941.json5
+++ b/t/selenium/MBS-9941.json5
@@ -28,7 +28,7 @@
     },
     {
       command: 'assertText',
-      target: 'id=area-bubble',
+      target: 'css=#area-bubble p:last-child',
       value: 'Du hast Frankreich ausgewählt.',
     },
     {


### PR DESCRIPTION
# MBS-13980 (I)

Update the artist, label, and place editing forms to display documentation bubbles for all fields.

Also update the initializeArea function and the area_bubble macro so that multiple area bubbles can be used in a single page.

# Problem

#3510  updated the release editor's information tab to display documentation bubbles for all fields, but many other forms still lack documentation bubbles.

# Solution

Add missing bubbles to the artist, label, and place forms.

The only tricky part of this was accommodating forms (artist and place) that have multiple area fields that should display different documentation. These forms previously used a single bubble for all their area fields, and the `initializeArea` function didn't support showing an initial documentation string before any area has been selected. I renamed the `area_bubble` TT macro to `area_bubble_selection` and updated it to only handle displaying the selected area, and then updated `initializeArea` so that selectors for the area span(s) and bubble are passed in.

# Testing

Loaded the affected forms and checked that the appropriate bubbles are displayed when I click on fields. Also checked that area fields render just the doc string before an area has been selected, but then additionally include the "You selected ..." text afterward.