### PR TITLE
MBS-13982: Wrap overlong release and release group titles in tables

### DIFF
--- a/root/release_group/ReleaseGroupIndex.js
+++ b/root/release_group/ReleaseGroupIndex.js
@@ -65,6 +65,7 @@ function buildReleaseStatusTable(
             ) : null}
           <td>
             <EntityLink
+              className="wrap-anywhere"
               entity={release}
               showArtworkPresence={showArtworkPresence}
             />

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -434,9 +434,10 @@ export function defineNameColumn<T: NonUrlRelatableEntityT | CollectionT>(
   return {
     Cell: ({row: {original}}) => (
       descriptive
-        ? <DescriptiveLink entity={original} />
+        ? <DescriptiveLink className="wrap-anywhere" entity={original} />
         : (
           <EntityLink
+            className="wrap-anywhere"
             entity={original}
             showArtworkPresence={props.showArtworkPresence}
             // Event lists show date in its own column


### PR DESCRIPTION
### Implement MBS-13982

# Problem
Releases and RGs with overlong symbol names cause awful horizontal scroll, for example with `/release-group/3c2b9f73-9ff6-4b87-a52f-4ee8e1803a5a` and `/artist/ab2d7e75-dbaa-45f7-97df-1ebbd6475fb9`.

# Solution
Use the existing class `wrap-anywhere` in `defineNameColumn` for tables using `react-table`, and also in `ReleaseGroupIndex` which does its own thing for now. This solves the horizontal scroll issues in these pages, and hopefully neither of these will lead to over the top wrapping anywhere else than on very small screens, in which case our display is going to suck either way.

We have had two-steps-forward-one-step-back situations on wrapping quite a bit (https://github.com/metabrainz/musicbrainz-server/pull/2561) and ideally we'd have something like "wrap only if a word is longer than X chars" but I guess there's no way to do that, so all I can hope is that this is again two steps forward and not just one...

# Testing
Manually, with the links above. Also tested that non-overlong titles don't seem wrap horribly at least on RG pages unless limit the screen a fair bit.