### PR TITLE
MBS-13977: Ignore country codes in yesasia.com links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -6847,7 +6847,7 @@ const CLEANUPS: CleanupEntries = {
     restrict: [LINK_TYPES.mailorder],
     clean(url) {
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?yesasia\.com\//, 'https://www.yesasia.com/');
-      url = url.replace(/^(https:\/\/www\.yesasia\.com)\/(?:global\/)?(?:[^/]*\/)?([\w.-]+)(?:en|ja|zh_CN|zh_TW)\/((?:info|list).html)(?:#.*)?$/, '$1/$2en/$3');
+      url = url.replace(/^(https:\/\/www\.yesasia\.com)\/(?:[^/]*\/)*([\w.-]+)(?:en|ja|zh_CN|zh_TW)\/((?:info|list).html)(?:#.*)?$/, '$1/$2en/$3');
       return url;
     },
     validate(url, id) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -7191,6 +7191,20 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://www.yesasia.com/1107024843-0-0-0-en/info.html',
        only_valid_entity_types: ['release'],
   },
+  {
+                     input_url: 'https://www.yesasia.com/us/the-brightest-darkness-2cd/1098658217-0-0-0-zh_TW/info.html',
+             input_entity_type: 'release',
+    expected_relationship_type: 'mailorder',
+            expected_clean_url: 'https://www.yesasia.com/1098658217-0-0-0-en/info.html',
+       only_valid_entity_types: ['release'],
+  },
+  {
+                     input_url: 'https://www.yesasia.com/us/jupiter/dunno/fr/chu-strike-type-a-single-dvd-%E6%97%A5%E6%9C%AC%E7%89%88/1133454584-0-0-0-zh_TW/info.html',
+             input_entity_type: 'release',
+    expected_relationship_type: 'mailorder',
+            expected_clean_url: 'https://www.yesasia.com/1133454584-0-0-0-en/info.html',
+       only_valid_entity_types: ['release'],
+  },
   // YouTube
   {
                      input_url: 'http://youtube.com/user/officialpsy/videos',


### PR DESCRIPTION
### Implement MBS-13977

# Description
We were only dropping "global" here but there's not only that but also all sort of other country codes such as "us" that can appear here. In fact, we tested and you can write literally anything there, even with multiple slashes (see last test example) and it happily gives us the same result. As such, this just drops any text before the relevant code section.

# Testing
Added a couple extra tests with different extra sections.