### PR TITLE
Add short note about exceptions to new capitalization warning

### DIFF
--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -463,6 +463,9 @@
           <strong>[% l('Warning:') | html_entity %]</strong>
           [% l('This medium may have incorrectly capitalized English track titles. Short articles, conjunctions, and prepositions like “and”, “of”, “or”, “to”, and “the” {guidelines|should typically be lowercased}.', { guidelines => { href => doc_link('Style/Language/English'), target => '_blank' } }) %]
         </p>
+        <p>
+          [% l('Common exceptions are {artist_intent_guideline|artist intent} and {japanese_guideline|Japanese releases}.', { artist_intent_guideline => { href => doc_link('Style/Principle/Error_correction_and_artist_intent#Artist_Intent'), target => '_blank' }, japanese_guideline => { href => doc_link('Style/Language/Japanese'), target => '_blank' } }) %]
+        </p>
         <!-- ko if: hasAddedMiscapitalizedTitles() && $root.isBeginner -->
           <label>
             <input id="confirm-miscapitalized-titles" type="checkbox" data-bind="checked: confirmedMiscapitalizedTitles" />


### PR DESCRIPTION
# Problem
**finalsummer** requested to indicate to beginner users some of the most common exceptions to the capitalization guideline, for cases where they might otherwise be prompted by the new warning to change things incorrectly

# Solution
@Aerozol proposed a simple new line, "Common exceptions are artist intent and Japanese releases," with the relevant links. This is short enough not to distract the users too much while still giving them enough info when relevant.

![image](https://github.com/user-attachments/assets/a20db385-b76e-404b-a68f-48071550835e)

# Testing
Manually, checked it shows properly and links work.