### PR TITLE
MBS-13964: Some recordings are missing a first release date

### DIFF
--- a/admin/sql/CreateMirrorOnlyTriggers.sql
+++ b/admin/sql/CreateMirrorOnlyTriggers.sql
@@ -24,6 +24,9 @@ CREATE TRIGGER a_upd_l_area_area_mirror AFTER UPDATE ON l_area_area
 CREATE TRIGGER a_del_l_area_area_mirror AFTER DELETE ON l_area_area
     FOR EACH ROW EXECUTE PROCEDURE a_del_l_area_area_mirror();
 
+CREATE TRIGGER a_upd_medium AFTER UPDATE ON medium
+    FOR EACH ROW EXECUTE PROCEDURE a_upd_medium_mirror();
+
 CREATE TRIGGER a_ins_release_mirror AFTER INSERT ON release
     FOR EACH ROW EXECUTE PROCEDURE a_ins_release_mirror();
 

--- a/admin/sql/CreateTriggers.sql
+++ b/admin/sql/CreateTriggers.sql
@@ -454,6 +454,9 @@ CREATE TRIGGER b_upd_link_type BEFORE UPDATE ON link_type
 CREATE TRIGGER b_upd_link_type_attribute_type BEFORE UPDATE ON link_type_attribute_type
     FOR EACH ROW EXECUTE PROCEDURE b_upd_last_updated_table();
 
+CREATE TRIGGER a_upd_medium AFTER UPDATE ON medium
+    FOR EACH ROW EXECUTE PROCEDURE a_upd_medium_mirror();
+
 CREATE TRIGGER b_upd_medium BEFORE UPDATE ON medium
     FOR EACH ROW EXECUTE PROCEDURE b_upd_last_updated_table();
 

--- a/admin/sql/updates/20250408-mbs-13964-all.sql
+++ b/admin/sql/updates/20250408-mbs-13964-all.sql
@@ -1,0 +1,34 @@
+\set ON_ERROR_STOP 1
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION set_mediums_recordings_first_release_dates(medium_ids INTEGER[])
+RETURNS VOID AS $$
+BEGIN
+  PERFORM set_recordings_first_release_dates((
+    SELECT array_agg(recording)
+      FROM track
+     WHERE track.medium = any(medium_ids)
+  ));
+  RETURN;
+END;
+$$ LANGUAGE 'plpgsql' STRICT;
+
+CREATE OR REPLACE FUNCTION a_upd_medium_mirror()
+RETURNS trigger AS $$
+BEGIN
+    -- DO NOT modify any replicated tables in this function; it's used
+    -- by a trigger on mirrors.
+    IF NEW.release IS DISTINCT FROM OLD.release THEN
+        PERFORM set_mediums_recordings_first_release_dates(ARRAY[OLD.id]);
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE 'plpgsql';
+
+CREATE TRIGGER a_upd_medium AFTER UPDATE ON medium
+    FOR EACH ROW EXECUTE PROCEDURE a_upd_medium_mirror();
+
+TRUNCATE recording_first_release_date;
+
+COMMIT;

--- a/t/pgtap/first_release_dates.sql
+++ b/t/pgtap/first_release_dates.sql
@@ -441,5 +441,37 @@ SELECT results_eq(
   'SELECT 1 WHERE false'
 );
 
+-- MBS-13964: Update `recording_first_release_date` via updates to
+-- `medium.release`. This occurs when merging releases via the "append"
+-- strategy.
+
+INSERT INTO release (id, gid, release_group, artist_credit, name)
+VALUES
+  (4, '75538934-f463-4188-ace5-b2d15a2344d5', 1, 1, 'name'),
+  (5, '80abcfbd-df3c-4cea-9823-2d5b21b678f4', 1, 1, 'name');
+
+INSERT INTO medium (id, gid, release, position, format, name)
+VALUES (4, 'f31af646-bad5-4a1c-9ffd-59c65f2e25d1', 4, 1, 1, '');
+
+INSERT INTO release_unknown_country (release, date_year)
+VALUES (5, 1999);
+
+INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length)
+VALUES
+  (4, 'ed303f01-e1ae-4549-acb7-a50452a3b5c2', 4, 1, '1', 1, 'name', 1, 1000);
+
+SELECT results_eq(
+  'recording_1_first_release_date',
+  'SELECT 1 WHERE false'
+);
+
+UPDATE medium SET release = 5 WHERE id = 4;
+DELETE FROM release WHERE id = 4;
+
+SELECT results_eq(
+  'recording_1_first_release_date',
+  'VALUES (1999::smallint, null::smallint, null::smallint)'
+);
+
 SELECT finish();
 ROLLBACK;

--- a/upgrade.json
+++ b/upgrade.json
@@ -236,7 +236,8 @@
       "20241017-mbs-9253-13464.sql",
       "20250425-mbs-13464.sql",
       "20241125-mbs-13832.sql",
-      "20250320-mbs-13768.sql"
+      "20250320-mbs-13768.sql",
+      "20250408-mbs-13964-all.sql"
     ],
     "master_and_standalone": [
       "20241017-mbs-9253-master_and_standalone.sql",


### PR DESCRIPTION
# Problem

MBS-13964

When releases are merged with the "append" strategy, then mediums are moved by updating their `release` column. (See the `Data::Release::merge` method.)

Since this affects the releases a recording appears on, we need a trigger on the `medium` table to update `recording_first_release_date` whenever a `medium.release` column is updated.

# Solution

Adds the necessary trigger. The upgrade script also takes care of truncating all existing data in the materialized table, so that it can be recalculated via the admin/BuildMaterializedTables script.

# Testing

 * Updated t/pgtap/first_release_dates.sql.
 * Ran t/script/CheckSchemaMigration.sh per HACKING.md.