### PR TITLE
MBS-13985: Show inline primary alias for work authors 

### DIFF
--- a/lib/MusicBrainz/Server/Data/Work.pm
+++ b/lib/MusicBrainz/Server/Data/Work.pm
@@ -14,6 +14,7 @@ use MusicBrainz::Server::Data::Utils::Cleanup qw( used_in_relationship );
 use MusicBrainz::Server::Entity::Work;
 use MusicBrainz::Server::Entity::WorkAttribute;
 use MusicBrainz::Server::Entity::WorkAttributeType;
+use MusicBrainz::Server::Translation qw( l );
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Relatable',
@@ -396,7 +397,13 @@ sub find_artists
 
     for my $work_id (@ids) {
         my @artists = uniq map { $_->{entity}->name } @{ $artists{$work_id} };
-        my @authors = uniq map { $_->{entity}->name } @{ $authors{$work_id} };
+        my @authors = uniq map {
+            $_->{entity}->name . (
+                $_->{entity}->primary_alias
+                    ? ' ' . l('({text})', { text => $_->{entity}->primary_alias })
+                    : ''
+            ),
+        } @{ $authors{$work_id} };
 
         $map{$work_id} = {
             authors => {

--- a/lib/MusicBrainz/Server/Data/Work.pm
+++ b/lib/MusicBrainz/Server/Data/Work.pm
@@ -398,9 +398,11 @@ sub find_artists
     for my $work_id (@ids) {
         my @artists = uniq map { $_->{entity}->name } @{ $artists{$work_id} };
         my @authors = uniq map {
-            $_->{entity}->name . (
-                $_->{entity}->primary_alias
-                    ? ' ' . l('({text})', { text => $_->{entity}->primary_alias })
+            my $name = $_->{entity}->name;
+            my $primary_alias = $_->{entity}->primary_alias;
+            $name . (
+                $primary_alias && $primary_alias ne $name
+                    ? ' ' . l('({text})', { text => $primary_alias })
                     : ''
             ),
         } @{ $authors{$work_id} };


### PR DESCRIPTION
### Implement MBS-13985

# Problem
Work authors and artists in inline search have no primary alias displayed. This is annoying for stuff like Russian composers.

# Solution
For work authors, this just displays the (already loaded) author primary alias in a parens.
Work artists are artist credits, not artist entities, so we would need to extract the artists instead and display those (this is still not done, and moved to MBS-13991).

# Testing
Manually