### PR TITLE
MBS-13989: Drop /c/ Patreon URL segment

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4724,7 +4724,7 @@ const CLEANUPS: CleanupEntries = {
     restrict: [LINK_TYPES.patronage],
     clean(url) {
       url = url.replace(/^((?:https?:\/\/)?(?:www\.)?patreon\.com\/user)\/(?:community|posts)(\?u=\d+).*$/, '$1$2');
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?patreon\.com\/(user\?u=\d+|(?!posts\/)\w+).*$/, 'https://www.patreon.com/$1');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?patreon\.com\/(?:c\/)?(user\?u=\d+|(?!posts\/)\w+).*$/, 'https://www.patreon.com/$1');
       return url;
     },
     validate(url) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4785,6 +4785,12 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://www.patreon.com/example',
   },
   {
+                     input_url: 'https://www.patreon.com/c/heyriddleriddle/',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'patronage',
+            expected_clean_url: 'https://www.patreon.com/heyriddleriddle',
+  },
+  {
                      input_url: 'https://www.patreon.com/user/posts?u=4212671&month=2017-4',
              input_entity_type: 'artist',
     expected_relationship_type: 'patronage',


### PR DESCRIPTION
### Implement MBS-13989

# Problem
Apparently Patreon adds a `/c/` segment to the URLs when logged in, which meant we were actually cleaning those up to just `https://www.patreon.com/c` and dropping the actual username.

# Solution
This just drops `/c/` from the URLs if present.

# Testing
Added a test, also checked just in case that we don't break `https://www.patreon.com/c` if someone *does* want to link to that guy.