### PR TITLE
Backup SolrCloud 9 collections for live mirrors

### DIFF
--- a/admin/BundleSearchIndexesDump
+++ b/admin/BundleSearchIndexesDump
@@ -135,6 +135,10 @@ for my $backup_dir (@backup_dirs)
     @extraneous_files = ();
     for my $filename (sort grep { ! /^\.\.?$/ } readdir $bdh)
     {
+        if ($filename =~ 'zk_backup') {
+            system 'rm', '-fr', "$working_dir/$backup_dir/$filename";
+            next;
+        }
         push @extraneous_files, $filename
             if ! $filename =~ 'backup\.properties|snapshot\.shard1';
     }

--- a/admin/BundleSearchIndexesDump
+++ b/admin/BundleSearchIndexesDump
@@ -140,7 +140,7 @@ for my $backup_dir (@backup_dirs)
             next;
         }
         push @extraneous_files, $filename
-            if ! $filename =~ 'backup\.properties|snapshot\.shard1';
+            if $filename !~ 'backup\.properties|snapshot\.shard1';
     }
     closedir $bdh;
     die "$working_dir/$backup_dir has extraneous files: @extraneous_files\n"

--- a/admin/BundleSearchIndexesDump
+++ b/admin/BundleSearchIndexesDump
@@ -185,7 +185,7 @@ EOF
         exit 70; # EX_SOFTWARE
     }
 
-    MusicBrainz::Script::MBDump::gpg_sign("$working_dir/$tar_file");
+    gpg_sign("$working_dir/$tar_file");
 }
 
 for my $hash_program ('md5sum', 'sha256sum') {
@@ -200,7 +200,7 @@ for my $hash_program ('md5sum', 'sha256sum') {
         exit 70; # EX_SOFTWARE
     }
 
-    MusicBrainz::Script::MBDump::gpg_sign("$working_dir/$hash_output_file");
+    gpg_sign("$working_dir/$hash_output_file");
 }
 
 _info 'Successfully bundled SolrCloud backups as search indexes dump.';

--- a/admin/BundleSolrBackup
+++ b/admin/BundleSolrBackup
@@ -203,7 +203,7 @@ EOF
         exit 70; # EX_SOFTWARE
     }
 
-    MusicBrainz::Script::MBDump::gpg_sign("$working_dir/$tar_file");
+    gpg_sign("$working_dir/$tar_file");
 }
 
 for my $hash_program ('md5sum', 'sha256sum') {
@@ -218,7 +218,7 @@ for my $hash_program ('md5sum', 'sha256sum') {
         exit 70; # EX_SOFTWARE
     }
 
-    MusicBrainz::Script::MBDump::gpg_sign("$working_dir/$hash_output_file");
+    gpg_sign("$working_dir/$hash_output_file");
 }
 
 _info 'Successfully bundled Solr backups.';

--- a/admin/BundleSolrBackup
+++ b/admin/BundleSolrBackup
@@ -145,7 +145,7 @@ for my $backup_dir (@backup_dirs)
     for my $filename (sort grep { ! /^\.\.?$/ } readdir $bsdh)
     {
         push @extraneous_files, $filename
-            if ! $filename =~ 'backup_0\.properties|index|shard_backup_metadata|zk_backup';
+            if $filename !~ 'backup_0\.properties|index|shard_backup_metadata|zk_backup';
     }
     closedir $bsdh;
     die "$working_dir/$backup_dir/$collection has extraneous files: @extraneous_files\n"

--- a/admin/BundleSolrBackup
+++ b/admin/BundleSolrBackup
@@ -1,0 +1,236 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use English;
+use Getopt::Long qw( GetOptions );
+use List::AllUtils qw ( any );
+use Pod::Usage qw( pod2usage );
+
+################################################################################
+
+=head1 NAME
+
+BundleSolrBackup - Bundle solr backup from SolrCloud backups
+
+=head1 SYNOPSIS
+
+BundleSolrBackup [options]
+
+Options:
+
+    -w, --working-dir DIRECTORY         directory that contains solr backups
+                                        to be turned into solr backup
+    -d, --debug                         print more progress messages
+
+    -h, --help                          show this help
+
+Environment:
+
+    BACKUP_STAMP                        timestamp used for backup directory name
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2020 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut
+
+################################################################################
+
+my $working_dir;
+my $debug_flag;
+my $help_flag;
+
+GetOptions(
+    'working-dir|w=s'            => \$working_dir,
+    'debug|d'                   => \$debug_flag,
+    'help|h'                    => \$help_flag,
+);
+
+pod2usage() if $help_flag;
+pod2usage(
+    -exitval => 64, # EX_USAGE
+    -message => "$0: unrecognized arguments",
+) if @ARGV;
+
+################################################################################
+
+$SIG{'INT'} = sub { exit 3 };
+
+use File::Copy qw( copy move );
+use POSIX qw( strftime );
+use String::ShellQuote qw( shell_quote );
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use DBDefs;
+use MusicBrainz::Script::MBDump qw( gpg_sign );
+
+################################################################################
+
+sub _debug { print '[debug] ', (sprintf shift, @_), "\n" if $debug_flag; }
+sub _info { print '[info] ', (sprintf shift, @_), "\n"; }
+sub _warn { warn '[warning] ', (sprintf shift, @_), "\n"; }
+sub _error { warn '[error] ', (sprintf shift, @_), "\n"; }
+
+my $BACKUP_STAMP = $ENV{BACKUP_STAMP};
+my $COMPRESSION_LEVEL = DBDefs->SOLR_BACKUP_COMPRESSION_LEVEL;
+my $COMPRESSION_THREADS = DBDefs->DUMP_COMPRESSION_THREADS;
+
+my @backup_dirs;
+my @extraneous_files;
+
+opendir(my $wdh, $working_dir) or die $OS_ERROR;
+for my $filename (sort grep { ! /^\.\.?$/ } readdir $wdh)
+{
+    if ($filename =~ /^backup_${BACKUP_STAMP}_/)
+    {
+        push @backup_dirs, $filename;
+    }
+    else
+    {
+        push @extraneous_files, $filename;
+    }
+}
+closedir $wdh;
+
+die "$working_dir has extraneous files: @extraneous_files\n"
+    if scalar @extraneous_files;
+
+my @public_domain_collections = qw(
+    area
+    artist
+    event
+    instrument
+    label
+    place
+    recording
+    release
+    release-group
+    series
+    url
+    work
+);
+
+my @private_collections = qw(
+    editor
+);
+
+for my $backup_dir (@backup_dirs)
+{
+    my $collection = $backup_dir =~ s/^backup_\d{8}-\d{6}_//r;
+    my $dump_dir = $collection;
+    opendir(my $bdh, "$working_dir/$backup_dir") or die $OS_ERROR;
+    if (any { /^$collection$/ } @private_collections)
+    {
+        system 'rm', '-fr', "$working_dir/$backup_dir";
+        next;
+    }
+    @extraneous_files = ();
+    for my $filename (sort grep { ! /^\.\.?$/ } readdir $bdh)
+    {
+        push @extraneous_files, $filename
+            if $filename ne $collection;
+    }
+    closedir $bdh;
+    die "$working_dir/$backup_dir has extraneous files: @extraneous_files\n"
+        if scalar @extraneous_files;
+    opendir(my $bsdh, "$working_dir/$backup_dir/$collection") or die $OS_ERROR;
+    for my $filename (sort grep { ! /^\.\.?$/ } readdir $bsdh)
+    {
+        push @extraneous_files, $filename
+            if ! $filename =~ 'backup_0\.properties|index|shard_backup_metadata|zk_backup';
+    }
+    closedir $bsdh;
+    die "$working_dir/$backup_dir/$collection has extraneous files: @extraneous_files\n"
+        if scalar @extraneous_files;
+
+    my $working_dump_dir = "$working_dir/$dump_dir";
+    move("$working_dir/$backup_dir", "$working_dump_dir") or die $OS_ERROR;
+
+    my $license_file = (grep { /^$collection$/ } @public_domain_collections)
+        ? "$FindBin::Bin/COPYING-PublicDomain"
+        : "$FindBin::Bin/COPYING-CCShareAlike";
+    copy($license_file, "$working_dump_dir/COPYING") or die $OS_ERROR;
+
+    my $readme_text = <<EOF;
+Backup timestamp: $BACKUP_STAMP
+
+The content of the subdirectory '$collection' is a backup of the search index by
+the same name from musicbrainz.org, in the new Apache Solr (8.9+) backup format.
+See https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-9.html#solr-8-9
+
+It is intended to be loaded in conjunction with an earlier MusicBrainz
+Postgres (full export) data dumps, preferably of the same day, in order
+to start a mirror with search kept in sync using the live data feed.
+See https://musicbrainz.org/doc/MusicBrainz_Server/Setup
+
+Since it has been created later than the above-mentioned full export,
+this backup has more updates, therefore these are NOT in sync
+and are NOT suitable for a snapshot/out-of-sync mirror.
+
+To load it, it is assumed that you use an up-to-date version of
+the MusicBrainz simple Solr search server schema (mbsssss)
+the MusicBrainz Solr (mb-solr) server in turn depends on.
+EOF
+    _write_file($working_dump_dir, 'README', $readme_text);
+
+    my $tar_file = "$collection.tar.zst";
+    _info("Creating $tar_file");
+    system
+        'bash', '-c',
+            'set -o pipefail; ' .
+            'tar' .
+            ' -C ' . shell_quote($working_dir) .
+            ' --create' .
+            ' --group=solr:8983' .
+            ' --owner=solr:8983' .
+            ' --remove-files' .
+            ' --verbose' .
+            ' -- ' .
+            shell_quote($dump_dir) .
+            " | zstd -T$COMPRESSION_THREADS -$COMPRESSION_LEVEL" .
+            ' > ' . shell_quote("$working_dir/$tar_file");
+    if ($CHILD_ERROR != 0)
+    {
+        _error('Tar returned ' . ($CHILD_ERROR >> 8));
+        exit 70; # EX_SOFTWARE
+    }
+
+    MusicBrainz::Script::MBDump::gpg_sign("$working_dir/$tar_file");
+}
+
+for my $hash_program ('md5sum', 'sha256sum') {
+    my $hash_output_file = uc($hash_program . 's');
+    chomp (my $hash_bin = `which g$hash_program` || `which $hash_program`);
+    my $hash_command = "cd $working_dir" .
+        " && $hash_bin --binary *.tar.zst > $hash_output_file";
+    system $hash_command;
+    if ($CHILD_ERROR != 0)
+    {
+        _error('Failed command with ' . ($CHILD_ERROR >> 8) . ": $hash_command");
+        exit 70; # EX_SOFTWARE
+    }
+
+    MusicBrainz::Script::MBDump::gpg_sign("$working_dir/$hash_output_file");
+}
+
+_info 'Successfully bundled Solr backups.';
+exit;
+
+################################################################################
+
+sub _write_file
+{
+    my ($parent_dir, $file, $contents) = @_;
+
+    open(my $fh, '>' . $parent_dir . "/$file") or die $OS_ERROR;
+    print $fh $contents or die $OS_ERROR;
+    close $fh or die $OS_ERROR;
+}

--- a/admin/RunSolrBackup
+++ b/admin/RunSolrBackup
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+if [[ -t 1 ]]
+then
+    exec 2>&1 | ts '%X %Z'
+fi
+
+exec 220>/tmp/.RunSolrBackup.lock || exit 1
+# Will be automatically released when the script exits.
+flock -n 220 || { echo "Failed to obtain lock. Another instance is running?" >&2; exit 1; }
+
+# This is to help with disk space monitoring - run "df" before and after
+echo "Disk space when RunSolrBackup starts:" ; df -m
+trap 'echo "Disk space when RunSolrBackup ends:" ; df -m' 0
+
+MB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
+cd "$MB_SERVER_ROOT"
+
+source admin/config.sh
+
+. ./admin/functions.sh
+make_temp_dir
+
+DUMP_DIR="$SOLR_BACKUP_DIR"
+DUMP_STAMP=`TZ=UTC date +'%Y%m%d-%H%M%S'`
+
+# Create necessary directories and set permissions.
+mkdir -m "$SOLR_BACKUP_DIR_MODE" -p "$DUMP_DIR/$DUMP_STAMP"
+chown "$SOLR_BACKUP_USER:$SOLR_BACKUP_GROUP" \
+    "$DUMP_DIR" \
+    "$DUMP_DIR"/"$DUMP_STAMP"
+
+echo Requesting SolrCloud backups
+BACKUP_STAMP="$DUMP_STAMP" \
+    ./admin/RequestSolrCloudBackups \
+    || exit $?
+
+echo Retrieving SolrCloud backups
+MBS_ADMIN_CONFIG=config.solr-backup.sh \
+    ./bin/rsync-solrcloud-backups "$TEMP_DIR" \
+    || exit $?
+
+echo Bundling Solr backups
+BACKUP_STAMP="$DUMP_STAMP" \
+    ./admin/BundleSolrBackup \
+    --working-dir "$TEMP_DIR" \
+    || exit $?
+
+echo Copying the dump to the local FTP directory
+chown "$SOLR_BACKUP_USER:$SOLR_BACKUP_GROUP" "$TEMP_DIR"/*
+chmod "$SOLR_BACKUP_FILE_MODE" "$TEMP_DIR"/*
+mv "$TEMP_DIR"/* "$DUMP_DIR"/"$DUMP_STAMP"/
+
+# Finally create a "latest-is" file, indicating the export we just did.
+rm -rf "$DUMP_DIR"/latest-is-*
+> "$DUMP_DIR"/latest-is-"$DUMP_STAMP"
+chmod "$SOLR_BACKUP_FILE_MODE" "$DUMP_DIR"/latest-is-"$DUMP_STAMP"
+chown "$SOLR_BACKUP_USER:$SOLR_BACKUP_GROUP" "$DUMP_DIR"/latest-is-"$DUMP_STAMP"
+
+# Finally finally, create a LATEST file whose *contents* are this export's tag
+rm -rf "$DUMP_DIR"/LATEST
+echo "$DUMP_STAMP" > "$DUMP_DIR"/LATEST
+chmod "$SOLR_BACKUP_FILE_MODE" "$DUMP_DIR"/LATEST
+chown "$SOLR_BACKUP_USER:$SOLR_BACKUP_GROUP" "$DUMP_DIR"/LATEST
+
+echo Deleting old full exports from the local FTP directory
+./bin/delete-old-fullexports -k -r "$DUMP_DIR"
+
+echo Syncing the local FTP directory with the FTP server
+MBS_ADMIN_CONFIG=config.solr-backup.sh ./bin/rsync-fullexport-files

--- a/admin/config.default.sh
+++ b/admin/config.default.sh
@@ -22,6 +22,13 @@ SEARCH_INDEXES_DUMP_GROUP=musicbrainz
 SEARCH_INDEXES_DUMP_DIR_MODE=755
 SEARCH_INDEXES_DUMP_FILE_MODE=644
 
+# Same, but for Solr backups.
+SOLR_BACKUP_DIR=/home/musicbrainz/solr-backups
+SOLR_BACKUP_USER=musicbrainz
+SOLR_BACKUP_GROUP=musicbrainz
+SOLR_BACKUP_DIR_MODE=755
+SOLR_BACKUP_FILE_MODE=644
+
 # Where to back things up to, who should own the backup files, and what mode
 # those files should have.
 # The backups include a full database export, and all replication data.

--- a/admin/config.solr-backup.sh
+++ b/admin/config.solr-backup.sh
@@ -1,0 +1,4 @@
+RSYNC_FULLEXPORT_DIR="$SOLR_BACKUP_DIR"
+RSYNC_FULLEXPORT_KEY='~/.ssh/rsync-data-solr-backups'
+RSYNC_LATEST_KEY='~/.ssh/rsync-data-solr-backups-latest'
+RSYNC_SOLRCLOUD_BACKUPS_KEY='~/.ssh/rsync-solrcloud-collections-backup'

--- a/admin/cron/daily-solr-backup.sh
+++ b/admin/cron/daily-solr-backup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+if [[ -t 1 ]]
+then
+    exec 2>&1 | ts '%X %Z'
+fi
+
+MB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../" && pwd)
+cd "$MB_SERVER_ROOT"
+
+# Only do this on the nominated days 3=Wed and 6=Sat (for reference 0=Sun)
+if date +%w | grep -qw '[36]'
+then
+    ./admin/RunSolrBackup
+fi

--- a/bin/rsync-solrcloud-backups
+++ b/bin/rsync-solrcloud-backups
@@ -18,7 +18,7 @@ SOLRCLOUD_COLLECTIONS_API="$(perl -Ilib -e 'use DBDefs; print DBDefs->SOLRCLOUD_
 RSYNC_SOLRCLOUD_BACKUPS_HOST="$(
     curl -sSL "$SOLRCLOUD_COLLECTIONS_API?action=OVERSEERSTATUS" \
         | jq -r '.leader' \
-        | sed 's/:.*//'
+        | sed 's/:.*//;s/^solrcloud-[0-9]*/mb-&.metabrainz.org/'
 )"
 
 if [ -n "$RSYNC_SOLRCLOUD_BACKUPS_HOST" ]; then

--- a/bin/rsync-solrcloud-backups
+++ b/bin/rsync-solrcloud-backups
@@ -28,7 +28,6 @@ if [ -n "$RSYNC_SOLRCLOUD_BACKUPS_HOST" ]; then
         --archive \
         --bwlimit="$RSYNC_SOLRCLOUD_BACKUPS_BANDWIDTH" \
         --delete \
-        --exclude="zk_backup" \
         --rsh "ssh -i $RSYNC_SOLRCLOUD_BACKUPS_KEY -c $RSYNC_SOLRCLOUD_BACKUPS_CIPHER_SPEC -o Compression=no -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p $RSYNC_SOLRCLOUD_BACKUPS_PORT" \
         --verbose \
         solr@"$RSYNC_SOLRCLOUD_BACKUPS_HOST":. \

--- a/docker/musicbrainz-solr-backup/crontab
+++ b/docker/musicbrainz-solr-backup/crontab
@@ -1,0 +1,2 @@
+SHELL=/bin/bash
+10 4 * * * $HOME/musicbrainz-server/admin/run admin/cron/daily-solr-backup.sh

--- a/docker/scripts/create_log_directories.sh
+++ b/docker/scripts/create_log_directories.sh
@@ -16,6 +16,7 @@ declare -rA log_directories_by_container_type=(
   ['json-dump']='daily-json-dump hourly-json-dump occasionally'
   ['search-indexes-dump']='daily-search-indexes-dump hourly-search-indexes-dump occasionally'
   ['sitemaps']='daily-sitemaps hourly-sitemaps occasionally'
+  ['solr-backup']='daily-solr-backup hourly-solr-backup occasionally'
 )
 
 HELP=$(cat <<EOH

--- a/docker/templates/Dockerfile.solr-backup.m4
+++ b/docker/templates/Dockerfile.solr-backup.m4
@@ -1,0 +1,19 @@
+m4_include(`server_base.m4')m4_dnl
+
+run_with_apt_cache \
+    apt_install(`jq zstd')
+
+RUN chown_mb(`/home/musicbrainz/log') && \
+    chown_mb(`/home/musicbrainz/solr-backups')
+
+COPY --chown=musicbrainz:musicbrainz --chmod=0600 \
+     docker/musicbrainz-solr-backup/crontab \
+     /var/spool/cron/crontabs/musicbrainz
+
+ENV MB_CONTAINER_TYPE solr-backup
+
+COPY \
+    docker/scripts/create_log_directories.sh \
+    /etc/my_init.d/90_create_log_directories.sh
+
+git_info

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -529,11 +529,12 @@ sub USE_SELENIUM_HEADER { 0 }
 # in that case anyway.
 sub DISABLE_LAST_LOGIN_UPDATE { 0 }
 
-# Used to create search indexes dump from SolrCloud.
+# Used to create backup and search indexes dump from SolrCloud.
 sub SOLRCLOUD_COLLECTIONS_API { undef }
 sub SOLRCLOUD_BACKUP_LOCATION { undef }
 sub SOLRCLOUD_RSYNC_BANDWIDTH { undef }
 sub SOLRCLOUD_SSH_CIPHER_SPEC { undef }
+sub SOLR_BACKUP_COMPRESSION_LEVEL { undef }
 sub SEARCH_INDEXES_DUMP_COMPRESSION_LEVEL { undef }
 
 # Controls the number of threads to use when compressing JSON dumps or search


### PR DESCRIPTION
# Problem

With SEARCH-685 (Upgrade to Solr 9), a new format is required for backing up collections with SolrCloud for initializing with MusicBrainz mirrors.

# Solution

This patch allows to make SolrCloud 8.9+ collections (formerly named as search indexes) backups available for use with MusicBrainz live mirrors. It mainly adapts the container and scripts that were used to dump Solr 7 search indexes.

The main differences are:
* Naming (from "search index dump" - which was often mixed with Postgres terms - to "collection backup" - which comes from the SolrCloud docs.)
* ZooKeeper information are made available in the  `zk_backup` directory (information about nodes are already available through public Grafana.)
* Files hierarchy within the archive:
    * SolrCloud backup directory
      (named after entity type)
      (contains COPYING and README for distribution not for loading)
      * SolrCloud collection directory
        (named after entity type too)
* Loading script (to be moved from `musicbrainz-docker` to `mb-solr`.)

Solr 7 search index dumps remain available during the transition period.

# Testing

* Built images [`metabrainz/musicbrainz-solr-backup`](https://hub.docker.com/r/metabrainz/musicbrainz-solr-backup/tags)`:test`
* Deployed a container on `aretha` 
* Ran manually, then through `cron`, publishing two dumps under [`solr-backups/`](http://ftp.musicbrainz.org/pub/musicbrainz/data/solr-backups/).
* Loaded the instrument backup archive with a modified version of the script from `musicbrainz-docker`. (I will submit this script to the repository `mb-solr`.)

# Documenting
<!--
    List changes to the documentation, which can be placed in the WikiDoc pages,
    in this Git repository, in another repository, in the database...
-->

The `README` file generated by `admin/BundleSolrBackup` contains more details about the purpose of the archives.

# Further action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

On merge, we have to:
* update infrastructure documentation (essentially search for `search-index` and add Solr backups).

On deployment (a new image is produced), we have to:
1. remove the `test` image,
2. replace the current test container with a production container.