### PR TITLE
MBS-13993: Ignore seeded external links that duplicate existing ones

### DIFF
--- a/root/static/scripts/tests/release-editor/seeds/mbs-13993.html
+++ b/root/static/scripts/tests/release-editor/seeds/mbs-13993.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <form action="/release/1bda2f85-0576-4077-b3fa-0fc939079b61/edit" method="POST">
+      <input type="hidden" name="urls.0.url" value="http://thedavidbowieknives.bandcamp.com/album/weapons-of-mass-seduction" />
+      <input type="hidden" name="urls.0.link_type" value="74" />
+      <input type="hidden" name="urls.1.url" value="http://thedavidbowieknives.bandcamp.com/album/weapons-of-mass-seduction" />
+      <input type="hidden" name="urls.1.link_type" value="85" />
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -827,6 +827,7 @@ const seleniumTests = [
   {name: 'MBS-13392.json5', login: true},
   {name: 'MBS-13604.json5', login: true},
   {name: 'MBS-13615.json5', login: true},
+  {name: 'MBS-13993.json5', login: true},
   {name: 'Artist_Credit_Editor.json5', login: true},
   {name: 'Autocomplete2.json5'},
   {name: 'External_Links_Editor.json5', login: true},

--- a/t/selenium/MBS-13993.json5
+++ b/t/selenium/MBS-13993.json5
@@ -1,0 +1,25 @@
+{
+  title: 'MBS-13993',
+  commands: [
+    {
+      command: 'open',
+      target: '/static/scripts/tests/release-editor/seeds/mbs-13993.html',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "Array.from(document.querySelectorAll('tr.external-link-item a.url')).map(a => a.href).join(',')",
+      value: 'http://thedavidbowieknives.bandcamp.com/album/weapons-of-mass-seduction',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelectorAll('tr.external-link-item .error').length",
+      value: '0',
+    },
+  ],
+}


### PR DESCRIPTION
# Problem

MBS-13993

# Solution

Group the existing links (ones with a relationship ID) by type-url pairs, and filter out any seeded links (ones without a relationship ID) that duplicate an existing type-url pair.

# Testing

Only the added Selenium test.