### PR TITLE
MBS-13966: Calculate first release dates for empty release groups

### DIFF
--- a/admin/sql/CreateFunctions.sql
+++ b/admin/sql/CreateFunctions.sql
@@ -1150,9 +1150,10 @@ BEGIN
                                   first_release_date_day = first.day
       FROM (
         SELECT rd.year, rd.month, rd.day
-        FROM release
+        FROM release_group
+        LEFT JOIN release ON release.release_group = release_group.id
         LEFT JOIN release_first_release_date rd ON (rd.release = release.id)
-        WHERE release.release_group = release_group_id
+        WHERE release_group.id = release_group_id
         ORDER BY
           rd.year NULLS LAST,
           rd.month NULLS LAST,

--- a/admin/sql/updates/20250425-mbs-13966.sql
+++ b/admin/sql/updates/20250425-mbs-13966.sql
@@ -1,0 +1,50 @@
+\set ON_ERROR_STOP 1
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION set_release_group_first_release_date(release_group_id INTEGER)
+RETURNS VOID AS $$
+BEGIN
+    UPDATE release_group_meta SET first_release_date_year = first.year,
+                                  first_release_date_month = first.month,
+                                  first_release_date_day = first.day
+      FROM (
+        SELECT rd.year, rd.month, rd.day
+        FROM release_group
+        LEFT JOIN release ON release.release_group = release_group.id
+        LEFT JOIN release_first_release_date rd ON (rd.release = release.id)
+        WHERE release_group.id = release_group_id
+        ORDER BY
+          rd.year NULLS LAST,
+          rd.month NULLS LAST,
+          rd.day NULLS LAST
+        LIMIT 1
+      ) AS first
+    WHERE id = release_group_id;
+    INSERT INTO artist_release_group_pending_update VALUES (release_group_id);
+END;
+$$ LANGUAGE 'plpgsql';
+
+UPDATE release_group_meta SET first_release_date_year = first.year,
+                              first_release_date_month = first.month,
+                              first_release_date_day = first.day
+  FROM (
+    SELECT DISTINCT ON (release_group.id)
+        release_group.id AS release_group, rd.year, rd.month, rd.day
+    FROM release_group
+    LEFT JOIN release ON release.release_group = release_group.id
+    LEFT JOIN release_first_release_date rd ON (rd.release = release.id)
+    ORDER BY
+      release_group.id,
+      rd.year NULLS LAST,
+      rd.month NULLS LAST,
+      rd.day NULLS LAST
+  ) AS first
+WHERE id = first.release_group
+  AND (
+    first_release_date_year IS DISTINCT FROM first.year
+    OR first_release_date_month IS DISTINCT FROM first.month
+    OR first_release_date_day IS DISTINCT FROM first.day
+  );
+
+COMMIT;

--- a/admin/sql/updates/schema-change/30.all.sql
+++ b/admin/sql/updates/schema-change/30.all.sql
@@ -4,6 +4,7 @@
 -- 20241125-mbs-13832.sql
 -- 20250320-mbs-13768.sql
 -- 20250408-mbs-13964-all.sql
+-- 20250425-mbs-13966.sql
 \set ON_ERROR_STOP 1
 BEGIN;
 SET search_path = musicbrainz, public;
@@ -330,5 +331,54 @@ CREATE TRIGGER a_upd_medium AFTER UPDATE ON medium
     FOR EACH ROW EXECUTE PROCEDURE a_upd_medium_mirror();
 
 TRUNCATE recording_first_release_date;
+
+--------------------------------------------------------------------------------
+SELECT '20250425-mbs-13966.sql';
+
+
+CREATE OR REPLACE FUNCTION set_release_group_first_release_date(release_group_id INTEGER)
+RETURNS VOID AS $$
+BEGIN
+    UPDATE release_group_meta SET first_release_date_year = first.year,
+                                  first_release_date_month = first.month,
+                                  first_release_date_day = first.day
+      FROM (
+        SELECT rd.year, rd.month, rd.day
+        FROM release_group
+        LEFT JOIN release ON release.release_group = release_group.id
+        LEFT JOIN release_first_release_date rd ON (rd.release = release.id)
+        WHERE release_group.id = release_group_id
+        ORDER BY
+          rd.year NULLS LAST,
+          rd.month NULLS LAST,
+          rd.day NULLS LAST
+        LIMIT 1
+      ) AS first
+    WHERE id = release_group_id;
+    INSERT INTO artist_release_group_pending_update VALUES (release_group_id);
+END;
+$$ LANGUAGE 'plpgsql';
+
+UPDATE release_group_meta SET first_release_date_year = first.year,
+                              first_release_date_month = first.month,
+                              first_release_date_day = first.day
+  FROM (
+    SELECT DISTINCT ON (release_group.id)
+        release_group.id AS release_group, rd.year, rd.month, rd.day
+    FROM release_group
+    LEFT JOIN release ON release.release_group = release_group.id
+    LEFT JOIN release_first_release_date rd ON (rd.release = release.id)
+    ORDER BY
+      release_group.id,
+      rd.year NULLS LAST,
+      rd.month NULLS LAST,
+      rd.day NULLS LAST
+  ) AS first
+WHERE id = first.release_group
+  AND (
+    first_release_date_year IS DISTINCT FROM first.year
+    OR first_release_date_month IS DISTINCT FROM first.month
+    OR first_release_date_day IS DISTINCT FROM first.day
+  );
 
 COMMIT;

--- a/t/pgtap/first_release_dates.sql
+++ b/t/pgtap/first_release_dates.sql
@@ -473,5 +473,28 @@ SELECT results_eq(
   'VALUES (1999::smallint, null::smallint, null::smallint)'
 );
 
+-- MBS-13966: Update a release group's first release date when it's emptied
+-- via a release move.
+
+SELECT results_eq(
+  'release_group_first_release_dates',
+  $$
+    VALUES
+      (1::integer, 1999::smallint, null::smallint, null::smallint),
+      (2::integer, null::smallint, null::smallint, null::smallint)
+  $$
+);
+
+UPDATE release SET release_group = 2 WHERE release_group = 1;
+
+SELECT results_eq(
+  'release_group_first_release_dates',
+  $$
+    VALUES
+      (1::integer, null::smallint, null::smallint, null::smallint),
+      (2::integer, 1999::smallint, null::smallint, null::smallint)
+  $$
+);
+
 SELECT finish();
 ROLLBACK;

--- a/upgrade.json
+++ b/upgrade.json
@@ -237,7 +237,8 @@
       "20250425-mbs-13464.sql",
       "20241125-mbs-13832.sql",
       "20250320-mbs-13768.sql",
-      "20250408-mbs-13964-all.sql"
+      "20250408-mbs-13964-all.sql",
+      "20250425-mbs-13966.sql"
     ],
     "master_and_standalone": [
       "20241017-mbs-9253-master_and_standalone.sql",


### PR DESCRIPTION
# Problem

MBS-13966

# Solution

The `set_release_group_first_release_date` function has been modified to select from `release_group` first, and then `LEFT JOIN` with release, in order to include RGs with no releases. I believe this is only triggered when the last release is moved out of an RG. (There should be no such issue when deleting the last release, since that implies its release events will be removed *first*, and the RG won't be empty yet.)

Note: The `artist_release_group` table depends on these values, but we're already clearing that table as part of MBS-9253, and will require users to run admin/BuildMaterializedTables again after upgrade.sh has completed.

There is a constraint trigger, `apply_artist_release_group_pending_updates`, on `release_group_meta` which calls `apply_artist_release_group_pending_updates`, but we're not inserting any release group IDs into `artist_release_group_pending_update` here, so it's harmless.

# Testing

Used this query to identify bad rows in the test.mb DB:

```SQL
WITH first AS (
    SELECT DISTINCT ON (release_group.id)
        release_group.id AS release_group, rd.year, rd.month, rd.day
    FROM release_group
    LEFT JOIN release ON release.release_group = release_group.id
    LEFT JOIN release_first_release_date rd ON (rd.release = release.id)
    ORDER BY
      release_group.id,
      rd.year NULLS LAST,
      rd.month NULLS LAST,
      rd.day NULLS LAST
  )
  SELECT count(*) FROM release_group_meta rgm
  JOIN first ON first.release_group = rgm.id
  WHERE rgm.first_release_date_year IS DISTINCT FROM first.year 
     OR rgm.first_release_date_month IS DISTINCT FROM first.month
     OR rgm.first_release_date_day IS DISTINCT FROM first.day;
```

(I had to build `release_first_release_date` first.) Then ran the upgrade script, and the above query again, which returned 0 rows (down from 165).