### PR TITLE
Propagate `EXTRA_SQL` failures in script/reset_selenium_env.sh

### DIFF
--- a/script/reset_selenium_env.sh
+++ b/script/reset_selenium_env.sh
@@ -64,7 +64,7 @@ echo `date` : Inserting Selenium test data
 OUTPUT=`./admin/psql SELENIUM < ./t/sql/selenium.sql 2>&1` || ( echo "$OUTPUT" && exit 1 )
 
 if [[ -f $EXTRA_SQL ]]; then
-    OUTPUT=`./admin/psql SELENIUM < "$EXTRA_SQL" 2>&1` || ( echo "$OUTPUT" && exit 1 )
+    OUTPUT=`./admin/psql SELENIUM -- -v ON_ERROR_STOP=1 < "$EXTRA_SQL" 2>&1` || ( echo "$OUTPUT" && exit 1 )
 fi
 
 if [[ $SIR_DIR ]]; then

--- a/script/reset_selenium_env.sh
+++ b/script/reset_selenium_env.sh
@@ -64,7 +64,7 @@ echo `date` : Inserting Selenium test data
 OUTPUT=`./admin/psql SELENIUM < ./t/sql/selenium.sql 2>&1` || ( echo "$OUTPUT" && exit 1 )
 
 if [[ -f $EXTRA_SQL ]]; then
-    OUTPUT=`./admin/psql SELENIUM -- -v ON_ERROR_STOP=1 < "$EXTRA_SQL" 2>&1` || ( echo "$OUTPUT" && exit 1 )
+    OUTPUT=`./admin/psql SELENIUM -- --single-transaction -v ON_ERROR_STOP=1 < "$EXTRA_SQL" 2>&1` || ( echo "$OUTPUT" && exit 1 )
 fi
 
 if [[ $SIR_DIR ]]; then


### PR DESCRIPTION
# Problem

 * If a Selenium test's SQL script fails, it currently does so silently without causing the test to fail immediately.
 * When this happens, it also doesn't roll back the changes.

# Solution

Adds two flags to the `psql` call:

 * `-v ON_ERROR_STOP=1` 
 * `--single-transaction`

# Testing

Running `./admin/psql SELENIUM -- --single-transaction -v ON_ERROR_STOP=1 < t/sql/mbs-10510.sql` locally and checking the exit code when the script has or doesn't have errors.