### PR TITLE
MBS-13997: Check both start and end date in DuplicateEvents 

### DIFF
--- a/lib/MusicBrainz/Server/Report/DuplicateEvents.pm
+++ b/lib/MusicBrainz/Server/Report/DuplicateEvents.pm
@@ -7,10 +7,12 @@ with 'MusicBrainz::Server::Report::EventReport',
 sub query { q{
 WITH duplicates AS (
     SELECT event.begin_date_year AS begin_date_year, event.begin_date_month AS begin_date_month, 
-           event.begin_date_day AS begin_date_day, l_event_place.entity1 AS entity1
+           event.begin_date_day AS begin_date_day, event.end_date_year AS end_date_year,
+           event.end_date_month AS end_date_month, event.end_date_day AS end_date_day,
+           l_event_place.entity1 AS entity1
      FROM event 
      JOIN l_event_place ON event.id = l_event_place.entity0
- GROUP BY l_event_place.entity1, event.begin_date_year, event.begin_date_month, event.begin_date_day
+ GROUP BY l_event_place.entity1, event.begin_date_year, event.begin_date_month, event.begin_date_day, event.end_date_year, event.end_date_month, event.end_date_day
    HAVING count(*) > 1
 ) 
 
@@ -23,6 +25,9 @@ SELECT event.id AS event_id,
        duplicates.begin_date_year = event.begin_date_year 
        AND duplicates.begin_date_month = event.begin_date_month 
        AND duplicates.begin_date_day = event.begin_date_day 
+       AND duplicates.end_date_year = event.end_date_year
+       AND duplicates.end_date_month = event.end_date_month
+       AND duplicates.end_date_day = event.end_date_day
        AND l_event_place.entity1 = duplicates.entity1
   )
   WHERE EXISTS (
@@ -33,6 +38,9 @@ SELECT event.id AS event_id,
     WHERE e2.begin_date_year = event.begin_date_year 
         AND e2.begin_date_month = event.begin_date_month 
         AND e2.begin_date_day = event.begin_date_day 
+        AND e2.end_date_year = event.end_date_year
+        AND e2.end_date_month = event.end_date_month
+        AND e2.end_date_day = event.end_date_day
         AND lep2.entity1 = duplicates.entity1
         AND e2.comment = ''
   )

--- a/lib/MusicBrainz/Server/Report/DuplicateEvents.pm
+++ b/lib/MusicBrainz/Server/Report/DuplicateEvents.pm
@@ -4,48 +4,50 @@ use Moose;
 with 'MusicBrainz::Server::Report::EventReport',
      'MusicBrainz::Server::Report::FilterForEditor::EventID';
 
-sub query { q{
-WITH duplicates AS (
-    SELECT event.begin_date_year AS begin_date_year, event.begin_date_month AS begin_date_month, 
-           event.begin_date_day AS begin_date_day, event.end_date_year AS end_date_year,
-           event.end_date_month AS end_date_month, event.end_date_day AS end_date_day,
-           l_event_place.entity1 AS entity1
-     FROM event 
-     JOIN l_event_place ON event.id = l_event_place.entity0
- GROUP BY l_event_place.entity1, event.begin_date_year, event.begin_date_month, event.begin_date_day, event.end_date_year, event.end_date_month, event.end_date_day
-   HAVING count(*) > 1
-) 
+sub query {<<~'SQL'}
+  WITH duplicates AS (
+      SELECT event.begin_date_year AS begin_date_year,
+             event.begin_date_month AS begin_date_month,
+             event.begin_date_day AS begin_date_day,
+             event.end_date_year AS end_date_year,
+             event.end_date_month AS end_date_month,
+             event.end_date_day AS end_date_day,
+             l_event_place.entity1 AS entity1
+        FROM event
+        JOIN l_event_place ON event.id = l_event_place.entity0
+    GROUP BY l_event_place.entity1, event.begin_date_year, event.begin_date_month, event.begin_date_day, event.end_date_year, event.end_date_month, event.end_date_day
+      HAVING count(*) > 1
+  )
 
-SELECT event.id AS event_id, 
-       row_number() OVER ( ORDER BY place.name COLLATE musicbrainz, event.begin_date_year, event.begin_date_month, event.begin_date_day )
-  FROM event 
-  JOIN l_event_place ON event.id = l_event_place.entity0 
-  JOIN place ON place.id = l_event_place.entity1
-  JOIN duplicates ON (
-       duplicates.begin_date_year = event.begin_date_year 
-       AND duplicates.begin_date_month = event.begin_date_month 
-       AND duplicates.begin_date_day = event.begin_date_day 
-       AND duplicates.end_date_year = event.end_date_year
-       AND duplicates.end_date_month = event.end_date_month
-       AND duplicates.end_date_day = event.end_date_day
-       AND l_event_place.entity1 = duplicates.entity1
-  )
-  WHERE EXISTS (
-    SELECT TRUE
-    FROM event e2
-    JOIN l_event_place lep2 ON e2.id = lep2.entity0 
-    JOIN place p2 ON p2.id = lep2.entity1
-    WHERE e2.begin_date_year = event.begin_date_year 
-        AND e2.begin_date_month = event.begin_date_month 
-        AND e2.begin_date_day = event.begin_date_day 
-        AND e2.end_date_year = event.end_date_year
-        AND e2.end_date_month = event.end_date_month
-        AND e2.end_date_day = event.end_date_day
-        AND lep2.entity1 = duplicates.entity1
-        AND e2.comment = ''
-  )
-};
-}
+  SELECT event.id AS event_id,
+         row_number() OVER ( ORDER BY place.name COLLATE musicbrainz, event.begin_date_year, event.begin_date_month, event.begin_date_day )
+    FROM event
+    JOIN l_event_place ON event.id = l_event_place.entity0
+    JOIN place ON place.id = l_event_place.entity1
+    JOIN duplicates ON (
+          duplicates.begin_date_year = event.begin_date_year
+      AND duplicates.begin_date_month = event.begin_date_month
+      AND duplicates.begin_date_day = event.begin_date_day
+      AND duplicates.end_date_year = event.end_date_year
+      AND duplicates.end_date_month = event.end_date_month
+      AND duplicates.end_date_day = event.end_date_day
+      AND l_event_place.entity1 = duplicates.entity1
+    )
+    WHERE EXISTS (
+      SELECT TRUE
+        FROM event e2
+        JOIN l_event_place lep2 ON e2.id = lep2.entity0
+        JOIN place p2 ON p2.id = lep2.entity1
+       WHERE e2.begin_date_year = event.begin_date_year
+         AND e2.begin_date_month = event.begin_date_month
+         AND e2.begin_date_day = event.begin_date_day
+         AND e2.end_date_year = event.end_date_year
+         AND e2.end_date_month = event.end_date_month
+         AND e2.end_date_day = event.end_date_day
+         AND lep2.entity1 = duplicates.entity1
+         AND e2.comment = ''
+    )
+  SQL
 
 __PACKAGE__->meta->make_immutable;
 no Moose;


### PR DESCRIPTION
### Implement MBS-13997

# Problem
The DuplicateEvents report only looks at matching start dates, not matching end dates, so it is currently suggesting festivals as duplicates of the first day of the same festival.

# Solution
There's no great reason why we would not look at end date as well, so this just does that. The only reason would be for cases where a beginner adds a duplicate *and* doesn't set an end date, but that's two mistakes in one and adding the end date is trivial with the copy button, so hopefully it's not too common (and there's a lot of these false positives in the report at the moment).

# Testing
Manually locally by adding these sorts of "duplicate" events and checking they disappear from the report after the changes.