### PR TITLE
MBS-13980: Add recording, RG, series, and work bubbles (II)

### DIFF
--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -216,30 +216,6 @@
   </table>
 [%- END -%]
 
-[%- MACRO iswc_bubble(work) BLOCK -%]
-    <div class="bubble" id="iswcs-bubble">
-      <p>[% l('You are about to add an ISWC to this work. The ISWC must be entered in
-               standard <code>T-DDD.DDD.DDD-C</code> format:') %]</p>
-      <ul>
-        <li>[% l('"DDD" is a nine digit work identifier.') %]</li>
-        <li>[% l('"C" is a single check digit.') %]</li>
-      </ul>
-    </div>
-[%- END -%]
-
-[%- MACRO isrc_bubble(recording) BLOCK -%]
-    <div class="bubble" id="isrcs-bubble">
-      <p>[% l('You are about to add an ISRC to this recording. The ISRC must be entered in
-               standard <code>CCXXXYYNNNNN</code> format:') %]</p>
-      <ul>
-        <li>[% l('"CC" is the appropriate for the registrant two-character country code.') %]</li>
-        <li>[% l('"XXX" is a three character alphanumeric registrant code, uniquely identifying the organisation which registered the code.') %]</li>
-        <li>[% l('"YY" is the last two digits of the year of registration.') %]</li>
-        <li>[% l('"NNNNN" is a unique 5-digit number identifying the particular sound recording.') %]</li>
-      </ul>
-    </div>
-[%- END -%]
-
 [%- MACRO ipi_bubble BLOCK -%]
     <div class="bubble" id="ipi-bubble">
       <p>[% l('{doc|IPI codes} are assigned by CISAC to “interested parties” in musical rights management.',

--- a/root/recording/edit_form.tt
+++ b/root/recording/edit_form.tt
@@ -66,6 +66,64 @@
   </div>
 
   <div class="documentation">
-    [%- isrc_bubble(link_entity(recording)) -%]
+    <div class="bubble" id="name-bubble">
+      <p>
+        [% l('The {doc|name} is usually the most common title from track listings on official releases.',
+             { doc => { href => doc_link('Recording#Title'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('Please see the {doc|style guidelines} for more information.',
+             { doc => { href => doc_link('Style/Recording#Title'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="artist-bubble">
+      <p>
+        [% l('For popular music, the {doc|artist} should usually match the track artist on the earliest release containing the recording.',
+             { doc => { href => doc_link('Recording#Artist'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('For classical music, it should contain the most important performers.') %]
+      </p>
+      <p>
+        [% l('Please see the {doc_style|style guidelines} and the {doc_classical|classical guidelines} for more information.',
+             { doc_style => { href => doc_link('Style/Recording#Artist'), target => '_blank' },
+               doc_classical => { href => doc_link('Style/Classical/Recording_Artist'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="comment-bubble">
+      <p>
+        [% l('The {doc|disambiguation} field helps users distinguish between similarly-named recordings by the same artist.',
+             { doc => { href => doc_link('Disambiguation_Comment'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('If this is a live recording, please also see the {doc|live recording} guidelines.',
+             { doc => { href => doc_link('Style/Recording#Live_recordings'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('It’s okay to leave it blank if there are no other recordings with similar names, and this isn’t a live recording.') %]
+      </p>
+    </div>
+
+    <div class="bubble" id="length-bubble">
+      <p>
+        [% l('The {doc|length} is the recording’s duration in MM:SS format.',
+             { doc => { href => doc_link('Recording#Length'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="isrcs-bubble">
+      <p>
+        [% l('The {doc|ISRC} is a 12-character alphanumeric string identifying this recording.',
+             { doc => { href => doc_link('ISRC'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="external-link-bubble">
+      <p>
+        [% l('External links are URLs associated with the recording, such as purchase or streaming pages, or entries in other databases.') %]
+      </p>
+    </div>
   </div>
 </form>

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -373,6 +373,10 @@
             You can select multiple types by using Ctrl + click (or Cmd + click on a Mac).',
            { doc => { href => doc_link('Release_Group/Type'), target => '_blank' } }) %]
     </p>
+    <p>
+      [% l('Please see the {doc|style guidelines} for more information.',
+           { doc => { href => doc_link('Style/Release_Group#Secondary_types'), target => '_blank' } }) %]
+    </p>
   </div>
 
   <div class="bubble" data-bind="bubble: $root.statusBubble">

--- a/root/release_group/edit_form.tt
+++ b/root/release_group/edit_form.tt
@@ -26,6 +26,73 @@
     [%- enter_edit() -%]
 
   </div>
+
+  <div class="documentation">
+    <div class="bubble" id="name-bubble">
+      <p>
+        [% l('The {doc|name} is usually the title from the earliest official release in the release group.',
+             { doc => { href => doc_link('Release_Group#Title'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('Please see the {doc|style guidelines} for more information.',
+             { doc => { href => doc_link('Style/Release_Group#Title'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="artist-bubble">
+      <p>
+        [% l('The {doc|artist} should usually match the earliest official release in the release group.',
+             { doc => { href => doc_link('Release_Group#Artist'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('Please see the {doc|style guidelines} for more information.',
+             { doc => { href => doc_link('Style/Release_Group#Artist'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="comment-bubble">
+      <p>
+        [% l('The {doc|disambiguation} field helps users distinguish between similarly-named release groups,
+              such as multiple self-titled albums by the same artist.',
+             { doc => { href => doc_link('Disambiguation_Comment'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('Please leave it blank if other information such as artist or type (album, single, etc.) already
+              distinguishes between the release groups.') %]
+      </p>
+    </div>
+
+    <div class="bubble" id="primary-type-bubble">
+      <p>
+        [% l('The {doc|primary type} describes how the release group is categorized.',
+             { doc => { href => doc_link('Release_Group/Type'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="secondary-types-bubble">
+      <p>
+        [% l('{doc|Secondary types} are additional attributes describing the release group.
+              Leave this blank if none apply.
+              You can select multiple types by using Ctrl + click (or Cmd + click on a Mac).',
+             { doc => { href => doc_link('Release_Group/Type'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('Please see the {doc|style guidelines} for more information.',
+             { doc => { href => doc_link('Style/Release_Group#Secondary_types'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="external-link-bubble">
+      <p>
+        [% l('External links are URLs associated with the release group, such as official pages, Wikipedia articles, reviews,
+              and entries in other databases.') %]
+      </p>
+      <p>
+        [% l('Please don’t add a Wikipedia page if a Wikidata item linking to the same article already exists.') %]
+      </p>
+    </div>
+  </div>
+
 </form>
 
 [%- guesscase_options() -%]

--- a/root/series/edit_form.tt
+++ b/root/series/edit_form.tt
@@ -31,10 +31,33 @@
   </div>
 
   <div class="documentation">
+    <div class="bubble" id="name-bubble">
+      <p>
+        [% l('The {doc|name} is the series’ official name.',
+             { doc => { href => doc_link('Series#Name'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="comment-bubble">
+      <p>
+        [% l('The {doc|disambiguation} field helps users distinguish between similarly-named series.',
+             { doc => { href => doc_link('Disambiguation_Comment'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('Feel free to leave it blank if the series’ name is likely to be unique.') %]
+      </p>
+    </div>
+
     [%- type_bubble(form.field('type_id'), series_types) -%]
 
     <div class="bubble" id="ordering-type-bubble" data-bind="bubble: orderingTypeBubble">
       <p data-bind="text: target() ? target().orderingTypeDescription() : ''"></p>
+    </div>
+
+    <div class="bubble" id="external-link-bubble">
+      <p>
+        [% l('External links are URLs associated with the series, such as official pages, social networking sites, and entries in other databases.') %]
+      </p>
     </div>
   </div>
 

--- a/root/static/scripts/artist/edit.js
+++ b/root/static/scripts/artist/edit.js
@@ -17,7 +17,9 @@ import initializeDuplicateChecker from '../edit/check-duplicates.js';
 import {installFormUnloadWarning} from '../edit/components/forms.js';
 import {initializeTooShortYearChecks} from '../edit/forms.js';
 import ArtistEdit from '../edit/MB/Control/ArtistEdit.js';
-import initializeBubble from '../edit/MB/Control/Bubble.js';
+import initializeBubble, {
+  initializeExternalLinksBubble,
+} from '../edit/MB/Control/Bubble.js';
 import typeBubble from '../edit/typeBubble.js';
 import initializeToggleEnded from '../edit/utility/toggleEnded.js';
 import initializeValidation from '../edit/validation.js';
@@ -45,11 +47,13 @@ $(function () {
     '#isni-bubble',
     'input[name=edit-artist\\.isni_codes\\.0]',
   );
+  // Area bubbles are initialized in ArtistEdit().
   initializeBubble(
     '#begin-end-date-bubble',
     'input[name^=edit-artist\\.period\\.begin_date\\.], ' +
       'input[name^=edit-artist\\.period\\.end_date\\.]',
   );
+  initializeExternalLinksBubble('#external-link-bubble');
 
   // Update the begin and end documentation bubbles to match the type.
   const updateBeginEndBubbles = () => {
@@ -66,17 +70,6 @@ $(function () {
   };
   $(typeIdField).on('change', () => updateBeginEndBubbles());
   updateBeginEndBubbles();
-
-  /*
-   * Display documentation bubbles for external components.
-   * Area bubbles are initialized in ArtistEdit().
-   */
-  const externalLinkBubble = initializeBubble('#external-link-bubble');
-  $(document).on(
-    'focus',
-    '#external-links-editor-container .external-link-item input.value',
-    (event) => externalLinkBubble.show(event.target),
-  );
 
   installFormUnloadWarning();
 

--- a/root/static/scripts/edit/MB/Control/Bubble.js
+++ b/root/static/scripts/edit/MB/Control/Bubble.js
@@ -9,6 +9,8 @@
 import $ from 'jquery';
 import ko from 'knockout';
 
+import '../../../../lib/jquery.ui/ui/jquery-ui.custom.js';
+
 import deferFocus from '../../utility/deferFocus.js';
 
 class BubbleBase {
@@ -345,4 +347,14 @@ export default function initializeBubble(bubble, control, vm, canBeShown) {
   }
 
   return bubbleDoc;
+}
+
+// Initializes the specified bubble for the external_links_editor() macro.
+export function initializeExternalLinksBubble(bubbleSelector) {
+  const bubble = initializeBubble(bubbleSelector);
+  $(document).on(
+    'focus',
+    '#external-links-editor-container .external-link-item input.value',
+    (event) => bubble.show(event.target),
+  );
 }

--- a/root/static/scripts/label/edit.js
+++ b/root/static/scripts/label/edit.js
@@ -14,7 +14,9 @@ import '../edit/components/FormRowTextListSimple.js';
 import initializeDuplicateChecker from '../edit/check-duplicates.js';
 import {installFormUnloadWarning} from '../edit/components/forms.js';
 import initializeArea from '../edit/MB/Control/Area.js';
-import initializeBubble from '../edit/MB/Control/Bubble.js';
+import initializeBubble, {
+  initializeExternalLinksBubble,
+} from '../edit/MB/Control/Bubble.js';
 import typeBubble from '../edit/typeBubble.js';
 import initializeValidation from '../edit/validation.js';
 import initializeGuessCase from '../guess-case/MB/Control/GuessCase.js';
@@ -41,14 +43,7 @@ $(function () {
     'input[name^=edit-label\\.period\\.begin_date\\.], ' +
       'input[name^=edit-label\\.period\\.end_date\\.]',
   );
-
-  // Display documentation bubbles for external components.
-  const externalLinkBubble = initializeBubble('#external-link-bubble');
-  $(document).on(
-    'focus',
-    '#external-links-editor-container .external-link-item input.value',
-    (event) => externalLinkBubble.show(event.target),
-  );
+  initializeExternalLinksBubble('#external-link-bubble');
 
   installFormUnloadWarning();
 

--- a/root/static/scripts/place/edit.js
+++ b/root/static/scripts/place/edit.js
@@ -14,7 +14,9 @@ import isBlank from '../common/utility/isBlank.js';
 import initializeDuplicateChecker from '../edit/check-duplicates.js';
 import {installFormUnloadWarning} from '../edit/components/forms.js';
 import initializeArea from '../edit/MB/Control/Area.js';
-import initializeBubble from '../edit/MB/Control/Bubble.js';
+import initializeBubble, {
+  initializeExternalLinksBubble,
+} from '../edit/MB/Control/Bubble.js';
 import typeBubble from '../edit/typeBubble.js';
 import initializeValidation, {errorField} from '../edit/validation.js';
 import initializeGuessCase from '../guess-case/MB/Control/GuessCase.js';
@@ -28,20 +30,14 @@ $(function () {
 
   initializeBubble('#name-bubble', 'input[name=edit-place\\.name]');
   initializeBubble('#comment-bubble', 'input[name=edit-place\\.comment]');
+  typeBubble('select[name=edit-place\\.type_id]');
   initializeBubble('#address-bubble', 'input[name=edit-place\\.address]');
   initializeBubble(
     '#begin-end-date-bubble',
     'input[name^=edit-place\\.period\\.begin_date\\.], ' +
       'input[name^=edit-place\\.period\\.end_date\\.]',
   );
-
-  // Display documentation bubbles for external components.
-  const externalLinkBubble = initializeBubble('#external-link-bubble');
-  $(document).on(
-    'focus',
-    '#external-links-editor-container .external-link-item input.value',
-    (event) => externalLinkBubble.show(event.target),
-  );
+  initializeExternalLinksBubble('#external-link-bubble');
 
   const coordsBubble = initializeBubble(
     '#coordinates-bubble',
@@ -133,9 +129,6 @@ $(function () {
       });
     }
   });
-
-  const typeIdField = 'select[name=edit-place\\.type_id]';
-  typeBubble(typeIdField);
 
   installFormUnloadWarning();
 

--- a/root/static/scripts/recording/edit.js
+++ b/root/static/scripts/recording/edit.js
@@ -16,14 +16,23 @@ import {
   initializeArtistCredit,
   installFormUnloadWarning,
 } from '../edit/components/forms.js';
-import initializeBubble from '../edit/MB/Control/Bubble.js';
+import initializeBubble, {
+  initializeExternalLinksBubble,
+} from '../edit/MB/Control/Bubble.js';
 import {initGuessFeatButton} from '../edit/utility/guessFeat.js';
 import initializeValidation from '../edit/validation.js';
 
 $(function () {
   initGuessFeatButton('edit-recording');
   initializeArtistCredit('edit-recording');
+
+  initializeBubble('#name-bubble', 'input[name=edit-recording\\.name]');
+  initializeBubble('#artist-bubble', '#ac-source-single-artist');
+  initializeBubble('#comment-bubble', 'input[name=edit-recording\\.comment]');
+  initializeBubble('#length-bubble', 'input[name=edit-recording\\.length]');
   initializeBubble('#isrcs-bubble', 'input[name=edit-recording\\.isrcs\\.0]');
+  initializeExternalLinksBubble('#external-link-bubble');
+
   installFormUnloadWarning();
   initializeValidation();
 });

--- a/root/static/scripts/release-group/edit.js
+++ b/root/static/scripts/release-group/edit.js
@@ -13,6 +13,9 @@ import {
   initializeArtistCredit,
   installFormUnloadWarning,
 } from '../edit/components/forms.js';
+import initializeBubble, {
+  initializeExternalLinksBubble,
+} from '../edit/MB/Control/Bubble.js';
 import {initGuessFeatButton} from '../edit/utility/guessFeat.js';
 import initializeValidation from '../edit/validation.js';
 import initializeGuessCase from '../guess-case/MB/Control/GuessCase.js';
@@ -21,6 +24,23 @@ $(function () {
   initGuessFeatButton('edit-release-group');
   initializeArtistCredit('edit-release-group');
   initializeGuessCase('release_group', 'id-edit-release-group');
+
+  initializeBubble('#name-bubble', 'input[name=edit-release-group\\.name]');
+  initializeBubble('#artist-bubble', '#ac-source-single-artist');
+  initializeBubble(
+    '#comment-bubble',
+    'input[name=edit-release-group\\.comment]',
+  );
+  initializeBubble(
+    '#primary-type-bubble',
+    'select[name=edit-release-group\\.primary_type_id]',
+  );
+  initializeBubble(
+    '#secondary-types-bubble',
+    'select[name=edit-release-group\\.secondary_type_ids]',
+  );
+  initializeExternalLinksBubble('#external-link-bubble');
+
   installFormUnloadWarning();
   initializeValidation();
 });

--- a/root/static/scripts/series/edit.js
+++ b/root/static/scripts/series/edit.js
@@ -9,7 +9,10 @@ import {getCatalystContext} from '../common/utility/catalyst.js';
 import initializeDuplicateChecker from '../edit/check-duplicates.js';
 import {installFormUnloadWarning} from '../edit/components/forms.js';
 import {createExternalLinksEditorForHtmlForm} from '../edit/externalLinks.js';
-import {BubbleDoc} from '../edit/MB/Control/Bubble.js';
+import initializeBubble, {
+  BubbleDoc,
+  initializeExternalLinksBubble,
+} from '../edit/MB/Control/Bubble.js';
 import typeBubble from '../edit/typeBubble.js';
 import initializeValidation from '../edit/validation.js';
 import initializeGuessCase from '../guess-case/MB/Control/GuessCase.js';
@@ -47,8 +50,10 @@ $(function () {
 
   createExternalLinksEditorForHtmlForm('edit-series');
 
-  const typeIdField = 'select[name=edit-series\\.type_id]';
-  typeBubble(typeIdField);
+  initializeBubble('#name-bubble', 'input[name=edit-series\\.name]');
+  initializeBubble('#comment-bubble', 'input[name=edit-series\\.comment]');
+  typeBubble('select[name=edit-series\\.type_id]');
+  initializeExternalLinksBubble('#external-link-bubble');
 
   installFormUnloadWarning();
 

--- a/root/static/scripts/work/edit.js
+++ b/root/static/scripts/work/edit.js
@@ -27,7 +27,9 @@ import parseIntegerOrNull from '../common/utility/parseIntegerOrNull.js';
 import FormRowSelectList from '../edit/components/FormRowSelectList.js';
 import {installFormUnloadWarning} from '../edit/components/forms.js';
 import {buildOptionsTree} from '../edit/forms.js';
-import initializeBubble from '../edit/MB/Control/Bubble.js';
+import initializeBubble, {
+  initializeExternalLinksBubble,
+} from '../edit/MB/Control/Bubble.js';
 import typeBubble from '../edit/typeBubble.js';
 import {createCompoundFieldFromObject} from '../edit/utility/createField.js';
 import {pushCompoundField, pushField} from '../edit/utility/pushField.js';
@@ -355,10 +357,19 @@ $(function () {
 
   renderWorkLanguages();
 
+  initializeBubble('#name-bubble', 'input[name=edit-work\\.name]');
+  initializeBubble('#comment-bubble', 'input[name=edit-work\\.comment]');
+  typeBubble('select[name=edit-work\\.type_id]');
+  initializeBubble(
+    '#languages-bubble',
+    'select[name^=edit-work\\.languages\\.0]',
+  );
   initializeBubble('#iswcs-bubble', 'input[name=edit-work\\.iswcs\\.0]');
-
-  const typeIdField = 'select[name=edit-work\\.type_id]';
-  typeBubble(typeIdField);
+  initializeBubble(
+    '#attributes-bubble',
+    'input[name=edit-work\\.attributes\\.0\\.value]',
+  );
+  initializeExternalLinksBubble('#external-link-bubble');
 
   installFormUnloadWarning();
 

--- a/root/work/edit_form.tt
+++ b/root/work/edit_form.tt
@@ -105,9 +105,58 @@
   </div>
 
   <div class="documentation">
-    [%- iswc_bubble(link_entity(work)) -%]
+    <div class="bubble" id="name-bubble">
+      <p>
+        [% l('The {doc|name} is the work’s canonical title in the language in which it was originally written.',
+             { doc => { href => doc_link('Work#Name'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="comment-bubble">
+      <p>
+        [% l('The {doc|disambiguation} field helps users distinguish between similarly-named works.',
+             { doc => { href => doc_link('Disambiguation_Comment'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('Please leave it blank if there are enough other differences between the works that they are unlikely to be confused.') %]
+      </p>
+      <p>
+        [% l('Please see the {doc|style guidelines} for more information.',
+             { doc => { href => doc_link('Style/Work#Disambiguation_comment'), target => '_blank' } }) %]
+      </p>
+    </div>
 
     [%- type_bubble(form.field('type_id'), work_types) -%]
+
+    <div class="bubble" id="languages-bubble">
+      <p>
+        [% l('The {doc|lyrics languages} should list any languages used in a significant portion of the work’s lyrics (or [No lyrics] if it has none).',
+             { doc => { href => doc_link('Work#Lyrics_languages'), target => '_blank' } }) %]
+      </p>
+      <p>
+        [% l('Please see the {doc|style guidelines} for more information.',
+             { doc => { href => doc_link('Style/Work#Lyrics_languages'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="iswcs-bubble">
+      <p>
+        [% l('The {doc|ISWC}, or International Standard Musical Work Code, is a code assigned to uniquely identify a work.',
+             { doc => { href => doc_link('ISWC'), target => '_blank' } }) %]
+      </p>
+    </div>
+
+    <div class="bubble" id="attributes-bubble">
+      <p>
+        [% l('Work attributes store additional information about this work, such as IDs assigned by regional rights-management organizations.') %]
+      </p>
+    </div>
+
+    <div class="bubble" id="external-link-bubble">
+      <p>
+        [% l('External links are URLs associated with the work, such as pages for purchasing sheet music, lyrics pages, and entries in other databases.') %]
+      </p>
+    </div>
   </div>
 
 </form>


### PR DESCRIPTION
# MBS-13980 (II)

Update the recording, release group, series, and work editing forms to display documentation bubbles for all fields.

# Problem

Some entity editing pages were still missing documentation bubbles for most or all of their inputs.

# Solution

Add bubbles using the strings that @reosarevok, @Aerozol, and I worked out in a shared doc.

I also added a new `initializeExternalLinksBubble` helper function for attaching a bubble to the external links component, and updated `edit/MB/Control/Bubble.js` to include `jquery-ui.custom.js` since it depends on it for positioning bubbles and the recording page wasn't including it otherwise.

# Testing

Loaded all the forms and checked that bubbles are displayed when inputs are focused.