### PR TITLE
MBS-14000: support bidrectional text in annotations and wikipedia extracts

### DIFF
--- a/lib/MusicBrainz/Server/Data/WikipediaExtract.pm
+++ b/lib/MusicBrainz/Server/Data/WikipediaExtract.pm
@@ -175,8 +175,7 @@ sub _extract_by_language_callback
     my (%opts) = @_;
     if ($opts{fetched}{content}) {
         return WikipediaExtract->new( title => $opts{fetched}{title},
-                                      content => sprintf '<bdi>%s</bdi>',
-                                                 $opts{fetched}{content},
+                                      content => $opts{fetched}{content} =~ s{<p>}{<p><bdi>}gr =~ s{</p>}{</bdi></p>}gr,
                                       canonical => $opts{fetched}{canonical},
                                       language => $opts{language},
                                       url => sprintf 'https://%s.wikipedia.org/wiki/%s',

--- a/lib/MusicBrainz/Server/Data/WikipediaExtract.pm
+++ b/lib/MusicBrainz/Server/Data/WikipediaExtract.pm
@@ -175,7 +175,8 @@ sub _extract_by_language_callback
     my (%opts) = @_;
     if ($opts{fetched}{content}) {
         return WikipediaExtract->new( title => $opts{fetched}{title},
-                                      content => $opts{fetched}{content},
+                                      content => sprintf '<bdi>%s</bdi>',
+                                                 $opts{fetched}{content},
                                       canonical => $opts{fetched}{canonical},
                                       language => $opts{language},
                                       url => sprintf 'https://%s.wikipedia.org/wiki/%s',

--- a/lib/MusicBrainz/Server/Filters.pm
+++ b/lib/MusicBrainz/Server/Filters.pm
@@ -47,7 +47,9 @@ sub format_wikitext
     return decode(
         'utf-8',
         Text::WikiFormat::format(
-            encode('utf-8' => $text), {}, {
+            encode('utf-8' => $text), {
+                paragraph => [ '<bdi><p>', '</p></bdi>'  ],
+            }, {
                 prefix => '//wiki.musicbrainz.org/',
                 extended => 1,
                 nofollow_extended => 1,

--- a/lib/MusicBrainz/Server/Filters.pm
+++ b/lib/MusicBrainz/Server/Filters.pm
@@ -48,7 +48,7 @@ sub format_wikitext
         'utf-8',
         Text::WikiFormat::format(
             encode('utf-8' => $text), {
-                paragraph => [ '<bdi><p>', '</p></bdi>'  ],
+                paragraph => [ '<p><bdi>', '</bdi></p>'  ],
             }, {
                 prefix => '//wiki.musicbrainz.org/',
                 extended => 1,

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -55,7 +55,7 @@ const condSubstThenTextContent = /^[^<>{}|]+/;
 const percentSign = /(%)/;
 const linkSubstStart = /^\{([0-9A-z_]+)\|/;
 const htmlTagStart = /^<(?=[a-z])/;
-const htmlTagName = /^(a|abbr|br|code|em|h1|h2|h3|h4|h5|h6|hr|li|ol|p|span|strong|ul)(?=[\s/>])/;
+const htmlTagName = /^(a|abbr|bdi|br|code|em|h1|h2|h3|h4|h5|h6|hr|li|ol|p|span|strong|ul)(?=[\s/>])/;
 const htmlTagEnd = /^>/;
 const htmlSelfClosingTagEnd = /^\s*\/>/;
 const htmlAttrStart = /^\s+(?=[a-z])/;

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Edit.pm
@@ -78,7 +78,7 @@ test 'Hide biography and website/homepage of beginners/limited users from not-lo
     $mech->get('/user/new_editor');
     html_ok($mech->content);
     my $tx = test_xpath_html($mech->content);
-    $tx->ok('//tr[@class="biography"]/td[count(*)=1]/p[text()="biography"]',
+    $tx->ok('//tr[@class="biography"]/td[count(*)=1]/p/bdi[text()="biography"]',
         'biography field of beginner/limited user is visible from logged-in user');
     $tx->ok('//tr/td[preceding-sibling::th[1][normalize-space(text())="Homepage:"]]/a[@href="http://test.website"]',
         'website field of beginner/limited user is visible from logged-in user');
@@ -100,7 +100,7 @@ test 'Hide biography and website/homepage of beginners/limited users from not-lo
     $mech->get('/user/new_editor');
     html_ok($mech->content);
     $tx = test_xpath_html($mech->content);
-    $tx->ok('//tr[@class="biography"]/td[count(*)=1]/p[text()="biography"]',
+    $tx->ok('//tr[@class="biography"]/td[count(*)=1]/p/bdi[text()="biography"]',
         'biography field of (not beginner/limited) user is visible from everyone');
     $tx->ok('//tr/td[preceding-sibling::th[1][normalize-space(text())="Homepage:"]]/a[@href="http://test.website"]',
         'website field of (not beginner/limited) user is visible from everyone');

--- a/t/lib/t/MusicBrainz/Server/Data/WikipediaExtract.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/WikipediaExtract.pm
@@ -33,7 +33,7 @@ test 'Get ja page from en' => sub {
     like($extract->content, qr{は、中田ヤスタカがプロデュースする広島県出身の3人組テクノポップユニット。}, 'contains japanese text');
 
     # check that content is wrapped in <bdi> tags
-    like($extract->content, qr{<bdi>.*</bdi>}s, 'content is wrapped in <bdi> tags');
+    like($extract->content, qr{<p><bdi>.*</bdi></p>}s, 'content is wrapped in <bdi> tags');
 
     LWP::UserAgent::Mockable->finished;
 };

--- a/t/lib/t/MusicBrainz/Server/Data/WikipediaExtract.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/WikipediaExtract.pm
@@ -32,6 +32,9 @@ test 'Get ja page from en' => sub {
 
     like($extract->content, qr{は、中田ヤスタカがプロデュースする広島県出身の3人組テクノポップユニット。}, 'contains japanese text');
 
+    # check that content is wrapped in <bdi> tags
+    like($extract->content, qr{<bdi>.*</bdi>}s, 'content is wrapped in <bdi> tags');
+
     LWP::UserAgent::Mockable->finished;
 };
 

--- a/t/lib/t/MusicBrainz/Server/Filters.pm
+++ b/t/lib/t/MusicBrainz/Server/Filters.pm
@@ -75,7 +75,7 @@ test 'Wiki documentation syntax' => sub {
         like(format_wikitext("[$type:$mbid|alt text]"),
              qr{<a href="/$type/$mbid">alt text</a>}, "[$type:mbid|text] links");
         like(format_wikitext(q{ג'יין בורדו (Jane Bordeaux) הוא הרכב מוזיקלי אינדי, קאנטרי ופולק עברי שהוקם בשנת 2012. חברי הלהקה הם דורון טלמון (הסולנית), מתי גלעד, יואב ארבל, רמי אוסרווסר וסתיו אחאי.}),
-             qr{<bdi>.*?</bdi>}s, 'text is wrapped in <bdi> tags');
+             qr{<p><bdi>.*?</bdi></p>}s, 'text is wrapped in <bdi> tags');
     }
 };
 

--- a/t/lib/t/MusicBrainz/Server/Filters.pm
+++ b/t/lib/t/MusicBrainz/Server/Filters.pm
@@ -74,6 +74,8 @@ test 'Wiki documentation syntax' => sub {
              qr{<a href="/$type/$mbid">$type:$mbid</a>}, "plain [$type:mbid] links");
         like(format_wikitext("[$type:$mbid|alt text]"),
              qr{<a href="/$type/$mbid">alt text</a>}, "[$type:mbid|text] links");
+        like(format_wikitext(q{ג'יין בורדו (Jane Bordeaux) הוא הרכב מוזיקלי אינדי, קאנטרי ופולק עברי שהוקם בשנת 2012. חברי הלהקה הם דורון טלמון (הסולנית), מתי גלעד, יואב ארבל, רמי אוסרווסר וסתיו אחאי.}),
+             qr{<bdi>.*?</bdi>}s, 'text is wrapped in <bdi> tags');
     }
 };
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

MBS-14000: annotation right-to-left rendering

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Wrap content in <bdi> tags for bidirectional text handling


# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

Verified bidirection text is rendered correctly in a local dev server.

Added unit tests.