### PR TITLE
Remove extra top margin in artist begin/end bubbles.

### DIFF
--- a/root/artist/edit_form.tt
+++ b/root/artist/edit_form.tt
@@ -157,22 +157,24 @@
     [%- isni_bubble() -%]
 
     <div class="bubble" id="begin-end-date-bubble">
-      <p class="desc desc-1">
-        [% l('The {doc|begin and end dates} describe when the artist was born and died.',
-             { doc => { href => doc_link('Artist#Begin_and_end_dates'), target => '_blank' } }) %]
-      </p>
-      <p class="desc desc-2 desc-5 desc-6">
-        [% l('The {doc|begin and end dates} describe when the group was formed and dissolved.',
-             { doc => { href => doc_link('Artist#Begin_and_end_dates'), target => '_blank' } }) %]
-      </p>
-      <p class="desc desc-4">
-        [% l('The {doc|begin date} is the real-life date when the character concept was created.
-              The end date should not be set.',
-             { doc => { href => doc_link('Artist#Begin_and_end_dates'), target => '_blank' } }) %]
-      </p>
-      <p class="desc desc-default">
-        [% l('The {doc|begin and end dates} describe when the artist started and stopped existing.',
-             { doc => { href => doc_link('Artist#Begin_and_end_dates'), target => '_blank' } }) %]
+      <p>
+        <span class="desc desc-1">
+          [% l('The {doc|begin and end dates} describe when the artist was born and died.',
+               { doc => { href => doc_link('Artist#Begin_and_end_dates'), target => '_blank' } }) %]
+        </span>
+        <span class="desc desc-2 desc-5 desc-6">
+          [% l('The {doc|begin and end dates} describe when the group was formed and dissolved.',
+               { doc => { href => doc_link('Artist#Begin_and_end_dates'), target => '_blank' } }) %]
+        </span>
+        <span class="desc desc-4">
+          [% l('The {doc|begin date} is the real-life date when the character concept was created.
+                The end date should not be set.',
+               { doc => { href => doc_link('Artist#Begin_and_end_dates'), target => '_blank' } }) %]
+        </span>
+        <span class="desc desc-default">
+          [% l('The {doc|begin and end dates} describe when the artist started and stopped existing.',
+               { doc => { href => doc_link('Artist#Begin_and_end_dates'), target => '_blank' } }) %]
+        </span>
       </p>
       <p>
         [% l('Please see the {doc|style guidelines} for more information.',
@@ -181,18 +183,20 @@
     </div>
 
     <div class="bubble" id="begin-end-area-bubble">
-      <p class="desc desc-1">
-        [% l('The begin and end areas describe where the artist was born and died.') %]
-      </p>
-      <p class="desc desc-2 desc-5 desc-6">
-        [% l('The begin and end areas describe where the group was formed and dissolved.') %]
-      </p>
-      <p class="desc desc-4">
-        [% l('The begin area is the real-life area where the character concept was created.
-              The end area should not be set.') %]
-      </p>
-      <p class="desc desc-default">
-        [% l('The begin and end areas describe where the artist was when it started and stopped existing.') %]
+      <p>
+        <span class="desc desc-1">
+          [% l('The begin and end areas describe where the artist was born and died.') %]
+        </span>
+        <span class="desc desc-2 desc-5 desc-6">
+          [% l('The begin and end areas describe where the group was formed and dissolved.') %]
+        </span>
+        <span class="desc desc-4">
+          [% l('The begin area is the real-life area where the character concept was created.
+                The end area should not be set.') %]
+        </span>
+        <span class="desc desc-default">
+          [% l('The begin and end areas describe where the artist was when it started and stopped existing.') %]
+        </span>
       </p>
       <p>
         [% l('Please see the {doc|style guidelines} for more information.',


### PR DESCRIPTION
Prevent the artist form's begin/end date and area doc bubbles from having a margin above the first paragraph.

# Problem

#3509 tried to remove extra padding at the top of bubbles, but I just noticed that it didn't affect some of the bubbles later added by #3516:

![Screenshot 2025-04-29 20 27 26](https://github.com/user-attachments/assets/3b9b1733-5f2e-4eb6-9391-6f9f457ccb50)


# Solution

Put all of the alternate strings inside of spans nested within the same paragraph so the `p:first-child` selector will work even when the first string isn't selected:

![Screenshot 2025-04-29 20 27 33](https://github.com/user-attachments/assets/dee76add-8c53-42c8-ad97-a69d162d3afa)

# Testing

Manually checked that the bubbles look less ugly now.