### PR TITLE
MBS-14001: Avoid Autocomplete2 CSS being overriden

### DIFF
--- a/root/static/styles/widgets.less
+++ b/root/static/styles/widgets.less
@@ -393,7 +393,7 @@ div.autocomplete2 {
     }
 }
 
-label.autocomplete2-label {
+#ac-source-single-artist-label, label.autocomplete2-label {
     display: none;
     &.visible { display: inline; }
 }


### PR DESCRIPTION
# Fix MBS-14001

# Problem
This CSS was being overriden by `table.row-form label` now that it was no longer just added inline to the autocomplete, meaning the label was shown in places where we don't want it.

# Solution
It seems `row-form` is a rare class and the only affected case of the label being overriden is `#ac-source-single-artist-label`, so we can just use the id selector directly and avoid the issue.

# Testing
Manually, both on `/release/add` (which should not have a label but did) and `/account/edit` (where the label should still appear for the `Location` field).