### PR TITLE
MBS-14002: Fall back to the same page on incomplete merges

### DIFF
--- a/root/area/AreaArtists.js
+++ b/root/area/AreaArtists.js
@@ -15,6 +15,7 @@ import {SanitizedCatalystContext} from '../context.mjs';
 import manifest from '../static/manifest.mjs';
 import ListMergeButtonsRow
   from '../static/scripts/common/components/ListMergeButtonsRow.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import AreaLayout from './AreaLayout.js';
 
@@ -30,7 +31,7 @@ component AreaArtists(
 
       {artists?.length ? (
         <form
-          action="/artist/merge_queue"
+          action={'/artist/merge_queue?' + returnToCurrentPage($c)}
           method="post"
         >
           <PaginatedResults pager={pager}>

--- a/root/area/AreaEvents.js
+++ b/root/area/AreaEvents.js
@@ -15,6 +15,7 @@ import {SanitizedCatalystContext} from '../context.mjs';
 import manifest from '../static/manifest.mjs';
 import ListMergeButtonsRow
   from '../static/scripts/common/components/ListMergeButtonsRow.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import AreaLayout from './AreaLayout.js';
 
@@ -30,7 +31,7 @@ component AreaEvents(
 
       {events.length > 0 ? (
         <form
-          action="/event/merge_queue"
+          action={'/event/merge_queue?' + returnToCurrentPage($c)}
           method="post"
         >
           <PaginatedResults pager={pager}>

--- a/root/area/AreaLabels.js
+++ b/root/area/AreaLabels.js
@@ -15,6 +15,7 @@ import {SanitizedCatalystContext} from '../context.mjs';
 import manifest from '../static/manifest.mjs';
 import ListMergeButtonsRow
   from '../static/scripts/common/components/ListMergeButtonsRow.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import AreaLayout from './AreaLayout.js';
 
@@ -30,7 +31,7 @@ component AreaLabels(
 
       {labels.length > 0 ? (
         <form
-          action="/label/merge_queue"
+          action={'/label/merge_queue?' + returnToCurrentPage($c)}
           method="post"
         >
           <PaginatedResults pager={pager}>

--- a/root/area/AreaPlaces.js
+++ b/root/area/AreaPlaces.js
@@ -17,6 +17,7 @@ import ListMergeButtonsRow
   from '../static/scripts/common/components/ListMergeButtonsRow.js';
 import {MAPBOX_ACCESS_TOKEN}
   from '../static/scripts/common/DBDefs-client.mjs';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import AreaLayout from './AreaLayout.js';
 
@@ -47,7 +48,7 @@ component AreaPlaces(
             </p>
           )}
           <form
-            action="/place/merge_queue"
+            action={'/place/merge_queue?' + returnToCurrentPage($c)}
             method="post"
           >
             <PaginatedResults pager={pager}>

--- a/root/area/AreaReleases.js
+++ b/root/area/AreaReleases.js
@@ -16,6 +16,7 @@ import {SanitizedCatalystContext} from '../context.mjs';
 import manifest from '../static/manifest.mjs';
 import ListMergeButtonsRow
   from '../static/scripts/common/components/ListMergeButtonsRow.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import AreaLayout from './AreaLayout.js';
 
@@ -34,7 +35,7 @@ component AreaReleases(
 
           {releases?.length ? (
             <form
-              action="/release/merge_queue"
+              action={'/release/merge_queue?' + returnToCurrentPage($c)}
               method="post"
             >
               <PaginatedResults pager={pager}>

--- a/root/artist/ArtistEvents.js
+++ b/root/artist/ArtistEvents.js
@@ -18,6 +18,7 @@ import {type EventFilterT}
   from '../static/scripts/common/components/FilterForm.js';
 import ListMergeButtonsRow
   from '../static/scripts/common/components/ListMergeButtonsRow.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import ArtistLayout from './ArtistLayout.js';
 
@@ -41,7 +42,7 @@ component ArtistEvents(
 
       {events.length > 0 ? (
         <form
-          action="/event/merge_queue"
+          action={'/event/merge_queue?' + returnToCurrentPage($c)}
           method="post"
         >
           <PaginatedResults pager={pager}>

--- a/root/artist/ArtistIndex.js
+++ b/root/artist/ArtistIndex.js
@@ -29,6 +29,7 @@ import WikipediaExtract
 import commaOnlyList, {commaOnlyListText}
   from '../static/scripts/common/i18n/commaOnlyList.js';
 import {bracketedText} from '../static/scripts/common/utility/bracketed.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 import uriWith from '../utility/uriWith.js';
 
 import ArtistLayout from './ArtistLayout.js';
@@ -263,7 +264,7 @@ component ArtistIndex(
 
       {existingReleaseGroups ? (
         <form
-          action="/release_group/merge_queue"
+          action={'/release_group/merge_queue?' + returnToCurrentPage($c)}
           method="post"
         >
           <PaginatedResults pager={pager}>
@@ -289,7 +290,7 @@ component ArtistIndex(
 
       {existingRecordings ? (
         <form
-          action="/recording/merge_queue"
+          action={'/recording/merge_queue?' + returnToCurrentPage($c)}
           method="post"
         >
           <PaginatedResults pager={pager}>

--- a/root/artist/ArtistRecordings.js
+++ b/root/artist/ArtistRecordings.js
@@ -19,6 +19,7 @@ import {type RecordingFilterT}
 import ListMergeButtonsRow
   from '../static/scripts/common/components/ListMergeButtonsRow.js';
 import bracketed from '../static/scripts/common/utility/bracketed.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import ArtistLayout from './ArtistLayout.js';
 
@@ -128,7 +129,7 @@ component ArtistRecordings(
 
       {recordings.length ? (
         <form
-          action="/recording/merge_queue"
+          action={'/recording/merge_queue?' + returnToCurrentPage($c)}
           method="post"
         >
           <PaginatedResults pager={pager}>

--- a/root/artist/ArtistReleases.js
+++ b/root/artist/ArtistReleases.js
@@ -18,6 +18,7 @@ import {type ReleaseFilterT}
   from '../static/scripts/common/components/FilterForm.js';
 import ListMergeButtonsRow
   from '../static/scripts/common/components/ListMergeButtonsRow.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import ArtistLayout from './ArtistLayout.js';
 
@@ -43,7 +44,7 @@ component ArtistReleases(
 
       {releases.length ? (
         <form
-          action="/release/merge_queue"
+          action={'/release/merge_queue?' + returnToCurrentPage($c)}
           method="post"
         >
           <PaginatedResults pager={pager}>

--- a/root/artist/ArtistWorks.js
+++ b/root/artist/ArtistWorks.js
@@ -18,6 +18,7 @@ import {type WorkFilterT}
   from '../static/scripts/common/components/FilterForm.js';
 import ListMergeButtonsRow
   from '../static/scripts/common/components/ListMergeButtonsRow.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import ArtistLayout from './ArtistLayout.js';
 
@@ -41,7 +42,7 @@ component ArtistWorks(
 
       {works?.length ? (
         <form
-          action="/work/merge_queue"
+          action={'/work/merge_queue?' + returnToCurrentPage($c)}
           method="post"
         >
           <PaginatedResults pager={pager}>

--- a/root/instrument/InstrumentArtists.js
+++ b/root/instrument/InstrumentArtists.js
@@ -15,6 +15,7 @@ import {SanitizedCatalystContext} from '../context.mjs';
 import manifest from '../static/manifest.mjs';
 import ListMergeButtonsRow
   from '../static/scripts/common/components/ListMergeButtonsRow.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import InstrumentLayout from './InstrumentLayout.js';
 
@@ -35,7 +36,7 @@ component InstrumentArtists(
 
       {artists && artists.length > 0 ? (
         <form
-          action="/artist/merge_queue"
+          action={'/artist/merge_queue?' + returnToCurrentPage($c)}
           method="post"
         >
           <PaginatedResults pager={pager}>

--- a/root/instrument/InstrumentRecordings.js
+++ b/root/instrument/InstrumentRecordings.js
@@ -15,6 +15,7 @@ import {SanitizedCatalystContext} from '../context.mjs';
 import manifest from '../static/manifest.mjs';
 import ListMergeButtonsRow
   from '../static/scripts/common/components/ListMergeButtonsRow.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import InstrumentLayout from './InstrumentLayout.js';
 
@@ -35,7 +36,7 @@ component InstrumentRecordings(
 
       {recordings && recordings.length > 0 ? (
         <form
-          action="/recording/merge_queue"
+          action={'/recording/merge_queue?' + returnToCurrentPage($c)}
           method="post"
         >
           <PaginatedResults pager={pager}>

--- a/root/instrument/InstrumentReleases.js
+++ b/root/instrument/InstrumentReleases.js
@@ -15,6 +15,7 @@ import {SanitizedCatalystContext} from '../context.mjs';
 import manifest from '../static/manifest.mjs';
 import ListMergeButtonsRow
   from '../static/scripts/common/components/ListMergeButtonsRow.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import InstrumentLayout from './InstrumentLayout.js';
 
@@ -35,7 +36,7 @@ component InstrumentReleases(
 
       {releases && releases.length > 0 ? (
         <form
-          action="/release/merge_queue"
+          action={'/release/merge_queue?' + returnToCurrentPage($c)}
           method="post"
         >
           <PaginatedResults pager={pager}>

--- a/root/isrc/Index.js
+++ b/root/isrc/Index.js
@@ -21,6 +21,7 @@ import ListMergeButtonsRow
 import formatTrackLength
   from '../static/scripts/common/utility/formatTrackLength.js';
 import loopParity from '../utility/loopParity.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 component Index(
   isrcs: $ReadOnlyArray<IsrcT>,
@@ -49,7 +50,7 @@ component Index(
         )}
       </h2>
       <form
-        action="/recording/merge_queue"
+        action={'/recording/merge_queue?' + returnToCurrentPage($c)}
         method="post"
       >
         <table className="tbl mergeable-table">

--- a/root/iswc/Index.js
+++ b/root/iswc/Index.js
@@ -17,6 +17,7 @@ import ListMergeButtonsRow
   from '../static/scripts/common/components/ListMergeButtonsRow.js';
 import WorkListEntry
   from '../static/scripts/common/components/WorkListEntry.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 component Index(
   iswcs: $ReadOnlyArray<IswcT>,
@@ -43,7 +44,7 @@ component Index(
         )}
       </h2>
       <form
-        action="/work/merge_queue"
+        action={'/work/merge_queue?' + returnToCurrentPage($c)}
         method="post"
       >
         <table className="tbl mergeable-table">

--- a/root/label/LabelIndex.js
+++ b/root/label/LabelIndex.js
@@ -26,6 +26,7 @@ import ListMergeButtonsRow
 import WikipediaExtract
   from '../static/scripts/common/components/WikipediaExtract.js';
 import commaOnlyList from '../static/scripts/common/i18n/commaOnlyList.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import LabelLayout from './LabelLayout.js';
 
@@ -81,7 +82,7 @@ component LabelIndex(
 
       {releases?.length ? (
         <form
-          action="/release/merge_queue"
+          action={'/release/merge_queue?' + returnToCurrentPage($c)}
           method="post"
         >
           <PaginatedResults pager={pager}>

--- a/root/place/PlaceEvents.js
+++ b/root/place/PlaceEvents.js
@@ -15,6 +15,7 @@ import {SanitizedCatalystContext} from '../context.mjs';
 import manifest from '../static/manifest.mjs';
 import ListMergeButtonsRow
   from '../static/scripts/common/components/ListMergeButtonsRow.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import PlaceLayout from './PlaceLayout.js';
 
@@ -30,7 +31,7 @@ component PlaceEvents(
 
       {events.length > 0 ? (
         <form
-          action="/event/merge_queue"
+          action={'/event/merge_queue?' + returnToCurrentPage($c)}
           method="post"
         >
           <PaginatedResults pager={pager}>

--- a/root/release_group/ReleaseGroupIndex.js
+++ b/root/release_group/ReleaseGroupIndex.js
@@ -31,6 +31,7 @@ import WikipediaExtract
 import formatBarcode from '../static/scripts/common/utility/formatBarcode.js';
 import loopParity from '../utility/loopParity.js';
 import releaseGroupType from '../utility/releaseGroupType.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import ReleaseGroupLayout from './ReleaseGroupLayout.js';
 
@@ -150,7 +151,7 @@ component ReleaseGroupIndex(
         <>
           <h2>{releaseGroupType(releaseGroup)}</h2>
           <form
-            action="/release/merge_queue"
+            action={'/release/merge_queue?' + returnToCurrentPage($c)}
             method="post"
           >
             <PaginatedResults pager={pager}>

--- a/root/report/DuplicateArtists.js
+++ b/root/report/DuplicateArtists.js
@@ -16,6 +16,7 @@ import EntityLink from '../static/scripts/common/components/EntityLink.js';
 import ListMergeButtonsRow
   from '../static/scripts/common/components/ListMergeButtonsRow.js';
 import loopParity from '../utility/loopParity.js';
+import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportArtistT, ReportDataT} from './types.js';
@@ -56,7 +57,7 @@ component DuplicateArtists(...{
       totalEntries={pager.total_entries}
     >
       <form
-        action="/artist/merge_queue"
+        action={'/artist/merge_queue?' + returnToCurrentPage($c)}
         method="post"
       >
         <PaginatedResults pager={pager}>


### PR DESCRIPTION
### Implement MBS-14002

# Description
This reverts commit 9b47fff01877ffb2cd3c9255f056737c5e81e127. The `returnTo` is useless for *working* merges, but it still has some use when cancelling a merge and when only one entity is selected so a merge cannot yet happen.

The same page will effectively end up open twice if the merge was opened on a new tab, but it doesn't feel like the alternative (the new tab ending in `/search` or the front page) is any better anyway.

# Testing
Manually, did not test all pages but it should be straightforward.