### PR TITLE
MBS-14007 / MBS-14010 / MBS-14012: Better autoselect and cleanup for podcasts

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5568,7 +5568,9 @@ const CLEANUPS: CleanupEntries = {
             };
           case LINK_TYPES.streamingfree.release:
             return {
-              result: prefix === 'album' || prefix === 'prerelease',
+              result: prefix === 'album' ||
+                      prefix === 'episode' ||
+                      prefix === 'prerelease',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.streamingfree.recording:

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -192,6 +192,9 @@ export const LINK_TYPES: LinkTypeMap = {
     place: 'f14b4e5f-0884-4bb0-b3fa-134cc2734f0e',
     series: '492a4e07-0ea9-4e82-870b-cab942b0576f',
   },
+  podcastfeed: {
+    series: '5ce55509-47a5-4374-a1c6-a68fd377bddf',
+  },
   purevolume: {
     artist: 'b6f02157-a9d3-4f24-9057-0675b2dbc581',
   },
@@ -1000,6 +1003,51 @@ const CLEANUPS: CleanupEntries = {
               target: ERROR_TARGETS.ENTITY,
             };
         }
+      }
+      return {result: false, target: ERROR_TARGETS.URL};
+    },
+  },
+  'applepodcasts': {
+    match: [/^(https?:\/\/)?([^/]+\.)?podcasts\.apple\.com\//i],
+    restrict: [
+      LINK_TYPES.podcastfeed,
+      {
+        recording: LINK_TYPES.streamingfree.recording,
+        release: LINK_TYPES.streamingfree.release,
+      },
+      {
+        recording: LINK_TYPES.streamingpaid.recording,
+        release: LINK_TYPES.streamingpaid.release,
+      },
+    ],
+    clean(url) {
+      url = url.replace(/^https?:\/\/podcasts\.apple\.com\//, 'https://podcasts.apple.com/');
+      // US page is the default, add its country-code to clarify (MBS-10623)
+      url = url.replace(/^(https:\/\/podcasts\.apple\.com)\/([a-z-]{3,})\//, '$1/us/$2/');
+      url = url.replace(/^(https:\/\/podcasts\.apple\.com\/[a-z]{2})\/podcast\/[^?#/]+\/(?:id)?[0-9]+\?i=([0-9]+)$/, '$1/episode/$2');
+      url = url.replace(/^(https:\/\/podcasts\.apple\.com\/[a-z]{2})\/(episode|podcast)\/(?:[^?#/]+\/)?(?:id)?([0-9]+)(?:\?.*)?$/, '$1/$2/id$3');
+      return url;
+    },
+    validate(url, id) {
+      const m = /^https:\/\/podcasts\.apple\.com\/[a-z]{2}\/([a-z-]{3,})\/id[0-9]+$/.exec(url);
+      if (m) {
+        const prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.podcastfeed.series:
+            return {
+              result: prefix === 'podcast',
+              target: ERROR_TARGETS.ENTITY,
+            };
+          case LINK_TYPES.streamingfree.recording:
+          case LINK_TYPES.streamingpaid.recording:
+          case LINK_TYPES.streamingfree.release:
+          case LINK_TYPES.streamingpaid.release:
+            return {
+              result: prefix === 'episode',
+              target: ERROR_TARGETS.ENTITY,
+            };
+        }
+        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
       }
       return {result: false, target: ERROR_TARGETS.URL};
     },

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5528,7 +5528,7 @@ const CLEANUPS: CleanupEntries = {
   },
   'spotify': {
     match: [/^(https?:\/\/)?(((?!(?:artists|shop))[^/])+\.)?(spotify\.(?:com|link))\/(?!(?:intl-[a-z]+\/)?user)/i],
-    restrict: [LINK_TYPES.streamingfree],
+    restrict: [LINK_TYPES.podcastfeed, LINK_TYPES.streamingfree],
     clean(url) {
       url = url.replace(/^(?:https?:\/\/)?embed\.spotify\.com\/\?uri=spotify:([a-z]+):([a-zA-Z0-9_-]+)$/, 'https://open.spotify.com/$1/$2');
       url = url.replace(/^(?:https?:\/\/)?(?:play|open)\.spotify\.com\/(?:intl-[a-z]+\/)?([a-z]+)\/([a-zA-Z0-9_-]+)(?:[/?#].*)?$/, 'https://open.spotify.com/$1/$2');
@@ -5556,6 +5556,11 @@ const CLEANUPS: CleanupEntries = {
       if (m) {
         const prefix = m[1];
         switch (id) {
+          case LINK_TYPES.podcastfeed.series:
+            return {
+              result: prefix === 'show',
+              target: ERROR_TARGETS.ENTITY,
+            };
           case LINK_TYPES.streamingfree.artist:
             return {
               result: prefix === 'artist',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -737,6 +737,20 @@ limited_link_type_combinations: [
                                 ],
             expected_clean_url: 'https://music.apple.com/jp/album/1263790414',
   },
+  // Apple Podcasts
+  {
+                     input_url: 'https://podcasts.apple.com/dk/podcast/bag-fjendens-linjer/id912730108',
+             input_entity_type: 'series',
+    expected_relationship_type: 'podcastfeed',
+            expected_clean_url: 'https://podcasts.apple.com/dk/podcast/id912730108',
+       only_valid_entity_types: ['series'],
+  },
+  {
+                     input_url: 'https://podcasts.apple.com/us/podcast/birder-language-with-rosemary-mosco/id1403064308?i=1000705676414',
+             input_entity_type: 'release',
+limited_link_type_combinations: ['streamingfree', 'streamingpaid'],
+            expected_clean_url: 'https://podcasts.apple.com/us/episode/id1000705676414',
+  },
   // (Internet) Archive
   {
                      input_url: 'http://web.archive.org/web/20100904165354/i265.photobucket.com/albums/ii229/drsaunde/487015.jpg',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5804,6 +5804,13 @@ limited_link_type_combinations: ['downloadpurchase', 'mailorder'],
             expected_clean_url: 'https://artists.spotify.com/songwriter/4wmgHQAAzg3gbnQWSyoMZp',
        only_valid_entity_types: ['artist'],
   },
+  {
+                     input_url: 'https://open.spotify.com/show/21X5WeU1eZTuyYmBbq613H',
+             input_entity_type: 'series',
+    expected_relationship_type: 'podcastfeed',
+            expected_clean_url: 'https://open.spotify.com/show/21X5WeU1eZTuyYmBbq613H',
+       only_valid_entity_types: ['series'],
+  },
   // SteamDB
   {
                      input_url: 'http://www.steamdb.info/app/331230/info/',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5681,14 +5681,14 @@ limited_link_type_combinations: [
                      input_url: 'https://open.spotify.com/episode/5yyMb4t3PWlikJNucu9A6Z',
              input_entity_type: 'recording',
     expected_relationship_type: 'streamingfree',
-       only_valid_entity_types: ['recording'],
+       only_valid_entity_types: ['recording', 'release'],
   },
   {
                      input_url: 'https://embed.spotify.com/?uri=spotify:episode:5yyMb4t3PWlikJNucu9A6Z',
              input_entity_type: 'recording',
     expected_relationship_type: 'streamingfree',
             expected_clean_url: 'https://open.spotify.com/episode/5yyMb4t3PWlikJNucu9A6Z',
-       only_valid_entity_types: ['recording'],
+       only_valid_entity_types: ['recording', 'release'],
   },
   {
                      input_url: 'http://play.spotify.com/album/3rFPzWNUrtoqMd9yNGaFMr?play=true&utm_source=open.spotify.com&utm_medium=open',


### PR DESCRIPTION
### Implement MBS-14007 / MBS-14010 / MBS-14012

# Description
This supports autoselecting podcast pages in Apple Podcasts and Spotify to the existing series-url "podcast feed" relationship type, and allows relating Apple and Spotify podcast episodes to releases and recordings (already available for Spotify). It also adds cleanup for Apple podcasts links. See commit messages for details.

# Testing
Added a bunch of extra `URLCleanup` tests.