### PR TITLE
Remove unused model_to_search_hint_type_id

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Alias.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Alias.pm
@@ -28,13 +28,6 @@ my %model_to_edit_type = (
     ) },
 );
 
-my %model_to_search_hint_type_id = entities_with('aliases',
-    take => sub {
-        my (undef, $info) = @_;
-        return ($info->{model} => $info->{aliases}{search_hint_type} );
-    },
-);
-
 sub aliases : Chained('load') PathPart('aliases')
 {
     my ($self, $c) = @_;
@@ -92,7 +85,6 @@ sub add_alias : Chained('load') PathPart('add-alias') Edit
         form_args => {
             parent_id => $entity->id,
             alias_model => $alias_model,
-            search_hint_type_id => $model_to_search_hint_type_id{ $self->{model} },
         },
         type => $model_to_edit_type{add}->{ $self->{model} },
         edit_args => {
@@ -172,7 +164,6 @@ sub edit_alias : Chained('alias') PathPart('edit') Edit
             parent_id => $entity->id,
             alias_model => $alias_model,
             id => $alias->id,
-            search_hint_type_id => $model_to_search_hint_type_id{ $self->{model} },
         },
         item => $alias,
         type => $model_to_edit_type{edit}->{ $self->{model} },

--- a/lib/MusicBrainz/Server/Form/Alias.pm
+++ b/lib/MusicBrainz/Server/Form/Alias.pm
@@ -60,12 +60,6 @@ has 'alias_model' => (
     required => 1,
 );
 
-has search_hint_type_id => (
-    isa => 'Int',
-    is => 'ro',
-    required => 1,
-);
-
 sub edit_field_names {
     qw( name locale sort_name period.begin_date period.end_date
         period.ended type_id primary_for_locale );


### PR DESCRIPTION
As far as I can tell this is entirely unused since 10 years ago with commit 4762b076d36ec786d2156ec4958d1cf061d0be68