### PR TITLE
MBS-14014: Drop and recreate `cover_art_archive.index_listing`

### DIFF
--- a/admin/sql/updates/20241125-mbs-13832.sql
+++ b/admin/sql/updates/20241125-mbs-13832.sql
@@ -2,8 +2,11 @@
 
 BEGIN;
 
+-- MBS-14014
+DROP VIEW IF EXISTS cover_art_archive.index_listing;
+
 -- CAA view
-CREATE OR REPLACE VIEW cover_art_archive.index_listing AS
+CREATE VIEW cover_art_archive.index_listing AS
 SELECT cover_art.*,
   (edit.close_time IS NOT NULL) AS approved,
   coalesce(cover_art.id = (SELECT id FROM cover_art_archive.cover_art_type
@@ -41,6 +44,5 @@ SELECT event_art.*,
         WHERE event_art_type.id = event_art.id) AS types
 FROM event_art_archive.event_art
 LEFT JOIN musicbrainz.edit ON edit.id = event_art.edit;
-
 
 COMMIT;

--- a/admin/sql/updates/schema-change/30.all.sql
+++ b/admin/sql/updates/schema-change/30.all.sql
@@ -243,8 +243,11 @@ CREATE UNIQUE INDEX artist_release_va_idx_uniq ON artist_release_va (release, ar
 SELECT '20241125-mbs-13832.sql';
 
 
+-- MBS-14014
+DROP VIEW IF EXISTS cover_art_archive.index_listing;
+
 -- CAA view
-CREATE OR REPLACE VIEW cover_art_archive.index_listing AS
+CREATE VIEW cover_art_archive.index_listing AS
 SELECT cover_art.*,
   (edit.close_time IS NOT NULL) AS approved,
   coalesce(cover_art.id = (SELECT id FROM cover_art_archive.cover_art_type
@@ -282,7 +285,6 @@ SELECT event_art.*,
         WHERE event_art_type.id = event_art.id) AS types
 FROM event_art_archive.event_art
 LEFT JOIN musicbrainz.edit ON edit.id = event_art.edit;
-
 
 --------------------------------------------------------------------------------
 SELECT '20250320-mbs-13768.sql';


### PR DESCRIPTION
# Problem

The upgrade script for MBS-13832 currently aborts with the following error when run against the production schema:

    ERROR:  cannot change name of view column "approved" to "filesize"
    HINT:  Use ALTER VIEW ... RENAME COLUMN ... to change name of view column instead.

This is due to MBS-14014.

# Solution

Any database created on/after schema 25 (which was in 2017) will have these filesize columns in the view already. Since this view is for internal use, the best option is to simply drop and recreate it. (It can't be replaced without dropping it first, as view columns can't be changed that way.)

# Testing

CheckSchemaMigration.sh
