### PR TITLE
MBS-14021: Report for pseudo-releases with cover art

### DIFF
--- a/lib/MusicBrainz/Server/Report/PseudoReleasesWithCoverArt.pm
+++ b/lib/MusicBrainz/Server/Report/PseudoReleasesWithCoverArt.pm
@@ -1,0 +1,34 @@
+package MusicBrainz::Server::Report::PseudoReleasesWithCoverArt;
+use Moose;
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub query {<<~'SQL'}
+    SELECT
+        r.id AS release_id,
+        row_number() OVER (ORDER BY ac.name COLLATE musicbrainz, r.name COLLATE musicbrainz)
+    FROM (
+        SELECT DISTINCT r.*
+          FROM release r
+         WHERE EXISTS (
+            SELECT 1 FROM cover_art_archive.cover_art WHERE cover_art.release = r.id
+         )
+           AND r.status = 4 --pseudo-release
+    ) r
+    JOIN artist_credit ac ON r.artist_credit = ac.id
+    SQL
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -79,6 +79,7 @@ my @all = qw(
     PartOfSetRelationships
     PlacesWithoutCoordinates
     PossibleCollaborations
+    PseudoReleasesWithCoverArt
     RecordingsWithoutVACredit
     RecordingsWithoutVALink
     RecordingsWithEarliestReleaseRelationships
@@ -187,6 +188,7 @@ use MusicBrainz::Server::Report::NoScript;
 use MusicBrainz::Server::Report::PartOfSetRelationships;
 use MusicBrainz::Server::Report::PlacesWithoutCoordinates;
 use MusicBrainz::Server::Report::PossibleCollaborations;
+use MusicBrainz::Server::Report::PseudoReleasesWithCoverArt;
 use MusicBrainz::Server::Report::RecordingsWithoutVACredit;
 use MusicBrainz::Server::Report::RecordingsWithoutVALink;
 use MusicBrainz::Server::Report::RecordingsWithEarliestReleaseRelationships;

--- a/root/report/PseudoReleasesWithCoverArt.js
+++ b/root/report/PseudoReleasesWithCoverArt.js
@@ -22,7 +22,7 @@ component PseudoReleasesWithCoverArt(...{
     <ReportLayout
       canBeFiltered={canBeFiltered}
       description={exp.l(
-        `This report shows pseudo-releases that have cover art in the Cover
+        `This report shows pseudo-releases that have images in the Cover
          Art Archive. Pseudo-releases {style|should not have cover art},
          except temporarily until an official release has been added.`,
         {style: '/doc/Style/Specific_types_of_releases/Pseudo-Releases'},

--- a/root/report/PseudoReleasesWithCoverArt.js
+++ b/root/report/PseudoReleasesWithCoverArt.js
@@ -1,0 +1,41 @@
+/*
+ * @flow strict
+ * Copyright (C) 2025 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import ReleaseList from './components/ReleaseList.js';
+import ReportLayout from './components/ReportLayout.js';
+import type {ReportDataT, ReportReleaseT} from './types.js';
+
+component PseudoReleasesWithCoverArt(...{
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report shows pseudo-releases that have cover art in the Cover
+         Art Archive. Pseudo-releases {style|should not have cover art},
+         except temporarily until an official release has been added.`,
+        {style: '/doc/Style/Specific_types_of_releases/Pseudo-Releases'},
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Pseudo-Releases that have cover art')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
+
+export default PseudoReleasesWithCoverArt;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -360,6 +360,12 @@ component ReportsIndex() {
           />
           <ReportsIndexEntry
             content={l(
+              `Pseudo-Releases that have cover art`,
+            )}
+            reportName="PseudoReleasesWithCoverArt"
+          />
+          <ReportsIndexEntry
+            content={l(
               `Releases that have Amazon cover art
               but no Cover Art Archive front cover`,
             )}

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -284,6 +284,7 @@ export default {
   'report/PartOfSetRelationships': (): Promise<mixed> => import('../report/PartOfSetRelationships.js'),
   'report/PlacesWithoutCoordinates': (): Promise<mixed> => import('../report/PlacesWithoutCoordinates.js'),
   'report/PossibleCollaborations': (): Promise<mixed> => import('../report/PossibleCollaborations.js'),
+  'report/PseudoReleasesWithCoverArt': (): Promise<mixed> => import('../report/PseudoReleasesWithCoverArt.js'),
   'report/RecordingsSameNameDifferentArtistsSameName': (): Promise<mixed> => import('../report/RecordingsSameNameDifferentArtistsSameName.js'),
   'report/RecordingsWithEarliestReleaseRelationships': (): Promise<mixed> => import('../report/RecordingsWithEarliestReleaseRelationships.js'),
   'report/RecordingsWithFutureDates': (): Promise<mixed> => import('../report/RecordingsWithFutureDates.js'),


### PR DESCRIPTION
### Implement MBS-14021

# Description
Pseudo-releases should never have cover art permanently - only until an official release has been added. This just lists any pseudo-releases with cover art, since the art always needs to be removed, moved to an existing official release, or moved to an official release after adding it.

# Testing
Tested the query on `isaac` to make sure it works, since I have no CAA on my local setup.