### PR TITLE
MBS-14024: Show genre rels on more places

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -14,7 +14,7 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
         subset => {
             split => ['artist'],
             show => ['artist', 'url'],
-            relationships => [qw( area artist event instrument label place series url )],
+            relationships => [qw( area artist event genre instrument label place series url )],
         },
         default     => ['url'],
         paged_subset => {

--- a/lib/MusicBrainz/Server/Controller/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/Label.pm
@@ -13,7 +13,7 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
         default => ['url'],
         subset => {
             show => ['artist', 'label', 'url'],
-            relationships => [qw( area artist instrument label place series url )],
+            relationships => [qw( area artist genre instrument label place series url )],
         },
         paged_subset => {
             relationships => [qw( event recording release release_group work )],

--- a/lib/MusicBrainz/Server/Controller/Place.pm
+++ b/lib/MusicBrainz/Server/Controller/Place.pm
@@ -11,7 +11,7 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
         cardinal    => ['edit'],
         default     => ['url'],
         subset      => {
-            show => [qw( area artist label place url work series instrument )],
+            show => [qw( area artist genre label place url work series instrument )],
             performances => [qw( url )],
         },
         paged_subset => {

--- a/lib/MusicBrainz/Server/Controller/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/Work.pm
@@ -29,7 +29,7 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
         cardinal => ['edit'],
         default => ['url'],
         subset => {
-            show => [qw( area artist event label place release release_group
+            show => [qw( area artist event genre label place release release_group
                          url work series instrument )],
         },
         paged_subset => {

--- a/root/static/scripts/common/components/Relationships.js
+++ b/root/static/scripts/common/components/Relationships.js
@@ -33,6 +33,7 @@ const displayTargets: DisplayTargets = {
     'area',
     'series',
     'instrument',
+    'genre',
   ],
   label: [
     'artist',
@@ -42,6 +43,7 @@ const displayTargets: DisplayTargets = {
     'area',
     'series',
     'instrument',
+    'genre',
   ],
   work: [
     'artist',
@@ -55,6 +57,7 @@ const displayTargets: DisplayTargets = {
     'series',
     'instrument',
     'event',
+    'genre',
   ],
 };
 


### PR DESCRIPTION
### Fix MBS-14024

# Problem
We had never updated the list of entity types that are displayed in many places where we have restrictions, so genre relationships for artist, label and place ("named after" ones) were not being displayed. 

# Solution
Add `genre` to the list of related entity types loaded / displayed for artist, label, place and work (I expect we will add "named after" to works eventually and I see no reason why we would want to require another patch for *those* to show).

# Testing
Manually, checking that the example relationships for `/relationship/cac1064d-1605-4d41-ac6d-040915480eb5`, `/relationship/b80f8b51-2212-415a-9ed1-bb5636b96d02` and `/relationship/ee182e02-eef7-43ae-b99c-eee1ed60ebc2` appear on the relevant entity pages.