### PR TITLE
MBS-14032: Build temporary `release_first_release_date` table for MBS-13966

### DIFF
--- a/admin/sql/updates/20250425-mbs-13966.sql
+++ b/admin/sql/updates/20250425-mbs-13966.sql
@@ -25,6 +25,16 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
+CREATE TEMPORARY TABLE tmp_release_first_release_date_2025_q2 (
+    release     INTEGER NOT NULL PRIMARY KEY,
+    year        SMALLINT,
+    month       SMALLINT,
+    day         SMALLINT
+) ON COMMIT DROP;
+
+INSERT INTO tmp_release_first_release_date_2025_q2
+    SELECT * FROM get_release_first_release_date_rows('TRUE');
+
 UPDATE release_group_meta SET first_release_date_year = first.year,
                               first_release_date_month = first.month,
                               first_release_date_day = first.day
@@ -33,7 +43,7 @@ UPDATE release_group_meta SET first_release_date_year = first.year,
         release_group.id AS release_group, rd.year, rd.month, rd.day
     FROM release_group
     LEFT JOIN release ON release.release_group = release_group.id
-    LEFT JOIN release_first_release_date rd ON (rd.release = release.id)
+    LEFT JOIN tmp_release_first_release_date_2025_q2 rd ON (rd.release = release.id)
     ORDER BY
       release_group.id,
       rd.year NULLS LAST,
@@ -46,5 +56,14 @@ WHERE id = first.release_group
     OR first_release_date_month IS DISTINCT FROM first.month
     OR first_release_date_day IS DISTINCT FROM first.day
   );
+
+-- Mirrors have a `a_upd_release_group_meta_mirror` trigger which inserts
+-- updated `release_group_meta` IDs into `artist_release_group_pending_update`,
+-- which in turn causes the associated entries in `artist_release_group`
+-- to be updated. That should be a no-op here, because the schema 30 upgrade
+-- already truncates `artist_release_group` (via dropping and recreating it)
+-- before this runs; but clear it anyway to avoid a pointless calculation in
+-- the `apply_artist_release_group_pending_updates` function.
+TRUNCATE artist_release_group_pending_update;
 
 COMMIT;

--- a/admin/sql/updates/schema-change/30.all.sql
+++ b/admin/sql/updates/schema-change/30.all.sql
@@ -376,6 +376,16 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
+CREATE TEMPORARY TABLE tmp_release_first_release_date_2025_q2 (
+    release     INTEGER NOT NULL PRIMARY KEY,
+    year        SMALLINT,
+    month       SMALLINT,
+    day         SMALLINT
+) ON COMMIT DROP;
+
+INSERT INTO tmp_release_first_release_date_2025_q2
+    SELECT * FROM get_release_first_release_date_rows('TRUE');
+
 UPDATE release_group_meta SET first_release_date_year = first.year,
                               first_release_date_month = first.month,
                               first_release_date_day = first.day
@@ -384,7 +394,7 @@ UPDATE release_group_meta SET first_release_date_year = first.year,
         release_group.id AS release_group, rd.year, rd.month, rd.day
     FROM release_group
     LEFT JOIN release ON release.release_group = release_group.id
-    LEFT JOIN release_first_release_date rd ON (rd.release = release.id)
+    LEFT JOIN tmp_release_first_release_date_2025_q2 rd ON (rd.release = release.id)
     ORDER BY
       release_group.id,
       rd.year NULLS LAST,
@@ -397,5 +407,14 @@ WHERE id = first.release_group
     OR first_release_date_month IS DISTINCT FROM first.month
     OR first_release_date_day IS DISTINCT FROM first.day
   );
+
+-- Mirrors have a `a_upd_release_group_meta_mirror` trigger which inserts
+-- updated `release_group_meta` IDs into `artist_release_group_pending_update`,
+-- which in turn causes the associated entries in `artist_release_group`
+-- to be updated. That should be a no-op here, because the schema 30 upgrade
+-- already truncates `artist_release_group` (via dropping and recreating it)
+-- before this runs; but clear it anyway to avoid a pointless calculation in
+-- the `apply_artist_release_group_pending_updates` function.
+TRUNCATE artist_release_group_pending_update;
 
 COMMIT;


### PR DESCRIPTION
# Problem

MBS-14032

A query in the upgrade script for MBS-13966 performs a join with `release_first_release_date`, but this table may not have any contents, as it's an optional build step (via admin/BuildMaterializedTables).

# Solution

While running admin/BuildMaterializedTables beforehand is a possible workaround, it's better if upgrade.sh doesn't have any other external requirements. The solution here is to build a temporary copy of the table (which is dropped on commit). In production, building this table only takes around 8s.

In addition, truncate the `artist_release_group_pending_update` table, because the entries are pointless (we require users to rebuild this table in full after the upgrade anyway).

# Testing

I tested the new script locally and against the production DB (in a ROLLBACK commit); the final `UPDATE` affects 0 rows in production, as expected.
