### PR TITLE
Hide "No row found" warning if the table is empty

### DIFF
--- a/admin/replication/ProcessReplicationChanges
+++ b/admin/replication/ProcessReplicationChanges
@@ -504,7 +504,11 @@ sub warn_if_existing_data_differs {
             }
         }
     } else {
-        warn "No row found in $table with keys $key_string.";
+        my $is_non_empty = $applying_change_sql->select_single_value(
+            "SELECT 1 FROM $table",
+        );
+        warn "No row found in $table with keys $key_string."
+            if $is_non_empty;
     }
 }
 


### PR DESCRIPTION
# Problem

We currently log a warning message if a replicated update or deletion is targeting a row that doesn't exist in the database.

This is confusing if the table in question belongs to a dump that wasn't imported: any update to that table will trigger a false warning, because no rows exist in it.

# Solution

This commit silences the warning if the table is empty.

# Tested

Currently untested.