### PR TITLE
Fix `gpg_sign` function calls

### DIFF
--- a/admin/BundleSearchIndexesDump
+++ b/admin/BundleSearchIndexesDump
@@ -70,7 +70,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 
 use DBDefs;
-use MusicBrainz::Script::MBDump qw( gpg_sign );
+use MusicBrainz::Script::MBDump;
 
 ################################################################################
 
@@ -185,7 +185,7 @@ EOF
         exit 70; # EX_SOFTWARE
     }
 
-    gpg_sign("$working_dir/$tar_file");
+    MusicBrainz::Script::MBDump::gpg_sign("$working_dir/$tar_file");
 }
 
 for my $hash_program ('md5sum', 'sha256sum') {
@@ -200,7 +200,7 @@ for my $hash_program ('md5sum', 'sha256sum') {
         exit 70; # EX_SOFTWARE
     }
 
-    gpg_sign("$working_dir/$hash_output_file");
+    MusicBrainz::Script::MBDump::gpg_sign("$working_dir/$hash_output_file");
 }
 
 _info 'Successfully bundled SolrCloud backups as search indexes dump.';

--- a/admin/BundleSolrBackup
+++ b/admin/BundleSolrBackup
@@ -70,7 +70,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 
 use DBDefs;
-use MusicBrainz::Script::MBDump qw( gpg_sign );
+use MusicBrainz::Script::MBDump;
 
 ################################################################################
 
@@ -203,7 +203,7 @@ EOF
         exit 70; # EX_SOFTWARE
     }
 
-    gpg_sign("$working_dir/$tar_file");
+    MusicBrainz::Script::MBDump::gpg_sign("$working_dir/$tar_file");
 }
 
 for my $hash_program ('md5sum', 'sha256sum') {
@@ -218,7 +218,7 @@ for my $hash_program ('md5sum', 'sha256sum') {
         exit 70; # EX_SOFTWARE
     }
 
-    gpg_sign("$working_dir/$hash_output_file");
+    MusicBrainz::Script::MBDump::gpg_sign("$working_dir/$hash_output_file");
 }
 
 _info 'Successfully bundled Solr backups.';


### PR DESCRIPTION
The `MBDump` package doesn't use `Exporter`.

--

This should fix the `Undefined subroutine &main::gpg_sign called at ./admin/BundleSearchIndexesDump line 188.` failure seen in `~/log/daily-search-indexes-dump/2025-05-24T16\:10\:01Z.log` in musicbrainz-search-indexes-dump.

`gpg_sign` should probably be moved to `Script::Utils`, but this change was easier to test.

@yvanzo I noticed the musicbrainz-solr-backup container already had these changes, but not musicbrainz-search-indexes-dump (until I applied them manually). Not sure if there are other local changes there we should commit properly.