### PR TITLE
MBS-14047: Support medium in NotFound

### DIFF
--- a/root/entity/NotFound.js
+++ b/root/entity/NotFound.js
@@ -138,6 +138,14 @@ const notFoundPages: {[namespace: string]: NotFoundPagesPropsT} = {
     args: defaultSearchArgs,
     footer: null,
   },
+  'medium': {
+    title: N_lp('Medium not found', 'header'),
+    message: N_l(
+      'Sorry, we could not find a medium with that MusicBrainz ID.',
+    ),
+    args: {},
+    footer: null,
+  },
   'otherlookup': {
     title: N_lp('Entity not found', 'header'),
     message: N_l(


### PR DESCRIPTION
### Fix MBS-14047

# Problem
When trying to reach a medium MBID that does not exist (such as `/medium/b83a8cb5-ae3f-4e7d-ad79-3b8dc09eb08b`) the `NotFound` component is called, but that has not been updated to support mediums, so it crashes.

# Solution
Add a `medium` option to `NotFound`. We could add a default to be used if nothing else fits so this doesn't happen again, although given it's not a serious issue, maybe it's better to get the crash and realize we missed something...

# Testing
Manually, making sure the offending link now displays a "not found" page properly locally.
