### PR TITLE
Silence Wikipedia extract load failures

### DIFF
--- a/root/static/scripts/common/components/CommonsImage.js
+++ b/root/static/scripts/common/components/CommonsImage.js
@@ -24,12 +24,14 @@ function loadCommonsImage(
   fetch(url)
     .then(resp => resp.json())
     .then((reqData) => {
-      callback(reqData.image);
+      try {
+        callback(reqData.image);
+      } catch (error) {
+        console.error(error);
+        Sentry.captureException(error);
+      }
     })
-    .catch((error) => {
-      console.error(error);
-      Sentry.captureException(error);
-    });
+    .catch(console.error);
 }
 
 component CommonsImage(

--- a/root/static/scripts/common/components/WikipediaExtract.js
+++ b/root/static/scripts/common/components/WikipediaExtract.js
@@ -43,12 +43,14 @@ function loadWikipediaExtract(
   fetch(url)
     .then(resp => resp.json())
     .then((reqData) => {
-      callback(reqData.wikipediaExtract);
+      try {
+        callback(reqData.wikipediaExtract);
+      } catch (error) {
+        console.error(error);
+        Sentry.captureException(error);
+      }
     })
-    .catch((error) => {
-      console.error(error);
-      Sentry.captureException(error);
-    });
+    .catch(console.error);
 }
 
 component WikipediaExtract(


### PR DESCRIPTION
# Problem

Sentry is being spammed with "NetworkError when attempting to fetch resource." That's not something we can resolve, so it's useless to store these events.

# Solution

Make the `Sentry.captureException` calls isolated to the `callback` invocation, which I think was the original intent. Otherwise just log to `console.error`.

The `CommonsImage` code is basically the same, so I made the same change there, even though it isn't enabled in production.

# Testing

Untested, but should be a straightforward patch.