### PR TITLE
MBS-14041: Don't display ended primary alias by entities

### DIFF
--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -839,7 +839,7 @@ sub find_best_primary_alias {
     my $short_lang = substr($lang, 0, 2);
     my ($best, $fallback);
     foreach my $alias (@$aliases_ref) {
-        next if !defined $alias->locale || !$alias->primary_for_locale;
+        next if !defined $alias->locale || !$alias->primary_for_locale || $alias->ended;
 
         # If we find an exact match for the user's language, use it.
         return $alias if $alias->locale eq $lang;


### PR DESCRIPTION
### Implement MBS-14041

# Description
An ended alias is no longer current, and as such it should not be chosen by `find_best_primary_alias` even if it is marked as a primary alias for a relevant locale.

We might want to make it so that setting ended unsets primary, since ended aliases probably should not be considered primary at all, but even if we do that having this as a fallback still makes sense. I opened MBS-14049 (and a forum discussion) for that potential change.

# Testing
Manually, making sure that the fallback is still shown after marking the otherwise most appropriate alias as ended. Also added MBS-14050 to add some proper tests for `find_best_primary_alias`, since it seems to have none at the moment.