### PR TITLE
MBS-14048: Block relationship editor submission if note is invalid 

### DIFF
--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -478,7 +478,7 @@ Readonly my @invisible_characters => (
 Readonly my $invisible_characters => join '', @invisible_characters;
 Readonly my $invisible_characters_class => qr/[$invisible_characters]/;
 
-# Keep in sync with invalidEditNote in static/scripts/release-editor/init.js
+# Keep in sync with static/scripts/edit/utility/isInvalidEditNote.js
 sub remove_invisible_characters {
     my $string = shift;
 

--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -349,7 +349,7 @@ sub is_date_range_valid {
     return Date::Calc::Delta_Days(@a, @b) >= 0;
 }
 
-# Keep in sync with invalidEditNote in static/scripts/release-editor/init.js
+# Keep in sync with static/scripts/edit/utility/isInvalidEditNote.js
 sub is_valid_edit_note
 {
     my $edit_note = shift;

--- a/root/static/scripts/edit/utility/isInvalidEditNote.js
+++ b/root/static/scripts/edit/utility/isInvalidEditNote.js
@@ -1,0 +1,34 @@
+/*
+ * @flow strict
+ * Copyright (C) 2025 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+const invisibleCharsPattern =
+  /[\u200b\u00AD\u3164\uFFA0\u115F\u1160\u2800\p{Cc}\p{Cf}\p{Mn}]/ug;
+
+// Keep in sync with is_valid_edit_note in Server::Validation
+export default function isInvalidEditNote(editNote: string): boolean {
+  if (empty(editNote)) {
+    // This is missing, not invalid
+    return false;
+  }
+
+  /*
+   * We don't want line format characters and other invisible characters
+   * to stop an edit note from being "empty"
+   */
+  const editNoteNoInvisibleChars = editNote.replace(
+    invisibleCharsPattern,
+    '',
+  );
+  return (
+    // If it's empty now but not earlier, it was all invisible characters
+    empty(editNoteNoInvisibleChars) ||
+    /^[\p{White_Space}\p{Punctuation}]+$/u.test(editNoteNoInvisibleChars) ||
+    /^\p{ASCII}$/u.test(editNoteNoInvisibleChars)
+  );
+}

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -522,9 +522,8 @@ releaseEditor.allowsSubmission = function () {
   return (
     !this.submissionInProgress() &&
     !errorsExist() &&
-    (this.action === 'edit' || !(
-      this.rootField.missingEditNote() || this.rootField.invalidEditNote()
-    )) &&
+    !this.rootField.invalidEditNote() &&
+    !(this.action === 'add' && this.rootField.missingEditNote()) &&
     this.allEdits().length > 0
   );
 };

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -36,6 +36,7 @@ import * as externalLinks from '../edit/externalLinks.js';
 import {createField} from '../edit/utility/createField.js';
 import getUpdatedTrackArtists from
   '../edit/utility/getUpdatedTrackArtists.js';
+import isInvalidEditNote from '../edit/utility/isInvalidEditNote.js';
 import {errorField, errorsExist} from '../edit/validation.js';
 import initializeGuessCase from '../guess-case/MB/Control/GuessCase.js';
 
@@ -346,28 +347,8 @@ releaseEditor.init = function (options) {
     return self.action === 'add' && empty(self.rootField.editNote());
   };
 
-  // Keep in sync with is_valid_edit_note in Server::Validation
   this.rootField.invalidEditNote = function () {
-    const editNote = self.rootField.editNote();
-    if (empty(editNote)) {
-      // This is missing, not invalid
-      return false;
-    }
-
-    /*
-     * We don't want line format characters and other invisible characters
-     * to stop an edit note from being "empty"
-     */
-    const editNoteNoInvisibleChars = editNote.replace(
-      /[\u200b\u00AD\u3164\uFFA0\u115F\u1160\u2800\p{Cc}\p{Cf}\p{Mn}]/ug,
-      '',
-    );
-    return (
-      // If it's empty now but not earlier, it was all invisible characters
-      empty(editNoteNoInvisibleChars) ||
-      /^[\p{White_Space}\p{Punctuation}]+$/u.test(editNoteNoInvisibleChars) ||
-      /^\p{ASCII}$/u.test(editNoteNoInvisibleChars)
-    );
+    return isInvalidEditNote(self.rootField.editNote());
   };
 
   this.seed(options.seed);

--- a/root/static/scripts/release/components/ReleaseRelationshipEditor.js
+++ b/root/static/scripts/release/components/ReleaseRelationshipEditor.js
@@ -54,6 +54,7 @@ import {
   withLoadedTypeInfoForRelationshipEditor,
 } from '../../edit/components/withLoadedTypeInfo.js';
 import {createField} from '../../edit/utility/createField.js';
+import isInvalidEditNote from '../../edit/utility/isInvalidEditNote.js';
 import reducerWithErrorHandling
   from '../../edit/utility/reducerWithErrorHandling.js';
 import {
@@ -1184,8 +1185,15 @@ export const reducer: ((
       break;
     }
     case 'update-edit-note': {
+      const errors = isInvalidEditNote(action.editNote)
+        ? [l(`Your edit note seems to have no actual content.
+              Please provide a note that will be helpful to
+              your fellow editors!`)]
+        : [];
+
       newState.editNoteField = {
         ...newState.editNoteField,
+        errors,
         value: action.editNote,
       };
       break;
@@ -1845,7 +1853,10 @@ component _ReleaseRelationshipEditor() {
         />
         <EnterEdit
           controlled
-          disabled={state.submissionInProgress}
+          disabled={
+            state.submissionInProgress ||
+            state.editNoteField.errors.length > 0
+          }
           form={state.enterEditForm}
           onChange={handleMakeVotableChange}
         />


### PR DESCRIPTION
### Implement MBS-14048

# Description
There's already a check at the `FormHandler` level which means trying to submit the relationship editor with an invalid edit note is blocked, but the error is returned as an alert popup (which is not super user-friendly) and ends up spamming sentry.

This reuses the same code we use in the release editor to block the submission at the Javascript level, so that the error is shown in a more reasonable way and already before the user tries to submit.

In a separate commit, I actually block submission on the release editor as well in any cases where the edit note is invalid. We were doing this only for adds but not edits so far because we implemented it the same way as we do for missing edit notes (which are only required for adds).

# Testing
Manually, both on the release editor and the relationship editor.