### PR TITLE
MBS-14046: Show anniversary banner 24h after anniversary time

### DIFF
--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -15,14 +15,13 @@ import {RT_MIRROR} from '../static/scripts/common/constants.js';
 import * as DBDefs from '../static/scripts/common/DBDefs.mjs';
 import {commaOnlyListText}
   from '../static/scripts/common/i18n/commaOnlyList.js';
-import parseDate from '../static/scripts/common/utility/parseDate.js';
 import {
   getRestrictionsForUser,
   isBeginner,
 } from '../static/scripts/common/utility/privileges.js';
-import {age} from '../utility/age.js';
 import {formatUserDateObject} from '../utility/formatUserDate.js';
 import getRequestCookie from '../utility/getRequestCookie.mjs';
+import isLeapYear from '../utility/isLeapYear.js';
 
 import Footer from './components/Footer.js';
 import Head from './components/Head.js';
@@ -64,24 +63,39 @@ function showBirthdayBanner($c: CatalystContextT) {
 
 component AnniversaryBanner() {
   const $c = React.useContext(CatalystContext);
-  const registrationDate = $c.user ? $c.user.registration_date : null;
-  if (registrationDate == null) {
+  const registrationDateString = $c.user ? $c.user.registration_date : null;
+  if (registrationDateString == null) {
     return null;
   }
 
-  const parsedDate = parseDate(registrationDate.slice(0, 10));
-  if (parsedDate == null) {
+  const oneDay = 24 * 60 * 60 * 1000;
+
+  const now = new Date();
+  const currentYear = now.getUTCFullYear();
+  const registrationDate = new Date(registrationDateString);
+  const registrationYear = registrationDate.getUTCFullYear();
+  const comparisonDate = new Date(registrationDate);
+  comparisonDate.setUTCFullYear(currentYear);
+  // If before anniversary, check based on previous year
+  if (now.getTime() < comparisonDate.getTime()) {
+    comparisonDate.setUTCFullYear(comparisonDate.getUTCFullYear() - 1);
+  }
+  // Congratulate people who joined Feb 29 every year
+  if (comparisonDate.getUTCDate() === 29 &&
+      comparisonDate.getUTCMonth() === 1 &&
+      !isLeapYear(currentYear)) {
+    comparisonDate.setUTCDate(28);
+  }
+  const difference = now.getTime() - comparisonDate.getTime();
+  const isAnniversary = difference > 0 && difference < oneDay;
+
+
+  const editorAge = currentYear - registrationYear;
+  if (editorAge === 0) {
     return null;
   }
 
-  const now = parseDate((new Date()).toISOString().slice(0, 10));
-  const editorAge = age({begin_date: parsedDate, end_date: now, ended: true});
-  if (editorAge == null) {
-    return null;
-  }
-
-  const showBanner =
-    editorAge[1] === 0 && editorAge[2] === 0 &&
+  const showBanner = isAnniversary &&
     !getRequestCookie($c.req, 'anniversary_message_dismissed_mtime');
 
   if (showBanner /*:: === true */) {
@@ -95,8 +109,8 @@ component AnniversaryBanner() {
              Happy anniversary, and thanks for contributing to MusicBrainz!`,
             `You’ve been a MusicBrainz editor for {num} years!
              Happy anniversary, and thanks for contributing to MusicBrainz!`,
-            editorAge[0],
-            {num: editorAge[0]},
+            editorAge,
+            {num: editorAge},
           )}
           {' '}
           <BirthdayCakes />

--- a/root/utility/getDaysInMonth.js
+++ b/root/utility/getDaysInMonth.js
@@ -7,6 +7,8 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import isLeapYear from './isLeapYear.js';
+
 const daysInMonth = [
   // non-leap year
   [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
@@ -15,6 +17,5 @@ const daysInMonth = [
 ];
 
 export default function getDaysInMonth(year: number, month: number): number {
-  const isLeapYear = year % 400 ? (year % 100 ? !(year % 4) : false) : true;
-  return daysInMonth[isLeapYear ? 1 : 0][month - 1];
+  return daysInMonth[isLeapYear(year) ? 1 : 0][month - 1];
 }

--- a/root/utility/isLeapYear.js
+++ b/root/utility/isLeapYear.js
@@ -1,0 +1,12 @@
+/*
+ * @flow strict
+ * Copyright (C) 2025 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+export default function isLeapYear(year: number): boolean {
+  return year % 400 ? (year % 100 ? !(year % 4) : false) : true;
+}


### PR DESCRIPTION
### Fix MBS-14046

# Problem
We were using `formatUserDateObject` in `showBirthdayBanner` to show that banner at the day that matches the birthday on the user's timezone, but for `AnniversaryBanner` we were just using the UTC date.
This meant some users were getting the banner on the "wrong" day, because the day in their timezone was different than on UTC.

# Solution
This changes the system so that the banner will be shown for 24 hours, starting on the exact anniversary of joining, avoiding the need to decide which day is "the right one" entirely.
For people who happened to join on Feb 29 on a leap year, this congratulates them on Feb 28 on non-leap years so they don't feel left out.

# Testing
Manually, messing with the timezone preferences *and* the `member_since` date of some random editor locally. I did not test the leap year code.