### PR TITLE
fix ACUM external DB display

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/ACUM.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/ACUM.pm
@@ -1,11 +1,12 @@
 package MusicBrainz::Server::Entity::URL::ACUM;
 
 use Moose;
+use utf8;
 
 extends 'MusicBrainz::Server::Entity::URL';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
 
-sub sidebar_name { 'ACUM' }
+sub sidebar_name { 'אקו״ם' }
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/root/static/scripts/common/constants.js
+++ b/root/static/scripts/common/constants.js
@@ -79,6 +79,7 @@ export const FAVICON_CLASSES: {
   '45cat.com': 'fortyfivecat',
   '45worlds.com': 'fortyfiveworlds',
   'abc.net.au/triplejunearthed': 'triplejunearthed',
+  'acum.org.il': 'acum',
   'adp.library.ucsb.edu': 'dahr',
   'allmusic.com': 'allmusic',
   'anghami.com': 'anghami',

--- a/root/static/styles/favicons.less
+++ b/root/static/styles/favicons.less
@@ -14,6 +14,7 @@
 .favicon("blog", 32);
 .favicon("review", 32);
 
+.favicon("acum", 32);
 .favicon("allmusic");
 .favicon("amazon", 32);
 .favicon("amazonmusic", 32);


### PR DESCRIPTION
use official Hebrew name for the sidebar and fix favicon display

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

ACUM external DB favicon is not displayed, instead there's the generic icon.


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Added ACUM to favicons.less and `FAVICON_CLASSES`. 

Finding out recently that external links can have non Latin names, I modified the sidebar name to be the official Hebrew one.


# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

tested on dev server
