### PR TITLE
MBS-14061: Improve OpenLibrary autocleanup based on ID

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4513,21 +4513,24 @@ const CLEANUPS: CleanupEntries = {
     match: [/^(https?:\/\/)?(www\.)?openlibrary\.org/i],
     restrict: [LINK_TYPES.otherdatabases],
     clean(url) {
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?openlibrary\.org\/(authors|books|works)\/(OL[0-9]+[AMW]).*$/, 'https://openlibrary.org/$1/$2');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?openlibrary\.org\/(?:authors|books|publishers|works)\/(OL[0-9]+A).*$/, 'https://openlibrary.org/authors/$1');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?openlibrary\.org\/(?:authors|books|publishers|works)\/(OL[0-9]+M).*$/, 'https://openlibrary.org/books/$1');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?openlibrary\.org\/(?:authors|books|publishers|works)\/(OL[0-9]+W).*$/, 'https://openlibrary.org/works/$1');
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?openlibrary\.org\/publishers\/([^/?#]+).*$/, 'https://openlibrary.org/publishers/$1');
       return url;
     },
     validate(url, id) {
-      let m = /^https:\/\/openlibrary\.org\/(authors|books|works)\/OL[0-9]+[AMW]$/.exec(url);
+      let m = /^https:\/\/openlibrary\.org\/(authors|books|works)\/OL[0-9]+([AMW])$/.exec(url);
       if (!m) {
         m = /^https:\/\/openlibrary\.org\/(publishers)\/[^/?#]+$/.exec(url);
       }
       if (m) {
         const prefix = m[1];
+        const suffix = m[2] || '';
         switch (id) {
           case LINK_TYPES.otherdatabases.artist:
             return {
-              result: prefix === 'authors',
+              result: prefix === 'authors' && suffix === 'A',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.label:
@@ -4537,12 +4540,12 @@ const CLEANUPS: CleanupEntries = {
             };
           case LINK_TYPES.otherdatabases.release:
             return {
-              result: prefix === 'books',
+              result: prefix === 'books' && suffix === 'M',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.work:
             return {
-              result: prefix === 'works',
+              result: prefix === 'works' && suffix === 'W',
               target: ERROR_TARGETS.ENTITY,
             };
         }

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4636,6 +4636,13 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist'],
   },
   {
+                     input_url: 'https://openlibrary.org/works/OL23919A/',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://openlibrary.org/authors/OL23919A',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'http://openlibrary.org/publishers/Penguin_Books,_Limited',
              input_entity_type: 'label',
     expected_relationship_type: 'otherdatabases',
@@ -4657,7 +4664,7 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['release'],
   },
   {
-                     input_url: 'https://openlibrary.org/works/OL20723256W?edition=',
+                     input_url: 'https://openlibrary.org/works/OL20723256W/Harrow_the_Ninth?edition=key%3A/books/OL28147941M',
              input_entity_type: 'work',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://openlibrary.org/works/OL20723256W',


### PR DESCRIPTION
### Implement MBS-14061

While the prefix for OpenLibrary links can be helpful in telling what kind of entity we are dealing with, the actual thing that determines the entity type is the letter at the end of the ID. A link like `/works/OL1234A` will actually be an author link for example and will redirect.
These links are also used relatively often (for example, Wikidata uses `/works` for all their OL links and just depends on redirects).

This "follows the redirect" by converting any link to the prefix appropriate to the given ID, and makes sure the ID is correct for the entity type on validation.

Publishers are weird and have no IDs, so this ignores them, except inasmuch as they *still* redirect given an ID of other type so this allows for that possibility.

# Testing
Amended the existing tests a bit.