### PR TITLE
MBS-14049: Unset primary when marking alias as ended

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Alias.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias.pm
@@ -15,6 +15,11 @@ sub enforce_dependencies {
         $opts->{primary_for_locale} = 0;
     }
 
+    if ($opts->{ended}) {
+        # Ended alias can't be primary
+        $opts->{primary_for_locale} = 0;
+    }
+
     unless (non_empty($opts->{sort_name})) {
         # Sortname defaults to the name
         $opts->{sort_name} = $opts->{name};

--- a/root/static/scripts/alias/AliasEditForm.js
+++ b/root/static/scripts/alias/AliasEditForm.js
@@ -68,6 +68,7 @@ type ActionT =
 type StateT = {
   +form: AliasEditFormT,
   +guessCaseOptions: GuessCaseOptionsStateT,
+  +isEnded: boolean,
   +isGuessCaseOptionsOpen: boolean,
   +isTypeSearchHint: boolean,
   +previousForm?: AliasEditFormT | null,
@@ -97,6 +98,7 @@ function createInitialState(form: AliasEditFormT, searchHintType: number) {
   return {
     form,
     guessCaseOptions: createGuessCaseOptionsState(),
+    isEnded: form.field.period.field.ended.value,
     isGuessCaseOptionsOpen: false,
     isTypeSearchHint: form.field.type_id.value === searchHintType,
     searchHintType,
@@ -113,6 +115,13 @@ function reducer(state: StateT, action: ActionT): StateT {
         newStateCtx.get('form', 'field', 'period'),
         action.action,
       );
+      const isEnded = newStateCtx.get(
+        'form', 'field', 'period', 'field', 'ended', 'value',
+      ).read();
+      newStateCtx.set('isEnded', isEnded);
+      if (isEnded) {
+        fieldCtx.set('primary_for_locale', 'value', false);
+      }
       break;
     }
     case 'update-name': {
@@ -320,7 +329,9 @@ const AliasEditForm = ({
             >
               <FormRowCheckbox
                 disabled={
-                  state.isTypeSearchHint || !state.form.field.locale.value
+                  state.isEnded ||
+                  state.isTypeSearchHint ||
+                  !state.form.field.locale.value
                 }
                 field={state.form.field.primary_for_locale}
                 label={exp.l(

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/DeleteAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/DeleteAlias.pm
@@ -60,8 +60,8 @@ test 'Deleting an alias' => sub {
             },
             ended => 0,
             type_id => 1,
-            locale => undef,
-            primary_for_locale => 0,
+            locale => 'en_US',
+            primary_for_locale => 1,
         },
         'The edit contains the right data',
     );

--- a/t/sql/series.sql
+++ b/t/sql/series.sql
@@ -5,8 +5,8 @@ INSERT INTO series (id, gid, name, comment, type, ordering_type, last_updated)
            (2, '2e8872b9-2745-4807-a84e-094d425ec267', 'Test Work Series', 'test comment 2', 4, 2, NOW()),
            (3, 'dbb23c50-d4e4-11e3-9c1a-0800200c9a66', 'Dumb Recording Series', '', 3, 1, NOW());
 
-INSERT INTO series_alias (id, series, name, type, sort_name) VALUES
-    (1, 1, 'Test Series Alias', 1, 'Test Series Alias');
+INSERT INTO series_alias (id, series, name, type, sort_name, locale, primary_for_locale) VALUES
+    (1, 1, 'Test Series Alias', 1, 'Test Series Alias', 'en_US', '1');
 
 INSERT INTO link (id, link_type, attribute_count) VALUES
     (1, 740, 1), (2, 740, 1), (3, 740, 1), (4, 740, 1),


### PR DESCRIPTION
### Implement MBS-14049

# Description
There doesn't seem to be any good reason why an ended alias would ever be correctly marked as primary for locale, since that is meant to indicate the most appropriate name for the entity in that locale and an outdated name should never be that.

As such, this unsets and blocks primary for locale when making an alias ended (with the checkbox or an end date), in a similar way as we already do when unsetting the locale or setting as search hint.

# Testing
Manually.

# Further action
Since this will disable the primary checkboxes for aliases currently set as ended, we should probably run a one-off script to unset primary for all of those in one go. There's a bunch of them.