### PR TITLE
MBS-14059: Fix ended checkbox margin in the relationship editor

### DIFF
--- a/root/static/scripts/relationship-editor/components/DialogDatePeriod.js
+++ b/root/static/scripts/relationship-editor/components/DialogDatePeriod.js
@@ -193,6 +193,7 @@ component _DialogDatePeriod(
           <FormRowCheckbox
             disabled={isDateNonEmpty(endDate)}
             field={field.field.ended}
+            hasNoLabel={false} // Disables the left margin.
             label={l('This relationship has ended.')}
             onChange={hooks.handleEndedChange}
           />


### PR DESCRIPTION
# Problem

MBS-14059

# Solution

The `no-label` class refers to the (aligned) labels on the left of the inputs. It's only intended for div-based forms, and has no use in the relationship dialog, which has a tabular layout.

# Testing

By observation after applying the change.