### PR TITLE
MBS-14062: Add TaggerIcon manifest to TagLookup results

### DIFF
--- a/root/taglookup/RecordingResults.js
+++ b/root/taglookup/RecordingResults.js
@@ -9,6 +9,7 @@
 
 import {RecordingResultsInline}
   from '../search/components/RecordingResults.js';
+import manifest from '../static/manifest.mjs';
 
 import TagLookupResults from './Results.js';
 
@@ -23,6 +24,7 @@ component TagLookupRecordingResults(...props: {
         query={props.query}
         results={props.results}
       />
+      {manifest('common/components/TaggerIcon', {async: true})}
     </TagLookupResults>
   );
 }

--- a/root/taglookup/ReleaseResults.js
+++ b/root/taglookup/ReleaseResults.js
@@ -8,6 +8,7 @@
  */
 
 import {ReleaseResultsInline} from '../search/components/ReleaseResults.js';
+import manifest from '../static/manifest.mjs';
 
 import TagLookupResults from './Results.js';
 
@@ -22,6 +23,7 @@ component TagLookupReleaseResults(...props: {
         query={props.query}
         results={props.results}
       />
+      {manifest('common/components/TaggerIcon', {async: true})}
     </TagLookupResults>
   );
 }


### PR DESCRIPTION
### Fix MBS-14062

# Problem
On tag lookup results, the tagger icon shows an error related to Google's Local Network Access Checks (in Chrome) rather than a permission prompt for local access like in search result pages.

# Solution
The issue seemed to be with the missing `manifest(TaggerIcon)` calls in `TagLookup` result pages compared to search. This just adds the missing calls.

# Testing
Manually, checking that the tagger button in a page like `/taglookup/index?tag-lookup.artist=&tag-lookup.release=foo&tag-lookup.tracknum=&tag-lookup.track=&tag-lookup.duration=&tag-lookup.filename=&tport=8000` now behaves in the same way as in a page like `/search/textsearch?limit=50&type=release&query=foo&tport=8000` (which Google was happy with).