### PR TITLE
MBS-14065: Show artist credits in release editor duplicates tab

### DIFF
--- a/root/release/edit/duplicates.tt
+++ b/root/release/edit/duplicates.tt
@@ -8,6 +8,7 @@
       <tr>
         <th></th>
         <th>[% l('Release') %]</th>
+        <th>[% l('Artist') %]</th>
         <th>[% l('Format') %]</th>
         <th>[% l('Tracks') %]</th>
         <th>[% l('Date') %]</th>
@@ -23,6 +24,7 @@
           <input type="radio" name="base-release" data-bind="attr: { value: gid }, checked: $parent.baseRelease" />
         </td>
         <td data-bind="html: html({ target: '_blank' })"></td>
+        <td data-bind="html: renderArtistCredit(artistCredit)"></td>
         <td data-bind="text: formats"></td>
         <td data-bind="text: tracks"></td>
         <td data-bind="html: dates.join('<br />')"></td>

--- a/root/static/scripts/release-editor/duplicates.js
+++ b/root/static/scripts/release-editor/duplicates.js
@@ -61,7 +61,8 @@ releaseEditor.findReleaseDuplicates = function () {
       return;
     }
 
-    var url = `/ws/2/release?release-group=${gid}&inc=labels+media&fmt=json`;
+    const inc = 'artist-credits+labels+media';
+    var url = `/ws/2/release?release-group=${gid}&inc=${inc}&fmt=json`;
 
     loadingFromRG = true;
     toggleLoadingIndicator(true);

--- a/t/selenium/release-editor/Duplicate_Selection.json5
+++ b/t/selenium/release-editor/Duplicate_Selection.json5
@@ -70,7 +70,7 @@
     {
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll('#duplicates-tab table.tbl > tbody > tr')).map(x => Array.from(x.querySelectorAll('td')).slice(1).map(x => x.textContent.trim()).join('\\t')).join('\\n')",
-      value: 'Whatever It Takes\tCD\t2\t2017-11-17\tXE\tInterscope RecordsKIDinaKORNER\t06025671583940602567158394\t0602567158394\nWhatever It Takes (Jorgen Odegard remix)\tDigital Media\t1\t2017-11-10\tAU\tInterscope RecordsKIDinaKORNER\t\t',
+      value: 'Whatever It Takes\tImagine Dragons\tCD\t2\t2017-11-17\tXE\tInterscope RecordsKIDinaKORNER\t06025671583940602567158394\t0602567158394\nWhatever It Takes (Jorgen Odegard remix)\tImagine Dragons\tDigital Media\t1\t2017-11-10\tAU\tInterscope RecordsKIDinaKORNER\t\t',
     },
     {
       command: 'click',
@@ -116,7 +116,7 @@
     {
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll('#duplicates-tab table.tbl > tbody > tr')).map(x => Array.from(x.querySelectorAll('td')).slice(1).map(x => x.textContent.trim()).join('\\t')).join('\\n')",
-      value: 'Whatever It Takes\tCD\t2\t2017-11-17\tXE\tInterscope RecordsKIDinaKORNER\t06025671583940602567158394\t0602567158394',
+      value: 'Whatever It Takes\tImagine Dragons\tCD\t2\t2017-11-17\tXE\tInterscope RecordsKIDinaKORNER\t06025671583940602567158394\t0602567158394',
     },
     {
       command: 'check',
@@ -217,7 +217,7 @@
     {
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll('#duplicates-tab table.tbl > tbody > tr')).map(x => Array.from(x.querySelectorAll('td')).slice(1).map(x => x.textContent.trim()).join('\\t')).join('\\n')",
-      value: 'Whatever It Takes (Jorgen Odegard remix)\tDigital Media\t1\t2017-11-10\tAU\tInterscope RecordsKIDinaKORNER\t\t',
+      value: 'Whatever It Takes (Jorgen Odegard remix)\tImagine Dragons\tDigital Media\t1\t2017-11-10\tAU\tInterscope RecordsKIDinaKORNER\t\t',
     },
     {
       command: 'check',


### PR DESCRIPTION
### Implement MBS-14065

# Description
Without artist credits, the tab is basically useless for classical music. See comparison screenshots below. I'm sure they can also be of some use for non-classical, although less often.

We were already loading the artist credits when searching by name, so this only adds the appropriate include when querying releases by RGs.

# Testing
Manually

Before (beta screenshot):
![Screenshot from 2025-06-17 16-23-22](https://github.com/user-attachments/assets/c448f949-7797-4a23-9e28-2da162103c85)

After (local screenshot):
![Screenshot from 2025-06-17 16-23-46](https://github.com/user-attachments/assets/c5750e1e-039c-484c-9687-2d8a6e336b14)
