### PR TITLE
oauth2: accept loopback IPs for installed applications

### DIFF
--- a/lib/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/lib/MusicBrainz/Server/Controller/OAuth2.pm
@@ -455,7 +455,7 @@ sub _check_redirect_uri
 
     if (!$application->is_server) {
         return 1 if $redirect_uri eq 'urn:ietf:wg:oauth:2.0:oob';
-        return 1 if $redirect_uri =~ /^http:\/\/localhost(:\d+)?(\/.*?)?$/;
+        return 1 if $redirect_uri =~ /^http:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?(\/.*?)?$/;
     }
     return 0;
 }


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->


The oauth implementation already accepts any localhost callback if the app is of type "installed application". Extend this to also support the IPv4/IPv6 addresses for the loopback device.

Background: Picard 3 will consistently use 127.0.0.1 for the local server access. Currently it is a mix of localhost and 127.0.0.1 depending on use case. See also https://github.com/metabrainz/picard/pull/2656

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Treat `localhost`, `127.0.0.1` and `[::1]` as equivalent in the callback URI check for app type "installed application".

# Note

This is unrelated to any future change to the new MB oauth system. We will do this switch for Picard once the new oauth2 URLs are considered stable and will not change anymore.