### PR TITLE
MBS-3193: Simplify after-apostrophe guess case

### DIFF
--- a/root/static/scripts/guess-case/utils/titleString.js
+++ b/root/static/scripts/guess-case/utils/titleString.js
@@ -69,22 +69,17 @@ function titleString(
              isApostrophe(input.getPreviousWord())) {
     outputString = lowercase;
     /*
-     * we got an 's (It is = It's), lowercase
      * we got an 'all (Y'all = You all), lowercase
-     * we got an 'em (Them = 'em), lowercase.
      * we got an 've (They have = They've), lowercase.
-     * we got an 'd (He had = He'd), lowercase.
+     * we got an 'll (You'll = You will), lowercase.
      * we got an 'cha (What you = What'cha), lowercase.
      * we got an 're (You are = You're), lowercase.
-     * we got an 'til (Until = 'til), lowercase.
-     * we got an 'way (Away = 'way), lowercase.
-     * we got an 'round (Around = 'round), lowercase
      * we got a 'mon (Come on = C'mon), lowercase
      */
   } else if (
     guessCaseMode.name === 'English' &&
     isApostrophe(input.getPreviousWord()) &&
-    lowercase.match(/^(?:s|round|em|ve|ll|d|cha|re|til|way|all|mon)$/i)
+    lowercase.match(/^(?:all|ve|ll|cha|re|mon)$/i)
   ) {
     outputString = lowercase;
     /*

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -169,7 +169,7 @@ test('Label', function (t) {
 });
 
 test('Recording', function (t) {
-  t.plan(2);
+  t.plan(4);
 
   const tests = [
     {
@@ -181,6 +181,16 @@ test('Recording', function (t) {
       input: 'ハイタッチ (w／o maaya)',
       expected: 'ハイタッチ (w／o Maaya)',
       message: 'w／o is not capitalized',
+    },
+    {
+      input: 'It\'S All Over Y\'All, You\'Re Done',
+      expected: 'It\'s All Over Y\'all, You\'re Done',
+      message: 'Common suffix contractions are lowercased after apostrophe',
+    },
+    {
+      input: 'Hit \'em \'til they go \'way \'n stuff!',
+      expected: 'Hit \'Em \'Til They Go \'Way \'n Stuff!',
+      message: 'Standalone contractions are uppercased, except if 1-char',
     },
   ];
 
@@ -773,8 +783,8 @@ test('no "quote blocks" over multiple track titles (MBS-8621)', function (t) {
 
   const tests = [
     {
-      input: 'Boot ’Em Up',
-      expected: 'Boot ’em Up',
+      input: 'Boot ’em Up',
+      expected: 'Boot ’Em Up',
     },
     {
       input: 'Look, no apostrophes!',


### PR DESCRIPTION
### Implement MBS-3193

# Problem
Most English style guides seem to specifically say that words such as 'Em and 'Til *should be uppercased* since they are contractions of words that would themselves be uppercased. People in the community have asked to change this often, and there's no reason that I can find why we do it (we've just always done it for at least the last 15 years).

# Solution
Remove the special-casing for *'em*, *'til*, *'way*, *'round*. Additionally, this drops the one-letter *'s* and *'d* checks from the regex since they should never be hit, we already lowercase all one-letter words after apostrophes in the previous check.

# Testing
I added a couple tests to make it harder for us to re-break these in the future. Didn't test manually further than that.