### PR TITLE
MBS-14006: Link to tickets in review in beta footer

### DIFF
--- a/root/layout.tt
+++ b/root/layout.tt
@@ -134,6 +134,10 @@
                          { branch => server_details.git.branch,
                            msg => html_escape(server_details.git.msg),
                            sha => server_details.git.sha }) ~%]
+                    [% IF server_details.is_beta =%]
+                        [%= l('See {tickets|all tickets in beta testing}.',
+                            { tickets => 'https://tickets.metabrainz.org/issues/?filter=10715' }) ~%]
+                    [%~ END %]
                 [%~ END %]
                 [%- IF last_replication_date -%]
                 <br />

--- a/root/layout/components/Footer.js
+++ b/root/layout/components/Footer.js
@@ -75,6 +75,15 @@ component Footer() {
                 </span>
               ),
             })}
+            {DBDefs.IS_BETA ? (
+              <>
+                {' '}
+                {exp.l(
+                  'See {tickets|all tickets in beta testing}.',
+                  {tickets: 'https://tickets.metabrainz.org/issues/?filter=10715'},
+                )}
+              </>
+            ) : null}
           </>
         ) : null}
 


### PR DESCRIPTION
### Implement MBS-14006

# Description
It seems sensible in order to always have a place to check whether there is something being tested in beta, even if the user has dismissed the banner. This adds a small `See all tickets in beta testing.` link (pointing to https://tickets.metabrainz.org/issues/?filter=10715) when `IS_BETA` is set.

![Screenshot from 2025-06-25 14-38-13](https://github.com/user-attachments/assets/d5ebd85d-9c1b-47cc-8832-24896872a247)

# Testing
Manually, in the front page (React) and Add artist (TT), with `IS_BETA` set and unset in `DBDefs`.