### PR TITLE
MBS-14005 / MBS-14079: Show containment for place areas in search (inline and not) 

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -185,6 +185,7 @@ sub direct : Private
     elsif ($type eq 'place') {
         $c->model('PlaceType')->load(@entities);
         $c->model('Area')->load(@entities);
+        $c->model('Area')->load_containment(map { $_->area } @entities);
     }
     elsif ($type eq 'instrument') {
         $c->model('InstrumentType')->load(@entities);

--- a/lib/MusicBrainz/Server/Data/Area.pm
+++ b/lib/MusicBrainz/Server/Data/Area.pm
@@ -88,6 +88,7 @@ sub load
     my ($self, @objs) = @_;
     my @areas = load_subobjects($self, ['area', 'begin_area', 'end_area', 'country'], @objs);
     $self->c->model('Area')->load_aliases(@areas);
+    return @areas;
 }
 
 sub load_containment {

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -964,6 +964,14 @@ sub external_search
             $self->c->model('Area')->load_containment(@entities);
         }
 
+        if ($type eq 'place')
+        {
+            my @entities = map { $_->entity } @results;
+            my @areas = grep { defined $_ } map { $_->area } @entities;
+            $self->c->model('Area')->load_ids(@areas);
+            $self->c->model('Area')->load_containment(@areas);
+        }
+
         if ($type eq 'release-group')
         {
             my @entities = map { $_->entity } @results;

--- a/root/search/components/PlaceResults.js
+++ b/root/search/components/PlaceResults.js
@@ -10,6 +10,8 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../../context.mjs';
+import DescriptiveLink
+  from '../../static/scripts/common/components/DescriptiveLink.js';
 import EntityLink from '../../static/scripts/common/components/EntityLink.js';
 import formatDate from '../../static/scripts/common/utility/formatDate.js';
 import formatEndDate
@@ -38,7 +40,7 @@ function buildResult(result: SearchResultT<PlaceT>, index: number) {
       </td>
       <td>{place.address}</td>
       <td>
-        {place.area ? <EntityLink entity={place.area} /> : null}
+        {place.area ? <DescriptiveLink entity={place.area} /> : null}
       </td>
       <td>{formatDate(place.begin_date)}</td>
       <td>{formatEndDate(place)}</td>


### PR DESCRIPTION
### Fix MBS-14005 / Implement MBS-14079

# Problem
Place search results only provide the basic area for the place. In many cases, this is not super useful information to be sure the place is the right one. For example, the MBS-14005 example is in "York" - not UK, but a district of Toronto. But nothing about Toronto or Canada is shown in the search results, so a user might well skip it thinking it has nothing to do with what they are looking for.

# Solution
For inline search, our code already tried to load the containment - but we had broken it in a previous commit so that nothing was ever loaded. The first commit just fixes that.

For normal search, this just loads the data for both direct and indexed search results and changes the area column to display containment.

# Testing
Manually in both inline and normal search, both indexed and direct.