### PR TITLE
MBS-14081: Log out accounts from Discourse after they've been marked as spam

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Admin.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin.pm
@@ -30,6 +30,7 @@ sub edit_user : Path('/admin/user/edit') Args(1) RequireAuth HiddenOnMirrors Sec
         $c->detach('/user/not_found');
     }
     $c->stash->{viewing_own_profile} = $c->user_exists && $c->user->id == $user->id;
+    my $is_spammer = $user->is_spammer;
 
     my $form = $c->form(
         form => 'Admin::EditUser',
@@ -48,7 +49,7 @@ sub edit_user : Path('/admin/user/edit') Args(1) RequireAuth HiddenOnMirrors Sec
             editing_disabled        => $user->is_editing_disabled,
             adding_notes_disabled   => $user->is_adding_notes_disabled,
             voting_disabled         => $user->is_voting_disabled,
-            spammer                 => $user->is_spammer,
+            spammer                 => $is_spammer,
             # user profile
             username                => $user->name,
             email                   => $user->email,
@@ -94,6 +95,10 @@ sub edit_user : Path('/admin/user/edit') Args(1) RequireAuth HiddenOnMirrors Sec
                 $user->email('editor-' . $user->id . '@musicbrainz.invalid');
                 $c->forward('/discourse/sync_sso', [$user]);
             }
+        }
+
+        if (!$is_spammer && $form_values->{spammer}) {
+            $c->forward('/discourse/log_out', [$user]);
         }
 
         $c->flash->{message} = 'User successfully edited.';


### PR DESCRIPTION
# Problem

MBS-14081

As the title says, we're not terminating any existing Discourse sessions after a user is marked as a spammer.

# Solution

Calls the `/discourse/log_out` endpoint if the spammer flag was set in the `/admin/user/edit` form values.

# Testing

Mostly untested, as it requires an actual Discourse setup. However, I did verify that the `$form_values->{spammer}` condition is met when the flag is set.