### PR TITLE
MBS-14082: Log out accounts after they've been marked as spam

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -264,6 +264,10 @@ sub begin : Private
 {
     my ($self, $c) = @_;
 
+    if ($c->user_exists && $c->user->is_spammer) {
+        $c->detach('/user/logout');
+    }
+
     my $attributes = $c->action->attributes;
 
     ensure_ssl($c) if $attributes->{RequireSSL};

--- a/t/lib/t/MusicBrainz/Server/Controller/Account.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Account.pm
@@ -4,6 +4,7 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
+use MusicBrainz::Server::Constants qw( $SPAMMER_FLAG );
 use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
@@ -26,6 +27,24 @@ test 'Updated email address is escaped in flash message' => sub {
         'We have sent you a verification email to ' .
         '<code>&quot;&amp;&amp;&amp;&quot;@example.com</code>.',
     );
+};
+
+test 'MBS-14082: Spam accounts are logged out' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c);
+
+    $mech->get_ok('/login');
+    $mech->submit_form(with_fields => {username => 'new_editor', password => 'password'});
+
+    $test->c->sql->do(<<~'SQL', $SPAMMER_FLAG);
+        UPDATE editor SET privs = privs | ? WHERE name = 'new_editor';
+        SQL
+
+    $mech->get_ok('/account/edit');
+    is($mech->uri->path, '/', 'The spammer is logged out and redirected to the homepage');
+    $mech->content_contains('Log in');
 };
 
 1;


### PR DESCRIPTION
# Problem

MBS-14082

Similar to [MBS-14081](https://tickets.metabrainz.org/browse/MBS-14081), but for MusicBrainz itself, it seems we don't log out spam editor accounts either (so they can still make changes to their profile, reset their password, and who knows what else).

# Solution

This just logs them out immediately in `Controller::Root::begin`.

# Testing

Tested locally by creating a fake spam account in one browser session and marking it as a spammer in another.