### PR TITLE
MBS-14100: Properly hydrate label filter

### DIFF
--- a/root/static/scripts/label/index.js
+++ b/root/static/scripts/label/index.js
@@ -9,5 +9,6 @@
 
 import '../common/components/Annotation.js';
 import '../common/components/CommonsImage.js';
+import '../common/components/Filter.js';
 import '../common/components/WikipediaExtract.js';
 import '../common/MB/Control/SelectAll.js';


### PR DESCRIPTION
### Fix MBS-14100

# Problem
The label filter button does nothing

# Solution
Just add `components/Filter` to `scripts/label/index.js`, which either I had somehow missed last time or we broke later.

# Testing
Manually, making sure the filter now shows and works.