### PR TITLE
MBS-14107: Support new style Brahms/IRCAM work links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1877,21 +1877,21 @@ const CLEANUPS: CleanupEntries = {
     match: [/^(https?:\/\/)?brahms\.ircam\.fr\//i],
     restrict: [LINK_TYPES.otherdatabases],
     clean(url) {
-      return url.replace(/^(?:https?:\/\/)?brahms\.ircam\.fr\/(?:(?:en|fr)\/)?((works\/work)(?:\/)([0-9]+)|(?!works)[^?/#]+).*$/, 'http://brahms.ircam.fr/$1');
+      return url.replace(/^(?:https?:\/\/)?brahms\.ircam\.fr\/(?:(?:en|fr)\/)?((works\/work)(?:\/)([0-9]+)|work\/[\w\d-]+|(?!work)[^?/#]+).*$/, 'http://brahms.ircam.fr/$1');
     },
     validate(url, id) {
-      const m = /^(?:https?:\/\/)?brahms\.ircam\.fr\/(works\/work|(?!works)[^?/#]+).*$/.exec(url);
+      const m = /^(?:https?:\/\/)?brahms\.ircam\.fr\/(works\/work\/|work\/|(?!works?)[^?/#]+).*$/.exec(url);
       if (m) {
         const prefix = m[1];
         switch (id) {
           case LINK_TYPES.otherdatabases.work:
             return {
-              result: prefix === 'works/work',
+              result: prefix === 'work/' || prefix === 'works/work/',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.artist:
             return {
-              result: prefix !== 'works/work',
+              result: prefix !== 'work/' && prefix !== 'works/work/',
               target: ERROR_TARGETS.ENTITY,
             };
         }

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1657,6 +1657,13 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['work'],
   },
   {
+                     input_url: 'https://brahms.ircam.fr/fr/work/luci#type',
+             input_entity_type: 'work',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'http://brahms.ircam.fr/work/luci',
+       only_valid_entity_types: ['work'],
+  },
+  {
                      input_url: 'http://brahms.ircam.fr/works/genre/328/?test/',
              input_entity_type: 'work',
     expected_relationship_type: undefined,


### PR DESCRIPTION
### Implement MBS-14107

# Description
New IRCAM work links are just `/work/$work_name` (e.g. https://brahms.ircam.fr/fr/work/luci) and were being blocked by our current code. This detects them and cleans them up as work links.

# Testing
Added a test to the list and made sure old links still work since they can still be found as search results and whatnot and there's no trivial way to convert one to the other (they don't even redirect yet).