### PR TITLE
MBS-14104: Check if merge recordings are really ambiguous

### DIFF
--- a/t/sql/release.sql
+++ b/t/sql/release.sql
@@ -34,10 +34,14 @@ INSERT INTO release_gid_redirect (gid, new_id) VALUES ('71dc55d8-0fc6-41c1-94e0-
 
 INSERT INTO artist (id, gid, name, sort_name, comment)
     VALUES (2, '7a906020-72db-11de-8a39-0800200c9a66', 'Various Artists', 'Various Artists', ''),
-           (3, '1a906020-72db-11de-8a39-0800200c9a66', 'Various Artists', 'Various Artists', 'Various Artists 2');
+           (3, '1a906020-72db-11de-8a39-0800200c9a66', 'Various Artists', 'Various Artists', 'Various Artists 2'),
+           (222, '27e56175-519e-45d7-90b7-91b8c5ed77d5', 'Various Artists', 'Various Artists', 'and another');
 INSERT INTO artist_credit (id, name, artist_count, gid)
-    VALUES (2, 'Various Artists', 1, 'c44109ce-57d7-3691-84c8-37926e3d41d2');
-INSERT INTO artist_credit_name (artist_credit, artist, name, position, join_phrase) VALUES (2, 2, 'Various Artists', 1, '');
+    VALUES (2, 'Various Artists', 1, 'c44109ce-57d7-3691-84c8-37926e3d41d2'),
+           (222, 'Various Artists', 1, 'c1a868ed-0867-48b1-b3c9-8ec5a79c0557');
+INSERT INTO artist_credit_name (artist_credit, artist, name, position, join_phrase)
+    VALUES (2, 2, 'Various Artists', 1, ''),
+           (222, 222, 'Various Artists', 1, '');
 
 INSERT INTO release_group (id, gid, name, artist_credit)
     VALUES (2, '25b6fe30-ff5b-11de-8a39-0800200c9a66', 'Various Release', 2);
@@ -66,7 +70,8 @@ INSERT INTO release (id, gid, name, artist_credit, release_group) VALUES (5, '53
 -- test merge strategies
 INSERT INTO release_group (id, gid, name, artist_credit)
     VALUES (100, '7a14d050-759c-41c0-b7a0-71424d1b177a', 'Pregap?', 1),
-           (101, '3a14d050-759c-41c0-b7a0-71424d1b177a', 'Empty Medium Merge', 2);
+           (101, '3a14d050-759c-41c0-b7a0-71424d1b177a', 'Empty Medium Merge', 2),
+           (102, '5ebc1512-6e22-483f-9781-437ddc78a506', 'Ambiguous Recordings', 222);
 INSERT INTO release (id, gid, name, release_group, artist_credit)
     VALUES (6, '7a906020-72db-11de-8a39-0800200c9a70', 'The Prologue (disc 1)', 1, 1),
            (7, '7a906020-72db-11de-8a39-0800200c9a71', 'The Prologue (disc 2)', 1, 1),
@@ -75,12 +80,16 @@ INSERT INTO release (id, gid, name, release_group, artist_credit)
            (100, '6b89a7f7-ac01-4b57-ab0a-381b10523b34', 'Pregap', 100, 1),
            (110, '94a44113-f3e7-4bf1-8d68-0d71922ac346', 'No pregap', 100, 1),
            (101, '3b89a7f7-ac01-4b57-ab0a-381b10523b34', 'One Empty Medium', 101, 2),
-           (111, '34a44113-f3e7-4bf1-8d68-0d71922ac346', 'No Empty Mediums', 101, 2);
+           (111, '34a44113-f3e7-4bf1-8d68-0d71922ac346', 'No Empty Mediums', 101, 2),
+           (112, '50644315-6824-4a76-bbb5-ac81ebd948aa', 'Ambiguous Recordings 1', 102, 222),
+           (113, '6ff98a19-8ce5-4ec8-bc05-43292035a931', 'Ambiguous Recordings 2', 102, 222);
 INSERT INTO recording (id, gid, name, artist_credit)
     VALUES (2, '50a772b0-f0cc-11df-98cf-0800200c9a66', 'Track on recording', 1),
            (3, '5d9cb570-f0cc-11df-98cf-0800200c9a66', 'Track on recording', 1),
            (4, '64cac850-f0cc-11df-98cf-0800200c9a66', 'Track on recording', 1),
-           (5, '691ee030-f0cc-11df-98cf-0800200c9a66', 'Track on recording', 1);
+           (5, '691ee030-f0cc-11df-98cf-0800200c9a66', 'Track on recording', 1),
+           (6, '3cf7b0fe-c66b-4baf-b028-d04891607e8b', 'Test to merge', 222),
+           (7, '73b2a7ae-37e2-43dd-86cc-a1e9bdee8f48', 'Test to merge into', 222);
 INSERT INTO medium (id, gid, release, track_count, position)
     VALUES (2, '0d4edc8f-f6b1-45dc-9a17-3ce4af1f382a', 6, 0, 1),
            (3, '253e4677-52f7-4129-8dfe-3dcd91b32d03', 7, 0, 1),
@@ -91,7 +100,11 @@ INSERT INTO medium (id, gid, release, track_count, position)
            (80, 'd4ab8af7-9ba0-4b0a-aaa4-625e26303a67', 101, 0, 1),
            (81, 'b03b17d3-c8d5-4865-8669-7061c3252637', 101, 0, 2),
            (90, 'e9f2406d-d793-43cb-a7c7-b59898625148', 111, 0, 1),
-           (91, 'a4f5a662-20c6-4856-ab65-cb9f37918b56', 111, 0, 2);
+           (91, 'a4f5a662-20c6-4856-ab65-cb9f37918b56', 111, 0, 2),
+           (92, '47689cac-e275-4929-831f-215ea5536977', 112, 0, 1),
+           (93, '5cfd6743-be93-4482-af89-8b2f0ef81295', 112, 0, 2),
+           (94, '91d7d747-41ec-4bb6-98f6-cf4389041d9c', 113, 0, 1),
+           (95, '871e20f8-a1a3-44d2-8766-718e1fa8456b', 113, 0, 2);
 INSERT INTO track (id, gid, name, artist_credit, medium, position, number, recording)
     VALUES (2, 'd6de1f70-4a29-4cce-a35b-aa2b56265583', 'Track on recording', 1, 2, 1, 1, 2),
            (3, '929e5fb9-cfe7-4764-b3f6-80e056f0c1da', 'Track on recording', 1, 3, 1, 1, 3),
@@ -101,7 +114,11 @@ INSERT INTO track (id, gid, name, artist_credit, medium, position, number, recor
            (70, '0f4846f2-f96b-4fc3-b979-5fce32f193e5', 'Not pregap', 1, 70, 1, '1', 2),
            (81, 'ab6e4cd4-fa17-434f-b6ce-d1622e6f3b82', 'A Track', 2, 81, 1, '1', 2),
            (90, 'bb6e4cd4-fa17-434f-b6ce-d1622e6f3b82', 'A Track', 2, 90, 1, '1', 2),
-           (91, 'cb6e4cd4-fa17-434f-b6ce-d1622e6f3b82', 'Another Track', 2, 91, 1, '1', 2);
+           (91, 'cb6e4cd4-fa17-434f-b6ce-d1622e6f3b82', 'Another Track', 2, 91, 1, '1', 2),
+           (92, 'e7e147a4-afa2-46de-bad6-1891507da721', 'Test to merge', 222, 92, 1, '1', 6),
+           (93, '5b333c97-9204-43bc-adf9-ed6172b4b839', 'Test to merge', 222, 93, 1, '1', 6),
+           (94, 'd8fdb31a-a1b1-48ca-ba31-54134828cc5a', 'Test to merge into', 222, 94, 1, '1', 7),
+           (95, 'f3df4491-c05d-45a8-ac3b-a4c3ad91bcc1', 'Test to merge into', 222, 95, 1, '1', 7);
 
 -- Test for searching by track artist
 INSERT INTO artist_credit (id, name, artist_count, gid)


### PR DESCRIPTION
### Fix MBS-14104

# Problem
We are blocking unambiguous recording merges as ambiguous. The error reported was on a SACD release where the same recording appears on both the CD and the SACD layers. Despite the fact that both were going to be merged into a single other recording (itself also appearing on both layers on the destination CD), the merge was detected as ambiguous.

# Solution
AFAICT we were giving the `ambiguous_recording_merge` error in every case where the same recording would get merged into two tracks in the destination release, regardless of whether the two tracks shared a recording so there was no actual ambiguity.
This checks that there's actually more than one recording ID among the destination recordings before screaming. 

# Testing
Added two tests, one for each case, to `Controller::Release::Merge`.