### PR TITLE
MBS-14109: Handle IMDb series links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -134,6 +134,7 @@ export const LINK_TYPES: LinkTypeMap = {
     recording: 'dad34b86-5a1a-4628-acf5-a48ccb0785f2',
     release: '7387c5a2-9abe-4515-b667-9eb5ed4dd4ce',
     release_group: '85b0a010-3237-47c7-8476-6fcefd4761af',
+    series: 'ed4083be-a0b3-4040-b5b4-7513a67e9dc8',
     work: 'e5c75559-4dda-452e-a900-ae375935164c',
   },
   imslp: {
@@ -3109,6 +3110,7 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.imdb.recording:
           case LINK_TYPES.imdb.release:
           case LINK_TYPES.imdb.release_group:
+          case LINK_TYPES.imdb.series:
           case LINK_TYPES.imdb.work:
             return {
               result: prefix === 'title/tt',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3091,10 +3091,17 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist', 'label', 'place'],
   },
   {
+                     input_url: 'https://www.imdb.com/title/tt27334988/?ref_=fn_all_ttl_1',
+             input_entity_type: 'series',
+    expected_relationship_type: 'imdb',
+            expected_clean_url: 'https://www.imdb.com/title/tt27334988/',
+       only_valid_entity_types: ['recording', 'release', 'release_group', 'series', 'work'],
+  },
+  {
                      input_url: 'https://www.imdb.com/title/tt0421082/',
              input_entity_type: 'release_group',
     expected_relationship_type: 'imdb',
-       only_valid_entity_types: ['recording', 'release', 'release_group', 'work'],
+       only_valid_entity_types: ['recording', 'release', 'release_group', 'series', 'work'],
   },
   // IMSLP (International Music Score Library Project)
   {


### PR DESCRIPTION
### Implement MBS-14109

# Description
We now support IMDb series links (for podcasts, which they cover). As such, this adds the appropriate autoselect and cleanup for it. Podcasts use the same `title/tt` URL schema as works and RGs.

# Testing
Added an IMDb podcast to the tests (with cleanup needed, straight from the original ticket), and of course made the other `title/tt` one expect `series` as an allowed option.