### PR TITLE
MBS-14110: Don't try to log in using outdated username

### DIFF
--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -226,9 +226,13 @@ sub cookie_login : Private
 
     return if $c->user_exists;
 
-    if (my $user_name = $self->_consume_remember_me_cookie($c)) {
-        $self->_renew_login_cookie($c, $user_name);
-        $c->set_authenticated($c->find_user({ username => $user_name }));
+    my $user_name = $self->_consume_remember_me_cookie($c);
+    if (defined $user_name) {
+        my $user = $c->find_user({ username => $user_name });
+        if (defined $user) {
+            $self->_renew_login_cookie($c, $user_name);
+            $c->set_authenticated($user);
+        }
     }
 }
 


### PR DESCRIPTION
### Fix MBS-14110

# Problem
When we rename a user, their remember_login cookie still points to their old, no longer existing username. That means we were trying to log a non-existing user if their session had expired, causing an ISE.

# Solution
This makes sure the user we're trying to log in actually exists. Renamed users with expired sessions will still have to log in again, but at least they won't get an ISE before that; logging in again is not a big issue anyway since that's the first thing I would tell them to do to propagate the change to LB anyway.

# Testing
Manually, by logging in with a random use with "remember me" checked in my local server, deleting the user's session cookie by hand, then renaming the user in incognito and reloading the page the user was on.