### PR TITLE
MBS-14084: Sort event lists by newest first

### DIFF
--- a/lib/MusicBrainz/Server/Data/Event.pm
+++ b/lib/MusicBrainz/Server/Data/Event.pm
@@ -230,7 +230,7 @@ sub _find_by_area_table {
 }
 
 sub _find_by_area_order {
-    return 'begin_date_year, begin_date_month, begin_date_day, time, name, id';
+    return 'begin_date_year DESC NULLS LAST, begin_date_month DESC NULLS LAST, begin_date_day DESC NULLS LAST, time DESC NULLS LAST, name, id';
 }
 
 sub find_by_artist
@@ -277,7 +277,7 @@ sub find_by_artist
                      WHERE entity0 = ?
                 ) s, ' . $self->_table .'
           WHERE ' . join(' AND ', @where_query) . '
-        ORDER BY event.begin_date_year, event.begin_date_month, event.begin_date_day, event.time, event.name COLLATE musicbrainz';
+        ORDER BY event.begin_date_year DESC NULLS LAST, event.begin_date_month DESC NULLS LAST, event.begin_date_day DESC NULLS LAST, event.time DESC NULLS LAST, event.name COLLATE musicbrainz';
 
     $self->query_to_list_limited($query, \@where_args, $limit, $offset);
 }
@@ -315,7 +315,7 @@ sub find_by_place
                      WHERE entity1 = ?
                 ) s, ' . $self->_table .'
           WHERE event.id = s.event
-       ORDER BY event.begin_date_year, event.begin_date_month, event.begin_date_day, event.time, event.name COLLATE musicbrainz';
+       ORDER BY event.begin_date_year DESC NULLS LAST, event.begin_date_month DESC NULLS LAST, event.begin_date_day DESC NULLS LAST, event.time DESC NULLS LAST, event.name COLLATE musicbrainz';
 
     $self->query_to_list_limited($query, [$place_id], $limit, $offset);
 }


### PR DESCRIPTION
### Implement MBS-14084

# Description
The most interesting events for most users are usually the ones in the near future or at least the ones that happened fairly recently. This sorts the events by descending date and time, ensuring that the ones without any date still sort last.

# Testing
Checked `/area/74e50e58-5deb-4b99-93a2-decbb365c07f/events` (which includes a null-date event and is the reason I went with `NULLS LAST`) and some artists and places clicking through from there.