### PR TITLE
MBS-14114: Report: Digital releases released too early

### DIFF
--- a/lib/MusicBrainz/Server/Report/ReleasedTooEarlyDigital.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasedTooEarlyDigital.pm
@@ -1,0 +1,41 @@
+package MusicBrainz::Server::Report::ReleasedTooEarlyDigital;
+use Moose;
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub query {<<~'SQL'}
+    SELECT DISTINCT ON (r.id)
+        r.id AS release_id,
+        row_number() OVER (ORDER BY ac.name COLLATE musicbrainz, r.name COLLATE musicbrainz)
+    FROM
+        ( SELECT r.*
+        FROM release r
+        LEFT JOIN (
+            SELECT release, date_year, date_month, date_day
+            FROM release_country
+            UNION ALL
+            SELECT release, date_year, date_month, date_day
+            FROM release_unknown_country
+        ) events ON (events.release = r.id)
+        JOIN medium m ON m.release = r.id
+        WHERE m.format = 12 -- there is one digital medium
+          AND date_year < 1999 -- first major label digital store
+        ) r
+    JOIN artist_credit ac ON r.artist_credit = ac.id
+    SQL
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut
+

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -87,6 +87,7 @@ my @all = qw(
     RecordingTrackDifferentName
     RecordingsWithFutureDates
     ReleasedTooEarly
+    ReleasedTooEarlyDigital
     ReleaseGroupsWithoutVACredit
     ReleaseGroupsWithoutVALink
     ReleaseLabelSameArtist
@@ -197,6 +198,7 @@ use MusicBrainz::Server::Report::RecordingsWithVaryingTrackLengths;
 use MusicBrainz::Server::Report::RecordingTrackDifferentName;
 use MusicBrainz::Server::Report::RecordingsWithFutureDates;
 use MusicBrainz::Server::Report::ReleasedTooEarly;
+use MusicBrainz::Server::Report::ReleasedTooEarlyDigital;
 use MusicBrainz::Server::Report::ReleaseGroupsWithoutVACredit;
 use MusicBrainz::Server::Report::ReleaseGroupsWithoutVALink;
 use MusicBrainz::Server::Report::ReleaseLabelSameArtist;

--- a/root/report/ReleasedTooEarlyDigital.js
+++ b/root/report/ReleasedTooEarlyDigital.js
@@ -11,7 +11,7 @@ import ReleaseList from './components/ReleaseList.js';
 import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportReleaseT} from './types.js';
 
-component ReleasedTooEarly(...{
+component ReleasedTooEarlyDigital(...{
   canBeFiltered,
   filtered,
   generated,
@@ -21,19 +21,20 @@ component ReleasedTooEarly(...{
   return (
     <ReportLayout
       canBeFiltered={canBeFiltered}
-      description={exp.l(
-        `This report shows releases which have disc IDs even though they
-         were released too early to have disc IDs, where one of the medium
-         formats didn't exist at the time the release was released or
-         where a disc ID is attached to a medium whose format does not
-         have disc IDs. Fully digital releases are excluded; for those, see
-         {digital_report|our digital-only report}.`,
-        {digital_report: '/report/ReleasedTooEarlyDigital'},
+      description={l(
+        `This report shows releases with at least one medium set to format
+         “Digital Media” which were released before 1999, the launch date
+         for the first digital music store supported by a major label.
+         While digital releases did exist before this, and not everything
+         older is automatically incorrect, a lot of releases that end up
+         here are likely to be digital reissues of older content that have
+         been incorrectly assigned the release date for the original,
+         physical release.`,
       )}
       entityType="release"
       filtered={filtered}
       generated={generated}
-      title={l('Releases released too early')}
+      title={l('Suspiciously early digital releases')}
       totalEntries={pager.total_entries}
     >
       <ReleaseList items={items} pager={pager} />
@@ -41,4 +42,4 @@ component ReleasedTooEarly(...{
   );
 }
 
-export default ReleasedTooEarly;
+export default ReleasedTooEarlyDigital;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -317,6 +317,10 @@ component ReportsIndex() {
             reportName="ReleasedTooEarly"
           />
           <ReportsIndexEntry
+            content={l('Suspiciously early digital releases')}
+            reportName="ReleasedTooEarlyDigital"
+          />
+          <ReportsIndexEntry
             content={l(
               `Releases where some (but not all) mediums
               have no format set`,

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -293,6 +293,7 @@ export default {
   'report/RecordingsWithVaryingTrackLengths': (): Promise<mixed> => import('../report/RecordingsWithVaryingTrackLengths.js'),
   'report/RecordingTrackDifferentName': (): Promise<mixed> => import('../report/RecordingTrackDifferentName.js'),
   'report/ReleasedTooEarly': (): Promise<mixed> => import('../report/ReleasedTooEarly.js'),
+  'report/ReleasedTooEarlyDigital': (): Promise<mixed> => import('../report/ReleasedTooEarlyDigital.js'),
   'report/ReleaseGroupsWithoutVaCredit': (): Promise<mixed> => import('../report/ReleaseGroupsWithoutVaCredit.js'),
   'report/ReleaseGroupsWithoutVaLink': (): Promise<mixed> => import('../report/ReleaseGroupsWithoutVaLink.js'),
   'report/ReleaseLabelSameArtist': (): Promise<mixed> => import('../report/ReleaseLabelSameArtist.js'),


### PR DESCRIPTION
### Implement MBS-14114

# Description
This adds a report for digital releases released before 1999. The cut year is picked because it's the year Sony launched the first major-label backed digital store.
1999 is not a good fit for the earliest date at the medium format level, since we do know that digital releases existed before that. But it seems like a good enough limit for a report under the assumption that most entries will be wrong but some will be correct.

The goal of this report is to help find and fix digital imports that are filed under the year of their original physical release, which is not rare; plenty of Spotify releases "from the 1960s" exist.

# Testing
Manually, making sure that quite a few results come up even with the sample data.