### PR TITLE
MBS-14115: Block last.fm links from release level

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -7575,6 +7575,17 @@ entitySpecificRules.release = function (url) {
       target: ERROR_TARGETS.ENTITY,
     };
   }
+  if (/^(https?:\/\/)?([^./]+\.)?last\.fm\//.test(url)) {
+    return {
+      error: l(
+        `Last.fm release pages are very often generated from MusicBrainz
+         data to begin with, and usually a bad match for specific MusicBrainz
+         releases, so adding Last.fm links to releases is currently blocked.`,
+      ),
+      result: false,
+      target: ERROR_TARGETS.URL,
+    };
+  }
   if (/^(https?:\/\/)?([^./]+\.)?wikidata\.org\//.test(url)) {
     return {
       error: l(

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3678,6 +3678,17 @@ limited_link_type_combinations: [
                      input_url: 'http://www.last.fm/it/label/Shyrec#shoutbox',
             expected_clean_url: 'https://www.last.fm/label/Shyrec',
   },
+  {
+                     input_url: 'https://www.last.fm/music/Nine+Inch+Nails/With+Teeth+(Instrumental)',
+             input_entity_type: 'release',
+    expected_relationship_type: undefined,
+       input_relationship_type: 'discographyentry',
+       only_valid_entity_types: [],
+                expected_error: {
+                                  error: 'is currently blocked',
+                                  target: 'url',
+                                },
+  },
   // Library of Congress Linked Data Service
   {
                      input_url: 'http://id.loc.gov/authorities/names/n79018119.html#tab1',


### PR DESCRIPTION
### Implement MBS-14115

# Description
This blocks last.fm links from being added to releases, in the same way we already block Wikipedia and Wikidata.

Last.fm album pages are usually either a horribly mess or based on MusicBrainz data, and in neither case is it useful to link them, but we have over 1000 "discography entry" links pointing at last.fm pages.

I'm marking these as URL errors since unlike Wikipedia, there is no other level we would want the user to add them on.

# Testing
Added a test matching the one for release level Wikipedia.