### PR TITLE
MBS-14124: Only try to merge each RG once

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -43,7 +43,7 @@ with 'MusicBrainz::Server::Controller::Role::Collection' => {
     entity_type => 'release',
 };
 
-use List::AllUtils qw( first nsort_by uniq );
+use List::AllUtils qw( first nsort_by uniq uniq_by );
 use MusicBrainz::Server::Translation qw( l N_l );
 use MusicBrainz::Server::Validation qw(
     is_integer
@@ -395,7 +395,8 @@ sub _merge_on_creation {
 
         my $new_rg_id = $new->release_group->id;
         # We want to make sure we're merging only different RGs!
-        my @old_entities = map +{ id => $_->id, name => $_->name },
+        my @old_entities = uniq_by { $_->{id} }
+            map +{ id => $_->id, name => $_->name },
             grep { $_->id != $new_rg_id }
             map { $entities_by_id->{$_}->release_group }
             @$old_ids;


### PR DESCRIPTION
### Fix MBS-14124

# Problem
When someone merged several releases in the same RG into another in a second RG and selected "merge RGs",
the RG would be added to the merge once for each release.

# Solution
This actually makes sure the `old_entities` we are merging are unique, on top of the existing check to make sure they are different from the RG we are merging into.

# Testing
Added a test merging two releases in  the same RG into a third in a second RG and ensuring that only one RG is being listed in the merge from section in the edit.