### PR TITLE
MBS-14125: Handle redirected MBIDs in the autocomplete's recent items

### DIFF
--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -833,6 +833,11 @@ const seleniumTests = [
   {name: 'MBS-13604.json5', login: true},
   {name: 'MBS-13615.json5', login: true},
   {name: 'MBS-13993.json5', login: true},
+  {
+    name: 'MBS-14125.json5',
+    login: true,
+    sql: 'whatever_it_takes.sql',
+  },
   {name: 'Artist_Credit_Editor.json5', login: true},
   {name: 'Autocomplete2.json5'},
   {name: 'External_Links_Editor.json5', login: true},

--- a/t/selenium/MBS-14125.json5
+++ b/t/selenium/MBS-14125.json5
@@ -1,0 +1,45 @@
+{
+  title: 'MBS-14125: Handle redirected MBIDs in the autocomplete\'s recent items',
+  commands: [
+    // Inject three MBIDs into recentAutocompleteEntities.artist:
+    //  1. A redirected MBID.
+    //  2. A primary MBID that points to the same entity as #1.
+    //  3. A bogus MBID that doesn't resolve to anything.
+    {
+      command: 'runScript',
+      target: "localStorage.setItem('recentAutocompleteEntities', JSON.stringify({artist: ['b3668303-75e1-4ec3-9b32-008598675340', 'd1fc999f-6184-41a6-bcb1-7c59bf74a6e1', '7ccae9ad-0959-4cb0-8945-2ce95c6f9726']}));",
+      value: '',
+    },
+    {
+      command: 'open',
+      target: '/recording/create',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#artist-credit-editor button.open-ac',
+      value: '',
+    },
+    // Wait for the recent entities list to load and appear.
+    // (The first artist input should be automatically focused to trigger this.)
+    {
+      command: 'pause',
+      target: '1000',
+      value: '',
+    },
+    // The redirected MBID should not trigger any recursion that causes
+    // infinite K.Flays to appear in the list.
+    {
+      command: 'assertEval',
+      target: "Array.from(document.querySelectorAll('#ac-source-artist-0-menu li.option-item')).map(x => x.childNodes[0].textContent).join(', ')",
+      value: 'K.Flay',
+    },
+    // The artist MBIDs in localStorage should have been filtered to contain
+    // only the single primary MBID.
+    {
+      command: 'assertEval',
+      target: "JSON.stringify(JSON.parse(localStorage.getItem('recentAutocompleteEntities')).artist)",
+      value: '["d1fc999f-6184-41a6-bcb1-7c59bf74a6e1"]',
+    },
+  ],
+}

--- a/t/sql/whatever_it_takes.sql
+++ b/t/sql/whatever_it_takes.sql
@@ -21,6 +21,9 @@ INSERT INTO artist_credit_name (artist_credit, position, artist, name, join_phra
     (2064806, 0, 870909, 'Imagine Dragons', ' & '),
     (2064806, 1, 679159, 'K.Flay', '');
 
+INSERT INTO artist_gid_redirect (gid, new_id, created) VALUES
+    ('b3668303-75e1-4ec3-9b32-008598675340', 679159, '2017-07-13 06:00:22.322448+00');
+
 INSERT INTO release_group (id, gid, name, artist_credit, type, comment, edits_pending, last_updated) VALUES
     (1803671, '69ed06a7-7a05-406a-92a2-f3216d1c1561', 'Whatever It Takes', 950778, 2, '', 0, '2017-05-09 04:59:12.01423+00'),
     (1882825, '251e0b53-9b79-48b9-9e0e-e4b9795825b9', 'Whatever It Takes (Jorgen Odegard remix)', 950778, 2, '', 0, '2017-11-09 17:17:25.768881+00');


### PR DESCRIPTION
# Problem

MBS-14125: If the "Recent Items" contains merged (to another) entities, JS try to load that entity infinitely

# Solution

 * If we detect an MBID redirect, replace the MBID in localStorage.
 * If an MBID doesn't resolve to anything, remove it.
 * If two (or more) MBIDs resolve to the same entity, ensure it's only pushed once onto the recent items list.

# Testing

I modified `recentAutocompleteEntities` in localStorage to contain some redirected, invalid, or duplicate artist MBIDs, then reloaded the page. Accessing the artist autocomplete from a relationship dialog no longer triggered an infinite number of requests. The list of MBIDs in localStorage was also updated as outlined above.