### PR TITLE
MBS-12524: Improve performance of cover art uploader

### DIFF
--- a/root/static/scripts/edit/MB/Art.js
+++ b/root/static/scripts/edit/MB/Art.js
@@ -214,9 +214,9 @@ MB.Art.file_data_uri = function (file) {
   var deferred = $.Deferred();
   var reader = new window.FileReader();
   reader.addEventListener('loadend', function () {
-    deferred.resolve(reader.result);
+    deferred.resolve(URL.createObjectURL(new Blob([reader.result])));
   });
-  reader.readAsDataURL(file);
+  reader.readAsArrayBuffer(file);
 
   return deferred.promise();
 };


### PR DESCRIPTION
# Problem

MBS-12524

# Solution

Links to the preview thumbnails via blob URLs, as suggested by chaban in https://tickets.metabrainz.org/browse/MBS-12524?focusedId=63664&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-63664 (thanks chaban!).

# Testing

This doesn't require any CAA services running in order to test, as it's purely a client-side issue. Just drag some files into the uploader, and observe memory usage using your browser's developer tools. (The speed at which the thumbnail now displays is also a hint.)