### PR TITLE
Break and unbreak selenium

### DIFF
--- a/docker/musicbrainz-tests/run_selenium_tests.sh
+++ b/docker/musicbrainz-tests/run_selenium_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -x
+set -o pipefail -x
 shopt -s nullglob
 
 cd "$MBS_ROOT"

--- a/package.json
+++ b/package.json
@@ -106,5 +106,5 @@
     "utf8": "3.0.0"
   },
   "private": true,
-  "packageManager": "yarn@4.2.2"
+  "packageManager": "yarn@4.9.2"
 }

--- a/t/sql/filtering.sql
+++ b/t/sql/filtering.sql
@@ -65,9 +65,11 @@ INSERT INTO release_label (release, label, catalog_number)
 
 INSERT INTO area (id, gid, name, type)
     VALUES (221, '8a754a16-0027-3a29-b6d7-2b40ea0481ed', 'United Kingdom', 1),
-           (222, '489ce91b-6658-3307-9877-795b68554c98', 'United States', 1);
+           (222, '489ce91b-6658-3307-9877-795b68554c98', 'United States', 1)
+    ON CONFLICT DO NOTHING;
 
-INSERT INTO country_area (area) VALUES (221), (222);
+INSERT INTO country_area (area) VALUES (221), (222)
+    ON CONFLICT DO NOTHING;
 
 INSERT INTO release_country (release, country, date_year, date_month, date_day)
     VALUES (3400, 221, 1993, NULL, NULL),

--- a/t/sql/mbs-10188.sql
+++ b/t/sql/mbs-10188.sql
@@ -78,10 +78,6 @@ INSERT INTO musicbrainz.country_area (area) VALUES
 INSERT INTO musicbrainz.release_country (release, country, date_year, date_month, date_day) VALUES
 	(1072194, 99, 1973, NULL, NULL),
 	(1608636, 99, 1980, NULL, NULL);
-INSERT INTO musicbrainz.area (id, gid, name, type, edits_pending, last_updated, begin_date_year, begin_date_month, begin_date_day, end_date_year, end_date_month, end_date_day, ended, comment) VALUES
-	(221, '8a754a16-0027-3a29-b6d7-2b40ea0481ed', 'United Kingdom', 1, 0, '2013-05-16 11:06:19.67235+00', NULL, NULL, NULL, NULL, NULL, NULL, '0', '');
-INSERT INTO musicbrainz.iso_3166_1 (area, code) VALUES
-	(221, 'GB');
 INSERT INTO musicbrainz.label (id, gid, name, begin_date_year, begin_date_month, begin_date_day, end_date_year, end_date_month, end_date_day, label_code, type, area, comment, edits_pending, last_updated, ended) VALUES
 	(62793, 'c029628b-6633-439e-bcee-ed02e8a338f7', 'EMI', 1972, NULL, NULL, NULL, NULL, NULL, 542, 4, 221, 'EMI Records, since 1972', 0, '2015-07-05 15:01:16.460867+00', '0');
 INSERT INTO musicbrainz.release_label (id, release, label, catalog_number, last_updated) VALUES

--- a/t/sql/selenium.sql
+++ b/t/sql/selenium.sql
@@ -67,6 +67,7 @@ INSERT INTO country_area (area) VALUES
     (73),
     (107),
     (176),
+    (221),
     (222),
     (241);
 

--- a/t/sql/vote_and_note_selenium.sql
+++ b/t/sql/vote_and_note_selenium.sql
@@ -1,12 +1,12 @@
 SET client_min_messages TO 'warning';
 
 INSERT INTO artist (id, gid, name, sort_name)
-    VALUES (1, 'a9d99e40-72d7-11de-8a39-0800200c9a66', 'Name', 'Name');
+    VALUES (3, 'a9d99e40-72d7-11de-8a39-0800200c9a66', 'Name', 'Name');
 
 INSERT INTO artist_credit (id, name, artist_count, gid)
     VALUES (1, 'Name', 1, '949a7fd5-fe73-3e8f-922e-01ff4ca958f7');
 INSERT INTO artist_credit_name (artist_credit, artist, name, position, join_phrase)
-    VALUES (1, 1, 'Name', 0, '');
+    VALUES (1, 3, 'Name', 0, '');
 
 INSERT INTO release_group (id, gid, name, artist_credit)
     VALUES (1, '3b4faa80-72d9-11de-8a39-0800200c9a66', 'Arrival', 1);


### PR DESCRIPTION
# Problem

t/selenium/Vote_And_Note_Submission.json5 is broken (along with a couple other tests), and the failures are not being reported by GitHub Actions.

# Solution

This fixes the exit code propagation in run_selenium_tests.sh, and then fixes some problematic SQL under t/sql/.

# Testing

CI