### PR TITLE
MBS-14136: Fix display of event relationship editor

### DIFF
--- a/root/static/styles/relationship-editor.less
+++ b/root/static/styles/relationship-editor.less
@@ -163,7 +163,7 @@ div.ar-descr {
     width: 95%;
 }
 
-div.relationship-editor, div.release-relationship-editor {
+#relationship-editor, div.release-relationship-editor {
     margin-top: 1em;
 
     legend button.add-item {


### PR DESCRIPTION
# Problem

MBS-14136

# Solution

`div.relationship-editor` is the hydrated container element which only exists on the TT-based forms. `fieldset#relationship-editor` exists on both the TT-based and React-based forms.

# Testing

Manually tested with http://localhost:5000/event/1efb6a48-0590-4a61-bdbf-745dea5e9edd/edit and http://localhost:5000/artist/b7ffd2af-418f-4be2-bdd1-22f8b48613da/edit