### PR TITLE
MBS-14133: Report for releases older than label start 

### DIFF
--- a/lib/MusicBrainz/Server/Report/ReleasedTooEarly.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasedTooEarly.pm
@@ -12,13 +12,7 @@ sub query {
         FROM
           ( SELECT r.*
             FROM release r
-            LEFT JOIN (
-                SELECT release, date_year, date_month, date_day
-                FROM release_country
-                UNION ALL
-                SELECT release, date_year, date_month, date_day
-                FROM release_unknown_country
-            ) events ON (events.release = r.id)
+            LEFT JOIN release_event events ON events.release = r.id
             JOIN medium m ON m.release = r.id
             LEFT JOIN medium_format mf ON mf.id = m.format
             LEFT JOIN medium_cdtoc mcd ON mcd.medium = m.id

--- a/lib/MusicBrainz/Server/Report/ReleasedTooEarlyDigital.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasedTooEarlyDigital.pm
@@ -11,13 +11,7 @@ sub query {<<~'SQL'}
     FROM
         ( SELECT r.*
         FROM release r
-        LEFT JOIN (
-            SELECT release, date_year, date_month, date_day
-            FROM release_country
-            UNION ALL
-            SELECT release, date_year, date_month, date_day
-            FROM release_unknown_country
-        ) events ON (events.release = r.id)
+        LEFT JOIN release_event events ON events.release = r.id
         JOIN medium m ON m.release = r.id
         WHERE m.format = 12 -- there is one digital medium
           AND date_year < 1999 -- first major label digital store

--- a/lib/MusicBrainz/Server/Report/ReleasedTooEarlyForLabel.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasedTooEarlyForLabel.pm
@@ -11,13 +11,7 @@ sub query {<<~'SQL'}
     FROM
         ( SELECT r.*
             FROM release r
-            LEFT JOIN (
-                SELECT release, date_year, date_month, date_day
-                  FROM release_country
-                UNION ALL
-                SELECT release, date_year, date_month, date_day
-                  FROM release_unknown_country
-            ) events ON (events.release = r.id)
+            LEFT JOIN release_event events ON events.release = r.id
             JOIN release_label rl ON rl.release = r.id
             JOIN label l ON rl.label = l.id
            WHERE events.date_year < l.begin_date_year

--- a/lib/MusicBrainz/Server/Report/ReleasedTooEarlyForLabel.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasedTooEarlyForLabel.pm
@@ -1,0 +1,41 @@
+package MusicBrainz::Server::Report::ReleasedTooEarlyForLabel;
+use Moose;
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub query {<<~'SQL'}
+    SELECT DISTINCT ON (r.id)
+        r.id AS release_id,
+        row_number() OVER (ORDER BY ac.name COLLATE musicbrainz, r.name COLLATE musicbrainz)
+    FROM
+        ( SELECT r.*
+            FROM release r
+            LEFT JOIN (
+                SELECT release, date_year, date_month, date_day
+                  FROM release_country
+                UNION ALL
+                SELECT release, date_year, date_month, date_day
+                  FROM release_unknown_country
+            ) events ON (events.release = r.id)
+            JOIN release_label rl ON rl.release = r.id
+            JOIN label l ON rl.label = l.id
+           WHERE events.date_year < l.begin_date_year
+        ) r
+    JOIN artist_credit ac ON r.artist_credit = ac.id
+    SQL
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut
+

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -90,6 +90,7 @@ my @all = qw(
     RecordingsWithFutureDates
     ReleasedTooEarly
     ReleasedTooEarlyDigital
+    ReleasedTooEarlyForLabel
     ReleaseGroupsWithoutVACredit
     ReleaseGroupsWithoutVALink
     ReleaseLabelSameArtist
@@ -203,6 +204,7 @@ use MusicBrainz::Server::Report::RecordingTrackDifferentName;
 use MusicBrainz::Server::Report::RecordingsWithFutureDates;
 use MusicBrainz::Server::Report::ReleasedTooEarly;
 use MusicBrainz::Server::Report::ReleasedTooEarlyDigital;
+use MusicBrainz::Server::Report::ReleasedTooEarlyForLabel;
 use MusicBrainz::Server::Report::ReleaseGroupsWithoutVACredit;
 use MusicBrainz::Server::Report::ReleaseGroupsWithoutVALink;
 use MusicBrainz::Server::Report::ReleaseLabelSameArtist;

--- a/root/report/ReleasedTooEarlyDigital.js
+++ b/root/report/ReleasedTooEarlyDigital.js
@@ -1,6 +1,6 @@
 /*
  * @flow strict
- * Copyright (C) 2018 MetaBrainz Foundation
+ * Copyright (C) 2025 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,
  * and is licensed under the GPL version 2, or (at your option) any

--- a/root/report/ReleasedTooEarlyForLabel.js
+++ b/root/report/ReleasedTooEarlyForLabel.js
@@ -1,0 +1,41 @@
+/*
+ * @flow strict
+ * Copyright (C) 2025 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import ReleaseList from './components/ReleaseList.js';
+import ReportLayout from './components/ReportLayout.js';
+import type {ReportDataT, ReportReleaseT} from './types.js';
+
+component ReleasedTooEarlyForLabel(...{
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases where the earliest release date
+         predates the begin date of at least one of the marked release labels.
+         This means either one of the two dates is incorrect,
+         or the label has been incorrectly selected.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l('Releases older than their release label')}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
+
+export default ReleasedTooEarlyForLabel;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -329,6 +329,10 @@ component ReportsIndex() {
             reportName="ReleasedTooEarlyDigital"
           />
           <ReportsIndexEntry
+            content={l('Releases older than their release label')}
+            reportName="ReleasedTooEarlyForLabel"
+          />
+          <ReportsIndexEntry
             content={l(
               `Releases where some (but not all) mediums
               have no format set`,

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -297,6 +297,7 @@ export default {
   'report/RecordingTrackDifferentName': (): Promise<mixed> => import('../report/RecordingTrackDifferentName.js'),
   'report/ReleasedTooEarly': (): Promise<mixed> => import('../report/ReleasedTooEarly.js'),
   'report/ReleasedTooEarlyDigital': (): Promise<mixed> => import('../report/ReleasedTooEarlyDigital.js'),
+  'report/ReleasedTooEarlyForLabel': (): Promise<mixed> => import('../report/ReleasedTooEarlyForLabel.js'),
   'report/ReleaseGroupsWithoutVaCredit': (): Promise<mixed> => import('../report/ReleaseGroupsWithoutVaCredit.js'),
   'report/ReleaseGroupsWithoutVaLink': (): Promise<mixed> => import('../report/ReleaseGroupsWithoutVaLink.js'),
   'report/ReleaseLabelSameArtist': (): Promise<mixed> => import('../report/ReleaseLabelSameArtist.js'),


### PR DESCRIPTION
### Implement MBS-14133

# Description
This adds a new report that shows releases with a release date that predates the start date for one of their release labels. By definition something is wrong here, be it the release label, the release date or the label date.

# Testing
Tested with sample data and it already found 140 hits, so this seems surprisingly common. Checked a bunch of them and the query seems to be working fine, and the data is indeed bad.