### PR TITLE
MBS-14131: Report for recordings with multiple same name works

### DIFF
--- a/lib/MusicBrainz/Server/Report/RecordingsWithDuplicateWorks.pm
+++ b/lib/MusicBrainz/Server/Report/RecordingsWithDuplicateWorks.pm
@@ -1,0 +1,34 @@
+package MusicBrainz::Server::Report::RecordingsWithDuplicateWorks;
+use Moose;
+
+with 'MusicBrainz::Server::Report::RecordingReport',
+     'MusicBrainz::Server::Report::FilterForEditor::RecordingID';
+
+sub query {<<~'SQL'}
+    SELECT
+        r.id AS recording_id,
+        row_number() OVER (ORDER BY ac.name COLLATE musicbrainz, r.name COLLATE musicbrainz)
+    FROM recording r
+    JOIN artist_credit ac ON ac.id = r.artist_credit
+    WHERE EXISTS (
+        SELECT work.name
+        FROM l_recording_work lrw
+        JOIN work ON lrw.entity1 = work.id
+        WHERE lrw.entity0 = r.id
+        GROUP BY work.name HAVING COUNT(*) > 1
+    )
+SQL
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -84,6 +84,7 @@ my @all = qw(
     PseudoReleasesWithCoverArt
     RecordingsWithoutVACredit
     RecordingsWithoutVALink
+    RecordingsWithDuplicateWorks
     RecordingsWithEarliestReleaseRelationships
     RecordingsWithVaryingTrackLengths
     RecordingTrackDifferentName
@@ -196,6 +197,7 @@ use MusicBrainz::Server::Report::PossibleCollaborations;
 use MusicBrainz::Server::Report::PseudoReleasesWithCoverArt;
 use MusicBrainz::Server::Report::RecordingsWithoutVACredit;
 use MusicBrainz::Server::Report::RecordingsWithoutVALink;
+use MusicBrainz::Server::Report::RecordingsWithDuplicateWorks;
 use MusicBrainz::Server::Report::RecordingsWithEarliestReleaseRelationships;
 use MusicBrainz::Server::Report::RecordingsWithVaryingTrackLengths;
 #use MusicBrainz::Server::Report::RecordingsSameNameDifferentArtistsSameName;

--- a/root/report/RecordingsWithDuplicateWorks.js
+++ b/root/report/RecordingsWithDuplicateWorks.js
@@ -1,0 +1,41 @@
+/*
+ * @flow strict
+ * Copyright (C) 2025 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import RecordingList from './components/RecordingList.js';
+import ReportLayout from './components/ReportLayout.js';
+import type {ReportDataT, ReportRecordingT} from './types.js';
+
+component RecordingsWithDuplicateWorks(...{
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportRecordingT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report lists recordings which are linked several times
+         to the same work or to works of the same name. While this can
+         be correct, in most cases either the relationships or the works
+         will be duplicated.`,
+      )}
+      entityType="recording"
+      filtered={filtered}
+      generated={generated}
+      title={l('Recordings with possible duplicate works')}
+      totalEntries={pager.total_entries}
+    >
+      <RecordingList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
+
+export default RecordingsWithDuplicateWorks;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -524,6 +524,10 @@ component ReportsIndex() {
             reportName="DuplicateRelationshipsRecordings"
           />
           <ReportsIndexEntry
+            content={l('Recordings with possible duplicate works')}
+            reportName="RecordingsWithDuplicateWorks"
+          />
+          <ReportsIndexEntry
             content={l('Recordings with varying track times')}
             reportName="RecordingsWithVaryingTrackLengths"
           />

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -289,6 +289,7 @@ export default {
   'report/PossibleCollaborations': (): Promise<mixed> => import('../report/PossibleCollaborations.js'),
   'report/PseudoReleasesWithCoverArt': (): Promise<mixed> => import('../report/PseudoReleasesWithCoverArt.js'),
   'report/RecordingsSameNameDifferentArtistsSameName': (): Promise<mixed> => import('../report/RecordingsSameNameDifferentArtistsSameName.js'),
+  'report/RecordingsWithDuplicateWorks': (): Promise<mixed> => import('../report/RecordingsWithDuplicateWorks.js'),
   'report/RecordingsWithEarliestReleaseRelationships': (): Promise<mixed> => import('../report/RecordingsWithEarliestReleaseRelationships.js'),
   'report/RecordingsWithFutureDates': (): Promise<mixed> => import('../report/RecordingsWithFutureDates.js'),
   'report/RecordingsWithoutVaCredit': (): Promise<mixed> => import('../report/RecordingsWithoutVaCredit.js'),


### PR DESCRIPTION
### Implement MBS-14131

# Description
This finds recordings linked to two or more works of the same name. This can be the same work twice, or two different works. There's two main use cases for this, both mostly due to merges: recordings linked to the same work with different attributes, and recordings linked to two works, such as a standard work and an arrangement work.

# Testing
Locally, where it found a fair amount of classical recordings with multiple dates and tracks listed as both a recording and a live recording.

# Further action
While this works, it's quite slow (10 to 15 seconds on sample data). Any suggestions to make it more efficient (while still not depending on work id but work name) much welcome!