### PR TITLE
MBS-14130: ACUM albums should link to release group instead of releases

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -581,7 +581,7 @@ export const CLEANUPS: CleanupEntries = {
               result: /\/results\?creatorid=[A-Z]-\d+-\d$/.test(url),
               target: ERROR_TARGETS.ENTITY,
             };
-          case LINK_TYPES.otherdatabases.release:
+          case LINK_TYPES.otherdatabases.release_group:
             return {
               result: /\/album\?albumid=[0-9A-Z]+$/.test(url),
               target: ERROR_TARGETS.ENTITY,

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -285,10 +285,10 @@ const testData = [
   // ACUM
   {
           input_url: 'https://nocs.acum.org.il/acumsitesearchdb/album?albumid=000608',
-          input_entity_type: 'release',
+          input_entity_type: 'release_group',
           expected_relationship_type: 'otherdatabases',
           expected_clean_url: 'https://nocs.acum.org.il/acumsitesearchdb/album?albumid=000608',
-          only_valid_entity_types: ['release'],
+          only_valid_entity_types: ['release_group'],
   },
   {
           input_url: 'https://nocs.acum.org.il/acumsitesearchdb/work?workid=29AJOVQ&tab=musical',


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

MBS-14130: ACUM albums should link to release group instead of releases


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

move ACUM album links to release groups

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

JS unit tests