### PR TITLE
MBS-14111: Show area anthem in overview

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -11,6 +11,9 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
         subset      => {
             show => [qw( area artist genre label place series instrument release_group url )],
         },
+        typed_subset => {
+            show => { work => [ '536b4ee4-bb2d-3b6f-a3f1-082f22e5b17d' ] }, # anthem
+        },
         paged_subset => {
             recordings => ['recording'],
             releases => ['release'],

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -292,7 +292,10 @@ sub show : PathPart('') Chained('load')
                        grep { $_->direction == $DIRECTION_BACKWARD }
                        grep { $_->link->type->gid eq 'dd9886f2-1dfe-4270-97db-283f6839a666' } @{ $artist->relationships };
     if (defined $base_name) {
-        $c->model('Relationship')->load_subset(['artist'], $base_name);
+        $c->model('Relationship')->load_subset(
+            target_types => ['artist'],
+            source_objs => [$base_name],
+        );
         $c->stash( legal_name => $base_name );
         my @aliases = uniq map { $_->name }
                       sort_by { $coll->getSortKey($_->name) }
@@ -328,8 +331,8 @@ sub show : PathPart('') Chained('load')
 
     if (@renamed_from || @renamed_into) {
         $c->model('Relationship')->load_subset(
-            ['artist'],
-            @renamed_from, @renamed_into,
+            target_types => ['artist'],
+            source_objs => [@renamed_from, @renamed_into],
         );
     }
 

--- a/lib/MusicBrainz/Server/Controller/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/Label.pm
@@ -162,8 +162,8 @@ sub show : PathPart('') Chained('load')
 
     if (@renamed_from || @renamed_into) {
         $c->model('Relationship')->load_subset(
-            ['label'],
-            @renamed_from, @renamed_into,
+            target_types => ['label'],
+            source_objs => [@renamed_from, @renamed_into],
         );
     }
 

--- a/lib/MusicBrainz/Server/Controller/Role/EditRelationships.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/EditRelationships.pm
@@ -405,12 +405,12 @@ role {
             my $key = $_->target_type . '-' . $_->id;
             ($key => $_)
         } $c->model('Relationship')->load_subset(
-            \%rel_ids_by_target_type,
-            $source->meta->clone_object(
+            target_types => \%rel_ids_by_target_type,
+            source_objs => [$source->meta->clone_object(
                 $source,
                 relationships => [],
                 has_loaded_relationships => 0,
-            ),
+            )],
         );
 
         for my $field (@field_values) {

--- a/lib/MusicBrainz/Server/Controller/Role/Load.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Load.pm
@@ -148,15 +148,33 @@ role
 
             if (defined $c->stash->{paged_link_type_group}) {
                 # Still load URL rels since we want them for the sidebar
-                $c->model('Relationship')->load_subset(['url'], $entity);
+                $c->model('Relationship')->load_subset(
+                    target_types => ['url'],
+                    source_objs => [$entity],
+                );
             } else {
-                my $types = $relationships->{subset}{$action};
-                if (!defined $types && !$loaded) {
-                    $types = $relationships->{default};
+                my $target_types = $relationships->{subset}{$action};
+                if (!defined $target_types && !$loaded) {
+                    $target_types = $relationships->{default};
                 }
-                if ($types) {
-                    $c->model('Relationship')->load_subset($types, $entity);
+                if ($target_types) {
+                    $c->model('Relationship')->load_subset(
+                        target_types => $target_types,
+                        source_objs => [$entity],
+                    );
                 }
+
+                my $link_and_target_types = $relationships->{typed_subset}{$action};
+                if ($link_and_target_types) {
+                    for my $target_type (keys %$link_and_target_types) {
+                        $c->model('Relationship')->load_subset(
+                            target_types => [$target_type],
+                            link_types => $link_and_target_types->{$target_type},
+                            source_objs => [$entity],
+                        );
+                    }
+                }
+
             }
         }
 

--- a/lib/MusicBrainz/Server/ControllerBase/WS/2.pm
+++ b/lib/MusicBrainz/Server/ControllerBase/WS/2.pm
@@ -559,7 +559,10 @@ sub load_relationships {
     if ($inc->has_rels)
     {
         my $types = $inc->get_rel_types();
-        my @rels = $c->model('Relationship')->load_subset($types, @for);
+        my @rels = $c->model('Relationship')->load_subset(
+            target_types => $types,
+            source_objs => \@for,
+        );
 
         my @entities_with_rels = @for;
 
@@ -573,7 +576,10 @@ sub load_relationships {
         {
             push(@entities_with_rels, @works);
             # Avoid returning recording-work relationships for other recordings
-            $c->model('Relationship')->load_subset_cardinal($types, @works);
+            $c->model('Relationship')->load_subset_cardinal(
+                target_types => $types,
+                source_objs => \@works,
+            );
         }
         $self->linked_works($c, $stash, \@works);
 

--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -136,6 +136,7 @@ sub _load
     my @source_objs = @{ $args{source_objs} };
     my $source_type = $args{source_type};
     my @target_types = uniq @{ $args{target_types} };
+    my @link_types = @{ $args{link_types} // [] };
     my @types = map { [ sort($source_type, $_) ] } @target_types;
     my $use_cardinality = $args{use_cardinality};
     my $rel_ids_by_target_type = $args{rel_ids_by_target_type};
@@ -182,6 +183,12 @@ sub _load
         # If the source and target types are the same, two possible conditions
         # will have been added above, so join them with an OR.
         @cond = join(' OR ', @cond);
+
+        # If specific link types have been passed, limit to links of those types
+        if (scalar @link_types > 0) {
+            push @cond, 'lt.gid = any(?)';
+            push @params, [@link_types];
+        }
 
         my $select = "l_${type0}_${type1}.* FROM l_${type0}_${type1}
                       JOIN link l ON link = l.id
@@ -466,6 +473,7 @@ sub _load_subset {
     my ($self, %args) = @_;
 
     my $target_types = $args{target_types};
+    my $link_types = $args{link_types};
     my $use_cardinality = $args{use_cardinality};
     my @source_objs = @{ $args{source_objs} };
 
@@ -490,6 +498,7 @@ sub _load_subset {
         push @rels, $self->_load(
             source_type => $source_type,
             target_types => $target_types,
+            link_types => $link_types,
             use_cardinality => $use_cardinality,
             source_objs => $source_objs_by_type{$source_type},
             rel_ids_by_target_type => $rel_ids_by_target_type,
@@ -502,11 +511,12 @@ sub _load_subset {
 }
 
 sub load_subset {
-    my ($self, $target_types, @source_objs) = @_;
+    my ($self, %args) = @_;
     return $self->_load_subset(
-        target_types => $target_types,
+        target_types => $args{target_types},
+        link_types => $args{link_types},
         use_cardinality => 0,
-        source_objs => \@source_objs,
+        source_objs => $args{source_objs},
     );
 }
 
@@ -529,11 +539,12 @@ sub load_cardinal {
 }
 
 sub load_subset_cardinal {
-    my ($self, $target_types, @source_objs) = @_;
+    my ($self, %args) = @_;
     return $self->_load_subset(
-        target_types => $target_types,
+        target_types => $args{target_types},
+        link_types => $args{link_types},
         use_cardinality => 1,
-        source_objs => \@source_objs,
+        source_objs => $args{source_objs},
     );
 }
 

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -1734,7 +1734,10 @@ sub update_amazon_asin {
 
     my $release = $self->get_by_id($release_id);
 
-    $self->c->model('Relationship')->load_subset(['url'], $release);
+    $self->c->model('Relationship')->load_subset(
+        target_types => ['url'],
+        source_objs => [$release],
+    );
 
     my @ordered_relationships =
         rev_sort_by { $_->last_updated } $release->all_relationships;

--- a/lib/MusicBrainz/Server/Edit/Work/RelatedEntities.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/RelatedEntities.pm
@@ -19,7 +19,10 @@ around '_build_related_entities' => sub
 
     my ($releases, undef) = $self->c->model('Release')->find_by_recording(\@recording_ids);
 
-    $self->c->model('Relationship')->load_subset([ 'artist' ], @works);
+    $self->c->model('Relationship')->load_subset(
+        target_types => [ 'artist' ],
+        source_objs => \@works,
+    );
 
     return {
         artist => [

--- a/t/lib/t/MusicBrainz/Server/Data/Relationship.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Relationship.pm
@@ -356,6 +356,41 @@ test 'Relationship credits are added to save old name if not renaming' => sub {
     is($relationship2->entity0_credit, '', 'no duplicate credit was added');
 };
 
+test 'Only appropriate rels are loaded with load_subset' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+relationships');
+    # Insert extra link of different type (remix) and to different entity (series)
+    MusicBrainz::Server::Test->prepare_test_database($c, <<~'EOSQL');
+        INSERT INTO link (id, link_type, attribute_count) VALUES (6, 157, 0);
+        INSERT INTO l_artist_recording (id, link, entity0, entity1) VALUES (4, 6, 1, 2);
+        INSERT INTO l_artist_series (id, link, entity0, entity1, link_order) VALUES (2, 5, 1, 1, 1);
+        EOSQL
+
+    my $artist = $c->model('Artist')->get_by_id(1);
+
+    $test->c->model('Relationship')->load($artist);
+    is(scalar($artist->all_relationships), 4, 'There are 4 rels');
+
+    $artist->clear_relationships;
+
+    $test->c->model('Relationship')->load_subset(
+        target_types => [ 'recording' ],
+        source_objs => [ $artist ],
+    );
+    is(scalar($artist->all_relationships), 3, 'There are 3 artist rels');
+
+    $artist->clear_relationships;
+
+    $test->c->model('Relationship')->load_subset(
+        target_types => [ 'recording' ],
+        link_types => [ '59054b12-01ac-43ee-a618-285fd397e461' ],
+        source_objs => [ $artist ],
+    );
+    is(scalar($artist->all_relationships), 2, 'There are 2 artist rels of type instrument');
+};
+
 test all => sub {
 
 my $test = shift;
@@ -460,11 +495,11 @@ $sql->commit;
 is($rel->id, 4);
 
 $artist1->clear_relationships;
-$rel_data->load_subset([ 'artist' ], $artist1);
+$rel_data->load_subset(target_types => [ 'artist' ], source_objs => [$artist1]);
 is(scalar($artist1->all_relationships), 0, 'filter to just artist rels');
 
 $artist1->clear_relationships;
-$rel_data->load_subset([ 'recording' ], $artist1);
+$rel_data->load_subset(target_types => [ 'recording' ], source_objs => [$artist1]);
 is(scalar($artist1->all_relationships), 1, 'filter to just recording rels');
 
 $artist1->clear_relationships;


### PR DESCRIPTION
### Implement MBS-14111

# Problem
Anthems are fairly important for areas, and it would make sense to display them in the area overview, but right now they are visible only on the Works tab alongside all the other works with a much less important connection to the area such as "written in".

# Solution
This introduces a new `typed_subset` option for rel loading which accepts a set of `entity_type`s paired with an array of `link_type` gids. Only those types will be loaded in the page specified.

# Testing
Added a test for `load_subset` to the `Data::Relationship` tests. Navigated around a bit to hopefully make sure I didn't break anything else, and of course tested that the Australian anthem now appears on `/area/106e0bec-b638-3b37-b731-f53d507dc00e`