### PR TITLE
MBS-14120: Indicate the edited release on edits entered from the relationship editor

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
@@ -2,7 +2,13 @@ package MusicBrainz::Server::Edit::Relationship::Create;
 use Moose;
 
 use List::AllUtils qw( any );
-use MusicBrainz::Server::Edit::Types qw( LinkAttributesArray PartialDateHash Nullable NullableOnPreview );
+use MusicBrainz::Server::Edit::Types qw(
+    EnteredFromEntity
+    LinkAttributesArray
+    PartialDateHash
+    Nullable
+    NullableOnPreview
+);
 use MusicBrainz::Server::Translation qw( N_lp );
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
@@ -10,6 +16,7 @@ with 'MusicBrainz::Server::Edit::Relationship',
      'MusicBrainz::Server::Edit::Relationship::RelatedEntities',
      'MusicBrainz::Server::Edit::Role::Preview',
      'MusicBrainz::Server::Edit::Role::DatePeriod',
+     'MusicBrainz::Server::Edit::Role::EnteredFrom',
      'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 use MooseX::Types::Moose qw( Bool Int Str );
@@ -54,6 +61,7 @@ has '+data' => (
             reverse_link_phrase => Str,
             long_link_phrase => Str,
         ],
+        entered_from => EnteredFromEntity,
         attributes   => Nullable[LinkAttributesArray],
         begin_date   => Nullable[PartialDateHash],
         end_date     => Nullable[PartialDateHash],

--- a/lib/MusicBrainz/Server/Edit/Relationship/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Delete.pm
@@ -14,7 +14,11 @@ use MusicBrainz::Server::Data::Utils qw(
     type_to_model
 );
 use MusicBrainz::Server::Edit::Utils qw( gid_or_id );
-use MusicBrainz::Server::Edit::Types qw( LinkAttributesArray PartialDateHash );
+use MusicBrainz::Server::Edit::Types qw(
+    EnteredFromEntity
+    LinkAttributesArray
+    PartialDateHash
+);
 use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MooseX::Types::Moose qw( Int Str Bool );
@@ -30,6 +34,7 @@ use MusicBrainz::Server::Translation qw( N_l N_lp );
 extends 'MusicBrainz::Server::Edit';
 with 'MusicBrainz::Server::Edit::Relationship',
      'MusicBrainz::Server::Edit::Relationship::RelatedEntities',
+     'MusicBrainz::Server::Edit::Role::EnteredFrom',
      'MusicBrainz::Server::Edit::Role::Preview';
 
 sub edit_type { $EDIT_RELATIONSHIP_DELETE }
@@ -68,6 +73,7 @@ has '+data' => (
                 ],
             ],
         ],
+        entered_from => EnteredFromEntity,
         edit_version => Optional[Int],
     ],
 );
@@ -268,6 +274,7 @@ sub initialize
             },
         },
         edit_version => 2,
+        defined $opts{entered_from} ? (entered_from => $opts{entered_from}) : (),
     });
 }
 

--- a/lib/MusicBrainz/Server/Edit/Relationship/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Edit.pm
@@ -16,7 +16,13 @@ use MusicBrainz::Server::Edit::Exceptions;
 use MusicBrainz::Server::Entity::LinkAttribute;
 use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
-use MusicBrainz::Server::Edit::Types qw( LinkAttributesArray PartialDateHash Nullable NullableOnPreview );
+use MusicBrainz::Server::Edit::Types qw(
+    EnteredFromEntity
+    LinkAttributesArray
+    PartialDateHash
+    Nullable
+    NullableOnPreview
+);
 use MusicBrainz::Server::Data::Utils qw(
     boolean_to_json
     partial_date_to_hash
@@ -34,6 +40,7 @@ extends 'MusicBrainz::Server::Edit::WithDifferences';
 with 'MusicBrainz::Server::Edit::Relationship',
      'MusicBrainz::Server::Edit::Relationship::RelatedEntities',
      'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Role::EnteredFrom',
      'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 sub edit_type { $EDIT_RELATIONSHIP_EDIT }
@@ -101,6 +108,7 @@ has '+data' => (
         entity0_credit => Optional[Str],
         entity1_credit => Optional[Str],
         link => find_type_constraint('LinkHash'),
+        entered_from => EnteredFromEntity,
         new => find_type_constraint('RelationshipHash'),
         old => find_type_constraint('RelationshipHash'),
         edit_version => Optional[Int],
@@ -366,6 +374,8 @@ sub initialize
     my ($self, %opts) = @_;
 
     my $relationship = delete $opts{relationship};
+    my $entered_from = delete $opts{entered_from};
+
     my $link = $relationship->link;
     my $type0 = $link->type->entity0_type;
     my $type1 = $link->type->entity1_type;
@@ -461,6 +471,7 @@ sub initialize
         entity0_credit => $relationship->entity0_credit,
         entity1_credit => $relationship->entity1_credit,
         edit_version => 2,
+        defined $entered_from ? (entered_from => $entered_from) : (),
         $self->_change_data($relationship, %opts),
     });
 }

--- a/lib/MusicBrainz/Server/Edit/Relationship/Reorder.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Reorder.pm
@@ -11,7 +11,11 @@ use MusicBrainz::Server::Constants qw(
 );
 use MusicBrainz::Server::Data::Utils qw( partial_date_to_hash type_to_model );
 use MusicBrainz::Server::Edit::Exceptions;
-use MusicBrainz::Server::Edit::Types qw( PartialDateHash LinkAttributesArray );
+use MusicBrainz::Server::Edit::Types qw(
+    EnteredFromEntity
+    PartialDateHash
+    LinkAttributesArray
+);
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw ( N_lp );
 use aliased 'MusicBrainz::Server::Entity::Link';
@@ -21,6 +25,7 @@ use aliased 'MusicBrainz::Server::Entity::Relationship';
 extends 'MusicBrainz::Server::Edit';
 with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
      'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Role::EnteredFrom',
      'MusicBrainz::Server::Edit::Relationship',
      'MusicBrainz::Server::Edit::Relationship::RelatedEntities';
 
@@ -67,6 +72,7 @@ has '+data' => (
                 new_order => Int,
             ],
         ],
+        entered_from => EnteredFromEntity,
         edit_version => Optional[Int],
     ],
 );

--- a/lib/MusicBrainz/Server/Edit/Role/EnteredFrom.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/EnteredFrom.pm
@@ -1,0 +1,45 @@
+package MusicBrainz::Server::Edit::Role::EnteredFrom;
+use Moose::Role;
+
+use MusicBrainz::Server::Constants qw( %ENTITIES );
+
+around build_display_data => sub {
+    my ($orig, $self, @args) = @_;
+
+    my $data = $self->$orig(@args);
+
+    my $entered_from_data = $self->data->{entered_from};
+
+    if ($entered_from_data) {
+        my $entity_properties = $ENTITIES{ $entered_from_data->{entity_type} };
+        my $model = $entity_properties->{model};
+
+        my $entity_class = "MusicBrainz::Server::Entity::$model";
+
+        my $entity = $self->c->model($model)->get_by_gid($entered_from_data->{gid}) ||
+                     $entity_class->new(
+                        name => $entered_from_data->{name},
+                     );
+
+        $self->c->model('ArtistCredit')->load($entity)
+            if $entity_properties->{artist_credits};
+
+        $data->{entered_from} = $entity->TO_JSON;
+    }
+
+    return $data;
+};
+
+no Moose::Role;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2025 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut
+

--- a/lib/MusicBrainz/Server/Edit/Types.pm
+++ b/lib/MusicBrainz/Server/Edit/Types.pm
@@ -5,6 +5,7 @@ use warnings;
 use MooseX::Types -declare => [qw(
     ArtistCreditDefinition
     CoordinateHash
+    EnteredFromEntity
     LinkAttributesArray
     PartialDateHash
     RecordingMergesArray
@@ -15,6 +16,7 @@ use Sub::Exporter -setup => { exports => [qw(
     ArtistCreditDefinition
     Changeset
     CoordinateHash
+    EnteredFromEntity
     LinkAttributesArray
     Nullable
     NullableOnPreview
@@ -65,6 +67,13 @@ subtype ArtistCreditDefinition,
             ]],
         preview => Optional[Str],
     ];
+
+subtype EnteredFromEntity,
+    as Optional[Dict[
+            entity_type => Str,
+            gid         => NullableOnPreview[Str],
+            name        => Str,
+        ]];
 
 subtype LinkAttributesArray,
     as ArrayRef[Dict[

--- a/lib/MusicBrainz/Server/Edit/Work/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/Create.pm
@@ -4,7 +4,7 @@ use Moose;
 use MooseX::Types::Moose qw( ArrayRef Int Maybe Str );
 use MooseX::Types::Structured qw( Dict Optional );
 use MusicBrainz::Server::Constants qw( $EDIT_WORK_CREATE );
-use MusicBrainz::Server::Edit::Types qw( Nullable );
+use MusicBrainz::Server::Edit::Types qw( EnteredFromEntity Nullable );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
 use MusicBrainz::Server::Translation qw( N_lp );
 
@@ -12,6 +12,7 @@ extends 'MusicBrainz::Server::Edit::Generic::Create';
 with 'MusicBrainz::Server::Edit::Work::RelatedEntities',
      'MusicBrainz::Server::Edit::Work',
      'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::EnteredFrom',
      'MusicBrainz::Server::Edit::Role::CheckOverlongString' => {
         get_string => sub { shift->{name} },
      };
@@ -28,6 +29,7 @@ has '+data' => (
     isa => Dict[
         name          => Str,
         comment       => Nullable[Str],
+        entered_from  => EnteredFromEntity,
         type_id       => Nullable[Int],
         language_id   => Nullable[Int],
         languages     => Optional[ArrayRef[Int]],

--- a/root/edit/EditIndex.js
+++ b/root/edit/EditIndex.js
@@ -26,6 +26,7 @@ import {editorMayAddNote, editorMayVoteOnEdit}
   from '../utility/edit.js';
 import formatUserDate from '../utility/formatUserDate.js';
 
+import EditEnteredFrom from './components/EditEnteredFrom.js';
 import EditHeader from './components/EditHeader.js';
 import EditNotes from './components/EditNotes.js';
 import EditorTypeInfo from './components/EditorTypeInfo.js';
@@ -50,6 +51,8 @@ component EditIndex(
     <Layout fullWidth={fullWidth} title={texp.l('Edit #{id}', {id: edit.id})}>
       <div id="content">
         <EditHeader edit={edit} />
+        <EditEnteredFrom edit={edit} />
+
 
         <h2>{l('Changes')}</h2>
         {edit.data ? detailsElement : (

--- a/root/edit/components/EditEnteredFrom.js
+++ b/root/edit/components/EditEnteredFrom.js
@@ -1,0 +1,32 @@
+/*
+ * @flow strict
+ * Copyright (C) 2025 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import DescriptiveLink
+  from '../../static/scripts/common/components/DescriptiveLink.js';
+
+component EditEnteredFrom(
+  edit: {
+    +display_data?: {
+      +entered_from?: NonUrlRelatableEntityT,
+      ...
+    },
+    ...
+  },
+) {
+  const enteredFrom = edit.display_data?.entered_from;
+  return enteredFrom ? (
+      <div className="entered-from">
+        {addColonText(l('Entered from'))}
+        {' '}
+        <DescriptiveLink entity={enteredFrom} />
+      </div>
+  ) : null;
+}
+
+export default EditEnteredFrom;

--- a/root/edit/components/ListEdit.js
+++ b/root/edit/components/ListEdit.js
@@ -13,6 +13,7 @@ import {SanitizedCatalystContext} from '../../context.mjs';
 import {getEditStatusClass} from '../../utility/edit.js';
 import getEditDetailsElement from '../utility/getEditDetailsElement.js';
 
+import EditEnteredFrom from './EditEnteredFrom.js';
 import EditHeader from './EditHeader.js';
 import EditNotes from './EditNotes.js';
 import EditSummary from './EditSummary.js';
@@ -29,6 +30,7 @@ component ListEdit(
   return (
     <div className="edit-list">
       <EditHeader edit={edit} isSummary voter={voter} />
+      <EditEnteredFrom edit={edit} />
 
       <input
         name={`enter-vote.vote.${index}.edit_id`}

--- a/root/static/scripts/release/components/ReleaseRelationshipEditor.js
+++ b/root/static/scripts/release/components/ReleaseRelationshipEditor.js
@@ -301,7 +301,14 @@ async function wsJsEditSubmission(
   }
   const submissionData = {
     editNote: state.editNoteField.value,
-    edits: edits.map(([/* relationships */, wsJsEdit]) => wsJsEdit),
+    edits: edits.map(([/* relationships */, wsJsEdit]) => {
+      const enteredFrom = {
+        entity_type: state.entity.entityType,
+        gid: state.entity.gid,
+      };
+      const amendedWsJsEdit = {...wsJsEdit, enteredFrom};
+      return amendedWsJsEdit;
+    }),
     makeVotable: state.enterEditForm.field.make_votable.value,
   };
   await sleep(500);

--- a/root/static/styles/edit.less
+++ b/root/static/styles/edit.less
@@ -4,6 +4,11 @@
     padding: 5px 10px 10px 10px;
 }
 
+.entered-from {
+    padding: 5px 10px 5px 10px;
+    background-color: @very-light-grey;
+}
+
 .overall-vote {
     float: right;
     margin-bottom: 1em;
@@ -230,8 +235,11 @@ table.vote-tally {
     margin: 20px 0;
     background-color: @effectively-white-bg;
 
-    .edit-header {
+    .edit-header, .entered-from {
         border-right: 10px solid transparent;
+    }
+
+    .edit-header {
         padding-top: 0;
 
         > h2 {

--- a/root/types/edit_types.js
+++ b/root/types/edit_types.js
@@ -271,6 +271,7 @@ declare type AddPlaceEditT = $ReadOnly<{
 declare type AddRelationshipEditT = $ReadOnly<{
   ...GenericEditT,
   +display_data: {
+    +entered_from?: NonUrlRelatableEntityT,
     +relationship: RelationshipT,
     +unknown_attributes: boolean,
   },
@@ -883,6 +884,7 @@ declare type EditRecordingEditT =
 declare type EditRelationshipEditT = $ReadOnly<{
   ...GenericEditT,
   +display_data: {
+    +entered_from?: NonUrlRelatableEntityT,
     +new: RelationshipT,
     +old: RelationshipT,
     +unknown_attributes: boolean,
@@ -1421,6 +1423,7 @@ declare type RemoveRelationshipEditT = $ReadOnly<{
     },
   },
   +display_data: {
+    +entered_from?: NonUrlRelatableEntityT,
     +relationship: RelationshipT,
   },
   +edit_type: EDIT_RELATIONSHIP_DELETE_T,
@@ -1499,6 +1502,7 @@ declare type ReorderMediumsEditT = $ReadOnly<{
 declare type ReorderRelationshipsEditT = $ReadOnly<{
   ...GenericEditT,
   +display_data: {
+    +entered_from?: NonUrlRelatableEntityT,
     +relationships: $ReadOnlyArray<{
       +new_order: number,
       +old_order: number,

--- a/root/types/wsjs.js
+++ b/root/types/wsjs.js
@@ -34,6 +34,7 @@ declare type WsJsRelationshipCommonT = {
   +begin_date?: PartialDateT,
   +end_date?: PartialDateT,
   +ended?: boolean,
+  +enteredFrom?: WsJsRelationshipEntityT,
   +entities: [WsJsRelationshipEntityT, WsJsRelationshipEntityT],
   +entity0_credit: string,
   +entity1_credit: string,
@@ -55,6 +56,7 @@ declare type WsJsEditRelationshipEditT = $ReadOnly<{
 
 declare type WsJsEditRelationshipDeleteT = $ReadOnly<{
   +edit_type: EDIT_RELATIONSHIP_DELETE_T,
+  +enteredFrom?: WsJsRelationshipEntityT,
   +id: number,
   +linkTypeID: number,
 }>;
@@ -67,6 +69,7 @@ declare type WsJsEditRelationshipT =
 
 declare type WsJsEditRelationshipsReorderT = {
   +edit_type: EDIT_RELATIONSHIPS_REORDER_T,
+  +enteredFrom?: WsJsRelationshipEntityT,
   +linkTypeID: number,
   +relationship_order: $ReadOnlyArray<{
     +link_order: number,

--- a/t/selenium/MBS-12911.json5
+++ b/t/selenium/MBS-12911.json5
@@ -65,6 +65,11 @@
         status: 2,
         data: {
           comment: '',
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity_gid: '$$__IGNORE__$$',
           entity_id: 1,
           languages: [],
@@ -81,6 +86,11 @@
         status: 2,
         data: {
           comment: '',
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity_gid: '$$__IGNORE__$$',
           entity_id: 2,
           languages: [],
@@ -98,6 +108,11 @@
         data: {
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: 'f66857fb-bb59-444e-97dc-62c73e5eddae',
             id: 636551,
@@ -130,6 +145,11 @@
         data: {
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '$$__IGNORE__$$',
             id: 2,
@@ -162,6 +182,11 @@
         data: {
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '6c97b1d7-aa12-480e-8376-fa435235f164',
             id: 636552,

--- a/t/selenium/MBS-12921.json5
+++ b/t/selenium/MBS-12921.json5
@@ -78,6 +78,11 @@
         data: {
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '24d4159a-99d9-425d-a7b8-1b9ec0261a33',
+            name: '★',
+          },
           entity0: {
             gid: '0f42ab32-22cd-4dcf-927b-a8d9a183d68b',
             id: 20937085,

--- a/t/selenium/MBS-12922.json5
+++ b/t/selenium/MBS-12922.json5
@@ -52,6 +52,11 @@
         data: {
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '24d4159a-99d9-425d-a7b8-1b9ec0261a33',
+            name: '★',
+          },
           entity0: {
             gid: '0f42ab32-22cd-4dcf-927b-a8d9a183d68b',
             id: 20937085,

--- a/t/selenium/MBS-13615.json5
+++ b/t/selenium/MBS-13615.json5
@@ -55,6 +55,11 @@
         data: {
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '1bda2f85-0576-4077-b3fa-0fc939079b61',
+            name: 'Weapons of Mass Seduction',
+          },
           entity0: {
             gid: 'b7eaa6da-50f1-463a-845f-2a3d9a47b881',
             id: 22521483,

--- a/t/selenium/Release_Relationship_Editor.json5
+++ b/t/selenium/Release_Relationship_Editor.json5
@@ -405,6 +405,11 @@
         status: 2,
         data: {
           comment: '',
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity_gid: '$$__IGNORE__$$',
           entity_id: 1,
           languages: [171, 455],
@@ -421,6 +426,11 @@
         status: 2,
         data: {
           comment: '',
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity_gid: '$$__IGNORE__$$',
           entity_id: 2,
           languages: [171, 455],
@@ -437,6 +447,11 @@
         status: 2,
         data: {
           comment: '',
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity_gid: '$$__IGNORE__$$',
           entity_id: 3,
           languages: [171, 455],
@@ -478,6 +493,11 @@
             year: 1998,
           },
           ended: 1,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '0798d15b-64e2-499f-9969-70167b1d8617',
             id: 39282,
@@ -521,6 +541,11 @@
             year: 1999,
           },
           ended: 1,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '5faa3d4f-6db9-4b93-a4c3-8efcea9b678f',
             id: 100084,
@@ -579,6 +604,11 @@
           ],
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '19506825-c404-43eb-9b09-86fc152c6780',
             id: 1040491,
@@ -626,6 +656,11 @@
           ],
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '$$__IGNORE__$$',
             id: 1,
@@ -682,6 +717,11 @@
             year: 1998,
           },
           ended: 1,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '0798d15b-64e2-499f-9969-70167b1d8617',
             id: 39282,
@@ -725,6 +765,11 @@
             year: 1999,
           },
           ended: 1,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '5faa3d4f-6db9-4b93-a4c3-8efcea9b678f',
             id: 100084,
@@ -783,6 +828,11 @@
           ],
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '821f9cce-be76-4278-ab5c-63169792deb1',
             id: 1040492,
@@ -830,6 +880,11 @@
           ],
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '$$__IGNORE__$$',
             id: 1,
@@ -886,6 +941,11 @@
             year: 1998,
           },
           ended: 1,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '0798d15b-64e2-499f-9969-70167b1d8617',
             id: 39282,
@@ -929,6 +989,11 @@
             year: 1999,
           },
           ended: 1,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '5faa3d4f-6db9-4b93-a4c3-8efcea9b678f',
             id: 100084,
@@ -987,6 +1052,11 @@
           ],
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '65d62fc9-a9d5-4470-aef1-1b5bff4b9424',
             id: 1040493,
@@ -1034,6 +1104,11 @@
           ],
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '$$__IGNORE__$$',
             id: 1,
@@ -1066,6 +1141,11 @@
         data: {
           edit_version: 2,
           ended: 1,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '30bcaa92-9870-4798-be1a-4e0036755316',
             id: 7282,
@@ -1099,6 +1179,11 @@
         data: {
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '30bcaa92-9870-4798-be1a-4e0036755316',
             id: 7282,
@@ -1131,6 +1216,11 @@
         data: {
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '0798d15b-64e2-499f-9969-70167b1d8617',
             id: 39282,
@@ -1264,6 +1354,11 @@
         status: 2,
         data: {
           edit_version: 2,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0_credit: 'brdms',
           entity1_credit: '',
           link: {
@@ -1330,6 +1425,11 @@
         status: 1,
         data: {
           edit_version: 2,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           relationship: {
             entity0: {
               gid: '5faa3d4f-6db9-4b93-a4c3-8efcea9b678f',
@@ -1374,6 +1474,11 @@
         status: 2,
         data: {
           edit_version: 2,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0_credit: 'brdms',
           entity1_credit: '',
           link: {
@@ -1440,6 +1545,11 @@
         status: 1,
         data: {
           edit_version: 2,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           relationship: {
             entity0: {
               gid: '5faa3d4f-6db9-4b93-a4c3-8efcea9b678f',
@@ -1484,6 +1594,11 @@
         status: 2,
         data: {
           edit_version: 2,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0_credit: 'brdms',
           entity1_credit: '',
           link: {
@@ -1550,6 +1665,11 @@
         status: 1,
         data: {
           edit_version: 2,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           relationship: {
             entity0: {
               gid: '5faa3d4f-6db9-4b93-a4c3-8efcea9b678f',
@@ -1594,6 +1714,11 @@
         status: 2,
         data: {
           edit_version: 2,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0_credit: 'oh',
           entity1_credit: '',
           link: {
@@ -1671,6 +1796,11 @@
         status: 1,
         data: {
           edit_version: 2,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           relationship: {
             entity0: {
               gid: '0798d15b-64e2-499f-9969-70167b1d8617',
@@ -1783,6 +1913,11 @@
         data: {
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '471c46a7-afc5-31c4-923c-d0444f5053a4',
             id: 194,
@@ -1862,6 +1997,11 @@
         data: {
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
             id: 249113,
@@ -1967,6 +2107,11 @@
           ],
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '0798d15b-64e2-499f-9969-70167b1d8617',
             id: 39282,
@@ -2013,6 +2158,11 @@
           ],
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '0798d15b-64e2-499f-9969-70167b1d8617',
             id: 39282,
@@ -2100,6 +2250,11 @@
           ],
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '0798d15b-64e2-499f-9969-70167b1d8617',
             id: 39282,
@@ -2297,6 +2452,11 @@
         data: {
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '30bcaa92-9870-4798-be1a-4e0036755316',
             id: 7282,
@@ -2329,6 +2489,11 @@
         data: {
           edit_version: 2,
           ended: 0,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '30bcaa92-9870-4798-be1a-4e0036755316',
             id: 7282,
@@ -2373,6 +2538,11 @@
             year: 1991,
           },
           ended: 1,
+          entered_from: {
+            entity_type: 'release',
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            name: 'Vision Creation Newsun',
+          },
           entity0: {
             gid: '0798d15b-64e2-499f-9969-70167b1d8617',
             id: 39282,


### PR DESCRIPTION
### Implement MBS-14120

# Description 
It's often quite hard to figure out the specific source for an edit entered through the relationship editor (especially when a recording is shared between multiple releases), and yet many editors (me included!) tend to forget about it and just enter notes like "See booklet on CAA" or the like.

This makes it so that edits entered from the release relationship editor get a new `entered_from` piece of data, allowing us to always specify what release the edit was, well, entered from.

<img width="1767" height="272" alt="image (3)" src="https://github.com/user-attachments/assets/00ea7aa0-ac83-40dc-9b17-1ee5cd0749f0" />


# Testing
Manually, plus updated the release editor selenium tests.