### PR TITLE
Unbreak ts install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - translations
 
 env:
-  TESTS_IMAGE_TAG: v-2025-08-19
+  TESTS_IMAGE_TAG: v-2025-08-28
 
 jobs:
   build-tests-image:

--- a/bin/ts
+++ b/bin/ts
@@ -1,0 +1,192 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+ts - timestamp input
+
+=head1 SYNOPSIS
+
+ts [-r] [-i | -s] [-m] [format]
+
+=head1 DESCRIPTION
+
+ts adds a timestamp to the beginning of each line of input.
+
+The optional format parameter controls how the timestamp is formatted,
+as used by L<strftime(3)>. The default format is "%b %d %H:%M:%S". In
+addition to the regular strftime conversion specifications, 
+"%.S" and "%.s" and "%.T"
+are like "%S" and "%s" and "%T", but provide subsecond resolution
+(ie, "30.00001" and "1301682593.00001" and "1:15:30.00001").
+
+If the -r switch is passed, it instead converts existing timestamps in
+the input to relative times, such as "15m5s ago". Many common timestamp
+formats are supported. Note that the Time::Duration and Date::Parse perl
+modules are required for this mode to work. Currently, converting localized
+dates is not supported.
+
+If both -r and a format is passed, the existing timestamps are
+converted to the specified format.
+
+If the -i or -s switch is passed, ts reports incremental timestamps instead of
+absolute ones. The default format changes to "%H:%M:%S", and "%.S" and "%.s" can
+be used as well. In case of -i, every timestamp will be the time elapsed since
+the last timestamp. In case of -s, the time elapsed since start of the program
+is used.
+
+The -m switch makes the system's monotonic clock be used.
+
+=head1 ENVIRONMENT
+
+The standard TZ environment variable controls what time zone dates
+are assumed to be in, if a timezone is not specified as part of the date.
+
+=head1 AUTHOR
+
+Copyright 2006 by Joey Hess <id@joeyh.name>
+
+Licensed under the GNU GPL.
+
+=cut
+
+use warnings;
+use strict;
+use POSIX q{strftime};
+no warnings 'utf8';
+
+$|=1;
+
+my $rel=0;
+my $inc=0;
+my $sincestart=0;
+my $mono=0;
+use Getopt::Long;
+GetOptions(
+	"r" => \$rel,
+	"i" => \$inc,
+	"s" => \$sincestart,
+	"m" => \$mono
+) && @ARGV <= 1 or die "usage: ts [-r] [-i | -s] [-m] [format]\n";
+
+if ($rel) {
+	eval q{
+		use Date::Parse;
+		use Time::Duration;
+	};
+	die $@ if $@;
+}
+
+my $use_format=@ARGV;
+my $format="%b %d %H:%M:%S";
+if ($inc || $sincestart) {
+	$format="%H:%M:%S";
+	$ENV{TZ}='GMT';
+}
+$format=shift if @ARGV;
+
+# For subsecond resolution, Time::HiRes is needed.
+my $hires=0;
+if ($format=~/\%\.[SsT]/ || $mono) {
+	require Time::HiRes;
+	use Time::HiRes qw(CLOCK_MONOTONIC);
+	$hires=1;
+}
+
+my $lastseconds = 0;
+my $lastmicroseconds = 0;
+my $monodelta;
+
+if ($mono) {
+	my $raw_time = Time::HiRes::clock_gettime(CLOCK_MONOTONIC);
+	$lastseconds = time;
+	$lastmicroseconds = int(1000000 * ($raw_time - int($raw_time)));
+	$monodelta = $lastseconds - int($raw_time);
+}
+elsif ($hires) {
+	($lastseconds, $lastmicroseconds) = Time::HiRes::gettimeofday();
+}
+else {
+	$lastseconds = time;
+}
+
+
+while (<STDIN>) {
+	if (! $rel) {
+		if ($hires) {
+			my $f=$format;
+            my $seconds;
+			my $microseconds;
+			if ($mono) {
+				my $raw_time =
+					Time::HiRes::clock_gettime(CLOCK_MONOTONIC) +
+					$monodelta;
+				$seconds = int($raw_time);
+				$microseconds = int(1000000 * ($raw_time - $seconds));
+			}
+			else {
+				($seconds, $microseconds) = Time::HiRes::gettimeofday();
+			}
+
+			if ($inc || $sincestart) {
+				my $deltaseconds = $seconds - $lastseconds;
+				my $deltamicroseconds = $microseconds - $lastmicroseconds;
+				if ($deltamicroseconds < 0) {
+					$deltaseconds -= 1;
+					$deltamicroseconds += 1000000;
+				}
+				if ($inc) {
+					$lastseconds = $seconds;
+					$lastmicroseconds = $microseconds;
+				}
+				$seconds = $deltaseconds;
+				$microseconds = $deltamicroseconds;
+			}
+			my $s=sprintf("%06i", $microseconds);
+			$f=~s/\%\.([SsT])/%$1.$s/g;
+			print strftime($f, localtime($seconds));
+		}
+		else {
+			if ($inc || $sincestart) {
+				my $seconds = time;
+				my $deltaseconds = $seconds - $lastseconds;
+				if ($inc) {
+					$lastseconds = $seconds;
+				}
+				print strftime($format, localtime($deltaseconds));
+			}
+			else {
+				print strftime($format, localtime);
+			}
+		}
+		print " ".$_;
+	}
+	else {
+		s{\b(
+			\d\d[-\s\/]\w\w\w	# 21 dec 17:05
+				(?:\/\d\d+)?	# 21 dec/93 17:05
+				[\s:]\d\d:\d\d	#       (time part of above)
+				(?::\d\d)?	#       (optional seconds)
+				(?:\s+[+-]\d\d\d\d)? #  (optional timezone)
+			|
+			\w{3}\s+\d{1,2}\s+\d\d:\d\d:\d\d # syslog form
+			|
+			\d\d\d\d[-:]\d\d[-:]\d\dT\d\d:\d\d:\d\d.\d+Z? # ISO-8601
+			|
+			(?:\w\w\w,?\s+)?	#       (optional Day)
+			\d+\s+\w\w\w\s+\d\d+\s+\d\d:\d\d:\d\d
+						# 16 Jun 94 07:29:35
+				(?:\s+\w\w\w|\s[+-]\d\d\d\d)?
+						#	(optional timezone)
+			|
+			\w\w\w\s+\w\w\w\s+\d\d\s+\d\d:\d\d
+						# lastlog format
+		  )\b
+		}{
+			$use_format
+				? strftime($format, localtime(str2time($1)))
+				: concise(ago(time - str2time($1), 2))
+		}exg;
+
+		print $_;
+	}
+}

--- a/bin/ts
+++ b/bin/ts
@@ -1,5 +1,7 @@
 #!/usr/bin/perl
 
+## no critic
+
 =head1 NAME
 
 ts - timestamp input

--- a/docker/templates/Dockerfile.tests.m4
+++ b/docker/templates/Dockerfile.tests.m4
@@ -44,7 +44,6 @@ run_with_apt_cache \
     rm -f /etc/apt/sources.list.d/nodesource.list \
         /etc/apt/sources.list.d/pgdg.list && \
     systemctl disable rabbitmq-server && \
-    install_ts && \
     install_perl && \
     install_cpanm_and_carton && \
     python3.13 -m ensurepip --upgrade && \
@@ -54,6 +53,8 @@ run_with_apt_cache \
     # Primarily needed to run rabbitmqctl.
     echo 'musicbrainz ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
     sudo -E -H -u musicbrainz mkdir MBS_ROOT
+
+install_ts
 
 ENV JAVA_HOME=/usr/local/jdk \
     PATH=/usr/local/jdk/bin:$PATH \

--- a/docker/templates/macros.m4
+++ b/docker/templates/macros.m4
@@ -199,11 +199,12 @@ run_with_apt_cache \
     echo "deb [signed-by=/etc/apt/keyrings/pgdg.asc] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     apt_install(`mbs_build_deps mbs_run_deps') && \
     rm -f /etc/apt/sources.list.d/pgdg.list && \
-    install_ts && \
     install_perl && \
     install_cpanm_and_carton && \
     # Clean build dependencies up
-    apt_purge(`mbs_build_deps')')
+    apt_purge(`mbs_build_deps')
+
+install_ts')
 
 m4_define(
     `install_perl_modules',
@@ -226,9 +227,7 @@ m4_define(
     `install_ts',
     `m4_dnl
 # Install ts (needed to run admin background task scripts locally)
-    curl -sSL https://git.joeyh.name/index.cgi/moreutils.git/plain/ts?h=0.69 -o /usr/local/bin/ts && \
-    echo "01b67f3d81e6205f01cc0ada87039293ebc56596955225300dd69ec1257124f5 */usr/local/bin/ts" | sha256sum --strict --check - && \
-    chmod +x /usr/local/bin/ts')
+COPY --chmod=755 bin/ts /usr/local/bin/ts')
 
 m4_define(
     `chown_mb',


### PR DESCRIPTION
Fetching https://git.joeyh.name/index.cgi/moreutils.git/plain/ts?h=0.69 now returns a 503 response containing an HTML page with the text "Please Wait...", likely as a form of aggressive rate-limiting. It eventually loads the correct page in-browser.

I've copied the 0.70 version of the script into our repository. A diff of 0.69..0.70 is below (no breaking changes).

```diff
--- bin/ts-0.69 2025-08-28 15:52:36
+++ bin/ts-0.70 2025-08-28 15:45:09
@@ -66,7 +66,7 @@
    "i" => \$inc,
    "s" => \$sincestart,
    "m" => \$mono
-) || die "usage: ts [-r] [-i | -s] [-m] [format]\n";
+) && @ARGV <= 1 or die "usage: ts [-r] [-i | -s] [-m] [format]\n";

 if ($rel) {
    eval q{
@@ -110,7 +110,7 @@
 }

-while (<>) {
+while (<STDIN>) {
    if (! $rel) {
        if ($hires) {
            my $f=$format;
```