### PR TITLE
MBS-14145: Encode utf8 args for md5

### DIFF
--- a/lib/MusicBrainz/Server/Data/Role/QueryToList.pm
+++ b/lib/MusicBrainz/Server/Data/Role/QueryToList.pm
@@ -3,6 +3,7 @@ package MusicBrainz::Server::Data::Role::QueryToList;
 use strict;
 use warnings;
 
+use Encode qw ( encode_utf8 );
 use Digest::MD5 qw( md5 );
 use Moose::Role;
 use Readonly;
@@ -40,7 +41,7 @@ sub query_to_list_limited {
             'query_to_list_limited:' .
             md5(join "\0",
                 $query,
-                map { ref($_) eq 'ARRAY' ? (@$_) : $_ } @args);
+                map { encode_utf8($_) } map { ref($_) eq 'ARRAY' ? (@$_) : $_ } @args);
         $hits = $self->c->cache->get($hits_cache_key);
     }
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
@@ -35,20 +35,20 @@ test 'Overview (release group) filtering' => sub {
     );
 
     $mech->get_ok(
-        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435?filter.name=Symphony',
-        'Fetched artist overview page with name filter "Symphony"',
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435?filter.name=ピアノ協奏曲／交響曲第2番',
+        'Fetched artist overview page with name filter "ピアノ協奏曲／交響曲第2番"',
     );
 
     $tx = test_xpath_html($mech->content);
     $tx->is(
         'count(//table[contains(@class, "tbl")]/tbody/tr)',
-        '2',
-        'There are two entries in the release group tables after filtering by name',
+        '1',
+        'There is one entry in the release group tables after filtering by name',
     );
     $tx->is(
         '//table[contains(@class, "tbl")]/tbody/tr[1]/td[2]',
-        'Concerto for Orchestra / Symphony no. 3',
-        'The first entry is named "Concerto for Orchestra / Symphony no. 3"',
+        'ピアノ協奏曲／交響曲第2番',
+        'The entry is named "ピアノ協奏曲／交響曲第2番"',
     );
 
     $mech->get_ok(
@@ -64,8 +64,8 @@ test 'Overview (release group) filtering' => sub {
     );
     $tx->is(
         '//table[contains(@class, "tbl")]/tbody/tr[1]/td[2]',
-        'Piano Concerto / Symphony no. 2',
-        'The entry is named "Piano Concerto / Symphony no. 2"',
+        'ピアノ協奏曲／交響曲第2番',
+        'The entry is named "ピアノ協奏曲／交響曲第2番"',
     );
 
     $mech->get_ok(
@@ -179,20 +179,20 @@ test 'Release page filtering' => sub {
     );
 
     $mech->get_ok(
-        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/releases?filter.name=Symphony',
-        'Fetched artist releases page with name filter "Symphony"',
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/releases?filter.name=ピアノ協奏曲／交響曲第2番',
+        'Fetched artist releases page with name filter "ピアノ協奏曲／交響曲第2番"',
     );
 
     $tx = test_xpath_html($mech->content);
     $tx->is(
         'count(//table[contains(@class, "tbl")]/tbody/tr)',
-        '2',
-        'There are two entries in the release table after filtering by name',
+        '1',
+        'There is one entry in the release table after filtering by name',
     );
     $tx->is(
         '//table[contains(@class, "tbl")]/tbody/tr[1]/td[1]',
-        'Concerto for Orchestra / Symphony no. 3',
-        'The first entry is named "Concerto for Orchestra / Symphony no. 3"',
+        'ピアノ協奏曲／交響曲第2番',
+        'The entry is named "ピアノ協奏曲／交響曲第2番"',
     );
 
     $mech->get_ok(
@@ -208,8 +208,8 @@ test 'Release page filtering' => sub {
     );
     $tx->is(
         '//table[contains(@class, "tbl")]/tbody/tr[1]/td[1]',
-        'Piano Concerto / Symphony no. 2',
-        'The entry is named "Piano Concerto / Symphony no. 2"',
+        'ピアノ協奏曲／交響曲第2番',
+        'The entry is named "ピアノ協奏曲／交響曲第2番"',
     );
 
     $mech->get_ok(
@@ -259,8 +259,8 @@ test 'Release page filtering' => sub {
     );
     $tx->is(
         '//table[contains(@class, "tbl")]/tbody/tr[1]/td[1]',
-        'Piano Concerto / Symphony no. 2',
-        'The first entry is named "Piano Concerto / Symphony no. 2"',
+        'ピアノ協奏曲／交響曲第2番',
+        'The first entry is named "ピアノ協奏曲／交響曲第2番"',
     );
 
     $mech->get_ok(
@@ -361,8 +361,8 @@ test 'Release page filtering' => sub {
     );
     $tx->is(
         '//table[contains(@class, "tbl")]/tbody/tr[1]/td[1]',
-        'Piano Concerto / Symphony no. 2',
-        'The entry is named "Piano Concerto / Symphony no. 2"',
+        'ピアノ協奏曲／交響曲第2番',
+        'The entry is named "ピアノ協奏曲／交響曲第2番"',
     );
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Filtering.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Filtering.pm
@@ -35,8 +35,8 @@ test 'Release page filtering' => sub {
     );
 
     $mech->get_ok(
-        '/label/5a584032-dcef-41bb-9f8b-19540116fb1c?filter.name=Symphony',
-        'Fetched label releases page with name filter "Symphony"',
+        '/label/5a584032-dcef-41bb-9f8b-19540116fb1c?filter.name=ピアノ協奏曲／交響曲第2番',
+        'Fetched label releases page with name filter "ピアノ協奏曲／交響曲第2番"',
     );
 
     $tx = test_xpath_html($mech->content);
@@ -47,8 +47,8 @@ test 'Release page filtering' => sub {
     );
     $tx->is(
         '//table[contains(@class, "tbl")]/tbody/tr[1]/td[1]',
-        'Piano Concerto / Symphony no. 2',
-        'The entry is named "Piano Concerto / Symphony no. 2"',
+        'ピアノ協奏曲／交響曲第2番',
+        'The entry is named "ピアノ協奏曲／交響曲第2番"',
     );
 
     $mech->get_ok(
@@ -115,8 +115,8 @@ test 'Release page filtering' => sub {
     );
     $tx->is(
         '//table[contains(@class, "tbl")]/tbody/tr[1]/td[1]',
-        'Piano Concerto / Symphony no. 2',
-        'The first entry is named "Piano Concerto / Symphony no. 2"',
+        'ピアノ協奏曲／交響曲第2番',
+        'The first entry is named "ピアノ協奏曲／交響曲第2番"',
     );
 
     $mech->get_ok(
@@ -149,8 +149,8 @@ test 'Release page filtering' => sub {
     );
     $tx->is(
         '//table[contains(@class, "tbl")]/tbody/tr[1]/td[1]',
-        'Piano Concerto / Symphony no. 2',
-        'The entry is named "Piano Concerto / Symphony no. 2"',
+        'ピアノ協奏曲／交響曲第2番',
+        'The entry is named "ピアノ協奏曲／交響曲第2番"',
     );
 
     $mech->get_ok(

--- a/t/sql/filtering.sql
+++ b/t/sql/filtering.sql
@@ -24,7 +24,7 @@ INSERT INTO artist_credit_name (artist_credit, position, artist, name, join_phra
 
 INSERT INTO release_group (id, gid, name, artist_credit, type)
     VALUES (3400, 'bee95816-da7d-3902-9038-3e8f9b3ebe9f', 'Concerto for Orchestra / Symphony no. 3', 3400, 1),
-           (3401, '6dfcff0b-9434-48b9-bf14-ed674dd626f5', 'Piano Concerto / Symphony no. 2', 3401, 1),
+           (3401, '6dfcff0b-9434-48b9-bf14-ed674dd626f5', 'ピアノ協奏曲／交響曲第2番', 3401, 1),
            (3402, '98b72608-a824-40c5-b5df-81cf981faf7e', 'Symphonies / Concertos / Choral and Vocal Works', 3400, 1),
            (3403, '33d71de2-d3c6-4906-908e-df59d70b283d', 'Lutosławski', 3400, 1),
            (3404, 'fc9b775a-6c06-3828-b6a4-220b65cfef60', 'String Quartet', 3400, NULL),
@@ -38,7 +38,7 @@ INSERT INTO release_group_secondary_type_join (release_group, secondary_type)
 
 INSERT INTO release (id, gid, name, artist_credit, status, release_group)
     VALUES (3400, 'bee95816-da7d-3902-9038-3e8f9b3ebe9a', 'Concerto for Orchestra / Symphony no. 3', 3400, 1, 3400),
-           (3401, '6dfcff0b-9434-48b9-bf14-ed674dd626fa', 'Piano Concerto / Symphony no. 2', 3401, 1, 3401),
+           (3401, '6dfcff0b-9434-48b9-bf14-ed674dd626fa', 'ピアノ協奏曲／交響曲第2番', 3401, 1, 3401),
            (3402, '98b72608-a824-40c5-b5df-81cf981faf7a', 'Symphonies / Concertos / Choral and Vocal Works', 3400, 1, 3402),
            (3403, '33d71de2-d3c6-4906-908e-df59d70b283a', 'Lutosławski', 3400, 1, 3403),
            (3404, 'fc9b775a-6c06-3828-b6a4-220b65cfef6a', 'String Quartet', 3400, NULL, 3404),


### PR DESCRIPTION
### Fix MBS-14145

# Problem
We are getting ISEs when trying to search for non-ASCII names in release list filters from label pages. The same happens with `find_by_artist_slow`, but since we use `find_by_artist_fast` in prod it hadn't been reported until the label filtering was put out.

# Solution
Turns out this wasn't even about the filters themselves: `md5` is unhappy with being passed UTF8 arguments without encoding them first, so the arguments for the queries in `query_to_list_limited` cache need to be encoded.

# Testing
Manually, plus changed one of the filtering test release titles to be Japanese.