### PR TITLE
MBS-14158: Do not require a slash for Geonames

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3034,10 +3034,10 @@ export const CLEANUPS: CleanupEntries = {
   },
   'geonames': {
     hostname: 'geonames.org',
-    match: [/^https?:\/\/([a-z]+\.)?geonames\.org\/([0-9]+)\/.*$/i],
+    match: [/^https?:\/\/([a-z]+\.)?geonames\.org\/([0-9]+).*$/i],
     restrict: [LINK_TYPES.geonames],
     clean(url) {
-      return url.replace(/^https?:\/\/(?:[a-z]+\.)?geonames.org\/([0-9]+)\/.*$/, 'http://sws.geonames.org/$1/');
+      return url.replace(/^https?:\/\/(?:[a-z]+\.)?geonames.org\/([0-9]+).*$/, 'http://sws.geonames.org/$1/');
     },
   },
   'goodreads': {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2940,6 +2940,13 @@ limited_link_type_combinations: [
             expected_clean_url: 'http://sws.geonames.org/6698548/',
        only_valid_entity_types: ['area', 'place'],
   },
+  {
+                     input_url: 'http://www.geonames.org/2749689',
+             input_entity_type: 'area',
+    expected_relationship_type: 'geonames',
+            expected_clean_url: 'http://sws.geonames.org/2749689/',
+       only_valid_entity_types: ['area', 'place'],
+  },
   // Goodreads
   {
                      input_url: 'http://goodreads.com/author/list/22650322.Joe_Hill',


### PR DESCRIPTION
### Implement MBS-14158

# Description
For some reason we were always expecting a slash and some extra bits after the Geonames ID. While the site does redirect to add this, links copied from other sources do not always include it since it serves no real purpose. This allows entering links with just the numeric ID.

# Testing
Added a test with just a bare ID.