### PR TITLE
MBS-13664: Remember last search type in header dropdown

### DIFF
--- a/root/layout/components/Search.js
+++ b/root/layout/components/Search.js
@@ -11,51 +11,64 @@ import SearchIcon from '../../static/scripts/common/components/SearchIcon.js';
 import {GOOGLE_CUSTOM_SEARCH} from '../../static/scripts/common/DBDefs.mjs';
 import {compare} from '../../static/scripts/common/i18n.js';
 
+const SEARCH_TYPE_KEY = 'mb_search_type';
+const SEARCH_TYPE_TIMESTAMP = 'mb_search_type_timestamp';
+const SEARCH_TYPE_PERSIST_KEY = 'mb_search_remember_enabled';
+const DEFAULT_TYPE = 'artist';
+const TIMEOUT = 48 * 60 * 60 * 1000; // 48 hours
+
+function getSavedType() {
+  if (typeof window === 'undefined') return DEFAULT_TYPE;
+  if (window.localStorage.getItem(SEARCH_TYPE_PERSIST_KEY) !== 'true') return DEFAULT_TYPE;
+  const savedType = window.localStorage.getItem(SEARCH_TYPE_KEY);
+  const savedTs = parseInt(window.localStorage.getItem(SEARCH_TYPE_TIMESTAMP), 10);
+  if (savedType && savedTs && (Date.now() - savedTs) < TIMEOUT) {
+    return savedType;
+  }
+  return DEFAULT_TYPE;
+}
+
+function saveType(type) {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(SEARCH_TYPE_KEY, type);
+    window.localStorage.setItem(SEARCH_TYPE_TIMESTAMP, Date.now().toString());
+  }
+}
+
 type SearchOptionValueT =
   (() => string) | null;
-
 type SearchOptionGroupT = {
   +[optionName: string]: SearchOptionValueT,
   ...
 };
-
 const TYPE_OPTION_GROUPS: $ReadOnlyArray<SearchOptionGroupT> = [
+  { artist: N_l('Artist') },
   {
-    artist:        N_l('Artist'),
-  },
-  { // musical production
-    event:         N_l('Event'),
-    recording:     N_l('Recording'),
-    release:       N_l('Release'),
+    event: N_l('Event'),
+    recording: N_l('Recording'),
+    release: N_l('Release'),
     release_group: N_l('Release group'),
-    series:        N_lp('Series', 'singular'),
-    work:          N_l('Work'),
-  },
-  { // other core entities
-    area:          N_l('Area'),
-    instrument:    N_l('Instrument'),
-    label:         N_l('Label'),
-    place:         N_l('Place'),
-  },
-  { // derived data
-    annotation:    N_l('Annotation'),
-    tag:           N_lp('Tag', 'noun, folksonomy'),
+    series: N_lp('Series', 'singular'),
+    work: N_l('Work'),
   },
   {
-    cdstub:        N_l('CD stub'),
+    area: N_l('Area'),
+    instrument: N_l('Instrument'),
+    label: N_l('Label'),
+    place: N_l('Place'),
   },
   {
-    editor:        N_l('Editor'),
+    annotation: N_l('Annotation'),
+    tag: N_lp('Tag', 'noun, folksonomy'),
   },
-  {
-    doc:           GOOGLE_CUSTOM_SEARCH ? N_l('Documentation') : null,
-  },
+  { cdstub: N_l('CD stub') },
+  { editor: N_l('Editor') },
+  { doc: GOOGLE_CUSTOM_SEARCH ? N_l('Documentation') : null },
 ];
 
 function localizedTypeOption(option: SearchOptionValueT) {
   return option ? option() : '';
 }
-
 function compareTypeOptionEntries(
   a: [string, SearchOptionValueT],
   b: [string, SearchOptionValueT],
@@ -66,29 +79,59 @@ function compareTypeOptionEntries(
   );
 }
 
-component SearchOptions() {
+function SearchOptions({type, onTypeChange}) {
   return (
-    <select id="headerid-type" name="type">
-      {TYPE_OPTION_GROUPS.map((group) => (
+    <select
+      id="headerid-type"
+      name="type"
+      value={type}
+      onChange={onTypeChange}
+      required
+    >
+      {TYPE_OPTION_GROUPS.map((group) =>
         Object.entries(group)
           .sort(compareTypeOptionEntries)
           .map(([key, option]) => {
             const text = localizedTypeOption(option);
-            if (!text) {
-              return null;
-            }
+            if (!text) return null;
             return (
               <option key={key} value={key}>
                 {text}
               </option>
             );
           })
-        ))}
+      )}
     </select>
   );
 }
 
-component Search() {
+function Search() {
+  const [rememberEnabled, setRememberEnabled] = React.useState(
+    typeof window !== 'undefined' && window.localStorage.getItem(SEARCH_TYPE_PERSIST_KEY) === 'true'
+  );
+  const [type, setType] = React.useState(getSavedType());
+
+  // Restore from localStorage on mount (cross-tab sync)
+  React.useEffect(() => {
+    setType(getSavedType());
+  }, []);
+
+  function handleTypeChange(e) {
+    setType(e.target.value);
+    if (rememberEnabled) saveType(e.target.value);
+  }
+
+  function handleRememberToggle(e) {
+    setRememberEnabled(e.target.checked);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(SEARCH_TYPE_PERSIST_KEY, e.target.checked.toString());
+      if (!e.target.checked) {
+        window.localStorage.removeItem(SEARCH_TYPE_KEY);
+        window.localStorage.removeItem(SEARCH_TYPE_TIMESTAMP);
+      }
+    }
+  }
+
   return (
     <form action="/search" method="get">
       <input
@@ -99,7 +142,15 @@ component Search() {
         type="text"
       />
       {' '}
-      <SearchOptions />
+      <SearchOptions type={type} onTypeChange={handleTypeChange} />
+      <label style={{marginLeft: '1em'}}>
+        <input
+          type="checkbox"
+          checked={rememberEnabled}
+          onChange={handleRememberToggle}
+        />
+        Remember last used search type (48h)
+      </label>
       {' '}
       <input
         id="headerid-method"


### PR DESCRIPTION
Introduce an opt-in option to persist the last used search type for up to 48 hours in the global search dropdown. This improves user convenience without affecting those preferring the default reset behavior. No server changes; all data is stored client-side.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
   Anything that helps us understand why you are making this change goes here.
   What problem are you trying to fix? What does this change address?
-->

:beginner: The global search dropdown resets to "artist" after every use. Many users prefer if their last chosen search type is remembered. However, changing the default for all could disrupt existing workflows.
Referenced ticket: MBS-13664


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

:beginner: Add a checkbox option for users to enable remembering their last search type. If enabled, the selected type persists for up to 48 hours using localStorage, and is then reset to "artist." Default behavior remains unchanged for users who do not opt in. All logic is strictly client-side; no server changes.


# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

:beginner: Have to do this 


# Documenting
<!--
    List changes to the documentation, which can be placed in the WikiDoc pages,
    in this Git repository, in another repository, in the database...
-->

:beginner: Have to do this


# Draft progress
<!--
    Replace the placeholder checklist with real items:
    * [x] Add persistence checkbox and logic
    * [ ] Write and verify manual test cases
    * [ ] Update WikiDocs with persistence instructions
    * [ ] Review UI label for clarity
-->

* [ ] :beginner: If you draft a pull request, mention missing tasks as items:
  * [ ] :beginner: And even subtasks as indented/nested items!


# Further action
<!--
   Other than merging your change, do you want / need us to do anything else
   with your change? This could include reviewing a specific part of your PR.
-->

1. :beginner: If any action is needed on merge or deployment, list it such as:
   1. Publish the new Search User Preferences WikiDocs page at https://wiki.musicbrainz.org/WikiDocs/Search_User_Preferences
   2. Monitor user feedback for any unexpected behavior or UI issues and address them in follow-up patches.
