### PR TITLE
Update HACKING-IMG.md

### DIFF
--- a/HACKING-IMG.md
+++ b/HACKING-IMG.md
@@ -21,8 +21,9 @@ Internet Archive storage.
 We provide a simple Plack script which emulates just enough of the
 Internet Archive S3 protocol to use it with MusicBrainz Server.
 
-Figure out where you want to store uploaded images, and set the
-`SSSSSS_STORAGE` environment variable to that location:
+Figure out where you want to store uploaded images, creating the
+directory if it does not exist, and set the `SSSSSS_STORAGE` environment
+variable to that location:
 
     $ SSSSSS_STORAGE=./ssssss plackup --port 5050 -r contrib/ssssss.psgi
 


### PR DESCRIPTION
Fixes some outdated information contained in the document, and makes some other minor improvements.

 1. The artwork-indexer now uses `poetry`, so its startup command has been fixed.
 2. There was a line suggesting you could keep the access/secret keys blank. ssssss.psgi doesn't seem to allow that, though. The instructions now define placeholder values for these.
 3. Instead of saying which particular sections of each config file to update, I've included full example config files.
 4. All of the DBDefs-related changes have been moved to one section at the end.
 5. Comments have been added to indicate what all of the host:port values should be pointing to (in case they need to be changed; e.g. on macOS I have to use port 8081 for the artwork-redirect service).