### PR TITLE
Escape path to handle paths with spaces in InitDb.pl

### DIFF
--- a/admin/InitDb.pl
+++ b/admin/InitDb.pl
@@ -83,8 +83,8 @@ sub RunSQLScript
         $ENV{'PGOPTIONS'} .= ' -c client_min_messages=WARNING';
     }
 
-    print "$psql $quiet $echo -f $path/$file $opts 2>&1 $stdout |\n" if $fVerbose;
-    open(PIPE, "$psql $quiet $echo -f $path/$file $opts 2>&1 $stdout |")
+    print "$psql $quiet $echo -f \"$path/$file\" $opts 2>&1 $stdout |\n" if $fVerbose;
+    open(PIPE, "$psql $quiet $echo -f \"$path/$file\" $opts 2>&1 $stdout |")
         or die "exec '$psql': $OS_ERROR";
     while (<PIPE>)
     {


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

When attempting to initialize the database I ran into a problem where it was trying to read my path as multiple parameters when passed to the shell.  


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Escaped the $path/$file on the line to execute the command and the associated logging.


# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

"It worked on my machine" where I had a space in the path I was initializing the DB from.  I'm not familiar enough with the application to know all the ways this might get called, I suppose it's possible some ways of getting there may already have it quoted and cause double quoting. 


# Documenting
<!--
    List changes to the documentation, which can be placed in the WikiDoc pages,
    in this Git repository, in another repository, in the database...
-->

Probably none.


# Draft progress
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] :beginner: Added escaped double quotes around path to file in InitDb.pl



# Further action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

Minor change - I don't think any action is needed unless someone is aware of a situation in which this might cause double quoting and wants to handle that scenario.
