### PR TITLE
MBS-14196: Rename label "Founded" to "Started"

### DIFF
--- a/po/mb_server.pot
+++ b/po/mb_server.pot
@@ -10785,7 +10785,7 @@ msgid "Label information"
 msgstr ""
 
 #: ../root/layout/components/sidebar/LabelSidebar.js:72
-msgid "Founded:"
+msgid "Started:"
 msgstr ""
 
 #: ../root/layout/components/sidebar/LabelSidebar.js:78

--- a/root/layout/components/MetaDescription.js
+++ b/root/layout/components/MetaDescription.js
@@ -94,7 +94,7 @@ function labelDescription(label: LabelT) {
     desc.push('Label Code: ' + label.label_code);
   }
   if (beginDate) {
-    desc.push('Founded: ' + beginDate);
+    desc.push('Started: ' + beginDate);
   }
   if (endDate) {
     desc.push('Defunct: ' + endDate);

--- a/root/layout/components/sidebar/LabelSidebar.js
+++ b/root/layout/components/sidebar/LabelSidebar.js
@@ -69,7 +69,7 @@ component LabelSidebar(label: LabelT) {
         <SidebarBeginDate
           age={labelAge}
           entity={label}
-          label={l('Founded:')}
+          label={l('Started:')}
         />
 
         <SidebarEndDate


### PR DESCRIPTION
Problem

Label entities represent specific brandings, not the underlying company.
Because of this, the begin date reflects when that branding started, not when the company was founded.
The UI currently shows “Founded:”, which is misleading.

Solution

Replaced “Founded:” with “Started:” in the Label sidebar, meta description, and translation template.
No schema changes were made, and Schema.org’s foundingDate remains unchanged.

Testing

Checked Label pages and confirmed the updated wording appears correctly and does not affect other entity types.
Verified translations update correctly through the modified .pot file.