### PR TITLE
[WIP] MBS-14227: External IDs for URLs

### DIFF
--- a/admin/sql/CreateIndexes.sql
+++ b/admin/sql/CreateIndexes.sql
@@ -679,6 +679,7 @@ CREATE INDEX unreferenced_row_log_idx_inserted ON unreferenced_row_log USING BRI
 
 CREATE UNIQUE INDEX url_idx_gid ON url (gid);
 CREATE UNIQUE INDEX url_idx_url ON url (url);
+CREATE INDEX url_idx_key ON url (key);
 
 CREATE INDEX vote_idx_edit ON vote (edit);
 CREATE INDEX vote_idx_editor_vote_time ON vote (editor, vote_time);

--- a/admin/sql/CreateTables.sql
+++ b/admin/sql/CreateTables.sql
@@ -3892,6 +3892,7 @@ CREATE TABLE url ( -- replicate
     id                  SERIAL,
     gid                 UUID NOT NULL,
     url                 TEXT NOT NULL,
+    key                 TEXT,
     edits_pending       INTEGER NOT NULL DEFAULT 0 CHECK (edits_pending >= 0),
     last_updated        TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );

--- a/admin/sql/updates/20260105-mbs-14227.sql
+++ b/admin/sql/updates/20260105-mbs-14227.sql
@@ -1,0 +1,10 @@
+\set ON_ERROR_STOP 1
+
+BEGIN;
+
+ALTER TABLE url ADD COLUMN key TEXT;
+
+-- Cannot be unique as some sites share IDs in URLs, for example Amazon and Amazon Music.
+CREATE INDEX url_idx_key ON url (key);
+
+COMMIT;

--- a/lib/MusicBrainz/Server/Controller/WS/2/URL.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/URL.pm
@@ -60,9 +60,9 @@ sub url_lookup_by_resource : Private
         if (scalar(@$resource) > $MAX_RESOURCE_PARAMS) {
             @$resource = @$resource[0 .. ($MAX_RESOURCE_PARAMS - 1)];
         }
-        @urls = $c->model('URL')->find_by_urls($resource);
+        @urls = $c->model('URL')->find_by_urls([ grep { $_ =~ m{^https?://} } @$resource ], [ grep { $_ !~ m{^https?://} } @$resource ]);
     } else {
-        my $url = $c->model('URL')->get_by_url($resource);
+        my $url = $resource =~ m{^https?://} ? $c->model('URL')->get_by_url($resource) : $c->model('URL')->get_by_key($resource);
         $c->detach('not_found') unless $url;
         @urls = $url;
     }
@@ -103,4 +103,3 @@ and is licensed under the GPL version 2, or (at your option) any
 later version: http://www.gnu.org/licenses/gpl-2.0.txt
 
 =cut
-

--- a/lib/MusicBrainz/Server/Entity/URL/ASIN.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/ASIN.pm
@@ -26,7 +26,7 @@ sub sidebar_name { shift->pretty_name }
 
 sub key {
     # Countries share ASINs.
-    return shift->url =~ s{^https://www\.amazon\.[a-z\.]+(?:\:[0-9]+)?/.*/([0-9B][0-9A-Z]{9})(?:[^0-9A-Z]|$)}{asin:$1}r;
+    return shift->url =~ s{^https://www\.amazon\.[a-z\.]+(?:\:[0-9]+)?/.*/([0-9B][0-9A-Z]{9})}{asin:$1}r;
 }
 
 override affiliate_url => sub {

--- a/lib/MusicBrainz/Server/Entity/URL/ASIN.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/ASIN.pm
@@ -24,6 +24,11 @@ sub pretty_name
 
 sub sidebar_name { shift->pretty_name }
 
+sub key {
+    # Countries share ASINs.
+    return shift->url =~ s{^https://www\.amazon\.[a-z\.]+(?:\:[0-9]+)?/.*/([0-9B][0-9A-Z]{9})(?:[^0-9A-Z]|$)}{asin:$1}r;
+}
+
 override affiliate_url => sub {
     my $self = shift;
 

--- a/lib/MusicBrainz/Server/Entity/URL/AmazonMusic.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/AmazonMusic.pm
@@ -29,7 +29,7 @@ sub sidebar_name { shift->pretty_name }
 
 sub key {
     # Countries share ASINs.
-    return shift->url =~ s{^https://music\.amazon\.[a-z\.]+/[a-z]+/(B[0-9A-Z]{9}|[0-9]{9}[0-9X])$}{asin:$1}r;
+    return shift->url =~ s{^https://music\.amazon\.[a-z\.]+/[a-z]+/(B[0-9A-Z]{9}|[0-9]{9}[0-9X])}{asin:$1}r;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MusicBrainz/Server/Entity/URL/AmazonMusic.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/AmazonMusic.pm
@@ -27,6 +27,11 @@ sub pretty_name
 
 sub sidebar_name { shift->pretty_name }
 
+sub key {
+    # Countries share ASINs.
+    return shift->url =~ s{^https://music\.amazon\.[a-z\.]+/[a-z]+/(B[0-9A-Z]{9}|[0-9]{9}[0-9X])$}{asin:$1}r;
+}
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/lib/MusicBrainz/Server/Entity/URL/AppleClassical.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/AppleClassical.pm
@@ -16,6 +16,11 @@ sub sidebar_name {
     }
 }
 
+sub key {
+    # Storefronts on Apple Music and Apple Music Classical share IDs.
+    return shift->url =~ s{^https://(?:classical\.)?music\.apple\.com/[a-z]{2}/([a-z-]{3,})/([0-9]+)$}{applemusic:$1:$2}r;
+}
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/lib/MusicBrainz/Server/Entity/URL/AppleClassical.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/AppleClassical.pm
@@ -18,7 +18,7 @@ sub sidebar_name {
 
 sub key {
     # Storefronts on Apple Music and Apple Music Classical share IDs.
-    return shift->url =~ s{^https://(?:classical\.)?music\.apple\.com/[a-z]{2}/([a-z-]{3,})/([0-9]+)$}{applemusic:$1:$2}r;
+    return shift->url =~ s{^https://(?:classical\.)?music\.apple\.com/[a-z]{2}/[a-z-]{3,}/([0-9]+)}{applemusic:$1}r;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MusicBrainz/Server/Entity/URL/AppleMusic.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/AppleMusic.pm
@@ -16,6 +16,11 @@ sub sidebar_name {
     }
 }
 
+sub key {
+    # Storefronts on Apple Music and Apple Music Classical share IDs.
+    return shift->url =~ s{^https://(?:classical\.)?music\.apple\.com/[a-z]{2}/([a-z-]{3,})/([0-9]+)$}{applemusic:$1:$2}r;
+}
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/lib/MusicBrainz/Server/Entity/URL/AppleMusic.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/AppleMusic.pm
@@ -18,7 +18,7 @@ sub sidebar_name {
 
 sub key {
     # Storefronts on Apple Music and Apple Music Classical share IDs.
-    return shift->url =~ s{^https://(?:classical\.)?music\.apple\.com/[a-z]{2}/([a-z-]{3,})/([0-9]+)$}{applemusic:$1:$2}r;
+    return shift->url =~ s{^https://(?:classical\.)?music\.apple\.com/[a-z]{2}/[a-z-]{3,}/([0-9]+)}{applemusic:$1}r;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MusicBrainz/Server/Entity/URL/Qobuz.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Qobuz.pm
@@ -8,6 +8,11 @@ with 'MusicBrainz::Server::Entity::URL::Sidebar';
 
 sub sidebar_name { 'Qobuz' }
 
+sub key {
+    # Countries share IDs.
+    return shift->url =~ s{^https://www\.qobuz\.com/(?:[a-z]{2}-[a-z]{2}/)?(?:album|interpreter|label)/([\w\d-]+)}{qobuz:$1}r;
+}
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;


### PR DESCRIPTION
# Problem

Some external sites include a region code in their URLs, yet their entity IDs are global. The MusicBrainz `/ws/2/url` API endpoint only retrieves by exact matches. For example, the [artist](https://musicbrainz.org/artist/9abe13bf-3311-432e-80f1-77f76ca32618) has an Apple Music JP link attached, requiring all lookups to be made with https://music.apple.com/jp/artist/1569322201, so any other region link (for example https://music.apple.com/us/artist/1569322201) doesn't return anything even though the entity is the same.

This mostly applies to artist, release and recording URLs for Apple Music, Apple Music Classical, iTunes, Amazon, Amazon Music, Qobuz, KKBOX and possibly others.

Solving this issue would primarily help seeding projects that need a strong match for artists, releases, recordings no matter the actual availability on the service or just irrelevant country links added on MusicBrainz.

At the moment projects can brute-force all region URLs in batches but this gets very inefficient when the query limit is 100 per request and let's say Apple Music already uses 10 for some "popular" regions.

At the moment projects can setup a database mirror and implement their own query logic, except that drastically increases complexity and resource requirements, and adds a [1h delay](https://metabrainz.org/api/) for the data to be available, all of which is prohibitive if the project is simpler than a full-blown hosted service.

At the moment all region links could also be added separately to the entity on MusicBrainz but there can already be 200 links just for one artist on Apple Music, therefore this approach will most likely result in spam and not be reasonable.

# Solution

Looking for input on all of the points below.

At the moment it is named `key` in code, doesn't really matter what it will be named, not sure about this.

External IDs can always be deduced from relevant validated URLs and therefore are always deduced. The deduction happens server-side before inserting the value into an indexed column in the database. For lookups the resource query parameter is reused because it was easy to differentiate between URLs and IDs and the naming "resource" already fits both types well.

Entity type is not included in the External ID since for most sites this string differs, developers would always have to figure out the terminology per site and adding more mapping rules for standardized type strings in URL->key seems like too much effort. If multiple URLs are returned because they have the same External ID but an unexpected entity type, they can be filtered out client-side based on the `relations` property.

External IDs are only used for lookups and not exposed to users in any way. I'm thinking the most they could be exposed is probably just via the API for URL resources. Since this is a relatively niche feature adding them to the MB UI seems like too much effort.

The format of the External ID at the moment is `type:id` where type is not necessarily the ID of the site but more like a type for the ID itself. For example Apple Music and Apple Music Classic share IDs, their type would be `applemusic` even though they are treated separately in other places in code. Same for Amazon and Amazon Music.

# Draft progress

* [X] Deduce External ID from URL.
* [ ] Cleanup naming, logic, etc.
* [ ] Implement deduction for all relevant URL specializations.
* [ ] Implement tests.

# Further action

1. Update [API documentation](https://musicbrainz.org/doc/MusicBrainz_API#url_(by_text)).
2. Deduce External IDs for existing URLs in database.
