### PR TITLE
MBS-14258: Add cancelled filter for artist events

### DIFF
--- a/lib/MusicBrainz/Server/Data/Event.pm
+++ b/lib/MusicBrainz/Server/Data/Event.pm
@@ -245,6 +245,15 @@ sub find_by_artist
 
     if (exists $args{filter}) {
         my %filter = %{ $args{filter} };
+        if (exists $filter{cancelled}) {
+            if ($filter{cancelled} == 1) {
+                # Show only cancelled events
+                push @where_query, 'cancelled IS TRUE';
+            } elsif ($filter{cancelled} == 2) {
+                # Show only non-cancelled events
+                push @where_query, 'cancelled IS FALSE';
+            }
+        }
         if (exists $filter{name}) {
             push @where_query, "(mb_simple_tsvector(event.name) @@ plainto_tsquery('mb_simple', mb_lower(?)) OR event.name = ?)";
             push @where_args, ($filter{name}) x 2;

--- a/lib/MusicBrainz/Server/Form/Filter/Event.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Event.pm
@@ -3,13 +3,17 @@ use strict;
 use warnings;
 
 use HTML::FormHandler::Moose;
-use MusicBrainz::Server::Translation qw( lp );
+use MusicBrainz::Server::Translation qw( l lp );
 extends 'MusicBrainz::Server::Form::Filter::Generic';
 
 has 'types' => (
     isa => 'ArrayRef[EventType]',
     is => 'ro',
     required => 1,
+);
+
+has_field 'cancelled' => (
+    type => 'Select',
 );
 
 has_field 'setlist' => (
@@ -22,7 +26,14 @@ has_field 'type_id' => (
 );
 
 sub filter_field_names {
-    return qw/ disambiguation name setlist type_id /;
+    return qw/ cancelled disambiguation name setlist type_id /;
+}
+
+sub options_cancelled {
+    return [
+        { value => 1, label => l('Cancelled only') },
+        { value => 2, label => l('Non-cancelled only') },
+    ];
 }
 
 sub options_type_id {
@@ -39,6 +50,7 @@ around TO_JSON => sub {
 
     my $json = $self->$orig;
     $json->{options_type_id} = $self->options_type_id;
+    $json->{options_cancelled} = $self->options_cancelled;
     return $json;
 };
 

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -18,6 +18,7 @@ type GenericFilterFormFieldsT = {
 
 type EventFilterFormT = FormT<{
   ...GenericFilterFormFieldsT,
+  readonly cancelled: FieldT<number>,
   readonly setlist: FieldT<string>,
   readonly type_id: FieldT<number>,
 }>;
@@ -25,6 +26,7 @@ type EventFilterFormT = FormT<{
 export type EventFilterT = Readonly<{
   ...EventFilterFormT,
   readonly entity_type: 'event',
+  readonly options_cancelled: SelectOptionsT,
   readonly options_type_id: SelectOptionsT,
 }>;
 
@@ -185,6 +187,22 @@ component FilterForm(
                   field={form.field.type_id}
                   options={form.options_type_id}
                 />
+                <tr>
+                  <td>
+                    {addColonText(l('Cancelled'))}
+                  </td>
+                  <td>
+                    <SelectField
+                      field={form.field.cancelled}
+                      options={{
+                        grouped: false,
+                        options: form.options_cancelled,
+                      }}
+                      style={{maxWidth: '40em'}}
+                      uncontrolled
+                    />
+                  </td>
+                </tr>
                 <tr>
                   <td>
                     {addColonText(l('Setlist contains'))}

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
@@ -427,7 +427,7 @@ test 'Event page filtering' => sub {
     );
     $tx->is(
         '//table[contains(@class, "tbl")]/tbody/tr/td[1]',
-        'Uncertain',
+        'Uncertain (cancelled)',
         'The entry is named "Uncertain"',
     );
 
@@ -446,6 +446,35 @@ test 'Event page filtering' => sub {
         '//table[contains(@class, "tbl")]/tbody/tr[1]/td[1]',
         '[concert]',
         'The first entry is named [concert]',
+    );
+
+    $mech->get_ok(
+        '/artist/dea28aa9-1086-4ffa-8739-0ccc759de1ce/events?filter.cancelled=1',
+        'Fetched artist events page with with cancelled events only option',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[contains(@class, "tbl")]/tbody/tr)',
+        '1',
+        'There is one entry in the event table after filtering by cancelled only',
+    );
+    $tx->is(
+        '//table[contains(@class, "tbl")]/tbody/tr/td[1]',
+        'Uncertain (cancelled)',
+        'The entry is named "Uncertain" and marked as cancelled',
+    );
+
+    $mech->get_ok(
+        '/artist/dea28aa9-1086-4ffa-8739-0ccc759de1ce/events?filter.cancelled=2',
+        'Fetched artist events page with with non-cancelled events only option',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[contains(@class, "tbl")]/tbody/tr)',
+        '3',
+        'There are three entries in the event table after filtering non-cancelled only',
     );
 };
 

--- a/t/sql/filtering.sql
+++ b/t/sql/filtering.sql
@@ -83,11 +83,11 @@ INSERT INTO release_unknown_country (release, date_year, date_month, date_day)
 
 -- Events
 
-INSERT INTO event (id, gid, name, type, setlist)
-    VALUES (3400, 'c681f4a3-26db-49e6-80a2-0dbc0a758161', 'Berliner Philharmoniker plays Schnittke and Shostakovich', 1, ''),
-           (3401, '96d6b7d0-90ed-449e-91d3-a05fd4d54b06', '[concert]', 1, '* [e42cce08-f3f1-4e9b-8bfe-11670ad22d52|Asteroid 4179: Toutatis] (Kaija Saariaho) (world premiere)\r* [439c1605-bf74-4e0c-b2d9-6f4f89619ec6|The Planets, op. 32] (Gustav Holst)'),
-           (3402, '5411fa48-5756-45f7-aadb-5aa3e5bd5954', '[concert]', 1, '* [1637948a-63f8-4cf5-bbb3-8faae3964b13|Seht die Sonne] (Magnus Lindberg) (world premiere)'),
-           (3403, '033c9bf9-eef9-409b-9bff-c8d2dea671f5', 'Uncertain', NULL, '');
+INSERT INTO event (id, gid, name, type, setlist, cancelled)
+    VALUES (3400, 'c681f4a3-26db-49e6-80a2-0dbc0a758161', 'Berliner Philharmoniker plays Schnittke and Shostakovich', 1, '', FALSE),
+           (3401, '96d6b7d0-90ed-449e-91d3-a05fd4d54b06', '[concert]', 1, '* [e42cce08-f3f1-4e9b-8bfe-11670ad22d52|Asteroid 4179: Toutatis] (Kaija Saariaho) (world premiere)\r* [439c1605-bf74-4e0c-b2d9-6f4f89619ec6|The Planets, op. 32] (Gustav Holst)', FALSE),
+           (3402, '5411fa48-5756-45f7-aadb-5aa3e5bd5954', '[concert]', 1, '* [1637948a-63f8-4cf5-bbb3-8faae3964b13|Seht die Sonne] (Magnus Lindberg) (world premiere)', FALSE),
+           (3403, '033c9bf9-eef9-409b-9bff-c8d2dea671f5', 'Uncertain', NULL, '', TRUE);
 
 
 -- Recordings


### PR DESCRIPTION
### Implement MBS-14258

# Description
This allows filtering artist events to show only events that got cancelled, or only events that did not.

This does *not* implement filtering for the artist's performance itself being cancelled in an event that still happened. That is a separate condition that needs additional work (and is not currently even displayed on the table, see MBS-13180).

# AI usage
None

# Testing
Manually on local server, plus added tests for this to `Artist::Filtering`.