### PR TITLE
Update restricted link types

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -328,6 +328,7 @@ export const RESTRICTED_LINK_TYPES: $ReadOnlyArray<string> = [
   LINK_TYPES.bandsintown,
   LINK_TYPES.bbcmusic,
   LINK_TYPES.bookbrainz,
+  LINK_TYPES.cdbaby,
   LINK_TYPES.cpdl,
   LINK_TYPES.discogs,
   LINK_TYPES.geonames,
@@ -348,6 +349,7 @@ export const RESTRICTED_LINK_TYPES: $ReadOnlyArray<string> = [
   LINK_TYPES.wikidata,
   LINK_TYPES.wikipedia,
   LINK_TYPES.youtube,
+  LINK_TYPES.youtubemusic,
 ].reduce(function (result, linkType) {
   return result.concat(Object.values(linkType));
 }, []);

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -343,10 +343,10 @@ export const RESTRICTED_LINK_TYPES: $ReadOnlyArray<string> = [
   LINK_TYPES.songfacts,
   LINK_TYPES.songkick,
   LINK_TYPES.soundcloud,
-  LINK_TYPES.wikidata,
-  LINK_TYPES.wikipedia,
   LINK_TYPES.vgmdb,
   LINK_TYPES.viaf,
+  LINK_TYPES.wikidata,
+  LINK_TYPES.wikipedia,
   LINK_TYPES.youtube,
 ].reduce(function (result, linkType) {
   return result.concat(Object.values(linkType));


### PR DESCRIPTION
# Description
This adds `cdbaby` and `youtubemusic` to our list of restricted URL relationship types. These two should not be selectable unless autoselected, as far as I can tell. Only autoselected links make sense as CDBaby or YouTube Music links.

# AI usage
None

# Testing
Checked that the two options are no longer available for non-autoselected URLs in `/artist/create`.

# Notes
Apple Music probably shouldn't be available either, but that depends on https://github.com/metabrainz/musicbrainz-server/pull/2837 so I added it only as part of that PR.