### PR TITLE
MBS-14271: Add form unload hook to event/genre forms 

### DIFF
--- a/root/static/scripts/common/hooks/useFormUnloadWarning.js
+++ b/root/static/scripts/common/hooks/useFormUnloadWarning.js
@@ -1,0 +1,72 @@
+/*
+ * @flow strict
+ * Copyright (C) 2025 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import {useEffect} from 'react';
+
+export default function useFormUnloadWarning() {
+  useEffect(() => {
+    let inputsChanged = false;
+    let submittingForm = false;
+
+    const form = document.querySelector('#page form');
+
+    if (!form) {
+      return;
+    }
+
+    function setInputsChanged() {
+      inputsChanged = true;
+    }
+
+    function setSubmittingForm() {
+      submittingForm = true;
+    }
+
+    function addFormUnloadWarning(event: Event) {
+      if (submittingForm) {
+        return;
+      }
+
+      // Check if there are pending relationship or URL changes.
+      if (!inputsChanged && !form?.querySelector([
+        '#relationship-editor .rel-add',
+        '#relationship-editor .rel-edit',
+        '#relationship-editor .rel-remove',
+        '#external-links-editor .rel-add',
+        '#external-links-editor .rel-edit',
+        '#external-links-editor .rel-remove',
+      ].join(', '))) {
+        return;
+      }
+
+      if (MUSICBRAINZ_RUNNING_TESTS) {
+        sessionStorage.setItem('didShowBeforeUnloadAlert', 'true');
+      }
+
+      event.preventDefault();
+    }
+
+    /*
+     * This is somewhat heavy-handed, in that it will still warn even if the
+     * user changes an input back to its original value.
+     */
+    form.addEventListener('change', setInputsChanged);
+
+    // Disarm the warning when the form is being submitted.
+    form.addEventListener('submit', setSubmittingForm);
+
+    window.addEventListener('beforeunload', addFormUnloadWarning);
+    // eslint-disable-next-line consistent-return
+    return () => {
+      form.removeEventListener('change', setInputsChanged);
+      form.removeEventListener('submit', setSubmittingForm);
+      window.removeEventListener('beforeunload', addFormUnloadWarning);
+    };
+  }, []);
+}

--- a/root/static/scripts/event/components/EventEditForm.js
+++ b/root/static/scripts/event/components/EventEditForm.js
@@ -13,6 +13,7 @@ import * as React from 'react';
 import {SanitizedCatalystContext} from '../../../../context.mjs';
 import type {EventFormT} from '../../../../event/types.js';
 import Bubble from '../../common/components/Bubble.js';
+import useFormUnloadWarning from '../../common/hooks/useFormUnloadWarning.js';
 import expand2react from '../../common/i18n/expand2react.js';
 import {getSourceEntityData} from '../../common/utility/catalyst.js';
 import isBlank from '../../common/utility/isBlank.js';
@@ -170,6 +171,8 @@ component EventEditForm(
   form as initialForm: EventFormT,
 ) {
   const $c = React.useContext(SanitizedCatalystContext);
+
+  useFormUnloadWarning();
 
   const typeOptions = {
     grouped: false as const,

--- a/root/static/scripts/genre/components/GenreEditForm.js
+++ b/root/static/scripts/genre/components/GenreEditForm.js
@@ -14,6 +14,7 @@ import {SanitizedCatalystContext} from '../../../../context.mjs';
 import type {
   GenreFormT,
 } from '../../../../genre/types.js';
+import useFormUnloadWarning from '../../common/hooks/useFormUnloadWarning.js';
 import {getSourceEntityData} from '../../common/utility/catalyst.js';
 import isBlank from '../../common/utility/isBlank.js';
 import EnterEdit from '../../edit/components/EnterEdit.js';
@@ -101,6 +102,8 @@ function reducer(state: StateT, action: ActionT): StateT {
 
 component GenreEditForm(form as initialForm: GenreFormT) {
   const $c = React.useContext(SanitizedCatalystContext);
+
+  useFormUnloadWarning();
 
   const [state, dispatch] = React.useReducer(
     reducer,


### PR DESCRIPTION
### Implement MBS-14271

# Problem
Currently users can close the event and genre React forms with no warning even if there are pending changes.

# Solution
This cherry-picks the `useFormUnloadWarning` hook I'm adding during the recording conversion (https://github.com/metabrainz/musicbrainz-server/pull/3378) to already prevent leaving without warning in our existing React entity forms, event and genre.

# AI usage
None

# Testing
Manually, by ensuring the forms still close without warning if no changes have been made, then making changes in the forms and making sure they do ask when I try to close them. Keep in mind this only works after the input has been marked as changed, which means for something like the name it only warns after the field has been blurred (if the only change is the name and you `ctrl+w` while still on the name field, it won't trigger). It still seems much better than nothing though.