### PR TITLE
MBS-14272: Don't block OTOTOY interviews

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5178,7 +5178,8 @@ export const CLEANUPS: CleanupEntries = {
   },
   'ototoy': {
     hostname: 'ototoy.jp',
-    match: [/^(https?:\/\/)?([^/]+\.)?ototoy\.jp/i],
+    // Skip /feature links (can be interviews, reviews or other)
+    match: [/^(https?:\/\/)?([^/]+\.)?ototoy\.jp\/(?!feature)/i],
     restrict: [LINK_TYPES.downloadpurchase],
     clean(url) {
       return url.replace(/^(?:https?:\/\/)?(?:www\.)?ototoy\.jp\/(labels|_\/default\/[ap])\/(\d+).*$/, 'https://ototoy.jp/$1/$2');


### PR DESCRIPTION
### Fix MBS-14272

# Problem
From its website: "OTOTOY is a hi-res music store and also brings you the music news, reviews and interviews" So far, we were only allowing for `downloadpurchase` for any entity types that have that, meaning that while reviews were not blocked (because RG has no purchase option), artist interviews were. Those links all look like `https://ototoy.jp/feature/[0-9]+`.

# Solution
Rather than trying to guess the right type for `/feature` links (probably mostly reviews for RGs and
interviews for artists, but are they always?) I am playing it safe and just excluding `/feature` links entirely from the autoselection mechanism.
This will mean they don't get cleaned up to `https`, but that is their site default anyway so it shouldn't cause many issues.

# AI usage
None

# Testing
Manually. I don't think we have a way to specifically test that a link is skipped (rather than allowed or blocked) by the system, but if I'm forgetting it and we do, let me know and I can add a test.