### PR TITLE
MBS-14268: Filter by ModBot notes on notes-received

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -451,8 +451,10 @@ sub notes_received : Path('/edit/notes-received') RequireAuth {
     # Expire the notification in 30 days.
     $store->expire($notes_viewed_key, 60 * 60 * 24 * 30);
 
+    my $modbot_condition = $c->req->params->{modbot_condition};
+
     my $edit_notes = $self->_load_paged($c, sub {
-        $c->model('EditNote')->find_by_recipient($c->user->id, shift, shift);
+        $c->model('EditNote')->find_by_recipient($c->user->id, $modbot_condition, shift, shift);
     });
 
     $c->model('Editor')->load(@$edit_notes);
@@ -465,6 +467,7 @@ sub notes_received : Path('/edit/notes-received') RequireAuth {
         component_path => 'edit/NotesReceived',
         component_props => {
             editNotes => to_json_array($edit_notes),
+            modbotCondition => $modbot_condition,
             pager => serialize_pager($c->stash->{pager}),
         },
     );

--- a/root/edit/NotesReceived.js
+++ b/root/edit/NotesReceived.js
@@ -15,13 +15,20 @@ import Layout from '../layout/index.js';
 import manifest from '../static/manifest.mjs';
 import linkedEntities from '../static/scripts/common/linkedEntities.mjs';
 import {isBeginner} from '../static/scripts/common/utility/privileges.js';
+import FormRow from '../static/scripts/edit/components/FormRow.js';
+import InlineSubmitButton
+  from '../static/scripts/edit/components/InlineSubmitButton.js';
 import NewNotesAlertCheckbox
   from '../static/scripts/edit/components/NewNotesAlertCheckbox.js';
 import getRequestCookie from '../utility/getRequestCookie.mjs';
 
 import EditNoteListEntry from './components/EditNoteListEntry.js';
 
-component NotesReceived(editNotes: $ReadOnlyArray<EditNoteT>, pager: PagerT) {
+component NotesReceived(
+  editNotes: $ReadOnlyArray<EditNoteT>,
+  modbotCondition?: '' | '=' | '!=',
+  pager: PagerT,
+) {
   const $c = React.useContext(CatalystContext);
 
   return (
@@ -38,6 +45,25 @@ component NotesReceived(editNotes: $ReadOnlyArray<EditNoteT>, pager: PagerT) {
           />
         )}
 
+        <form style={{marginTop: '1em'}}>
+          <FormRow>
+            <label>
+              {addColonText(l('ModBot notes'))}
+              {' '}
+              <select
+                defaultValue={modbotCondition ?? ''}
+                name="modbot_condition"
+              >
+                <option value="">{l('Show all notes')}</option>
+                <option value="=">{l('Show only notes by ModBot')}</option>
+                <option value="!=">
+                  {l('Show only notes by someone else')}
+                </option>
+              </select>
+            </label>
+            <InlineSubmitButton />
+          </FormRow>
+        </form>
 
         {editNotes.length ? (
           <div className="edit-notes">


### PR DESCRIPTION
# Implement MBS-14268

# Description
In some cases, ModBot notes can be quite spammy (such as when entering RG merges from release merges, or artist credit changes  from artist edits). In these cases it is useful to be able to filter them out of the notes received list entirely to concentrate on more useful notes.

On the other hand, seeing only ModBot notes can be useful when trying to quickly view edits that failed because of conflicts and should be re-entered.

This adds a three-option select which allows the user to show all notes in notes-received (the default), or to only see ModBot or non-ModBot notes.

# AI usage
None

# Testing
Manually with sample data, by entering a RG+release merge (to cause a double whammy of ModBot edit notes) and adding a non-ModBot note by a different user in a separate edit. Filtering shows only the relevant edit notes as expected, or all three if not selecting a preference.

<img width="701" height="381" alt="image" src="https://github.com/user-attachments/assets/c65ecb21-8424-4e26-89b0-5b7db317e1d4" />


<img width="701" height="381" alt="image" src="https://github.com/user-attachments/assets/ab17122a-22e7-423b-ba67-62720a3bf02e" />
