### PR TITLE
MBS-14308: Fix `readUInt32LE` RangeError in the template renderer

### DIFF
--- a/root/server/createServer.mjs
+++ b/root/server/createServer.mjs
@@ -18,22 +18,36 @@ import sanitizedContext from '../utility/sanitizedContext.mjs';
 import {badRequest, getResponse} from './response.mjs';
 
 function connectionListener(socket) {
+  /*
+   * A UInt32LE header indicates how many bytes we expect to receive for
+   * `requestBody`. That byte count is stored in `expectedBytes` once
+   * the header is fully received.
+   */
   let expectedBytes = 0;
   let recvBuffer = null;
   let recvBytes = 0;
+  let recvHeaderBytes = 0;
   let context;
 
   function clearRecv() {
     expectedBytes = 0;
     recvBuffer = null;
     recvBytes = 0;
+    recvHeaderBytes = 0;
   }
 
   function receiveData(data) {
     if (!recvBuffer) {
-      expectedBytes = data.readUInt32LE(0);
+      while (recvHeaderBytes < 4 && data.length > 0) {
+        // Read the UInt32LE header one byte at a time.
+        expectedBytes |= data[0] << (recvHeaderBytes * 8);
+        recvHeaderBytes++;
+        data = data.slice(1);
+      }
+      if (recvHeaderBytes < 4) {
+        return;
+      }
       recvBuffer = Buffer.allocUnsafe(expectedBytes);
-      data = data.slice(4);
     }
 
     let overflow = null;


### PR DESCRIPTION
# Problem

MBS-14308

# Solution

This commit was written with the help of [kiro-cli](https://kiro.dev/cli/), which uses a variety of models underneath. Here's what it had to say, which I think is useful:

"The bug is clear. When a new data chunk arrives and recvBuffer is null, the code assumes the first 4 bytes are always present in that chunk to read the UInt32LE length prefix. But TCP is a stream — a chunk can arrive with fewer than 4 bytes, causing readUInt32LE(0) to throw RangeError: Attempt to access memory outside buffer bounds."

Initially, the model suggested a different fix which added additional allocations, and after some back-and-forth, I got it to produce some code which reads the header byte-by-byte. I wrote the comments and chose the variable name.

# AI usage

See above.

# Testing

While I'm not sure how to reliably trigger the bug through normal browsing, I had the AI generate a script which triggers the issue, which helped me verify that the fix worked. Didn't notice any other change in browsing various pages. I also added logging on both the Perl & JS sides to verify that the number of bytes sent by Perl still matches the `expectedBytes` on the JS side.