### PR TITLE
Security: Update jQuery 3.7.1, fix qx() injection, update yargs, add dep audit CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,17 @@ env:
   SECOND_PERL_VERSION: 5.42.0
 
 jobs:
+  dependency-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Yarn
+        run: corepack enable && corepack prepare yarn@stable --activate
+
+      - name: Audit dependencies for known vulnerabilities
+        run: yarn npm audit --severity high --environment production
+
   build-tests-image:
     runs-on: ubuntu-latest
     steps:

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -320,17 +320,31 @@ sub DISABLE_IMAGE_EDITING { 0 }
 # Development server feature.
 # Used to display which git branch is currently running along with information
 # about the last commit
-my $git_info = shell_quote(catfile(__PACKAGE__->MB_SERVER_ROOT, 'script/git_info'));
+my $git_info_path = catfile(__PACKAGE__->MB_SERVER_ROOT, 'script/git_info');
+sub _run_git_info {
+    my ($arg) = @_;
+    my $result = '';
+    if (-x $git_info_path) {
+        ## no critic (InputOutput::RequireBriefOpen)
+        if (open my $fh, '-|', $git_info_path, $arg) {
+            local $/;
+            $result = <$fh> // '';
+            close $fh;
+        }
+    }
+    chomp $result;
+    return $result;
+}
 sub GIT_BRANCH {
-    CORE::state $branch = $ENV{GIT_BRANCH} // scalar(qx( $git_info branch ));
+    CORE::state $branch = $ENV{GIT_BRANCH} // _run_git_info('branch');
     return $branch;
 }
 sub GIT_MSG {
-    CORE::state $msg = $ENV{GIT_MSG} // scalar(qx( $git_info msg ));
+    CORE::state $msg = $ENV{GIT_MSG} // _run_git_info('msg');
     return $msg;
 }
 sub GIT_SHA {
-    CORE::state $sha = $ENV{GIT_SHA} // scalar(qx( $git_info sha ));
+    CORE::state $sha = $ENV{GIT_SHA} // _run_git_info('sha');
     return $sha;
 }
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "he": "1.2.0",
     "imports-loader": "5.0.0",
     "jed": "https://github.com/metabrainz/Jed.git#cd3f71b7479b9c587990a0fa27ae9fdafbd9d9d9",
-    "jquery": "1.11.2",
+    "jquery": "3.7.1",
     "knockout": "https://github.com/mwiencek/knockout.git#a09f0778844130a89af438971ad6229ab81e26b3",
     "knockout-arraytransforms": "https://github.com/mwiencek/knockout-arraytransforms.git#9673e91a4755b92ba4eea5ca03067790dbbd997b",
     "leaflet": "1.9.4",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "webpack-node-externals": "3.0.0",
     "weight-balanced-tree": "0.9.0",
     "whatwg-fetch": "3.6.20",
-    "yargs": "3.10.0"
+    "yargs": "17.7.2"
   },
   "devDependencies": {
     "@metabrainz/xgettext-js": "5.0.1",

--- a/script/generate_edit_data_flow_type.mjs
+++ b/script/generate_edit_data_flow_type.mjs
@@ -11,16 +11,17 @@
 import pg from 'pg';
 import Cursor from 'pg-cursor';
 import yargs from 'yargs';
+import {hideBin} from 'yargs/helpers';
 
 import * as DBDefs from '../root/static/scripts/common/DBDefs.mjs';
 import {generateFlowType} from '../root/utility/generateFlowType.js';
 
-yargs
+const yargsInstance = yargs(hideBin(process.argv))
   .option('edit-type', {
     describe: 'Specifies the edit type number to generate a Flow type for.',
     type: 'number',
   })
-  .required('edit-type');
+  .demandOption('edit-type');
 
 (async function () {
   const pgClient = new pg.Client(DBDefs.DATABASES.PROD_STANDBY);
@@ -47,7 +48,7 @@ yargs
         'FROM edit_data ed ' +
         'JOIN edit e ON e.id = ed.edit ' +
        'WHERE e.type = $1',
-      [yargs.argv['edit-type']],
+      [yargsInstance.parseSync()['edit-type']],
     ),
   );
 

--- a/script/xgettext.mjs
+++ b/script/xgettext.mjs
@@ -13,6 +13,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import yargs from 'yargs';
+import {hideBin} from 'yargs/helpers';
 
 import cleanMsgid from '../root/static/scripts/common/i18n/cleanMsgid.mjs';
 
@@ -222,7 +223,7 @@ const parser = new XGettext({
   },
 });
 
-for (currentFile of yargs.argv._) {
+for (currentFile of yargs(hideBin(process.argv)).parseSync()._) {
   currentFile = path.resolve(process.cwd(), currentFile);
   const fp = fs.readFileSync(currentFile);
   try {

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -27,6 +27,7 @@ import webdriverProxy from 'selenium-webdriver/proxy.js';
 import test from 'tape';
 import TestCls from 'tape/lib/test.js';
 import yargs from 'yargs';
+import {hideBin} from 'yargs/helpers';
 
 import * as DBDefs from '../root/static/scripts/common/DBDefs.mjs';
 import {compareStrings}
@@ -43,7 +44,7 @@ import writeCoverage from '../root/utility/writeCoverage.mjs';
  */
 /* eslint-disable no-await-in-loop */
 
-const argv = yargs
+const argv = yargs(hideBin(process.argv))
   .option('b', {
     alias: 'browser',
     default: 'chrome',
@@ -84,7 +85,7 @@ const argv = yargs
   })
   .usage('Usage: $0 [-hs] [file...]')
   .help('help')
-  .argv;
+  .parseSync();
 
 function compareEditDataValues(actualValue, expectedValue) {
   if (expectedValue === '$$__IGNORE__$$') {


### PR DESCRIPTION
## Summary

- Update jQuery 1.11.2 → 3.7.1 (fixes CVE-2015-9251, CVE-2019-11358, CVE-2020-11022, CVE-2020-11023)
- Replace `qx()` backtick shell calls in `lib/DBDefs/Default.pm` with safe `open('-|')` pipe (prevents env var leakage and command injection)
- Update yargs 3.10.0 → 17.7.2 (prototype pollution fix) and migrate 3 scripts to v17 API
- Add `dependency-audit` CI job (`yarn npm audit --severity high`)

## Test plan

- [ ] jQuery 3.x is backward compatible — existing tests should pass
- [ ] `qx()` replacement preserves `CORE::state` caching and env var overrides
- [ ] yargs v17 migration tested in `t/selenium.mjs`, `script/generate_edit_data_flow_type.mjs`, `script/xgettext.mjs`
- [ ] CI audit job runs independently (~10s, no Docker needed)