### PR TITLE
Beta: Minor display fixes for seeded links

### DIFF
--- a/root/static/scripts/external-links-editor/state.js
+++ b/root/static/scripts/external-links-editor/state.js
@@ -305,7 +305,7 @@ function getInitialLinks(
       duplicateOf: null,
       error: null,
       isNew: true,
-      isSubmitted: false,
+      isSubmitted: linkTypeId != null,
       key: uniqueId(),
       originalUrlEntity: null,
       rawUrl,

--- a/root/static/scripts/external-links-editor/state.js
+++ b/root/static/scripts/external-links-editor/state.js
@@ -734,7 +734,6 @@ export function reducer(
             const cleanUrl = linkCtx.read().url.trim();
             linkCtx
               .set('isSubmitted', true)
-              .set('rawUrl', cleanUrl)
               .set('url', getUnicodeUrl(cleanUrl));
 
             const updatedLink = linkCtx.read();
@@ -786,7 +785,7 @@ export function reducer(
         }
         linkCtx
           .set(acceptedLink)
-          .set('rawUrl', acceptedUrl)
+          .set('rawUrl', acceptedLink.rawUrl)
           .set('url', getUnicodeUrl(acceptedUrl))
           .set('urlPopoverLinkState', null);
         return undefined;

--- a/root/static/scripts/tests/release-editor/seeds/external_links.html
+++ b/root/static/scripts/tests/release-editor/seeds/external_links.html
@@ -6,6 +6,8 @@
       <input type="hidden" name="urls.1.url" value="http://www.amazon.co.jp/" />
       <input type="hidden" name="urls.1.link_type" value="77" />
       <input type="hidden" name="urls.2.link_type" value="288" />
+      <input type="hidden" name="urls.3.url" value="https://open.spotify.com/album/3fu9okw4JVoyJQtGumKJHQ?foo=bar" />
+      <input type="hidden" name="urls.3.link_type" value="85" />
       <button type="submit">Submit</button>
     </form>
   </body>

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -202,7 +202,7 @@
     {
       command: 'assertEval',
       target: "document.getElementsByClassName('raw-url')[0].value.trim()",
-      value: 'https://en.wikipedia.org/wiki/No_Age2',
+      value: 'https://en.wikipedia.org/wiki/No_Age2?oldformat=true',
     },
     // Close popover
     {

--- a/t/selenium/release-editor/Seeding.json5
+++ b/t/selenium/release-editor/Seeding.json5
@@ -301,6 +301,23 @@
       target: "Array.from(document.querySelectorAll('#external-links-editor tr[class=\"relationship-item\"]')).slice(0, 3).map(x => [x.querySelector('select').value, x.querySelector('.error') ? x.querySelector('.error').textContent : ''].join('\\t')).join('\\n')",
       value: '\tPlease select a link type for the URL you’ve entered.\n77\t\n288\t',
     },
+    // Seeded URLs should be turned into a link if a type is specified.
+    {
+      command: 'assertEval',
+      target: "document.querySelector('tr.external-link-item:nth-child(7) a.url')?.href",
+      value: 'https://open.spotify.com/album/3fu9okw4JVoyJQtGumKJHQ',
+    },
+    {
+      command: 'runScript',
+      target: "document.querySelector('tr.external-link-item:nth-child(7) > td.link-actions button.edit-item')?.click()",
+      value: '',
+    },
+    // The raw URL that was submitted is preserved in the URLInputPopover.
+    {
+      command: 'assertEval',
+      target: "document.querySelector('div#url-input-popover input.raw-url')?.value",
+      value: 'https://open.spotify.com/album/3fu9okw4JVoyJQtGumKJHQ?foo=bar',
+    },
     // MBS-7250: seeding empty date parts gives an ISE
     {
       command: 'open',


### PR DESCRIPTION
# Problem

See the [comments from Lioncat6](https://tickets.metabrainz.org/browse/MBS-11889?focusedId=80116&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-80116) on Jira.

# Solution

 * Links seeded together with a type will now be initially marked as submitted (turned into a link).

 * For consistency with seeding, preserve the raw URL when pasted inline or via the `URLInputPopover`.

# AI usage

nil

# Testing

Added a Selenium test case which I ran locally.