### PR TITLE
Set MB.tree on Release Editor for UserScript

### DIFF
--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -494,5 +494,6 @@ releaseEditor.allowsSubmission = function () {
 };
 
 MB._releaseEditor = releaseEditor;
+MB.tree = tree;
 
 $(confirmNavigationFallback);


### PR DESCRIPTION
# Problem

I want to interact with an new External Links Editor in the Release Editor from my UserScript, but Release Editor page doesn't have a `MB.tree`, because it comes from Relationship Editor https://github.com/metabrainz/musicbrainz-server/blob/a575da88be0754bc12821a9730fc6ef1743d6521/root/static/scripts/relationship-editor/components/RelationshipEditor.js#L91 but Release Editor doesn't have a Relationship Editor.

(IMO probably good to have a release(-group) relationship editor on release editor, but it would be another ticket)

# Solution

Just set `MB.tree` in Release Editor.

AFAIK other entities editor have a relationship editor, any external links editor usage should be covered now.

# AI usage

I'm not using an AI at all, for this pull-request.

# Testing

nothing, but should be fine :tm:
