### PR TITLE
MBS-14295: Clean up vkdb links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5105,7 +5105,6 @@ export const CLEANUPS: CleanupEntries = {
       'lortel.org',
       'theatricalia.com',
       'imvdb.com',
-      'vkdb.jp',
       'ci.nii.ac.jp',
       'iss.ndl.go.jp',
       'finnmusic.net',
@@ -5139,7 +5138,6 @@ export const CLEANUPS: CleanupEntries = {
       /^(https?:\/\/)?(www\.)?lortel\.org\//i,
       /^(https?:\/\/)?(www\.)?theatricalia\.com\//i,
       /^(https?:\/\/)?(www\.)?imvdb\.com/i,
-      /^(https?:\/\/)?(www\.)?vkdb\.jp/i,
       /^(https?:\/\/)?(www\.)?ci\.nii\.ac\.jp/i,
       /^(https?:\/\/)?(www\.)?iss\.ndl\.go\.jp\//i,
       /^(https?:\/\/)?(www\.)?finnmusic\.net/i,
@@ -7118,6 +7116,15 @@ export const CLEANUPS: CleanupEntries = {
     restrict: [LINK_TYPES.socialnetwork],
     clean(url) {
       return url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?vk\.com/, 'https://vk.com');
+    },
+  },
+  'vkdb': {
+    hostname: 'vkdb.jp',
+    match: [/^(https?:\/\/)?(www\.)?vkdb\.jp/i],
+    restrict: [LINK_TYPES.otherdatabases],
+    clean(url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?vkdb\.jp\/([^/?#]+).*$/, 'https://www.vkdb.jp/$1');
+      return url;
     },
   },
   'vkgy': {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -7238,6 +7238,19 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://vk.com/video-2000471995_63471995',
        only_valid_entity_types: ['recording'],
   },
+  // vkdb
+  {
+                     input_url: 'http://www.vkdb.jp/cocklobin.html#gsc.tab=0',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.vkdb.jp/cocklobin.html',
+  },
+  {
+                     input_url: 'https://vkdb.jp/ITEM_B00AQMB6RI#gsc.tab=0',
+             input_entity_type: 'release_group',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.vkdb.jp/ITEM_B00AQMB6RI',
+  },
   // vkgy
   {
                      input_url: 'http://www.vk.gy/artists/skull/',


### PR DESCRIPTION
### Implement MBS-14295

# Description
This just adds a basic cleanup to vkdb links, mostly meant to get rid of the `#gsc.tab=0` parameter the site seems to automatically add now.

Might as well ensure `https` + `www` too while at it.

# AI usage
None

# Testing
Added two tests to the test file.