### PR TITLE
MBS-14321: Support Niconico Shorts

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4908,11 +4908,12 @@ export const CLEANUPS: CleanupEntries = {
     restrict: [{...LINK_TYPES.streamingfree, ...LINK_TYPES.videochannel}],
     clean(url) {
       url = url.replace(/^(?:https?:\/\/)?ch\.nicovideo\.jp\/([^/]+).*$/, 'https://ch.nicovideo.jp/$1');
-      url = url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?nicovideo\.jp\/(user\/[0-9]+|watch\/(?:sm|so|nm|ax|ca|cw|nl|z[a-d])[0-9]+).*$/, 'https://www.nicovideo.jp/$1');
+      url = url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?nicovideo\.jp\/(user\/[0-9]+|(?:watch|shorts)\/(?:sm|so|ss|nm|ax|ca|cw|nl|z[a-d])[0-9]+).*$/, 'https://www.nicovideo.jp/$1');
+      url = url.replace('/shorts/', '/watch/');
       return url;
     },
     validate(url, id) {
-      const m = /^(?:https?:\/\/)?(ch|www)\.nicovideo\.jp\/(?:(user)\/[0-9]+|(watch)\/(?:sm|so|nm|ax|ca|cw|nl|z[a-d])[0-9]+|[^/]+)$/.exec(url);
+      const m = /^(?:https?:\/\/)?(ch|www)\.nicovideo\.jp\/(?:(user)\/[0-9]+|(watch)\/(?:sm|so|ss|nm|ax|ca|cw|nl|z[a-d])[0-9]+|[^/]+)$/.exec(url);
       if (m) {
         const subdomain = m[1];
         const prefix = m[2] || m[3];

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4906,6 +4906,20 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['recording', 'release'],
   },
   {
+                     input_url: 'https://www.nicovideo.jp/watch/ss46168470?',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'streamingfree',
+            expected_clean_url: 'https://www.nicovideo.jp/watch/ss46168470',
+       only_valid_entity_types: ['recording', 'release'],
+  },
+  {
+                     input_url: 'https://www.nicovideo.jp/shorts/ss46168470?',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'streamingfree',
+            expected_clean_url: 'https://www.nicovideo.jp/watch/ss46168470',
+       only_valid_entity_types: ['recording', 'release'],
+  },
+  {
                      input_url: 'https://www.nicovideo.jp/user/1050860/top',
              input_entity_type: 'artist',
     expected_relationship_type: 'videochannel',


### PR DESCRIPTION
Implement https://tickets.metabrainz.org/browse/MBS-14321 .

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Note, because of those reasons, this code replaces `/shorts/` to old `/watch/`:
* YouTube Shorts `/shorts/vid` are also replaced to `/watch?v=vid`
* current version of their iOS app (version 12.25, just in case) 's share button uses `/watch/` URL for Shorts, so they probably handle it forever
  * Shorts uses `ss` prefix for video ID, we can replace it by simple `replace()` if needed


# AI usage
None

# Testing
Two tests added to test file.