### PR TITLE
MBS-14322: Use Dailymotion /user channel URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2357,10 +2357,12 @@ export const CLEANUPS: CleanupEntries = {
           case 'video':
             afterSlash = path.replace(/([^_]+).*/, '$1');
             break;
+          case 'user':
           default:
-            afterSlash = new RegExp('^' + root + '/*$').test(path)
-              ? root
-              : afterSlash;
+            if (root !== 'user') {
+              afterSlash = 'user/' + root;
+            }
+            afterSlash = afterSlash.replace(/user\/([^_/]+).*/, 'user/$1');
             break;
         }
         return 'https://www.dailymotion.com/' + afterSlash;
@@ -2368,20 +2370,20 @@ export const CLEANUPS: CleanupEntries = {
       return url;
     },
     validate(url, id) {
-      const m = /^https:\/\/www\.dailymotion\.com\/(?:(video\/)?[^/?#]+)$/.exec(url);
+      const m = /^https:\/\/www\.dailymotion\.com\/(?:(?:(user|video)\/)?[^/?#]+)$/.exec(url);
       if (m) {
         const prefix = m[1];
         if (Object.values(LINK_TYPES.videochannel).includes(id)) {
-          if (prefix === 'video/') {
+          if (prefix === 'video') {
             return {
               error: linkToChannelMsg(),
               result: false,
               target: ERROR_TARGETS.ENTITY,
             };
           }
-          return {result: prefix === undefined};
+          return {result: prefix === 'user'};
         }
-        if (prefix === 'video/') {
+        if (prefix === 'video') {
           return {result: true};
         }
         return {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2195,7 +2195,21 @@ limited_link_type_combinations: [
                      input_url: 'https://dailymotion.com/who-knows#uploads',
              input_entity_type: 'artist',
     expected_relationship_type: 'videochannel',
-            expected_clean_url: 'https://www.dailymotion.com/who-knows',
+            expected_clean_url: 'https://www.dailymotion.com/user/who-knows',
+       only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
+  },
+  {
+                     input_url: 'https://www.dailymotion.com/LYRIKALBESTIAL/videos?sort=visited',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'videochannel',
+            expected_clean_url: 'https://www.dailymotion.com/user/LYRIKALBESTIAL',
+       only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
+  },
+  {
+                     input_url: 'https://www.dailymotion.com/user/LYRIKALBESTIAL/playlists',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'videochannel',
+            expected_clean_url: 'https://www.dailymotion.com/user/LYRIKALBESTIAL',
        only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
   },
   {
@@ -2203,6 +2217,13 @@ limited_link_type_combinations: [
              input_entity_type: 'recording',
     expected_relationship_type: 'streamingfree',
             expected_clean_url: 'https://www.dailymotion.com/video/xyztuvw',
+       only_valid_entity_types: ['recording', 'release'],
+  },
+  {
+                     input_url: 'https://www.dailymotion.com/video/x9ujy50?playlist=xa4xsa',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'streamingfree',
+            expected_clean_url: 'https://www.dailymotion.com/video/x9ujy50',
        only_valid_entity_types: ['recording', 'release'],
   },
   {


### PR DESCRIPTION
### Implement MBS-14322

# Problem
Dailymotion channels now prefer (redirect to) a `/user` prefix. We were currently blocking these entirely. 

# Solution
This allows `/user` links and changes the old style non-prefix links to also use `/user` since it seems preferred. I also drop subpaths of the user page (`/playlists` and `/videos` seem to be the main ones).



# AI usage
None 

# Testing
Added a test for the /user page and amended the existing tests. Also added an extra test to make sure that video links in playlists are still cleaned up with the style the site now seems to use.