### PR TITLE
Exclude oauth2 namespace from `REQUIRE_LOGIN_FOR_VIEWING`

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -412,11 +412,14 @@ sub begin : Private
     # anything here, make sure it is reflected there, too (if applicable).
 
     if (DBDefs->REQUIRE_LOGIN_FOR_VIEWING && !$c->user_exists) {
-        my $action_name = $c->action->name;
+        my $action = $c->action;
+        my $namespace = $action->namespace;
+        my $private_path = $action->private_path;
         unless (
-            $action_name eq 'index' ||
-            $action_name eq 'login' ||
-            $action_name eq 'register'
+            $namespace eq 'oauth2' ||
+            $private_path eq '/index' ||
+            $private_path eq '/user/login' ||
+            $private_path eq '/account/register'
         ) {
             $attributes->{RequireAuth} = 1;
         }


### PR DESCRIPTION
# Problem

CORS error attempting to access https://beta.musicbrainz.org/oauth2/token.

# Solution

/oauth2 endpoints are part of the website containers, so get hit by the `REQUIRE_LOGIN_FOR_VIEWING` restriction. This excludes the oauth2 namespace.

# Testing

Tested locally with `curl`.

Also deployed it to test.mb (which also has `REQUIRE_LOGIN_FOR_VIEWING` enabled), and kepstin verified that magicisrc-test works with it.