### PR TITLE
Beta: Fix missing link type errors in the event/genre external links editors

### DIFF
--- a/root/static/scripts/edit/components/withLoadedTypeInfo.js
+++ b/root/static/scripts/edit/components/withLoadedTypeInfo.js
@@ -27,14 +27,11 @@ type LoadableEntityTypeT =
   | 'series_type'
   | 'work_type';
 
-export default function withLoadedTypeInfo<Config: {...}, Instance = mixed>(
-  WrappedComponent: component(ref: React.RefSetter<Instance>, ...Config),
+export default function withLoadedTypeInfo<Config: {...}>(
+  WrappedComponent: component(...Config),
   typeInfoToLoad: $ReadOnlySet<LoadableEntityTypeT>,
-): component(ref: React.RefSetter<Instance>, ...Config) {
-  const ComponentWrapper = React.forwardRef((
-    props: Config,
-    ref: React.RefSetter<Instance>,
-  ) => {
+): component(...Config) {
+  const ComponentWrapper = (props: Config) => {
     const [isLoading, setLoading] = React.useState<boolean>(true);
 
     const [
@@ -145,21 +142,18 @@ export default function withLoadedTypeInfo<Config: {...}, Instance = mixed>(
           </p>
         )
       ) : (
-        <WrappedComponent {...props} ref={ref} />
+        <WrappedComponent {...props} />
       )
     );
-  });
+  };
 
   return ComponentWrapper;
 }
 
-export function withLoadedTypeInfoForRelationshipEditor<
-  Config: {...},
-  Instance = mixed,
->(
-  WrappedComponent: component(ref: React.RefSetter<Instance>, ...Config),
+export function withLoadedTypeInfoForRelationshipEditor<Config: {...}>(
+  WrappedComponent: component(...Config),
   extraTypeInfoToLoad?: $ReadOnlyArray<LoadableEntityTypeT> = [],
-): component(ref: React.RefSetter<Instance>, ...Config) {
+): component(...Config) {
   return withLoadedTypeInfo(
     WrappedComponent,
     new Set([

--- a/root/static/scripts/event/components/EventEditForm.js
+++ b/root/static/scripts/event/components/EventEditForm.js
@@ -36,6 +36,9 @@ import {
   type StateT as GuessCaseOptionsStateT,
   createInitialState as createGuessCaseOptionsState,
 } from '../../edit/components/GuessCaseOptions.js';
+import {
+  withLoadedTypeInfoForRelationshipEditor,
+} from '../../edit/components/withLoadedTypeInfo.js';
 import isValidSetlist from '../../edit/utility/isValidSetlist.js';
 import {
   applyAllPendingErrors,
@@ -373,7 +376,11 @@ component EventEditForm(
   );
 }
 
-export default (hydrate<React.PropsOf<EventEditForm>>(
-  'div.event-edit-form',
-  EventEditForm,
-): component(...React.PropsOf<EventEditForm>));
+export default (
+  hydrate<React.PropsOf<EventEditForm>>(
+    'div.event-edit-form',
+    withLoadedTypeInfoForRelationshipEditor<React.PropsOf<EventEditForm>>(
+      EventEditForm,
+    ),
+  ) as component(...React.PropsOf<EventEditForm>)
+);

--- a/root/static/scripts/event/components/EventEditForm.js
+++ b/root/static/scripts/event/components/EventEditForm.js
@@ -58,9 +58,16 @@ import type {
 import {
   hasErrorsOnNewOrChangedLinks,
 } from '../../external-links-editor/validation.js';
-import {
-  NonHydratedRelationshipEditorWrapper as RelationshipEditorWrapper,
-} from '../../relationship-editor/components/RelationshipEditorWrapper.js';
+import RelationshipEditor, {
+  loadOrCreateInitialState as loadOrCreateInitialRelationshipEditorState,
+  reducer as relationshipEditorReducer,
+} from '../../relationship-editor/components/RelationshipEditor.js';
+import type {
+  RelationshipEditorStateT,
+} from '../../relationship-editor/types.js';
+import type {
+  RelationshipEditorActionT,
+} from '../../relationship-editor/types/actions.js';
 
 /* eslint-disable ft-flow/sort-keys */
 type ActionT =
@@ -70,6 +77,7 @@ type ActionT =
   | {+type: 'toggle-type-bubble'}
   | {+type: 'update-date-range', +action: DateRangeFieldsetActionT}
   | {+type: 'update-external-links-editor', +action: LinksEditorActionT}
+  | {+type: 'update-relationship-editor', +action: RelationshipEditorActionT}
   | {+type: 'update-name', +action: NameActionT};
 /* eslint-enable ft-flow/sort-keys */
 
@@ -78,6 +86,7 @@ type StateT = {
   +form: EventFormT,
   +guessCaseOptions: GuessCaseOptionsStateT,
   +isGuessCaseOptionsOpen: boolean,
+  +relationshipEditor: RelationshipEditorStateT,
   +showTypeBubble: boolean,
 };
 
@@ -93,6 +102,10 @@ function createInitialState({
     form,
     guessCaseOptions: createGuessCaseOptionsState(),
     isGuessCaseOptionsOpen: false,
+    relationshipEditor: loadOrCreateInitialRelationshipEditorState({
+      formName: form.name,
+      seededRelationships: $c.stash.seeded_relationships,
+    }),
     showTypeBubble: false,
   };
 }
@@ -133,11 +146,28 @@ function reducer(state: StateT, action: ActionT): StateT {
         })
         .set('guessCaseOptions', nameState.guessCaseOptions)
         .set('isGuessCaseOptionsOpen', nameState.isGuessCaseOptionsOpen);
+
+      if (action.type === 'set-name') {
+        newStateCtx.set(
+          'relationshipEditor',
+          relationshipEditorReducer(state.relationshipEditor, {
+            changes: {name: action.name},
+            entityType: state.relationshipEditor.entity.entityType,
+            type: 'update-entity',
+          }),
+        );
+      }
     }
     {type: 'update-external-links-editor', const action} => {
       newStateCtx.set(
         'externalLinksEditor',
         externalLinksEditorReducer(state.externalLinksEditor, action),
+      );
+    }
+    {type: 'update-relationship-editor', const action} => {
+      newStateCtx.set(
+        'relationshipEditor',
+        relationshipEditorReducer(state.relationshipEditor, action),
       );
     }
     {type: 'toggle-type-bubble'} => {
@@ -212,6 +242,12 @@ component EventEditForm(
     action: DateRangeFieldsetActionT,
   ) => {
     dispatch({action, type: 'update-date-range'});
+  }, [dispatch]);
+
+  const relationshipEditorDispatch = React.useCallback((
+    action: RelationshipEditorActionT,
+  ) => {
+    dispatch({action, type: 'update-relationship-editor'});
   }, [dispatch]);
 
   const hasErrors = hasSubfieldErrors(state.form) ||
@@ -319,9 +355,10 @@ component EventEditForm(
           />
         </DateRangeFieldset>
 
-        <RelationshipEditorWrapper
+        <RelationshipEditor
+          dispatch={relationshipEditorDispatch}
           formName={state.form.name}
-          seededRelationships={$c.stash.seeded_relationships}
+          state={state.relationshipEditor}
         />
 
         <ExternalLinksEditorFieldset

--- a/root/static/scripts/external-links-editor/components/ExternalLinksEditor.js
+++ b/root/static/scripts/external-links-editor/components/ExternalLinksEditor.js
@@ -23,7 +23,6 @@ import {
   hasSessionStorage,
   sessionStorageWrapper,
 } from '../../common/utility/storage.js';
-import withLoadedTypeInfo from '../../edit/components/withLoadedTypeInfo.js';
 import {
   compactEntityJson,
 } from '../../edit/utility/compactEntityJson.js';
@@ -189,7 +188,7 @@ function prepareExternalLinksHtmlFormSubmission(
   );
 }
 
-component _ExternalLinksEditor(
+component ExternalLinksEditor(
   dispatch: (LinksEditorActionT) => void,
   state: LinksEditorStateT,
 ) {
@@ -284,12 +283,5 @@ component _ExternalLinksEditor(
     </table>
   );
 }
-
-const ExternalLinksEditor:
-  component(...React.PropsOf<_ExternalLinksEditor>) =
-    withLoadedTypeInfo<React.PropsOf<_ExternalLinksEditor>, void>(
-      _ExternalLinksEditor,
-      new Set(['link_attribute_type', 'link_type']),
-    );
 
 export default ExternalLinksEditor;

--- a/root/static/scripts/external-links-editor/components/ExternalLinksEditor.js
+++ b/root/static/scripts/external-links-editor/components/ExternalLinksEditor.js
@@ -190,7 +190,6 @@ function prepareExternalLinksHtmlFormSubmission(
 }
 
 component _ExternalLinksEditor(
-  /*:: ref: React.RefSetter<void>, */
   dispatch: (LinksEditorActionT) => void,
   state: LinksEditorStateT,
 ) {
@@ -287,10 +286,7 @@ component _ExternalLinksEditor(
 }
 
 const ExternalLinksEditor:
-  component(
-    ref: React.RefSetter<void>,
-    ...React.PropsOf<_ExternalLinksEditor>
-  ) =
+  component(...React.PropsOf<_ExternalLinksEditor>) =
     withLoadedTypeInfo<React.PropsOf<_ExternalLinksEditor>, void>(
       _ExternalLinksEditor,
       new Set(['link_attribute_type', 'link_type']),

--- a/root/static/scripts/external-links-editor/components/StandaloneExternalLinksEditor.js
+++ b/root/static/scripts/external-links-editor/components/StandaloneExternalLinksEditor.js
@@ -24,9 +24,7 @@ import {
 
 import ExternalLinksEditor from './ExternalLinksEditor.js';
 
-component _StandaloneExternalLinksEditor(
-  /*:: ref: React.RefSetter<void>, */
-) {
+component _StandaloneExternalLinksEditor() {
   const $c = React.useContext(SanitizedCatalystContext);
 
   const [state, dispatch] = React.useReducer(

--- a/root/static/scripts/genre/components/GenreEditForm.js
+++ b/root/static/scripts/genre/components/GenreEditForm.js
@@ -28,6 +28,9 @@ import {
   type StateT as GuessCaseOptionsStateT,
   createInitialState as createGuessCaseOptionsState,
 } from '../../edit/components/GuessCaseOptions.js';
+import {
+  withLoadedTypeInfoForRelationshipEditor,
+} from '../../edit/components/withLoadedTypeInfo.js';
 import ExternalLinksEditorFieldset
   // eslint-disable-next-line @stylistic/max-len
   from '../../external-links-editor/components/ExternalLinksEditorFieldset.js';
@@ -174,7 +177,11 @@ component GenreEditForm(form as initialForm: GenreFormT) {
   );
 }
 
-export default (hydrate<React.PropsOf<GenreEditForm>>(
-  'div.genre-edit-form',
-  GenreEditForm,
-): component(...React.PropsOf<GenreEditForm>));
+export default (
+  hydrate<React.PropsOf<GenreEditForm>>(
+    'div.genre-edit-form',
+    withLoadedTypeInfoForRelationshipEditor<React.PropsOf<GenreEditForm>>(
+      GenreEditForm,
+    ),
+  ) as component(...React.PropsOf<GenreEditForm>)
+);

--- a/root/static/scripts/genre/components/GenreEditForm.js
+++ b/root/static/scripts/genre/components/GenreEditForm.js
@@ -45,13 +45,21 @@ import type {
 import {
   hasErrorsOnNewOrChangedLinks,
 } from '../../external-links-editor/validation.js';
-import {
-  NonHydratedRelationshipEditorWrapper as RelationshipEditorWrapper,
-} from '../../relationship-editor/components/RelationshipEditorWrapper.js';
+import RelationshipEditor, {
+  loadOrCreateInitialState as loadOrCreateInitialRelationshipEditorState,
+  reducer as relationshipEditorReducer,
+} from '../../relationship-editor/components/RelationshipEditor.js';
+import type {
+  RelationshipEditorStateT,
+} from '../../relationship-editor/types.js';
+import type {
+  RelationshipEditorActionT,
+} from '../../relationship-editor/types/actions.js';
 
 /* eslint-disable ft-flow/sort-keys */
 type ActionT =
   | {+type: 'update-external-links-editor', +action: LinksEditorActionT}
+  | {+type: 'update-relationship-editor', +action: RelationshipEditorActionT}
   | {+type: 'update-name', +action: NameActionT};
 /* eslint-enable ft-flow/sort-keys */
 
@@ -60,6 +68,7 @@ type StateT = {
   +form: GenreFormT,
   +guessCaseOptions: GuessCaseOptionsStateT,
   +isGuessCaseOptionsOpen: boolean,
+  +relationshipEditor: RelationshipEditorStateT,
 };
 
 function createInitialState({
@@ -74,6 +83,10 @@ function createInitialState({
     form,
     guessCaseOptions: createGuessCaseOptionsState(),
     isGuessCaseOptionsOpen: false,
+    relationshipEditor: loadOrCreateInitialRelationshipEditorState({
+      formName: form.name,
+      seededRelationships: $c.stash.seeded_relationships,
+    }),
   };
 }
 
@@ -92,11 +105,28 @@ function reducer(state: StateT, action: ActionT): StateT {
         .set('form', 'field', 'name', nameState.field)
         .set('guessCaseOptions', nameState.guessCaseOptions)
         .set('isGuessCaseOptionsOpen', nameState.isGuessCaseOptionsOpen);
+
+      if (action.type === 'set-name') {
+        newStateCtx.set(
+          'relationshipEditor',
+          relationshipEditorReducer(state.relationshipEditor, {
+            changes: {name: action.name},
+            entityType: state.relationshipEditor.entity.entityType,
+            type: 'update-entity',
+          }),
+        );
+      }
     }
     {type: 'update-external-links-editor', const action} => {
       newStateCtx.set(
         'externalLinksEditor',
         externalLinksEditorReducer(state.externalLinksEditor, action),
+      );
+    }
+    {type: 'update-relationship-editor', const action} => {
+      newStateCtx.set(
+        'relationshipEditor',
+        relationshipEditorReducer(state.relationshipEditor, action),
       );
     }
   }
@@ -116,6 +146,12 @@ component GenreEditForm(form as initialForm: GenreFormT) {
 
   const nameDispatch = React.useCallback((action: NameActionT) => {
     dispatch({action, type: 'update-name'});
+  }, [dispatch]);
+
+  const relationshipEditorDispatch = React.useCallback((
+    action: RelationshipEditorActionT,
+  ) => {
+    dispatch({action, type: 'update-relationship-editor'});
   }, [dispatch]);
 
   const missingRequired = isBlank(state.form.field.name.value);
@@ -162,9 +198,10 @@ component GenreEditForm(form as initialForm: GenreFormT) {
             uncontrolled
           />
         </fieldset>
-        <RelationshipEditorWrapper
+        <RelationshipEditor
+          dispatch={relationshipEditorDispatch}
           formName={state.form.name}
-          seededRelationships={$c.stash.seeded_relationships}
+          state={state.relationshipEditor}
         />
         <ExternalLinksEditorFieldset
           dispatch={dispatch}

--- a/root/static/scripts/relationship-editor/components/RelationshipEditorWrapper.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipEditorWrapper.js
@@ -34,15 +34,7 @@ import RelationshipEditor, {
 
 type PropsT = InitialStateArgsT;
 
-component _RelationshipEditorWrapper(
-  /*
-   * Hack required due to withLoadedTypeInfo's use of `forwardRef`.
-   * Remove once we upgrade to React v19.
-   */
-  // eslint-disable-next-line no-unused-vars
-  ref: React.RefSetter<mixed>,
-  ...props: PropsT
-) {
+component _RelationshipEditorWrapper(...props: PropsT) {
   const [state, dispatch] = React.useReducer(
     reducer,
     props,
@@ -65,7 +57,7 @@ component _RelationshipEditorWrapper(
 }
 
 export const NonHydratedRelationshipEditorWrapper:
-  component(ref: React.RefSetter<mixed>, ...PropsT) =
+  component(...PropsT) =
     withLoadedTypeInfoForRelationshipEditor<PropsT>(
       _RelationshipEditorWrapper,
     );

--- a/root/static/scripts/release/components/ReleaseRelationshipEditor.js
+++ b/root/static/scripts/release/components/ReleaseRelationshipEditor.js
@@ -1688,14 +1688,7 @@ component _ReleaseGroupRelationshipSection(
 const ReleaseGroupRelationshipSection =
   React.memo(_ReleaseGroupRelationshipSection);
 
-component _ReleaseRelationshipEditor(
-  /*
-   * Hack required due to withLoadedTypeInfo's use of `forwardRef`.
-   * Remove once we upgrade to React v19.
-   */
-  // eslint-disable-next-line no-unused-vars
-  ref: React.RefSetter<mixed>
-) {
+component _ReleaseRelationshipEditor() {
   const [state, dispatch] = React.useReducer(
     reducer,
     null,

--- a/root/static/scripts/series/components/SeriesRelationshipEditor.js
+++ b/root/static/scripts/series/components/SeriesRelationshipEditor.js
@@ -42,15 +42,7 @@ function getSeriesType(typeId: number | null): SeriesTypeT | null {
     : linkedEntities.series_type[typeId];
 }
 
-component _SeriesRelationshipEditor(
-  /*
-   * Hack required due to withLoadedTypeInfo's use of `forwardRef`.
-   * Remove once we upgrade to React v19.
-   */
-  // eslint-disable-next-line no-unused-vars
-  ref: React.RefSetter<mixed>,
-  ...props: PropsT
-) {
+component _SeriesRelationshipEditor(...props: PropsT) {
   const [state, dispatch] = React.useReducer(
     reducer,
     props,
@@ -187,7 +179,7 @@ component _SeriesRelationshipEditor(
 }
 
 const NonHydratedSeriesRelationshipEditor:
-  component(ref: React.RefSetter<mixed>, ...PropsT) =
+  component(...PropsT) =
     withLoadedTypeInfoForRelationshipEditor<PropsT>(
       _SeriesRelationshipEditor,
     );

--- a/root/static/scripts/url/components/UrlRelationshipEditor.js
+++ b/root/static/scripts/url/components/UrlRelationshipEditor.js
@@ -25,15 +25,7 @@ import useEntityNameFromField
 
 type PropsT = InitialStateArgsT;
 
-component _UrlRelationshipEditor(
-  /*
-   * Hack required due to withLoadedTypeInfo's use of `forwardRef`.
-   * Remove once we upgrade to React v19.
-   */
-  // eslint-disable-next-line no-unused-vars
-  ref: React.RefSetter<mixed>,
-  ...props: PropsT
-) {
+component _UrlRelationshipEditor(...props: PropsT) {
   const [state, dispatch] = React.useReducer(
     reducer,
     props,
@@ -71,7 +63,7 @@ component _UrlRelationshipEditor(
 }
 
 const NonHydratedUrlRelationshipEditor:
-  component(ref: React.RefSetter<mixed>, ...PropsT) =
+  component(...PropsT) =
     withLoadedTypeInfoForRelationshipEditor<PropsT>(
       _UrlRelationshipEditor,
     );

--- a/t/lib/t/MusicBrainz/Server/Controller/Genre/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Genre/Edit.pm
@@ -33,8 +33,8 @@ test 'Editing a genre' => sub {
     html_ok($mech->content);
 
     my @edits = capture_edits {
-        $mech->submit_form_ok({
-            with_fields => { 'edit-genre.name' => 'surrogate stone' },
+        $mech->post_ok('/genre/ceeaa283-5d7b-4202-8d1d-e25d116b2a18/edit', {
+            'edit-genre.name' => 'surrogate stone',
         },
         'The form returned a 2xx response code')
     } $c;


### PR DESCRIPTION
# Problem

https://tickets.metabrainz.org/browse/MBS-11889?focusedId=80171&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-80171

# Solution

We need to load `link_type` and `link_attribute_type` info before React-based forms can initialize the external-links-editor state. So the forms themselves are now wrapped in `withLoadedTypeInfoForRelationshipEditor`. There are also some related cleanup commits.

# Testing

Tested the relationship and external links editors on artist/event/genre create/edit pages. Ensured the link type errors are no longer present in the latter two.