### PR TITLE
MBS-14323: Beta: Fix showing custom error messages in external-links-editor

### DIFF
--- a/root/static/scripts/external-links-editor/validation.js
+++ b/root/static/scripts/external-links-editor/validation.js
@@ -360,43 +360,45 @@ function getRelationshipError(
       message: check.error ?? '',
       target: check.target ?? URLCleanup.ERROR_TARGETS.NONE,
     };
-    if (error.target === URLCleanup.ERROR_TARGETS.URL) {
-      error.message = l(
-        `This URL is not allowed for the selected link type,
-         or is incorrectly formatted.`,
-      );
-    } else if (error.target === URLCleanup.ERROR_TARGETS.RELATIONSHIP) {
-      error.message =
-        l('This URL is not allowed for the selected link type.');
-    } else if (error.target === URLCleanup.ERROR_TARGETS.ENTITY) {
-      error.message = match (checker) {
-        {entityType: 'area', ...} =>
-          l('This URL is not allowed for areas.'),
-        {entityType: 'artist', ...} =>
-          l('This URL is not allowed for artists.'),
-        {entityType: 'event', ...} =>
-          l('This URL is not allowed for events.'),
-        {entityType: 'genre', ...} =>
-          l('This URL is not allowed for genres.'),
-        {entityType: 'instrument', ...} =>
-          l('This URL is not allowed for instruments.'),
-        {entityType: 'label', ...} =>
-          l('This URL is not allowed for labels.'),
-        {entityType: 'place', ...} =>
-          l('This URL is not allowed for places.'),
-        {entityType: 'recording', ...} =>
-          l('This URL is not allowed for recordings.'),
-        {entityType: 'release', ...} =>
-          l('This URL is not allowed for releases.'),
-        {entityType: 'release_group', ...} =>
-          l('This URL is not allowed for release groups.'),
-        {entityType: 'series', ...} =>
-          l('This URL is not allowed for series.'),
-        {entityType: 'work', ...} =>
-          l('This URL is not allowed for works.'),
-        // URLs don't themselves have an external links editor
-        {entityType: 'url', ...} => '',
-      };
+    if (empty(error.message)) {
+      if (error.target === URLCleanup.ERROR_TARGETS.URL) {
+        error.message = l(
+          `This URL is not allowed for the selected link type,
+           or is incorrectly formatted.`,
+        );
+      } else if (error.target === URLCleanup.ERROR_TARGETS.RELATIONSHIP) {
+        error.message =
+          l('This URL is not allowed for the selected link type.');
+      } else if (error.target === URLCleanup.ERROR_TARGETS.ENTITY) {
+        error.message = match (checker) {
+          {entityType: 'area', ...} =>
+            l('This URL is not allowed for areas.'),
+          {entityType: 'artist', ...} =>
+            l('This URL is not allowed for artists.'),
+          {entityType: 'event', ...} =>
+            l('This URL is not allowed for events.'),
+          {entityType: 'genre', ...} =>
+            l('This URL is not allowed for genres.'),
+          {entityType: 'instrument', ...} =>
+            l('This URL is not allowed for instruments.'),
+          {entityType: 'label', ...} =>
+            l('This URL is not allowed for labels.'),
+          {entityType: 'place', ...} =>
+            l('This URL is not allowed for places.'),
+          {entityType: 'recording', ...} =>
+            l('This URL is not allowed for recordings.'),
+          {entityType: 'release', ...} =>
+            l('This URL is not allowed for releases.'),
+          {entityType: 'release_group', ...} =>
+            l('This URL is not allowed for release groups.'),
+          {entityType: 'series', ...} =>
+            l('This URL is not allowed for series.'),
+          {entityType: 'work', ...} =>
+            l('This URL is not allowed for works.'),
+          // URLs don't themselves have an external links editor
+          {entityType: 'url', ...} => '',
+        };
+      }
     }
     return error;
   }

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -860,6 +860,7 @@ const seleniumTests = [
     login: true,
     sql: 'whatever_it_takes.sql',
   },
+  {name: 'MBS-14323.json5', login: true},
   {name: 'Artist_Credit_Editor.json5', login: true},
   {name: 'Autocomplete2.json5'},
   {name: 'External_Links_Editor.json5', login: true},

--- a/t/selenium/MBS-14323.json5
+++ b/t/selenium/MBS-14323.json5
@@ -1,0 +1,20 @@
+{
+  title: 'MBS-14323',
+  commands: [
+    {
+      command: 'open',
+      target: '/label/create',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: 'https://www.youtube.com/watch?v=J_8mdH20qTQ${KEY_ENTER}',
+    },
+    {
+      command: 'assertText',
+      target: "xpath=(//tr[contains(@class, 'external-link-item')]//div[contains(@class, 'error')])[1]",
+      value: 'Please link to a channel, not a specific video. Videos should be linked to the appropriate recordings or releases instead.',
+    },
+  ],
+}


### PR DESCRIPTION
# Problem

MBS-14323

# Solution

Added `if (empty(error.message)) { ... }` to avoid overriding custom errors.

# Testing

New Selenium test.