### PR TITLE
MBS-14316: Validate event times at the JS level

### DIFF
--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -269,6 +269,7 @@ sub is_valid_isrc
     return $isrc =~ /^[A-Z]{2}[A-Z0-9]{3}[0-9]{7}$/;
 }
 
+# Converted to JavaScript at root/static/scripts/edit/utility/isValidTime.js
 sub is_valid_time
 {
     my $time = shift;

--- a/root/static/scripts/edit/utility/isValidTime.js
+++ b/root/static/scripts/edit/utility/isValidTime.js
@@ -1,0 +1,14 @@
+/*
+ * @flow strict
+ * Copyright (C) 2026 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+const timePattern = /^([01][0-9]|2[0-3]):[0-5][0-9]$/;
+
+export default function isValidTime(time: string): boolean {
+  return empty(time) || timePattern.test(time.trim());
+}

--- a/root/static/scripts/event/components/EventEditForm.js
+++ b/root/static/scripts/event/components/EventEditForm.js
@@ -40,6 +40,7 @@ import {
   withLoadedTypeInfoForRelationshipEditor,
 } from '../../edit/components/withLoadedTypeInfo.js';
 import isValidSetlist from '../../edit/utility/isValidSetlist.js';
+import isValidTime from '../../edit/utility/isValidTime.js';
 import {
   applyAllPendingErrors,
   hasSubfieldErrors,
@@ -72,6 +73,7 @@ import type {
 /* eslint-disable ft-flow/sort-keys */
 type ActionT =
   | {readonly type: 'set-setlist', readonly setlist: string}
+  | {readonly type: 'set-time', readonly time: string}
   | {readonly type: 'set-type', readonly type_id: string}
   | {readonly type: 'show-all-pending-errors'}
   | {readonly type: 'toggle-type-bubble'}
@@ -197,6 +199,20 @@ function reducer(state: StateT, action: ActionT): StateT {
         }
       });
     }
+    {type: 'set-time', const time} => {
+      fieldCtx.update('time', (timeFieldCtx) => {
+        timeFieldCtx.set('value', time);
+        if (isValidTime(time)) {
+          timeFieldCtx.set('has_errors', false);
+          timeFieldCtx.set('errors', []);
+        } else {
+          timeFieldCtx.set('has_errors', true);
+          timeFieldCtx.set('errors', [
+            l('This is not a valid time.'),
+          ]);
+        }
+      });
+    }
     {type: 'set-type', const type_id} => {
       fieldCtx.set('type_id', 'value', type_id);
     }
@@ -245,6 +261,12 @@ component EventEditForm(
     event: SyntheticEvent<HTMLTextAreaElement>,
   ) => {
     dispatch({setlist: event.currentTarget.value, type: 'set-setlist'});
+  }, [dispatch]);
+
+  const handleTimeChange = React.useCallback((
+    event: SyntheticEvent<HTMLInputElement>,
+  ) => {
+    dispatch({time: event.currentTarget.value, type: 'set-time'});
   }, [dispatch]);
 
   const dispatchDateRange = React.useCallback((
@@ -358,9 +380,9 @@ component EventEditForm(
             className="time"
             field={state.form.field.time}
             label={addColonText(lp('Time', 'event'))}
+            onChange={handleTimeChange}
             placeholder={l('HH:MM')}
             size={5}
-            uncontrolled
           />
         </DateRangeFieldset>
 

--- a/root/static/scripts/tests/index-web.js
+++ b/root/static/scripts/tests/index-web.js
@@ -60,6 +60,7 @@ require('./utility/isGuid.js');
 require('./utility/isObjectEmpty.js');
 require('./utility/isShortenedUrl.js');
 require('./utility/isSpecialPurpose.js');
+require('./utility/isValidTime.js');
 require('./utility/natatime.js');
 require('./utility/parseDate.js');
 require('./utility/primaryAreaCode.js');

--- a/root/static/scripts/tests/utility/isValidTime.js
+++ b/root/static/scripts/tests/utility/isValidTime.js
@@ -1,0 +1,56 @@
+/*
+ * @flow strict
+ * Copyright (C) 2026 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import test from 'tape';
+
+import isValidTime from '../../edit/utility/isValidTime.js';
+
+test('isValidTime', function (t) {
+  t.plan(8);
+
+  t.ok(
+    isValidTime(''),
+    'null "time" is valid',
+  );
+
+  t.ok(
+    isValidTime('11:11'),
+    'HH:MM time is valid',
+  );
+
+  t.ok(
+    isValidTime(' 11:11   '),
+    'HH:MM time is valid if surrounded by spaces',
+  );
+
+  t.ok(
+    !isValidTime('eight am'),
+    'Non-number "time" is invalid',
+  );
+
+  t.ok(
+    !isValidTime('1:11'),
+    'Time with just H:MM is invalid',
+  );
+
+  t.ok(
+    !isValidTime('11:1'),
+    'Time with just HH:M is invalid',
+  );
+
+  t.ok(
+    !isValidTime('26:26'),
+    'Time with nonsensical HH is invalid',
+  );
+
+  t.ok(
+    !isValidTime('08:75'),
+    'Time with nonsensical MM is invalid',
+  );
+});


### PR DESCRIPTION
### Fix MBS-14316

# Problem
We are only validating event times at the Perl level. But when a Perl error is returned, since errors block form submission, there is no way to correct it and submit the form.

# Solution
This moves validation to happen primarily at the JS level in form state. We keep the validation on Perl as well as a fallback, as with other form validation.

# AI usage
None

# Testing
Added a test for the JS version of `isValidTime`, plus tested editing an event manually a bit.