### PR TITLE
Disallow toggle-legacy-browser in robots.txt

### DIFF
--- a/root/robots.txt.production
+++ b/root/robots.txt.production
@@ -28,6 +28,7 @@ Disallow: /tag/
 Disallow: /taglookup
 Disallow: /tags
 Disallow: /test/
+Disallow: /toggle-legacy-browser
 Disallow: /tops/
 Disallow: /track/
 Disallow: /url/


### PR DESCRIPTION
# Description
This disallows the `toggle-legacy-browser` path in our `robots.txr`. I saw Google has been trying to index this, which is useless.

# AI usage
None

# Testing
None