### PR TITLE
Ensure sir doesn't index replication changes until they are applied

### DIFF
--- a/admin/replication/LoadReplicationChanges
+++ b/admin/replication/LoadReplicationChanges
@@ -342,6 +342,8 @@ for my $f (@pending_files)
     }
 }
 
+toggle_search_indexing(0);
+
 # Load them
 print localtime() . " : Importing the pending data files\n";
 system "$FindBin::Bin/ImportReplicationChanges",
@@ -404,6 +406,7 @@ if (-x "$FindBin::Bin/hooks/post-process") {
 $count += 1;
 if ($limit > 0 && $count >= $limit) {
     print localtime() . " : Hit packet limit $limit.\n";
+    toggle_search_indexing(1);
     exit 0;
 }
 # Loop back round and start again
@@ -471,6 +474,23 @@ EOF
 
     print localtime() . " : Replication abandoned\n";
     exit 1;
+}
+
+sub toggle_search_indexing {
+    my $enabled = shift;
+
+    my $sir_schema_exists = $sql->select_single_value(<<~'SQL');
+        SELECT 1
+          FROM information_schema.schemata
+          WHERE schema_name = 'sir'
+        SQL
+
+    if ($sir_schema_exists) {
+        $sql->do(
+            'UPDATE sir.control SET indexing_enabled = ?',
+            $enabled,
+        );
+    }
 }
 
 =head1 COPYRIGHT AND LICENSE


### PR DESCRIPTION
# Problem

The next major version of sir will consume changes from replication packets (triggered on insertion to `dbmirror2.pending_data`) rather than RabbitMQ. This can be problematic, because the insertion triggers will run before the changes have been applied to the database.

# Solution

To work around this, sir will read a flag from the `sir.control` table to start/stop indexing. It remains disabled until all packets have been applied.

# AI usage

nil

# Testing

Not tested yet.