### PR TITLE
MBS-14344: UTF8-decode string defs in dbdefs_to_js.pl

### DIFF
--- a/script/dbdefs_to_js.pl
+++ b/script/dbdefs_to_js.pl
@@ -5,6 +5,7 @@ use warnings;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use DBDefs;
+use Encode qw( decode_utf8 );
 use JSON;
 use Readonly;
 
@@ -84,7 +85,12 @@ my @conversions = (
     },
     {
         defs => \@STRING_DEFS,
-        convert => sub { \('' . (shift // '')) },
+        convert => sub {
+            my $value = '' . (shift // '');
+            $value = decode_utf8($value)
+                unless utf8::is_utf8($value);
+            return \$value;
+        },
         flowtype => 'string',
     },
     {


### PR DESCRIPTION
# Problem

MBS-14344

# Solution

`DBDefs->GIT_MSG` is a UTF-8 encoded string:

```
SV = PV(0x5569a594b920) at 0x5569a5a83888
  REFCNT = 1
  FLAGS = (POK,pPOK)
  PV = 0x5569a49b9620 "Last commit by Nicol\xC3\xA1s Tamargo on 2026-05-04: Call reorder_for_entities on all series entities"\0
  CUR = 95
  LEN = 97
```

This commit runs `decode_utf8` on all strings that have the internal UTF8 flag off, giving:

```
SV = PV(0x55a6c4b23b70) at 0x55a6c4b622b8
  REFCNT = 1
  FLAGS = (POK,pPOK,UTF8)
  PV = 0x55a6c3a940e0 "Last commit by Nicol\xC3\xA1s Tamargo on 2026-05-04: Call reorder_for_entities on all series entities"\0 [UTF8 "Last commit by Nicol\x{e1}s Tamargo on 2026-05-04: Call reorder_for_entities on all series entities"]
  CUR = 95
  LEN = 97
```

# AI usage

none

# Testing

Locally on the commit referenced above.