### PR TITLE
Make sample dump smaller

### DIFF
--- a/admin/DumpSampleData
+++ b/admin/DumpSampleData
@@ -16,8 +16,8 @@ the script dumps the following three artists, along with all releases,
 recordings, and works related to them:
 
  * b7ffd2af-418f-4be2-bdd1-22f8b48613da (Nine Inch Nails)
- * 164f0d73-1234-4e2c-8743-d77bf2191051 (Kanye West)
- * 9ddd7abc-9e1b-471d-8031-583bc6bc8be9 (Пётр Ильич Чайковский)
+ * 1d11e2a1-4531-4d61-a8c7-7b5c6a608fd2 (Ice Cube)
+ * c278de2c-9696-4fdf-a919-0781cd945e2c (Игорь Стравинский)
 
 Options:
 

--- a/lib/MusicBrainz/Script/SampleDataDump.pm
+++ b/lib/MusicBrainz/Script/SampleDataDump.pm
@@ -162,10 +162,10 @@ sub run {
     my $sample_artist_gids = [
         # Nine Inch Nails
         'b7ffd2af-418f-4be2-bdd1-22f8b48613da',
-        # Kanye West
-        '164f0d73-1234-4e2c-8743-d77bf2191051',
-        # Пётр Ильич Чайковский
-        '9ddd7abc-9e1b-471d-8031-583bc6bc8be9',
+        # Ice Cube
+        '1d11e2a1-4531-4d61-a8c7-7b5c6a608fd2',
+        # Игорь Стравинский
+        'c278de2c-9696-4fdf-a919-0781cd945e2c',
     ];
 
     my $total = scalar @{$sample_artist_gids};


### PR DESCRIPTION
# Description
Tchaikovsky just brings way too many releases. Changing to Stravinsky which should have a lot less, while still having *many* and ensuring non-Latin coverage in the sample.

Replacing Kanye with Ice Cube who hasn't, AFAICT, gone as mad.

# AI usage
None

# Testing
None but should be a trivial replacement