### PR TITLE
Fix Perl 5.42 warnings

### DIFF
--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -6,7 +6,7 @@ use warnings;
 use base 'Exporter';
 
 use DateTime::Duration;
-use DateTime::Locale '1.00';
+use DateTime::Locale 1.00 ();
 use File::Basename qw( dirname );
 use File::Slurp qw( read_file );
 use File::Spec;

--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -12,7 +12,7 @@ use MusicBrainz::Server::Data::Utils qw(
     non_empty
 );
 use MusicBrainz::Server::Entity::Preferences;
-use MusicBrainz::Server::Entity::Types qw( Area ); ## no critic 'ProhibitUnusedImport'
+use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
 use MusicBrainz::Server::Constants qw( :privileges );
 use MusicBrainz::Server::Filters qw( format_wikitext );


### PR DESCRIPTION
# Problem

Perl prints the following warnings every time the server starts.

```
Attempt to call undefined import method with arguments ("1.00") via package "DateTime::Locale" (Perhaps you forgot to load the package?) at lib/MusicBrainz/Server/Constants.pm line 9.
Attempt to call undefined import method with arguments ("Area") via package "MusicBrainz::Server::Entity::Types" (Perhaps you forgot to load the package?) at lib/MusicBrainz/Server/Entity/Editor.pm line 15.
```
# Solution

See commits.

# AI usage

None.

# Testing

```sh
plackup -Ilib -r -o localhost -p 5000
```
