### PR TITLE
MBS-14349: Fix "do called while not in transaction" during replication

### DIFF
--- a/admin/replication/LoadReplicationChanges
+++ b/admin/replication/LoadReplicationChanges
@@ -486,6 +486,7 @@ sub toggle_search_indexing {
         SQL
 
     if ($sir_schema_exists) {
+        $sql->auto_commit(1);
         $sql->do(
             'UPDATE sir.control SET indexing_enabled = ?',
             $enabled,


### PR DESCRIPTION
Sets auto-commit before updating the `sir.control` table, as there is no transaction open.

# Testing

Tested in my local musicbrainz-docker mirror with sir installed.