### PR TITLE
ci: version bumps and zizmor-powered hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,23 +23,23 @@ jobs:
     steps:
       - name: Check the cache for musicbrainz-tests-image
         id: tests-image-cache-check
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: /tmp/musicbrainz-tests.tar
           key: musicbrainz-tests-image-${{ env.TESTS_IMAGE_TAG }}
           lookup-only: true
 
       - if: steps.tests-image-cache-check.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - if: steps.tests-image-cache-check.outputs.cache-hit != 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - if: steps.tests-image-cache-check.outputs.cache-hit != 'true'
         run: make -C docker config
 
       - if: steps.tests-image-cache-check.outputs.cache-hit != 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.tests
@@ -50,7 +50,7 @@ jobs:
           outputs: type=docker,dest=/tmp/musicbrainz-tests.tar
 
       - if: steps.tests-image-cache-check.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: /tmp/musicbrainz-tests.tar
           key: musicbrainz-tests-image-${{ env.TESTS_IMAGE_TAG }}
@@ -60,12 +60,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: mbs_checkout
 
       - name: Restore musicbrainz-tests image from cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: /tmp/musicbrainz-tests.tar
           key: musicbrainz-tests-image-${{ env.TESTS_IMAGE_TAG }}
@@ -83,13 +83,13 @@ jobs:
           docker exec "$CONTAINER_NAME" ./docker/musicbrainz-tests/run_js_perl_and_pgtap_tests.sh
 
       - if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: js_nyc_output
           path: nyc_output
 
       - if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: js_perl_and_pgtap_junit_output
           path: junit_output
@@ -103,12 +103,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: mbs_checkout
 
       - name: Restore musicbrainz-tests image from cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: /tmp/musicbrainz-tests.tar
           key: musicbrainz-tests-image-${{ env.TESTS_IMAGE_TAG }}
@@ -129,25 +129,25 @@ jobs:
             ./docker/musicbrainz-tests/run_selenium_tests.sh
 
       - if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: selenium_${{ matrix.partition }}_service_logs
           path: service_logs
 
       - if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: selenium_${{ matrix.partition }}_nyc_output
           path: nyc_output
 
       - if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: selenium_${{ matrix.partition }}_junit_output
           path: junit_output
 
       - if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: selenium_${{ matrix.partition }}_screenshots
           path: screenshots
@@ -159,12 +159,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: mbs_checkout
 
       - name: Restore musicbrainz-tests image from cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: /tmp/musicbrainz-tests.tar
           key: musicbrainz-tests-image-${{ env.TESTS_IMAGE_TAG }}
@@ -180,7 +180,7 @@ jobs:
 
           docker exec "$CONTAINER_NAME" sh -c 'cd /home/musicbrainz/musicbrainz-server; chown -R musicbrainz:musicbrainz .'
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: "*_nyc_output"
         id: nyc_download
@@ -199,19 +199,19 @@ jobs:
         id: nyc_merge
 
       - if: steps.nyc_merge.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage_report
           path: coverage
 
       - if: always()
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: "*_junit_output"
         id: junit_download
 
       - if: steps.junit_download.outcome == 'success'
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@v6
         with:
           report_paths: '*_junit_output/*.xml'
           annotate_only: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,23 +23,25 @@ jobs:
     steps:
       - name: Check the cache for musicbrainz-tests-image
         id: tests-image-cache-check
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/musicbrainz-tests.tar
           key: musicbrainz-tests-image-${{ env.TESTS_IMAGE_TAG }}
           lookup-only: true
 
       - if: steps.tests-image-cache-check.outputs.cache-hit != 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - if: steps.tests-image-cache-check.outputs.cache-hit != 'true'
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - if: steps.tests-image-cache-check.outputs.cache-hit != 'true'
         run: make -C docker config
 
       - if: steps.tests-image-cache-check.outputs.cache-hit != 'true'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           file: docker/Dockerfile.tests
@@ -50,7 +52,7 @@ jobs:
           outputs: type=docker,dest=/tmp/musicbrainz-tests.tar
 
       - if: steps.tests-image-cache-check.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/musicbrainz-tests.tar
           key: musicbrainz-tests-image-${{ env.TESTS_IMAGE_TAG }}
@@ -60,12 +62,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: mbs_checkout
+          persist-credentials: false
 
       - name: Restore musicbrainz-tests image from cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/musicbrainz-tests.tar
           key: musicbrainz-tests-image-${{ env.TESTS_IMAGE_TAG }}
@@ -83,13 +86,13 @@ jobs:
           docker exec "$CONTAINER_NAME" ./docker/musicbrainz-tests/run_js_perl_and_pgtap_tests.sh
 
       - if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: js_nyc_output
           path: nyc_output
 
       - if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: js_perl_and_pgtap_junit_output
           path: junit_output
@@ -103,12 +106,13 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: mbs_checkout
+          persist-credentials: false
 
       - name: Restore musicbrainz-tests image from cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/musicbrainz-tests.tar
           key: musicbrainz-tests-image-${{ env.TESTS_IMAGE_TAG }}
@@ -129,25 +133,25 @@ jobs:
             ./docker/musicbrainz-tests/run_selenium_tests.sh
 
       - if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: selenium_${{ matrix.partition }}_service_logs
           path: service_logs
 
       - if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: selenium_${{ matrix.partition }}_nyc_output
           path: nyc_output
 
       - if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: selenium_${{ matrix.partition }}_junit_output
           path: junit_output
 
       - if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: selenium_${{ matrix.partition }}_screenshots
           path: screenshots
@@ -159,12 +163,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: mbs_checkout
+          persist-credentials: false
 
       - name: Restore musicbrainz-tests image from cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/musicbrainz-tests.tar
           key: musicbrainz-tests-image-${{ env.TESTS_IMAGE_TAG }}
@@ -180,7 +185,7 @@ jobs:
 
           docker exec "$CONTAINER_NAME" sh -c 'cd /home/musicbrainz/musicbrainz-server; chown -R musicbrainz:musicbrainz .'
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: "*_nyc_output"
         id: nyc_download
@@ -199,19 +204,19 @@ jobs:
         id: nyc_merge
 
       - if: steps.nyc_merge.outcome == 'success'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage_report
           path: coverage
 
       - if: always()
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: "*_junit_output"
         id: junit_download
 
       - if: steps.junit_download.outcome == 'success'
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
         with:
           report_paths: '*_junit_output/*.xml'
           annotate_only: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
       - translations
   workflow_dispatch:
 
+permissions: {}
+
 env:
   MTCAPTCHA_PUBLIC_KEY: ${{ secrets.MTCAPTCHA_PUBLIC_KEY }}
   MTCAPTCHA_PRIVATE_KEY: ${{ secrets.MTCAPTCHA_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           CONTAINER_NAME=mbtest-js-perl-and-pgtap
 
-          ./mbs_checkout/docker/musicbrainz-tests/run_tests_container.sh "$CONTAINER_NAME" "${{ env.TESTS_IMAGE_TAG }}"
+          ./mbs_checkout/docker/musicbrainz-tests/run_tests_container.sh "$CONTAINER_NAME" "${TESTS_IMAGE_TAG}"
 
           docker exec "$CONTAINER_NAME" ./docker/musicbrainz-tests/initialize_tests_image.sh
           docker exec "$CONTAINER_NAME" ./docker/musicbrainz-tests/run_js_perl_and_pgtap_tests.sh
@@ -124,15 +124,17 @@ jobs:
 
       - name: Run tests container
         run: |
-          CONTAINER_NAME=mbtest-selenium-${{ matrix.partition }}
+          CONTAINER_NAME="mbtest-selenium-${PARTITION}"
 
-          ./mbs_checkout/docker/musicbrainz-tests/run_tests_container.sh "$CONTAINER_NAME" "${{ env.TESTS_IMAGE_TAG }}"
+          ./mbs_checkout/docker/musicbrainz-tests/run_tests_container.sh "$CONTAINER_NAME" "${TESTS_IMAGE_TAG}"
 
           docker exec "$CONTAINER_NAME" ./docker/musicbrainz-tests/initialize_tests_image.sh
           docker exec \
-            --env SELENIUM_JS_OPTIONS='--run-partition ${{ matrix.partition }}/4' \
+            --env SELENIUM_JS_OPTIONS="--run-partition ${PARTITION}/4" \
             "$CONTAINER_NAME" \
             ./docker/musicbrainz-tests/run_selenium_tests.sh
+        env:
+          PARTITION: ${{ matrix.partition }}
 
       - if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -183,7 +185,7 @@ jobs:
         run: |
           CONTAINER_NAME=mbtest-generate-reports
 
-          ./mbs_checkout/docker/musicbrainz-tests/run_tests_container.sh "$CONTAINER_NAME" "${{ env.TESTS_IMAGE_TAG }}"
+          ./mbs_checkout/docker/musicbrainz-tests/run_tests_container.sh "$CONTAINER_NAME" "${TESTS_IMAGE_TAG}"
 
           docker exec "$CONTAINER_NAME" sh -c 'cd /home/musicbrainz/musicbrainz-server; chown -R musicbrainz:musicbrainz .'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,25 +25,25 @@ jobs:
     steps:
       - name: Check the cache for musicbrainz-tests-image
         id: tests-image-cache-check
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/musicbrainz-tests.tar
           key: musicbrainz-tests-image-${{ env.TESTS_IMAGE_TAG }}
           lookup-only: true
 
       - if: steps.tests-image-cache-check.outputs.cache-hit != 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - if: steps.tests-image-cache-check.outputs.cache-hit != 'true'
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - if: steps.tests-image-cache-check.outputs.cache-hit != 'true'
         run: make -C docker config
 
       - if: steps.tests-image-cache-check.outputs.cache-hit != 'true'
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: docker/Dockerfile.tests
@@ -54,7 +54,7 @@ jobs:
           outputs: type=docker,dest=/tmp/musicbrainz-tests.tar
 
       - if: steps.tests-image-cache-check.outputs.cache-hit != 'true'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/musicbrainz-tests.tar
           key: musicbrainz-tests-image-${{ env.TESTS_IMAGE_TAG }}
@@ -64,13 +64,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: mbs_checkout
           persist-credentials: false
 
       - name: Restore musicbrainz-tests image from cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/musicbrainz-tests.tar
           key: musicbrainz-tests-image-${{ env.TESTS_IMAGE_TAG }}
@@ -88,13 +88,13 @@ jobs:
           docker exec "$CONTAINER_NAME" ./docker/musicbrainz-tests/run_js_perl_and_pgtap_tests.sh
 
       - if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: js_nyc_output
           path: nyc_output
 
       - if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: js_perl_and_pgtap_junit_output
           path: junit_output
@@ -108,13 +108,13 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: mbs_checkout
           persist-credentials: false
 
       - name: Restore musicbrainz-tests image from cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/musicbrainz-tests.tar
           key: musicbrainz-tests-image-${{ env.TESTS_IMAGE_TAG }}
@@ -135,25 +135,25 @@ jobs:
             ./docker/musicbrainz-tests/run_selenium_tests.sh
 
       - if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: selenium_${{ matrix.partition }}_service_logs
           path: service_logs
 
       - if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: selenium_${{ matrix.partition }}_nyc_output
           path: nyc_output
 
       - if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: selenium_${{ matrix.partition }}_junit_output
           path: junit_output
 
       - if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: selenium_${{ matrix.partition }}_screenshots
           path: screenshots
@@ -165,13 +165,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: mbs_checkout
           persist-credentials: false
 
       - name: Restore musicbrainz-tests image from cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/musicbrainz-tests.tar
           key: musicbrainz-tests-image-${{ env.TESTS_IMAGE_TAG }}
@@ -187,7 +187,7 @@ jobs:
 
           docker exec "$CONTAINER_NAME" sh -c 'cd /home/musicbrainz/musicbrainz-server; chown -R musicbrainz:musicbrainz .'
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: "*_nyc_output"
         id: nyc_download
@@ -206,19 +206,19 @@ jobs:
         id: nyc_merge
 
       - if: steps.nyc_merge.outcome == 'success'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage_report
           path: coverage
 
       - if: always()
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: "*_junit_output"
         id: junit_download
 
       - if: steps.junit_download.outcome == 'success'
-        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
         with:
           report_paths: '*_junit_output/*.xml'
           annotate_only: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,9 +2,13 @@ name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
   push:
-    branches: ["main"]
+    branches: ["master"]
+    paths:
+      - '.github/**'
   pull_request:
     branches: ["**"]
+    paths:
+      - '.github/**'
 
 permissions: {}
 


### PR DESCRIPTION
# Problem

GitHub Actions and their misconfigurations are often a target for threat actors due to a number of security pitfalls, some of which GitHub is aware of and provides best practice guidance for, others are inherent to the architecture of GitHub Actions.

In addition, most if not all of our action `uses` pointed at outdated versions. (Most if not all of the annotations on any given workflow run were due to Node runtime deprecations, for example.)

# Solution

In each commit, this PR introduces a new set of improvements to our GitHub Actions configurations:

- Bump major versions of actions where available (among other things, this fixes the deprecation warnings described above)
- Apply auto-fixes identified by [zizmor](https://zizmor.sh/), a powerful static analysis tool for GitHub Actions (most of the fixes are action version pins, but one disables credential persistence; the latter can be explicitly added back if we figure out we really need it)
- Remediates another set of zizmor findings by disabling all permissions by default at the workflow level (if we find we need them for specific jobs, we can add them back at the per-job level)
- Adds a new workflow designed to run zizmor and report back findings

# AI usage

Zilch

# Testing

Ran zizmor locally without applying auto-fixes to see what it would find, then applied auto-fixes and manual fixes after that.


# Further action

The zizmor-based fixes here are based on the default ["persona"](https://docs.zizmor.sh/usage/#using-personas). There are more findings in this repo emitted under stricter personas that are probably worth at least glancing at if not also remediating, but I wanted to at least give default-persona changes a go to see if, e.g., we need to add back credential persistence or job-level permissions before going stricter.