### PR TITLE
MBS-14353: Clean up UTM parameters from Yandex Music links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -7466,7 +7466,7 @@ export const CLEANUPS: CleanupEntries = {
     match: [/^(https?:\/\/)?music\.yandex\.(?:com|by|kz|ru|uz)\/(?!video)/i],
     restrict: [LINK_TYPES.streamingfree],
     clean(url) {
-      url = url.replace(/^https?:\/\/music\.yandex\.(?:com|by|kz|ru|uz)\//, 'https://music.yandex.com/');
+      url = url.replace(/^https?:\/\/music\.yandex\.(?:com|by|kz|ru|uz)\/([^?]+).*$/, 'https://music.yandex.com/$1');
       url = url.replace(/^https:\/\/music\.yandex\.com\/(?:#!\/)?(album|artist|label)\/(\d+)(\/track\/\d+)?$/, 'https://music.yandex.com/$1/$2$3');
       url = url.replace(/^https:\/\/music\.yandex\.com\/iframe\/#album?\/(\d+)$/, 'https://music.yandex.com/album/$1');
       url = url.replace(/^https:\/\/music\.yandex\.com\/iframe\/#track?\/(\d+):(\d+)$/, 'https://music.yandex.com/album/$2/track/$1');

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -7641,6 +7641,13 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['release'],
   },
   {
+                     input_url: 'https://music.yandex.ru/album/45182?utm_source=web&utm_medium=copy_link',
+             input_entity_type: 'release',
+    expected_relationship_type: 'streamingfree',
+            expected_clean_url: 'https://music.yandex.com/album/45182',
+       only_valid_entity_types: ['release'],
+  },
+  {
                      input_url: 'https://music.yandex.com/iframe/#album/22248502',
              input_entity_type: 'release',
     expected_relationship_type: 'streamingfree',


### PR DESCRIPTION
### Fix MBS-14353

# Problem
Yandex Music links with UTM parameters were being rejected rather than cleaned (or allowed unchanged). 

# Solution
This more generally cleans up anything after a ? since I expect that should be safe but can be pared down to UTM params specifically if we find a case where that is a problem.

# AI usage
None

# Testing
Added an extra test with the example from the ticket.