### PR TITLE
MBS-14351: Display area label rels under area/labels

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -9,12 +9,13 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
     relationships   => {
         cardinal    => ['edit'],
         subset      => {
-            show => [qw( area artist genre label place series instrument release_group url )],
+            show => [qw( area artist genre place series instrument release_group url )],
         },
         subset_cardinal => {
             show => [qw( work )],
         },
         paged_subset => {
+            labels => ['label'],
             recordings => ['recording'],
             releases => ['release'],
             works => ['work'],
@@ -187,22 +188,34 @@ Shows labels for an area.
 sub labels : Chained('load')
 {
     my ($self, $c) = @_;
-    my $labels = $self->_load_paged($c, sub {
-        $c->model('Label')->find_by_area($c->stash->{area}->id, shift, shift);
-    });
-    $c->model('LabelType')->load(@$labels);
-    $c->model('Area')->load(@$labels);
-    $c->model('Area')->load_containment(map { $_->{area} } @$labels);
-    $c->model('Label')->load_aliases(@$labels);
-    $c->model('Label')->load_meta(@$labels);
-    if ($c->user_exists) {
-        $c->model('Label')->rating->load_user_ratings($c->user->id, @$labels);
+
+    my $stash = $c->stash;
+    my $paged_link_type_group = $stash->{paged_link_type_group};
+    my $labels;
+
+    unless ($paged_link_type_group) {
+        $labels = $self->_load_paged($c, sub {
+            $c->model('Label')->find_by_area($stash->{area}->id, shift, shift);
+        });
+        $c->model('LabelType')->load(@$labels);
+        $c->model('Area')->load(@$labels);
+        $c->model('Area')->load_containment(map { $_->{area} } @$labels);
+        $c->model('Label')->load_aliases(@$labels);
+        $c->model('Label')->load_meta(@$labels);
+        if ($c->user_exists) {
+            $c->model('Label')->rating->load_user_ratings($c->user->id, @$labels);
+        }
     }
 
+    my $pager = defined $stash->{pager}
+        ? serialize_pager($stash->{pager})
+        : undef;
+
     my %props = (
-        area         => $c->stash->{area}->TO_JSON,
-        labels       => to_json_array($labels),
-        pager        => serialize_pager($c->stash->{pager}),
+        area => $stash->{area}->TO_JSON,
+        labels => to_json_array($labels),
+        pagedLinkTypeGroup => to_json_object($paged_link_type_group),
+        pager => $pager,
     );
 
     $c->stash(

--- a/root/area/AreaLabels.js
+++ b/root/area/AreaLabels.js
@@ -11,6 +11,8 @@ import * as React from 'react';
 
 import LabelList from '../components/list/LabelList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
+import RelationshipsTable
+  from '../components/RelationshipsTable.js';
 import {SanitizedCatalystContext} from '../context.mjs';
 import manifest from '../static/manifest.mjs';
 import ListMergeButtonsRow
@@ -21,43 +23,57 @@ import AreaLayout from './AreaLayout.js';
 
 component AreaLabels(
   area: AreaT,
-  labels: $ReadOnlyArray<LabelT>,
+  labels: ?ReadonlyArray<LabelT>,
+  pagedLinkTypeGroup: ?PagedLinkTypeGroupT,
   pager: PagerT,
 ) {
   const $c = React.useContext(SanitizedCatalystContext);
   return (
     <AreaLayout entity={area} page="labels" title={l('Labels')}>
-      <h2>{l('Labels')}</h2>
+      {pagedLinkTypeGroup ? null : (
+        <>
+          <h2>{l('Labels')}</h2>
 
-      {labels.length > 0 ? (
-        <form
-          action={'/label/merge_queue?' + returnToCurrentPage($c)}
-          method="post"
-        >
-          <PaginatedResults pager={pager}>
-            <LabelList
-              checkboxes="add-to-merge"
-              labels={labels}
-              showRatings
-            />
-          </PaginatedResults>
-          {$c.user ? (
-            <>
-              <ListMergeButtonsRow
-                label={l('Add selected labels for merging')}
-              />
-              {manifest(
-                'common/components/ListMergeButtonsRow',
-                {async: true},
-              )}
-            </>
-          ) : null}
-        </form>
-      ) : (
-        <p>
-          {l('This area is not currently associated with any labels.')}
-        </p>
+          {labels?.length ? (
+            <form
+              action={'/label/merge_queue?' + returnToCurrentPage($c)}
+              method="post"
+            >
+              <PaginatedResults pager={pager}>
+                <LabelList
+                  checkboxes="add-to-merge"
+                  labels={labels}
+                  showRatings
+                />
+              </PaginatedResults>
+              {$c.user ? (
+                <>
+                  <ListMergeButtonsRow
+                    label={l('Add selected labels for merging')}
+                  />
+                  {manifest(
+                    'common/components/ListMergeButtonsRow',
+                    {async: true},
+                  )}
+                </>
+              ) : null}
+            </form>
+          ) : (
+            <p>
+              {l('This area is not currently associated with any labels.')}
+            </p>
+          )}
+        </>
       )}
+      <RelationshipsTable
+        entity={area}
+        fallbackMessage={l(
+          'This area has no relationships to any labels.',
+        )}
+        heading={l('Relationships')}
+        pagedLinkTypeGroup={pagedLinkTypeGroup}
+        pager={pager}
+      />
       {manifest('common/MB/Control/SelectAll', {async: true})}
       {manifest('common/ratings', {async: true})}
     </AreaLayout>


### PR DESCRIPTION
### Implement MBS-14351

# Description
This moves display of Area-Label relationships from the area overview page to area/labels.
Right now this is only "label is headquartered in area", which is clearly not about the area itself and would seem to be a much better fit in the Labels tab.
More generally I cannot think of any Area-Label rel that would be primarily about the area rather than
the label, so this is probably fairly future-proof (but if needed, we could always load a `subset_cardinal` in `show` if desired later).

# AI usage
None

# Testing
Manually