### PR TITLE
MBS-14346: Allow ra.co 'promoter' labels

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5563,7 +5563,7 @@ export const CLEANUPS: CleanupEntries = {
     }],
     clean(url) {
       url = url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?ra\.co\//, 'https://ra.co/');
-      url = url.replace(/^https:\/\/ra\.co\/(clubs|dj|events|labels|podcast|reviews|tracks)\/([^/?#]+).*$/, 'https://ra.co/$1/$2');
+      url = url.replace(/^https:\/\/ra\.co\/(clubs|dj|events|labels|podcast|promoters|reviews|tracks)\/([^/?#]+).*$/, 'https://ra.co/$1/$2');
       return url;
     },
     validate(url, id) {
@@ -5606,7 +5606,7 @@ export const CLEANUPS: CleanupEntries = {
             };
           case LINK_TYPES.otherdatabases.label:
             return {
-              result: prefix === 'labels',
+              result: prefix === 'labels' || prefix === 'promoters',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.place:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5511,6 +5511,13 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['event'],
   },
   {
+                     input_url: 'https://ra.co/promoters/140688/news',
+             input_entity_type: 'label',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://ra.co/promoters/140688',
+       only_valid_entity_types: ['label'],
+  },
+  {
                      input_url: 'http://es.ra.co/labels/2795',
              input_entity_type: 'label',
     expected_relationship_type: 'otherdatabases',


### PR DESCRIPTION
### Implement

# Description
Event promoters can be stored in MusicBrainz as labels, but we were not allowing RA `/promoters` links at all. This allows them as label links.

# AI usage
None

# Testing
Added an entry to the URL tests