### PR TITLE
SampleDataDump: Set `isolation_level` to `SERIALIZABLE READ ONLY DEFERRABLE`

### DIFF
--- a/lib/MusicBrainz/Script/SampleDataDump.pm
+++ b/lib/MusicBrainz/Script/SampleDataDump.pm
@@ -154,7 +154,7 @@ sub run {
         c => $c,
         compression => 'xz',
         output_dir => $self->output_dir,
-        isolation_level => 'READ COMMITTED',
+        isolation_level => 'SERIALIZABLE READ ONLY DEFERRABLE',
     );
     $mbdump_handle = $mbdump;
     $sample_dump = $self;


### PR DESCRIPTION
# Problem

We recently published a un-importable sample data dump which contained invalid foreign key references. This is because `READ COMMITTED` allows nonrepeatable and phantom reads. [1]

# Solution

This switches it to use `SERIALIZABLE` (as our full dumps use), plus `READ ONLY DEFERRABLE`, which ensures it can't conflict with any other `SERIALIZABLE` transaction. [2]

# AI usage

none

# Testing

This was tested in the production-cron container already in order to produce https://ftp.musicbrainz.org/pub/musicbrainz/data/sample/20260512-010948/.

# References

[1] https://www.postgresql.org/docs/current/transaction-iso.html
[2] https://www.postgresql.org/docs/current/sql-set-transaction.html
