### PR TITLE
ci: add Dependabot config for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
# Problem
Since we pin our CI actions to very specific versions as of #3777, we need to make sure to keep them up to date.

# Solution
This PR adds a Dependabot configuration to help keep our CI actions up to date.

To maintain stability and significantly reduce risk of supply-chain compromise, Dependabot is configured with a 7-day minimum cooldown. See zizmor's [dependabot-cooldown](https://docs.zizmor.sh/audits/#dependabot-cooldown) audit rule description for more information.

# AI usage
None

# Testing
Validated config file schema against docs; local copy of zizmor also found and warned about lack of cooldown config when it wasn't yet written.
