### PR TITLE
Update Flow to 0.314.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -21,7 +21,6 @@ unused-promise=error
 
 [options]
 autoimports=true
-exact_by_default=true
 format.bracket_spacing=false
 format.single_quotes=true
 module.name_mapper.extension='less' -> '<PROJECT_ROOT>/root/lessstub.js.flow'

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "7.0.1",
     "eslint-plugin-simple-import-sort": "^7.0.0",
-    "flow-bin": "0.313.0",
+    "flow-bin": "0.314.0",
     "flow-typed": "4.1.1",
     "gettext-parser": "4.2.0",
     "globals": "17.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5461,12 +5461,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-bin@npm:0.313.0":
-  version: 0.313.0
-  resolution: "flow-bin@npm:0.313.0"
+"flow-bin@npm:0.314.0":
+  version: 0.314.0
+  resolution: "flow-bin@npm:0.314.0"
   bin:
     flow: cli.js
-  checksum: 10c0/6315b8f4b161cbf7a0bf079402a210a3810ef60986e2200e58231ff80a3d3020275c51d1727a73d28dbdf74047e50847af230c20d7986175293012226dfc982b
+  checksum: 10c0/7050ec0f89fd02af8dda3cd606aeb904c70ddb042615f73b709dfc21b8d1292c592ad8dbbb7d7bb2e617d6058b7fecc42e8cbee8a19fb0fa4aeca4c8e8833bd2
   languageName: node
   linkType: hard
 
@@ -7842,7 +7842,7 @@ __metadata:
     eslint-plugin-simple-import-sort: "npm:^7.0.0"
     fast-diff: "npm:1.3.0"
     filesize: "npm:10.1.6"
-    flow-bin: "npm:0.313.0"
+    flow-bin: "npm:0.314.0"
     flow-typed: "npm:4.1.1"
     generic-diff: "npm:1.0.1"
     gettext-parser: "npm:4.2.0"


### PR DESCRIPTION
https://github.com/facebook/flow/releases/tag/v0.314.0

No errors.

`exact_by_default=true` is the default and `false` deprecated, so we can drop it from `.flowconfig`.
