### PR TITLE
MBS-9209, MBS-14360, MBS-14361: Digest auth changes

### DIFF
--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -420,6 +420,7 @@ Readonly our $ADDING_NOTES_DISABLED_FLAG    => 2048;
 Readonly our $SPAMMER_FLAG                  => 4096;
 Readonly our $BEGINNER_FLAG                 => 8192;
 Readonly our $VOTING_DISABLED_FLAG          => 16384;
+Readonly our $DIGEST_AUTH_TOKEN_FLAG        => 32768;
 # If you update this, also update root/utility/sanitizedEditor.js
 Readonly our $PUBLIC_PRIVILEGE_FLAGS        => $AUTO_EDITOR_FLAG |
                                                $BOT_FLAG |

--- a/lib/MusicBrainz/Server/Controller/Account.pm
+++ b/lib/MusicBrainz/Server/Controller/Account.pm
@@ -16,6 +16,7 @@ use MusicBrainz::Server::ControllerUtils::JSON qw( serialize_pager );
 use MusicBrainz::Server::Data::Utils qw(
     boolean_to_json
     contains_string
+    is_blank
     non_empty
 );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
@@ -854,7 +855,7 @@ sub donation : Local RequireAuth HiddenOnMirrors
     );
 }
 
-sub applications : Path('/account/applications') RequireAuth RequireSSL
+sub applications : Path('/account/applications') RequireAuth RequireSSL SecureForm
 {
     my ($self, $c) = @_;
 
@@ -869,12 +870,17 @@ sub applications : Path('/account/applications') RequireAuth RequireSSL
         return ($applications, $hits);
     }, prefix => 'apps_');
 
+    my $digest_auth_form = $c->form( form => 'Account::DigestAuthentication' );
+    my $is_digest_auth_enabled = !is_blank($c->user->ha1);
+
     $c->stash(
         current_view => 'Node',
         component_path => 'account/applications/ApplicationList',
         component_props => {
             applications => to_json_array($applications),
             appsPager => serialize_pager($c->stash->{apps_pager}),
+            digestAuthForm => $digest_auth_form->TO_JSON,
+            isDigestAuthEnabled => boolean_to_json($is_digest_auth_enabled),
             tokens => to_json_array($tokens),
             tokensPager => serialize_pager($c->stash->{tokens_pager}),
         },
@@ -1016,6 +1022,44 @@ sub remove_application : Path('/account/applications/remove') Args(1) RequireAut
         );
         $c->detach;
     }
+}
+
+=head2 digest_authentication
+
+This form allows users to reset the token used for digest auth in the
+web service, or disable digest auth entirely.
+
+=cut
+
+sub digest_authentication : Path('/account/digest-authentication') RequireAuth RequireSSL DenyWhenReadonly SecureForm
+{
+    my ($self, $c) = @_;
+
+    my $form = $c->form( form => 'Account::DigestAuthentication' );
+    my %component_props;
+
+    if ($c->form_posted_and_valid($form)) {
+        my $action = $form->field('action')->value;
+
+        if ($action eq 'disable') {
+            $c->model('MB')->with_transaction(sub {
+                $c->model('Editor')->disable_digest_auth_token($c->user->id);
+            });
+        } elsif ($action eq 'reset_token') {
+            $c->model('MB')->with_transaction(sub {
+                my $new_token = $c->model('Editor')->reset_digest_auth_token($c->user->id);
+                $component_props{token} = $new_token;
+            });
+        }
+    }
+
+    $component_props{form} = $form->TO_JSON;
+
+    $c->stash(
+        current_view => 'Node',
+        component_path => 'account/DigestAuthentication.js',
+        component_props => \%component_props,
+    );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -12,6 +12,7 @@ use DateTime;
 use DateTime::Format::Pg;
 use Digest::MD5 qw( md5_hex );
 use Encode;
+use Text::Trim qw( trim );
 use MusicBrainz::Server::Constants qw( :edit_status entities_with );
 use MusicBrainz::Server::Entity::Preferences;
 use MusicBrainz::Server::Entity::Editor;
@@ -95,7 +96,9 @@ sub _column_mapping
         gender_id               => 'gender',
         area_id                 => 'area',
         birth_date              => 'birth_date',
-        ha1                     => 'ha1',
+                                   # The `ha1` column is `CHAR(32)`, so an empty value will consist of 32 spaces.
+                                   # Trim blank values so that they're stored as '' on the instance.
+        ha1                     => sub { my ($row, $prefix) = @_; return trim($row->{ $prefix . 'ha1' }); },
         deleted                 => 'deleted',
     };
 }
@@ -358,7 +361,7 @@ sub insert
 
     my $plaintext = $data->{password};
     $data->{password} = hash_password($plaintext);
-    $data->{ha1} = ha1_password($data->{name}, $plaintext);
+    $data->{ha1} = '';
 
     return Sql::run_in_transaction(sub {
         return $self->_entity_class->new(
@@ -366,7 +369,7 @@ sub insert
             name => $data->{name},
             password => $data->{password},
             privs => $data->{privs} // 0,
-            ha1 => $data->{ha1},
+            ha1 => '',
             registration_date => DateTime->now,
         );
     }, $self->sql);
@@ -415,9 +418,9 @@ sub update_password
     my ($self, $editor_name, $password) = @_;
 
     Sql::run_in_transaction(sub {
-        $self->sql->do(<<~'SQL', hash_password($password), $password, $editor_name);
+        $self->sql->do(<<~'SQL', hash_password($password), $editor_name);
             UPDATE editor
-            SET password = ?, ha1 = md5(name || ':musicbrainz.org:' || ?), 
+            SET password = ?,
                 last_login_date = now()
             WHERE lower(name) = lower(?)
             SQL

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -12,7 +12,18 @@ use DateTime;
 use DateTime::Format::Pg;
 use Encode;
 use Text::Trim qw( trim );
-use MusicBrainz::Server::Constants qw( :edit_status entities_with );
+use MusicBrainz::Server::Constants qw(
+    :create_entity
+    :edit_status
+    :privileges
+    :vote
+    %ENTITIES
+    $EDIT_EVENT_ADD_EVENT_ART
+    $EDIT_HISTORIC_ADD_RELEASE
+    $EDIT_RELEASE_ADD_COVER_ART
+    $PASSPHRASE_BCRYPT_COST
+    entities_with
+);
 use MusicBrainz::Server::Entity::Preferences;
 use MusicBrainz::Server::Entity::Editor;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
@@ -23,17 +34,6 @@ use MusicBrainz::Server::Data::Utils qw(
     load_subobjects
     placeholders
     sanitize_username
-);
-use MusicBrainz::Server::Constants qw(
-    :create_entity
-    :edit_status
-    :privileges
-    :vote
-    %ENTITIES
-    $EDIT_HISTORIC_ADD_RELEASE
-    $EDIT_RELEASE_ADD_COVER_ART
-    $EDIT_EVENT_ADD_EVENT_ART
-    $PASSPHRASE_BCRYPT_COST
 );
 
 extends 'MusicBrainz::Server::Data::Entity';

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -10,7 +10,6 @@ use Authen::Passphrase::BlowfishCrypt;
 use Authen::Passphrase::RejectAll;
 use DateTime;
 use DateTime::Format::Pg;
-use Digest::MD5 qw( md5_hex );
 use Encode;
 use Text::Trim qw( trim );
 use MusicBrainz::Server::Constants qw( :edit_status entities_with );
@@ -1059,11 +1058,6 @@ sub hash_password {
         cost => $PASSPHRASE_BCRYPT_COST,
         passphrase => encode('utf-8', $password),
     )->as_rfc2307;
-}
-
-sub ha1_password {
-    my ($username, $password) = @_;
-    return md5_hex(join(':', encode('utf-8', $username), 'musicbrainz.org', encode('utf-8', $password)));
 }
 
 sub consume_remember_me_token {

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -18,6 +18,7 @@ use MusicBrainz::Server::Entity::Editor;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 use MusicBrainz::Server::Data::Utils qw(
     generate_token
+    ha1_password
     hash_to_row
     load_subobjects
     placeholders
@@ -430,6 +431,20 @@ sub disable_digest_auth_token {
     my ($self, $editor_id) = @_;
 
     $self->sql->do(q(UPDATE editor SET ha1 = '' WHERE id = ?), $editor_id);
+}
+
+sub reset_digest_auth_token {
+    my ($self, $editor_id) = @_;
+
+    my $username = $self->sql->select_single_value(<<~'SQL', $editor_id);
+        SELECT name FROM editor WHERE id = ?
+        SQL
+    my $token = generate_token();
+    my $ha1 = ha1_password($username, $token);
+    $self->sql->do(<<~'SQL', $ha1, $editor_id);
+        UPDATE editor SET ha1 = ? WHERE id = ?
+        SQL
+    return $token;
 }
 
 sub update_profile

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -18,6 +18,7 @@ use MusicBrainz::Server::Constants qw(
     :privileges
     :vote
     %ENTITIES
+    $DIGEST_AUTH_TOKEN_FLAG
     $EDIT_EVENT_ADD_EVENT_ART
     $EDIT_HISTORIC_ADD_RELEASE
     $EDIT_RELEASE_ADD_COVER_ART
@@ -441,8 +442,11 @@ sub reset_digest_auth_token {
         SQL
     my $token = generate_token();
     my $ha1 = ha1_password($username, $token);
-    $self->sql->do(<<~'SQL', $ha1, $editor_id);
-        UPDATE editor SET ha1 = ? WHERE id = ?
+    $self->sql->do(<<~'SQL', $ha1, $DIGEST_AUTH_TOKEN_FLAG, $editor_id);
+        UPDATE editor
+           SET ha1 = ?,
+               privs = privs | ?
+         WHERE id = ?
         SQL
     return $token;
 }

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -12,6 +12,8 @@ use Class::MOP;
 use Clone qw( clone );
 use Data::Compare;
 use Data::UUID::MT;
+use Digest::MD5 qw( md5_hex );
+use Encode;
 use Math::Random::Secure qw( irand );
 use MIME::Base64 qw( encode_base64url );
 use JSON::XS;
@@ -48,6 +50,7 @@ our @EXPORT_OK = qw(
     generate_gid
     generate_token
     get_area_containment_join
+    ha1_password
     hash_structure
     hash_to_row
     is_blank
@@ -299,6 +302,11 @@ sub get_area_containment_join {
              ORDER BY descendant, parent, depth
         )
         SQL
+}
+
+sub ha1_password {
+    my ($username, $password) = @_;
+    return md5_hex(join(':', encode('utf-8', $username), 'musicbrainz.org', encode('utf-8', $password)));
 }
 
 sub hash_to_row

--- a/lib/MusicBrainz/Server/Form/Account/DigestAuthentication.pm
+++ b/lib/MusicBrainz/Server/Form/Account/DigestAuthentication.pm
@@ -1,0 +1,36 @@
+package MusicBrainz::Server::Form::Account::DigestAuthentication;
+
+use strict;
+use warnings;
+
+use HTML::FormHandler::Moose;
+
+extends 'MusicBrainz::Server::Form';
+
+with 'MusicBrainz::Server::Form::Role::CSRFToken';
+
+has '+name' => ( default => 'digestauth' );
+
+has_field 'action' => (
+    type => 'Select',
+    required => 1,
+);
+
+sub options_action {
+    return [
+        'disable' => 'disable',
+        'reset_token' => 'reset_token',
+    ];
+}
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2026 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/root/account/DigestAuthentication.js
+++ b/root/account/DigestAuthentication.js
@@ -1,0 +1,62 @@
+/*
+ * @flow strict
+ * Copyright (C) 2026 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import Layout from '../layout/index.js';
+import FieldErrors from '../static/scripts/edit/components/FieldErrors.js';
+
+component DigestAuthentication(
+  form: DigestAuthFormT,
+  token?: string,
+) {
+  const action = form.field.action.value;
+
+  return (
+    <Layout fullWidth title={lp('Digest access authentication', 'header')}>
+      <h1>{lp('Digest access authentication', 'header')}</h1>
+
+        {form.has_errors ? (
+          <FieldErrors field={form} />
+        ) : action === 'disable' ? (
+          <p>
+            {exp.l(`Digest authentication is
+                    <strong>disabled</strong> on your account.`)}
+          </p>
+        ) : action === 'reset_token' ? (
+          <>
+            <p>
+              {exp.l(
+                `Your new digest authentication token is below.
+                 Use this in place of your MusicBrainz account password in
+                 applications that require it.
+                 You cannot retrieve this token again after closing the page;
+                 if it’s lost, you can reset it from
+                 {applications_url|Applications}.`,
+                {applications_url: '/account/applications'},
+              )}
+            </p>
+            <p>
+              <code>{token}</code>
+            </p>
+          </>
+        ) : null}
+
+        <p>
+          {exp.lp(
+            '{applications_url|Back to Applications}.',
+            'interactive',
+            {applications_url: '/account/applications'},
+          )}
+        </p>
+    </Layout>
+  );
+}
+
+export default DigestAuthentication;

--- a/root/account/applications/ApplicationList.js
+++ b/root/account/applications/ApplicationList.js
@@ -16,6 +16,8 @@ import Layout from '../../layout/index.js';
 import {compare} from '../../static/scripts/common/i18n.js';
 import {commaOnlyListText}
   from '../../static/scripts/common/i18n/commaOnlyList.js';
+import FormCsrfToken
+  from '../../static/scripts/edit/components/FormCsrfToken.js';
 import formatUserDate from '../../utility/formatUserDate.js';
 import loopParity from '../../utility/loopParity.js';
 
@@ -78,6 +80,8 @@ function formatScopes(token: EditorOAuthTokenT) {
 component ApplicationList(
   applications: ReadonlyArray<ApplicationT>,
   appsPager: PagerT,
+  digestAuthForm: DigestAuthFormT,
+  isDigestAuthEnabled: boolean,
   tokens: ReadonlyArray<EditorOAuthTokenT>,
   tokensPager: PagerT,
 ) {
@@ -159,6 +163,75 @@ component ApplicationList(
         ) : (
           <p>{l('You do not have any registered applications.')}</p>
         )}
+
+      <h2>{l('Digest access authentication')}</h2>
+
+      <p>
+        {exp.l(
+          `Some applications use a legacy form of authentication
+           called {digest_url|HTTP Digest Access Authentication}.
+           This requires us to store a password using an
+           {md5_url|insecure hash function}.
+           Rather than storing your MusicBrainz account password this way,
+           we require generating a separate token if you want to use such an
+           application; use this token in place of your password when
+           the application asks for one.`,
+          {
+            digest_url:
+              'https://en.wikipedia.org/wiki/Digest_access_authentication',
+            md5_url: 'https://en.wikipedia.org/wiki/MD5',
+          },
+        )}
+      </p>
+      <p>
+        {l(
+          `We don’t track which applications are using digest authentication.
+           You can choose to either reset the token,
+           or disable this access method entirely.`,
+        )}
+      </p>
+      <p>
+        {isDigestAuthEnabled
+          ? exp.l(`Digest authentication is
+                  <strong>enabled</strong> on your account.`)
+          : exp.l(`Digest authentication is
+                   <strong>disabled</strong> on your account.`)}
+      </p>
+
+      <p>
+        <form action="/account/digest-authentication" method="post">
+          <FormCsrfToken form={digestAuthForm} />
+          {isDigestAuthEnabled ? (
+            <>
+              <button
+                className="styled-button"
+                name="digestauth.action"
+                type="submit"
+                value="disable"
+              >
+                {l('Disable digest authentication')}
+              </button>
+              <button
+                className="styled-button"
+                name="digestauth.action"
+                type="submit"
+                value="reset_token"
+              >
+                {l('Reset the digest authentication token')}
+              </button>
+            </>
+          ) : (
+            <button
+              className="styled-button"
+              name="digestauth.action"
+              type="submit"
+              value="reset_token"
+            >
+              {l('Enable digest authentication')}
+            </button>
+          )}
+        </form>
+      </p>
     </Layout>
   );
 }

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -27,6 +27,7 @@ export default {
   'account/applications/RevokeApplicationAccess': (): Promise<unknown> => import('../account/applications/RevokeApplicationAccess.js'),
   'account/ChangePassword': (): Promise<unknown> => import('../account/ChangePassword.js'),
   'account/DeleteOwnAccount': (): Promise<unknown> => import('../account/DeleteOwnAccount.js'),
+  'account/DigestAuthentication': (): Promise<unknown> => import('../account/DigestAuthentication.js'),
   'account/Donation': (): Promise<unknown> => import('../account/Donation.js'),
   'account/EditProfile': (): Promise<unknown> => import('../account/EditProfile.js'),
   'account/EmailVerificationStatus': (): Promise<unknown> => import('../account/EmailVerificationStatus.js'),

--- a/root/static/scripts/edit/components/FieldErrors.js
+++ b/root/static/scripts/edit/components/FieldErrors.js
@@ -41,7 +41,7 @@ export component FieldErrorsList(
 }
 
 component FieldErrors(
-  field: AnyFieldT,
+  field: FormOrAnyFieldT,
   hasHtmlErrors: boolean = false,
   includeSubFields: boolean = true,
  ) {

--- a/root/types/forms.js
+++ b/root/types/forms.js
@@ -16,6 +16,11 @@ declare type ConfirmFormT = FormT<{
   readonly submit: FieldT<string>,
 }>;
 
+declare type DigestAuthFormT = FormT<{
+  readonly action: FieldT<string>,
+  readonly csrf_token: FieldT<string>,
+}>;
+
 declare type TextListItemFieldT = CompoundFieldT<{
   readonly removed: FieldT<boolean>,
   readonly value: FieldT<string>,

--- a/t/lib/t/MusicBrainz/Server/Authentication/WS.pm
+++ b/t/lib/t/MusicBrainz/Server/Authentication/WS.pm
@@ -123,6 +123,14 @@ test 'Digest authentication' => sub {
     $mech->credentials('localhost:80', 'musicbrainz.org', $username_utf8, ' ' x 32);
     $mech->get($path);
     is($mech->status, HTTP_UNAUTHORIZED, 'Blank password is rejected after disabling digest auth');
+
+    my $token = $c->model('Editor')->reset_digest_auth_token($editor->id);
+    $mech->credentials('localhost:80', 'musicbrainz.org', $username_utf8, $token);
+    $mech->get_ok($path, 'New digest auth token is accepted');
+
+    $mech->credentials('localhost:80', 'musicbrainz.org', $username_utf8, 'pass');
+    $mech->get($path);
+    is($mech->status, HTTP_UNAUTHORIZED, 'Account password is rejected after setting new digest auth token');
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -61,6 +61,7 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   'Controller::Account::applications',
   'Controller::Account::change_password',
   'Controller::Account::delete',
+  'Controller::Account::digest_authentication',
   'Controller::Account::donation',
   'Controller::Account::edit',
   'Controller::Account::edit_application',

--- a/t/lib/t/MusicBrainz/Server/Data/Editor.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Editor.pm
@@ -23,7 +23,6 @@ use MusicBrainz::Server::Constants qw(
 use MusicBrainz::Server::Context;
 use Set::Scalar;
 use Sql;
-use Digest::MD5 qw( md5_hex );
 use t::Util::Moose::Attribute qw( object_attributes attribute_value_is );
 
 BEGIN { use MusicBrainz::Server::Data::Editor; }
@@ -119,8 +118,8 @@ test 'Creating a new editor' => sub {
     );
     is(
         $editor->ha1,
-        md5_hex(join(':', $editor->name, 'musicbrainz.org', 'password')),
-        'The ha1 for the new editor was generated correctly',
+        '',
+        'The ha1 for the new editor is empty',
     );
 
     my $now = DateTime::Format::Pg->parse_datetime(

--- a/t/lib/t/MusicBrainz/Server/Data/Editor.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Editor.pm
@@ -13,6 +13,7 @@ use DateTime;
 use DateTime::Format::Pg;
 use MusicBrainz::Server::Constants qw(
     :edit_status
+    $DIGEST_AUTH_TOKEN_FLAG
     $EDIT_SERIES_CREATE
     $EDIT_ARTIST_EDIT
     $EDIT_RELATIONSHIP_CREATE
@@ -982,11 +983,23 @@ test 'Test reset_digest_auth_token' => sub {
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+oauth');
 
+    my $editor = $c->model('Editor')->get_by_id(14);
+    is(
+        $editor->privileges & $DIGEST_AUTH_TOKEN_FLAG,
+        0,
+        'The digest auth token flag is unset on the editor',
+    );
+
     my $token = $c->model('Editor')->reset_digest_auth_token(14);
     my $ha1 = ha1_password('æditorⅣ', $token);
 
-    my $editor = $c->model('Editor')->get_by_id(14);
+    $editor = $c->model('Editor')->get_by_id(14);
     is($editor->ha1, $ha1, 'The ha1 is reset');
+    is(
+        $editor->privileges & $DIGEST_AUTH_TOKEN_FLAG,
+        $DIGEST_AUTH_TOKEN_FLAG,
+        'The digest auth token flag is set on the editor',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Data/Editor.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Editor.pm
@@ -21,6 +21,7 @@ use MusicBrainz::Server::Constants qw(
     :vote
 );
 use MusicBrainz::Server::Context;
+use MusicBrainz::Server::Data::Utils qw( ha1_password );
 use Set::Scalar;
 use Sql;
 use t::Util::Moose::Attribute qw( object_attributes attribute_value_is );
@@ -959,6 +960,33 @@ test 'Marking an editor as spammer changes all Yes/No votes on open edits to Abs
     is(scalar @{ $edit->votes }, 2, 'There is two votes');
     is($edit->votes->[1]->vote, $VOTE_ABSTAIN, 'New vote is Abstain');
     is($edit->votes->[1]->editor_id, 2, 'New vote is by editor 2');
+};
+
+test 'Test disable_digest_auth_token' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+oauth');
+
+    my $editor = $c->model('Editor')->get_by_id(14);
+    is($editor->ha1, 'cee82955d47bf0bd71038244579e766f', 'The ha1 is non-empty before disabling');
+
+    $c->model('Editor')->disable_digest_auth_token(14);
+    $editor = $c->model('Editor')->get_by_id(14);
+    is($editor->ha1, '', 'The ha1 is empty after disabling');
+};
+
+test 'Test reset_digest_auth_token' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+oauth');
+
+    my $token = $c->model('Editor')->reset_digest_auth_token(14);
+    my $ha1 = ha1_password('æditorⅣ', $token);
+
+    my $editor = $c->model('Editor')->get_by_id(14);
+    is($editor->ha1, $ha1, 'The ha1 is reset');
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Data/Utils.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Utils.pm
@@ -1,4 +1,5 @@
 package t::MusicBrainz::Server::Data::Utils;
+use utf8;
 use strict;
 use warnings;
 
@@ -11,6 +12,7 @@ use MusicBrainz::Server::Context;
 use MusicBrainz::Server::Data::Utils qw(
     order_by
     generate_gid
+    ha1_password
     is_blank
     take_while
     sanitize
@@ -256,6 +258,10 @@ test 'Test is_blank' => sub {
     ok(is_blank(''), q('' is blank));
     ok(is_blank(' '), q(' ' is blank));
     ok(!is_blank(' x '), q(' x ' is not blank));
+};
+
+test 'Test ha1_password' => sub {
+    is(ha1_password('æditorⅣ', 'pass'), 'cee82955d47bf0bd71038244579e766f');
 };
 
 1;


### PR DESCRIPTION
# Problem

Addresses the following tickets:

MBS-9209 - Allow individual users to opt out of HTTP Digest auth
MBS-14360 - Use a separate password for HTTP Digest authentication
MBS-14361 - Disable HTTP Digest authentication for new accounts

# Solution

More info can be found in the commits.

Note that MBS-14361 only disables it for new accounts by default. New users can still opt-in to generating a digest auth token.

Existing accounts' `ha1` columns are untouched, so their MB account password will continue to work for digest auth; in a blog post we should recommend that they disable it or generate a token instead.

# AI usage

none

# Testing

Tested the new UI on the applications page manually, ensuring digest auth was properly enabled/disabled by fetching `/ws/2/collection` via curl. Added a small number of automated tests, too.

# Documenting

https://wiki.musicbrainz.org/MusicBrainz_API#Authentication should be updated to mention that digest auth is deprecated, and that in order to use it, a token must be generated.

# Further action

Once this is released to production, we should announce the deprecation of digest auth on the blog.