### PR TITLE
MBS-14352: Support @ handles for Youtube Music artists

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -7593,6 +7593,8 @@ export const CLEANUPS: CleanupEntries = {
       url = url.replace(/^(https?:\/\/)?music\.youtube\.com(?:\/#)?/, 'https://music.youtube.com');
       // Channel (artist) URL
       url = url.replace(/\/channel\/([^/?#]+).*$/, '/channel/$1');
+      // YouTube handle
+      url = url.replace(/^https:\/\/music\.youtube\.com\/(@[a-zA-Z0-9_%.-]+).*$/, 'https://music.youtube.com/$1');
       // Video (track) URL
       url = url.replace(/^https:\/\/music\.youtube\.com\/.*[?&](v=[a-zA-Z0-9_-]+).*$/, 'https://music.youtube.com/watch?$1');
       // Playlist (release) URL
@@ -7627,7 +7629,8 @@ export const CLEANUPS: CleanupEntries = {
             };
           }
           return {
-            result: /^https:\/\/music\.youtube\.com\/channel\/[^/?#]+$/.test(url),
+            result: /^https:\/\/music\.youtube\.com\/channel\/[^/?#]+$/.test(url) ||
+                    /^https:\/\/music\.youtube\.com\/@[a-zA-Z0-9_%.-]+$/.test(url),
             target: ERROR_TARGETS.URL,
           };
         case LINK_TYPES.streamingfree.recording:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -7846,6 +7846,13 @@ limited_link_type_combinations: ['streamingfree', 'streamingpaid'],
        only_valid_entity_types: ['artist'],
   },
   {
+                     input_url: 'https://music.youtube.com/@retland?si=XZgqAHnyrtcIGjbN',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'youtubemusic',
+            expected_clean_url: 'https://music.youtube.com/@retland',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'https://music.youtube.com/playlist?list=OLAK5uy_lcx2mROj6Pf7bLJzgYWtl73ILCEKjnrKY&src=Linkfire&lId=c8d7d454-d63c-4bba-a34c-2512e803dadb&cId=d3d58fd7-4c47-11e6-9fd0-066c3e7a8751',
              input_entity_type: 'release',
        input_relationship_type: 'streamingfree',


### PR DESCRIPTION
### Implement MBS-14352

# Description
These are now linked to from within YouTube Music itself so blocking them does not seem like a good idea. YouTube itself already does this for a long time and there we support both types of channel links, so I'm doing the same here (converting from one to the other is not trivial).

For YouTube (https://github.com/metabrainz/musicbrainz-server/pull/2709) we actually display `@whatever` on the sidebar for these handles, but for music streaming pages we generally always just show the "Stream at" link, so for now I did not change that and both styles of link will show as "Stream at YouTube Music".

# AI usage
None

# Testing
Added a test plus did some basic manual checking.