### PR TITLE
MBS-14353 (II): Clean end slashes in Yandex links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -7352,7 +7352,7 @@ export const CLEANUPS: CleanupEntries = {
     restrict: [LINK_TYPES.streamingfree],
     clean(url) {
       url = url.replace(/^https?:\/\/music\.yandex\.(?:com|by|kz|ru|uz)\/([^?]+).*$/, 'https://music.yandex.com/$1');
-      url = url.replace(/^https:\/\/music\.yandex\.com\/(?:#!\/)?(album|artist|label)\/(\d+)(\/track\/\d+)?$/, 'https://music.yandex.com/$1/$2$3');
+      url = url.replace(/^https:\/\/music\.yandex\.com\/(?:#!\/)?(album|artist|label)\/(\d+)(\/track\/\d+)?\/?$/, 'https://music.yandex.com/$1/$2$3');
       url = url.replace(/^https:\/\/music\.yandex\.com\/iframe\/#album?\/(\d+)$/, 'https://music.yandex.com/album/$1');
       url = url.replace(/^https:\/\/music\.yandex\.com\/iframe\/#track?\/(\d+):(\d+)$/, 'https://music.yandex.com/album/$2/track/$1');
       return url;

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -7544,7 +7544,7 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['label'],
   },
   {
-                     input_url: 'https://music.yandex.ru/album/22248502',
+                     input_url: 'https://music.yandex.ru/album/22248502/',
              input_entity_type: 'release',
     expected_relationship_type: 'streamingfree',
             expected_clean_url: 'https://music.yandex.com/album/22248502',


### PR DESCRIPTION
# Description
Small extra amendment for MBS-14353 which also cleans up final slashes when present (requested in the comments of the ticket).

# AI usage
None

# Testing
Amended a test to have an end slash.