### PR TITLE
Reject authentication attempts against empty/blank `ha1` values in production

### DIFF
--- a/lib/MusicBrainz/Server/Authentication/WS/Credential.pm
+++ b/lib/MusicBrainz/Server/Authentication/WS/Credential.pm
@@ -4,10 +4,12 @@ use warnings;
 
 use parent qw/Catalyst::Authentication::Credential::HTTP/;
 
-use DBDefs;
 use Encode qw( decode );
 use HTTP::Status qw( HTTP_BAD_REQUEST );
 use Try::Tiny;
+
+use DBDefs;
+use MusicBrainz::Server::Data::Utils qw( is_blank );
 
 sub authenticate
 {
@@ -30,7 +32,14 @@ sub authenticate
     };
 
     $auth = $self->SUPER::authenticate($c, $realm, $auth_info);
-    if ($auth && ($auth->requires_password_reset || $auth->deleted)) {
+    if (
+        $auth &&
+        (
+            $auth->requires_password_reset ||
+            $auth->deleted ||
+            is_blank($auth->ha1)
+        )
+    ) {
         $self->authentication_failed($c, $realm, $auth_info);
     }
     else {

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -424,6 +424,12 @@ sub update_password
     }, $self->sql);
 }
 
+sub disable_digest_auth_token {
+    my ($self, $editor_id) = @_;
+
+    $self->sql->do(q(UPDATE editor SET ha1 = '' WHERE id = ?), $editor_id);
+}
+
 sub update_profile
 {
     my ($self, $editor, $update) = @_;

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -50,6 +50,7 @@ our @EXPORT_OK = qw(
     get_area_containment_join
     hash_structure
     hash_to_row
+    is_blank
     is_special_artist
     is_special_label
     is_valid_token
@@ -718,6 +719,11 @@ sub merge_date_period {
     merge_partial_date(@args, field => $_)
         for qw( begin_date end_date );
     merge_boolean_attributes(@args, columns => ['ended']);
+}
+
+sub is_blank {
+    my $value = shift;
+    return !non_empty($value) || $value =~ /^\s*$/;
 }
 
 sub is_special_artist {

--- a/t/lib/t/MusicBrainz/Server/Authentication/WS.pm
+++ b/t/lib/t/MusicBrainz/Server/Authentication/WS.pm
@@ -3,6 +3,7 @@ use utf8;
 use strict;
 use warnings;
 
+use Encode qw( encode_utf8 );
 use HTTP::Status qw( :constants );
 use Test::Routine;
 use Test::More;
@@ -14,7 +15,7 @@ with 't::Context', 't::Mechanize';
 
 =head1 DESCRIPTION
 
-This test checks OAuth authentication in the web service, by attempting
+This test checks OAuth/Digest authentication in the web service, by attempting
 to request data for a private collection.
 
 =cut
@@ -86,6 +87,42 @@ test 'Authenticate WS bearer' => sub {
     is($test->mech->status, HTTP_UNAUTHORIZED, 'Expired token is rejected');
     $test->mech->get($path, Authorization => 'Bearer Nlaa7v15QHm9g8rUOmT3dQ');
     is($test->mech->status, HTTP_UNAUTHORIZED, 'Expired bearer is rejected');
+};
+
+test 'Digest authentication' => sub {
+    my $test = shift;
+    my $c = $test->c;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+oauth');
+
+    my $path = '/ws/2/collection/906dddc8-91c8-4a1c-8237-31b6d24c988d';
+    $mech->get($path);
+    is($mech->status, HTTP_UNAUTHORIZED, 'GET with no auth is rejected');
+
+    my $username = 'æditorⅣ';
+    my $username_utf8 = encode_utf8($username);
+    $mech->credentials('localhost:80', 'musicbrainz.org', $username_utf8, 'pass');
+    $mech->get_ok($path, 'Account password is accepted');
+
+    $mech->credentials('localhost:80', 'musicbrainz.org', $username_utf8, 'wrongpass');
+    $mech->get($path);
+    is($mech->status, HTTP_UNAUTHORIZED, 'Wrong account password is rejected');
+
+    my $editor = $c->model('Editor')->get_by_name($username);
+    $c->model('Editor')->disable_digest_auth_token($editor->id);
+    $mech->credentials('localhost:80', 'musicbrainz.org', $username_utf8, 'pass');
+    $mech->get($path);
+    is($mech->status, HTTP_UNAUTHORIZED, 'Account password is rejected after disabling digest auth');
+
+    $mech->credentials('localhost:80', 'musicbrainz.org', $username_utf8, '');
+    $mech->get($path);
+    is($mech->status, HTTP_UNAUTHORIZED, 'Empty password is rejected after disabling digest auth');
+
+    # The `ha1` column is `CHAR(32)`, so an empty value will consist of 32 spaces.
+    $mech->credentials('localhost:80', 'musicbrainz.org', $username_utf8, ' ' x 32);
+    $mech->get($path);
+    is($mech->status, HTTP_UNAUTHORIZED, 'Blank password is rejected after disabling digest auth');
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Data/Utils.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Utils.pm
@@ -11,6 +11,7 @@ use MusicBrainz::Server::Context;
 use MusicBrainz::Server::Data::Utils qw(
     order_by
     generate_gid
+    is_blank
     take_while
     sanitize
     trim
@@ -248,6 +249,13 @@ test 'Test model_to_type' => sub {
 
     is(model_to_type('URL'), 'url',
        'model_to_type of "URL" is "url"');
+};
+
+test 'Test is_blank' => sub {
+    ok(is_blank(undef), 'undef is blank');
+    ok(is_blank(''), q('' is blank));
+    ok(is_blank(' '), q(' ' is blank));
+    ok(!is_blank(' x '), q(' x ' is not blank));
 };
 
 1;

--- a/t/sql/oauth.sql
+++ b/t/sql/oauth.sql
@@ -23,4 +23,5 @@ INSERT INTO editor_oauth_token (editor, application, refresh_token, access_token
            (14, 2, NULL, '8YCRGDkkIooBHeriCgk1d6oUpWJ-XCDd', now() + interval '1 hour', 1);
 
 INSERT INTO editor_collection (gid, editor, name, public, type)
-    VALUES ('181685d4-a23a-4140-a343-b7d15de26ff7', 11, 'editor1''s super secret collection', FALSE, 1);
+    VALUES ('181685d4-a23a-4140-a343-b7d15de26ff7', 11, 'editor1''s super secret collection', FALSE, 1),
+           ('906dddc8-91c8-4a1c-8237-31b6d24c988d', 14, 'æditorⅣ''s super secret collection', FALSE, 1);


### PR DESCRIPTION
# Problem

In #3790, we'll begin setting the `ha1` column to an empty/blank string for new users (MBS-14361) and users who explicitly disable it (MBS-9209). Setting `ha1 = ''` in the database in fact sets it to 32 spaces, since the column is `CHAR(32)`.

`Catalyst::Authentication::Credential::HTTP` has a "feature" where it will either interpret the password field (`ha1` in our case) as either plain-text or `md5(username:realm:password)`, accepting either that works. (I couldn't find this documented and had to read the code to figure it out.) This means blanking `ha1` and then sending 32 spaces as the password would be accepted by the credential verifier.

# Solution

To prevent this, we add an additional check in `Authentication::WS::Credential` that rejects any authentication attempt against a blank `ha1`.

# AI usage

None

# Testing

Added additional automated tests, and manually tested digest auth locally with `curl`.

# Further action

This PR should be deployed to production/beta before #3790. Once merged, 3790 should be rebased.