### PR TITLE
Fix Flow error on updating POT files

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "yargs": "3.10.0"
   },
   "devDependencies": {
-    "@metabrainz/xgettext-js": "5.0.2",
+    "@metabrainz/xgettext-js": "5.0.3",
     "@stylistic/eslint-plugin": "5.10.0",
     "babel-plugin-istanbul": "7.0.1",
     "babel-plugin-syntax-hermes-parser": "0.36.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2180,14 +2180,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metabrainz/xgettext-js@npm:5.0.2":
-  version: 5.0.2
-  resolution: "@metabrainz/xgettext-js@npm:5.0.2"
+"@metabrainz/xgettext-js@npm:5.0.3":
+  version: 5.0.3
+  resolution: "@metabrainz/xgettext-js@npm:5.0.3"
   dependencies:
     estree-walker: "npm:3.0.3"
-    hermes-parser: "npm:0.35.0"
+    hermes-parser: "npm:0.36.1"
     lodash: "npm:4.18.1"
-  checksum: 10c0/228c3fb2d88c4d55b55fa2bee520347cde940c59b7ba812d5619f84d4223842c797ee27d91a0b8f3281f386995e1bfbb032ada463d2de499da618a6458c18ade
+  checksum: 10c0/dd6b5fba51a4a62da1d0c93faab30dbceb5f1c8641e189e2767172abb72d4625eb7c462baa7934c5eba429a01057c3ca0c75d2fae6f626199621714da783792c
   languageName: node
   linkType: hard
 
@@ -6079,26 +6079,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hermes-estree@npm:0.35.0":
-  version: 0.35.0
-  resolution: "hermes-estree@npm:0.35.0"
-  checksum: 10c0/a88c9dc63b8b3679b1aeb43e72e977597096c1bd7d59978c952f1d6df6d1a517c4a817c70b1b701854996b485adfa66c2fc7f80871029a7f0c04306f6717b59a
-  languageName: node
-  linkType: hard
-
 "hermes-estree@npm:0.36.1":
   version: 0.36.1
   resolution: "hermes-estree@npm:0.36.1"
   checksum: 10c0/9f552e1f809e05a4ddc5dcc10c5d1d5e375eade985026c3f8876a227db76c33059d25f93f92628a0e43d29a6da6977fbb643fafc8830babad62c1b88b2b56739
-  languageName: node
-  linkType: hard
-
-"hermes-parser@npm:0.35.0":
-  version: 0.35.0
-  resolution: "hermes-parser@npm:0.35.0"
-  dependencies:
-    hermes-estree: "npm:0.35.0"
-  checksum: 10c0/49d98093a2094758db5b536627c6cf5146b140f66e63143acf471c62f1d3fd8bd6ae10a33f2372f72e3653deda5d4615c6dae89d01248849440916209901fc4a
   languageName: node
   linkType: hard
 
@@ -7825,7 +7809,7 @@ __metadata:
     "@babel/register": "npm:7.28.6"
     "@babel/runtime": "npm:7.28.6"
     "@floating-ui/react": "npm:0.27.19"
-    "@metabrainz/xgettext-js": "npm:5.0.2"
+    "@metabrainz/xgettext-js": "npm:5.0.3"
     "@sentry/browser": "npm:7.119.2"
     "@sentry/node": "npm:7.119.2"
     "@stylistic/eslint-plugin": "npm:5.10.0"


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Since the pull request https://github.com/metabrainz/musicbrainz-server/pull/3792, running `po/update_pot.sh` was failing with the following Flow error.

```
Error parsing "/musicbrainz-server/root/static/scripts/common/components/Autocomplete2/types.js":
/musicbrainz-server/node_modules/@metabrainz/xgettext-js/node_modules/hermes-parser/dist/HermesParser.js:91
        const syntaxError = new SyntaxError(err); // $FlowExpectedError[prop-missing]
                            ^

SyntaxError: '>' expected at end of type parameters (66:24)
export type ActionT<out T extends EntityItemT> =
                   ~~~~~^
    at Object.parse (/musicbrainz-server/node_modules/@metabrainz/xgettext-js/node_modules/hermes-parser/dist/HermesParser.js:91:29)
    at Object.parse (/musicbrainz-server/node_modules/@metabrainz/xgettext-js/node_modules/hermes-parser/dist/index.js:145:28)
    at XGettext._parseInput (file:///musicbrainz-server/node_modules/@metabrainz/xgettext-js/xgettext.js:155:15)
    at XGettext.getMatches (file:///musicbrainz-server/node_modules/@metabrainz/xgettext-js/xgettext.js:80:21)
    at file:///musicbrainz-server/script/xgettext.mjs:2385:12
    at ModuleJob.run (node:internal/modules/esm/module_job:439:25)
    at async node:internal/modules/esm/loader:633:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5) {
  loc: { line: 66, column: 24 }
}
```

See the comment https://github.com/metabrainz/xgettext-js/pull/3#issuecomment-4771316430

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

The new version 5.0.3 of our fork `@metabrainz/xgettext-js` updates the required version of `hermes-parser` to 0.36.1 thus passing Flow 0.318.0.

See the pull request https://github.com/metabrainz/xgettext-js/pull/3.

# AI usage
<!--
    If you used AI / LLM tools while working on this pull request, you must
    disclose it as per the MetaBrainz Foundation's contribution guidelines
    (https://github.com/metabrainz/guidelines).
-->

nope

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

See manual testing at https://github.com/metabrainz/xgettext-js/pull/3 and https://github.com/metabrainz/musicbrainz-server/pull/3378#pullrequestreview-4551761491