### PR TITLE
MBS-14397: Add RedundantWriterRelationships report

### DIFF
--- a/lib/MusicBrainz/Server/Report/RedundantWriterRelationships.pm
+++ b/lib/MusicBrainz/Server/Report/RedundantWriterRelationships.pm
@@ -1,0 +1,42 @@
+package MusicBrainz::Server::Report::RedundantWriterRelationships;
+use Moose;
+
+with 'MusicBrainz::Server::Report::WorkReport',
+     'MusicBrainz::Server::Report::FilterForEditor::WorkID';
+
+sub query {<<~'SQL'}
+    SELECT DISTINCT w.id AS work_id,
+           row_number() OVER (ORDER BY w.type, w.name COLLATE musicbrainz)
+    FROM work w
+    JOIN l_artist_work law ON law.entity1 = w.id
+    JOIN link l ON l.id = law.link
+    JOIN link_type lt ON l.link_type = lt.id
+    WHERE lt.gid = 'a255bca1-b157-4518-9108-7b147dc3fc68' --writer
+    AND EXISTS (
+        SELECT 1
+        FROM l_artist_work law2
+        JOIN link l2 ON law2.link = l2.id
+        JOIN link_type lt2 ON l2.link_type = lt2.id
+        WHERE law2.entity1 = w.id
+        AND law2.entity0 = law.entity0
+        AND (
+            lt2.gid = 'd59d99ea-23d4-4a80-b066-edca32ee158f' --composer
+            OR
+            lt2.gid = '3e48faba-ec01-47fd-8e89-30e81161661c' --lyricist
+        )
+    )
+    SQL
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2026 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -89,6 +89,7 @@ my @all = qw(
     RecordingsWithVaryingTrackLengths
     RecordingTrackDifferentName
     RecordingsWithFutureDates
+    RedundantWriterRelationships
     ReleasedTooEarly
     ReleasedTooEarlyDigital
     ReleasedTooEarlyForLabel
@@ -204,6 +205,7 @@ use MusicBrainz::Server::Report::RecordingsWithVaryingTrackLengths;
 #use MusicBrainz::Server::Report::RecordingsSameNameDifferentArtistsSameName;
 use MusicBrainz::Server::Report::RecordingTrackDifferentName;
 use MusicBrainz::Server::Report::RecordingsWithFutureDates;
+use MusicBrainz::Server::Report::RedundantWriterRelationships;
 use MusicBrainz::Server::Report::ReleasedTooEarly;
 use MusicBrainz::Server::Report::ReleasedTooEarlyDigital;
 use MusicBrainz::Server::Report::ReleasedTooEarlyForLabel;

--- a/root/report/RedundantWriterRelationships.js
+++ b/root/report/RedundantWriterRelationships.js
@@ -1,0 +1,43 @@
+/*
+ * @flow strict
+ * Copyright (C) 2026 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import ReportLayout from './components/ReportLayout.js';
+import WorkList from './components/WorkList.js';
+import type {ReportDataT, ReportWorkT} from './types.js';
+
+component RedundantWriterRelationships(...{
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportWorkT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows works which have a writer relationship and a
+         composer or lyricist relationship to the same artist.
+         Writer is generally used as a more generic alternative when
+         it is not known if an artist was a lyricist, composer, or both.
+         As such, in most cases both of these relationships should not
+         be present at the same time.`,
+      )}
+      entityType="work"
+      filtered={filtered}
+      generated={generated}
+      title={l('Works with possibly redundant writer relationships')}
+      totalEntries={pager.total_entries}
+    >
+      <WorkList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
+
+export default RedundantWriterRelationships;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -636,6 +636,10 @@ component ReportsIndex() {
             reportName="DeprecatedRelationshipWorks"
           />
           <ReportsIndexEntry
+            content={l('Works with possibly redundant writer relationships')}
+            reportName="RedundantWriterRelationships"
+          />
+          <ReportsIndexEntry
             content={l('Works with annotations')}
             reportName="AnnotationsWorks"
           />

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -300,6 +300,7 @@ export default {
   'report/RecordingsWithoutVaLink': (): Promise<unknown> => import('../report/RecordingsWithoutVaLink.js'),
   'report/RecordingsWithVaryingTrackLengths': (): Promise<unknown> => import('../report/RecordingsWithVaryingTrackLengths.js'),
   'report/RecordingTrackDifferentName': (): Promise<unknown> => import('../report/RecordingTrackDifferentName.js'),
+  'report/RedundantWriterRelationships': (): Promise<unknown> => import('../report/RedundantWriterRelationships.js'),
   'report/ReleasedTooEarly': (): Promise<unknown> => import('../report/ReleasedTooEarly.js'),
   'report/ReleasedTooEarlyDigital': (): Promise<unknown> => import('../report/ReleasedTooEarlyDigital.js'),
   'report/ReleasedTooEarlyForLabel': (): Promise<unknown> => import('../report/ReleasedTooEarlyForLabel.js'),


### PR DESCRIPTION
### Implement MBS-14397

# Description
This adds a report for works that have both writer and composer/lyricist relationships for the same artist.

# AI usage
None

# Testing
Locally with sample data, which surprisingly contained 19 pages of results already (checked around and they seem legit, many of them "composer, writer"). I think "writer" has been used for "lyricist" in quite a few cases, which hopefully this will help us find.