### PR TITLE
MBS-14398: Restore selectAll to collection index

### DIFF
--- a/root/collection/CollectionIndex.js
+++ b/root/collection/CollectionIndex.js
@@ -219,6 +219,7 @@ component CollectionIndex(...props: Props) {
           ) : null}
         </form>
       ) : <p>{l('This collection is empty.')}</p>}
+      {manifest('common/MB/Control/SelectAll', {async: true})}
       {manifest('common/ratings', {async: true})}
     </CollectionLayout>
   );


### PR DESCRIPTION
### Fix MBS-14398

# Description
Multi-select (from the header or by shift-clicking) stopped working in collection pages with 6f0b33c862b4f271c61a929b943c930da1ce42f4, which removed `SelectAll` from `common.js` but missed adding it to `CollectionIndex`.

# AI usage
None

# Testing
Locally, both shift-clicking and the header checkbox work and entities get deleted from the collection when clicking the button afterwards.