### PR TITLE
Ignore nonexistent/deleted editors in the `user.updated` webhook handler

### DIFF
--- a/lib/MusicBrainz/Server/Controller/MetaBrainz.pm
+++ b/lib/MusicBrainz/Server/Controller/MetaBrainz.pm
@@ -330,8 +330,13 @@ sub _user_updated_handler {
     die 'Invalid user_id' unless is_database_row_id($user_id);
 
     my $editor = $c->model('Editor')->get_by_id($user_id);
-    die 'Editor does not exist or was deleted'
-        unless defined $editor && !$editor->deleted;
+    unless (defined $editor && !$editor->deleted) {
+        $c->log->debug(
+            'user.updated event received for nonexistent or deleted user ' .
+            "(id=$user_id)",
+        );
+        return;
+    }
 
     my $old = $payload->{old};
     my $new = $payload->{new};

--- a/t/lib/t/MusicBrainz/Server/Controller/MetaBrainz.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/MetaBrainz.pm
@@ -520,6 +520,51 @@ test 'The user.updated webhook errors on an empty update' => sub {
     is($content->{status}, 'error', 'response contains an error');
 };
 
+test 'The user.updated webhook ignores nonexistent or deleted users' => sub {
+    my $test = shift;
+    my $c = $test->c;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+editor');
+
+    no warnings 'redefine';
+    local *DBDefs::DISCOURSE_SERVER = sub { '' };
+    use warnings 'redefine';
+
+    $c->model('Editor')->delete(1);
+    $c->model('Editor')->delete(2);
+
+    my $editor1 = $c->model('Editor')->get_by_id(1);
+    # editor id=2 (Alice) has an annotation so won't be fully deleted
+    my $editor2 = $c->model('Editor')->get_by_id(2);
+    ok(!defined $editor1, 'editor 1 was fully deleted');
+    ok(defined $editor2 && $editor2->deleted, 'editor 2 was deleted');
+
+    my $res = $mech->request(_make_webhook_request(
+        event => 'user.updated',
+        payload => {
+            user_id => 1,
+            old => { name => 'new_editor' },
+            new => { name => 'new_editor2' },
+            updated_at => '2000-01-01T00:00:00+00:00',
+        },
+    ));
+    is($res->code, HTTP_OK,
+       'webhook response for nonexistent editor is 200');
+
+    $res = $mech->request(_make_webhook_request(
+        event => 'user.updated',
+        payload => {
+            user_id => 2,
+            old => { name => 'Alice' },
+            new => { name => 'Alice2' },
+            updated_at => '2000-01-01T00:00:00+00:00',
+        },
+    ));
+    is($res->code, HTTP_OK,
+       'webhook response for deleted editor is 200');
+};
+
 test 'The user.created webhook ignores an existing editor' => sub {
     my $test = shift;
     my $c = $test->c;


### PR DESCRIPTION
# Problem

This should avoid failures like:
https://metabrainz.org/admin/users/webhook-deliveries-admin/details/?id=b06fdbf6-55b8-494e-9876-87b5b481f0fc https://metabrainz-foundation-inc.sentry.io/issues/133843838/

These events are expected to be processed quickly before the user has any chance to delete their account, but there were some issues in the initial webhooks release that caused some events to have significantly delayed processing. Those issues have been fixed, so this scenario is not expected to occur normally anymore. Regardless, there's no point in retrying such events if the user deleted their account.

# Solution

Replaces `die` with `return`.

# AI usage

None, although previous test cases in t/lib/t/MusicBrainz/Server/Controller/MetaBrainz.pm were LLM assisted, and I copied one of them before updating it by hand.

# Testing

Added a new test case to t/lib/t/MusicBrainz/Server/Controller/MetaBrainz.pm.