### PR TITLE
MBS-14402: Some pages fail to load properly when a UI language is set

### DIFF
--- a/root/layout/components/Head.js
+++ b/root/layout/components/Head.js
@@ -138,15 +138,15 @@ component Head(
 
       {manifest('vendors')}
 
+      {$c.stash.current_language === 'en'
+        ? null
+        : manifest('jed-' + $c.stash.current_language)}
+
       {manifest('common-chunks')}
 
       {manifest('common/jquery-global')}
 
       {manifest('common/sentry')}
-
-      {$c.stash.current_language === 'en'
-        ? null
-        : manifest('jed-' + $c.stash.current_language)}
 
       {MUSICBRAINZ_RUNNING_TESTS ? manifest('selenium') : null}
 


### PR DESCRIPTION
# Problem

MBS-14402

Many "x is not a function" errors are being logged to Sentry: https://metabrainz-foundation-inc.sentry.io/issues/?environment=production&project=4509277087465552&query=is%3Aunresolved%20%22is%20not%20a%20function%22&referrer=issue-list&sort=recommended&statsPeriod=14d

It can be reproduced easily by changing the UI language and loading an area page (among others), although it may work some of the time.

There's a race condition where an async script (which React moves to the head element) may be fetched and executed before the jed-$lang bundle has been. Since common-chunks contains the wrapGettext module which requires jed-$lang to be loaded, we must reorder it above common-chunks. (The async entry script, when executed, will already defer the entrypoint function until after common-chunks has loaded, but it doesn't know about jed-$lang because it's never imported anywhere.)

I thought this was a recent regression, but apparently not since there are older events in Sentry related to it (although the error message changed).

# Solution

Moves the jed-$lang bundle above common-chunks.

# AI usage

None.

# Testing

Checked that exceptions are no longer thrown on the examples in the ticket.