### PR TITLE
MBS-14389: Edit search: filter by release status

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -307,6 +307,7 @@ sub search : Path('/search/edits')
         rg_secondary_types => [ $c->model('ReleaseGroupSecondaryType')->get_all ],
         series_types => [ $c->model('SeriesType')->get_all ],
         work_types => [ $c->model('WorkType')->get_all ],
+        release_statuses => [ $c->model('ReleaseStatus')->get_all ],
     );
     return unless %{ $c->req->query_params };
 

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/ReleaseStatus.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/ReleaseStatus.pm
@@ -1,0 +1,20 @@
+package MusicBrainz::Server::EditSearch::Predicate::ReleaseStatus;
+use Moose;
+use namespace::autoclean;
+
+extends 'MusicBrainz::Server::EditSearch::Predicate::Set';
+
+sub combine_with_query {
+    my ($self, $query) = @_;
+    return unless $self->arguments;
+
+    $query->add_where([
+        'EXISTS (SELECT 1 FROM edit_release A JOIN release B ON A.release = B.id WHERE A.edit = edit.id AND ' .
+        join(' ', 'B.status', $self->operator,
+             $self->operator eq '='  ? 'any(?)' :
+             $self->operator eq '!=' ? 'all(?)' : die q(Shouldn't get here)) . ')',
+        $self->sql_arguments,
+    ]) if $self->arguments > 0;
+}
+
+1;

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -32,6 +32,7 @@ use MusicBrainz::Server::EditSearch::Predicate::WorkType;
 use MusicBrainz::Server::EditSearch::Predicate::ArtistArea;
 use MusicBrainz::Server::EditSearch::Predicate::LabelArea;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseCountry;
+use MusicBrainz::Server::EditSearch::Predicate::ReleaseStatus;
 use MusicBrainz::Server::EditSearch::Predicate::RelationshipType;
 use MusicBrainz::Server::EditSearch::Predicate::EditNoteAuthor;
 use MusicBrainz::Server::EditSearch::Predicate::EditNoteContent;
@@ -65,6 +66,7 @@ my %field_map = (
     artist_area => 'MusicBrainz::Server::EditSearch::Predicate::ArtistArea',
     label_area => 'MusicBrainz::Server::EditSearch::Predicate::LabelArea',
     release_country => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseCountry',
+    release_status => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseStatus',
     link_type => 'MusicBrainz::Server::EditSearch::Predicate::RelationshipType',
     editor_flag => 'MusicBrainz::Server::EditSearch::Predicate::EditorFlag',
     applied_edits => 'MusicBrainz::Server::EditSearch::Predicate::AppliedEdits',

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -82,6 +82,8 @@
                predicate_link(field.field_name, field, 'area');
              CASE 'MusicBrainz::Server::EditSearch::Predicate::ReleaseCountry';
                predicate_country(field.field_name, field);
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::ReleaseStatus';
+               predicate_entity_type(field.field_name, release_statuses, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::RelationshipType';
                predicate_link_type(field.field_name, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::AreaType';
@@ -515,8 +517,9 @@
                    [ 'release_language', l('Release language') ],
                    [ 'release_quality', l('Release data quality') ],
                    [ 'artist_area', l('Artist area') ],
-                   [ 'label_area', l('Label area') ]
-                   [ 'release_country', l('Release country') ]
+                   [ 'label_area', l('Label area') ],
+                   [ 'release_country', l('Release country') ],
+                   [ 'release_status', l('Release status') ],
                    [ 'link_type', l('Relationship type') ],
                    [ 'editor_flag', l('Editor flag'), {requires_login => 1} ],
                    [ 'applied_edits', l('Applied edit count of editor'), {requires_login => 1} ],
@@ -567,6 +570,7 @@
     [% predicate_link('artist_area', undef, 'area') %]
     [% predicate_link('label_area', undef, 'area') %]
     [% predicate_country('release_country') %]
+    [% predicate_entity_type('release_status', release_statuses) %]
     [% predicate_link_type('link_type') %]
     [% predicate_editor_flag('editor_flag') %]
     [% predicate_int('applied_edits') %]


### PR DESCRIPTION
### Implement MBS-14389

# Description
This allows searching for edits based on release status. It is based on what we already do for release quality on the predicate side, and it is so equivalent to `predicate_entity_type` on the display side that I am just reusing that for it (we can rename the macro if that is confusing but I wasn't sure of what would be a good name - it's the "attributes" discussion again :) ).

# AI usage
None

# Testing
Locally with sample data, checked both `=` and `!=` conditions, added a new release with a specific status and made sure that showed up too.