### PR TITLE
MBS-14404: Reject Facebook "share" URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2921,6 +2921,23 @@ export const CLEANUPS: CleanupEntries = {
           target: ERROR_TARGETS.URL,
         };
       }
+      if (/https:\/\/www\.facebook\.com\/share\//.test(url)) {
+        return {
+          error: exp.l(
+            `This is a redirect link. Please follow {redirect_url|your link}
+             and add the link it redirects to instead.`,
+            {
+              redirect_url: {
+                href: url,
+                rel: 'noopener noreferrer',
+                target: '_blank',
+              },
+            },
+          ),
+          result: false,
+          target: ERROR_TARGETS.URL,
+        };
+      }
       if (/facebook.com\/pages\//.test(url)) {
         return {
           result: /\/pages\/[^/?#]+\/\d+/.test(url),

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2869,6 +2869,18 @@ limited_link_type_combinations: [
                                   target: 'url',
                                 },
   },
+  {
+                     input_url: 'https://www.facebook.com/share/1BiNcRpu8m?mibextid=wwXIfr',
+             input_entity_type: 'artist',
+    expected_relationship_type: undefined,
+            expected_clean_url: 'https://www.facebook.com/share/1BiNcRpu8m?mibextid=wwXIfr',
+       input_relationship_type: 'socialnetwork',
+       only_valid_entity_types: [],
+                expected_error: {
+                                  error: 'a redirect link',
+                                  target: 'url',
+                                },
+  },
   // Finna.fi
   {
                      input_url: 'https://www.finna.fi/Record/viola.163990',


### PR DESCRIPTION
### Implement MBS-14404

# Description
These links (such as https://www.facebook.com/share/1BiNcRpu8m?mibextid=wwXIfr) are redirect links, so I'm rejecting them with the same "please follow the redirect and add the proper link" message we use for this sort of thing elsewhere. I implemented it inside `URLCleanup` for now since they are associated with Facebook which we clean up, although I am tempted to just move all of these to `IsShortenedUrl` like we already do with some (but not all) Spotify shorteners.

# AI usage
None

# Testing
Added a test, and tested locally as well to double-check that the error is shown and the redirect link is made clickable in the error text for ease of correction.