### PR TITLE
MBS-14399: Accept new /a LibraryThing author URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3875,6 +3875,7 @@ export const CLEANUPS: CleanupEntries = {
     restrict: [LINK_TYPES.otherdatabases],
     clean(url) {
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?librarything\.com\/(author|nseries|work)\/([0-9a-z-]+)(?:[/?#].*)?$/, 'https://www.librarything.com/$1/$2');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?librarything\.com\/a\/(?:[a-z]+\/)?([0-9]+)(?:[/?#].*)?$/, 'https://www.librarything.com/a/$1');
       return url;
     },
     validate(url, id) {
@@ -3884,7 +3885,7 @@ export const CLEANUPS: CleanupEntries = {
         switch (id) {
           case LINK_TYPES.otherdatabases.artist:
             return {
-              result: prefix === 'author',
+              result: prefix === 'author' || prefix === 'a',
               target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.series:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3890,6 +3890,20 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist'],
   },
   {
+                     input_url: 'https://www.librarything.com/a/5179415/Alex-Ross',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.librarything.com/a/5179415',
+       only_valid_entity_types: ['artist'],
+  },
+  {
+                     input_url: 'https://www.librarything.com/a/reviews/3801/Tori-Amos',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.librarything.com/a/3801',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'https://www.librarything.com/work/7940036/reviews',
              input_entity_type: 'work',
     expected_relationship_type: 'otherdatabases',


### PR DESCRIPTION
### Implement MBS-14399

# Description
LibraryThing has moved their author URLs to `https://www.librarything.com/a/[numeric-ID]/[unneeded-slug]`. This for now maintains the whole existing setup but also allows the new `/a/` URLs, dropping extra sections such as `/reviews` or `/charts` that can get added to the URLs.

I would expect them to eventually also migrate works to this style, and potentially we could be able to drop the old style cleanup and validation entirely and stick to the new one, but now this seems good enough.

# AI usage
None

# Testing
Added a test for the base sort of URL, and another for an URL with an extra section segment