### PR TITLE
MBS-14407: Block https://artists.landr.com/ aggregator

### DIFF
--- a/root/static/scripts/edit/utility/isShortenedUrl.js
+++ b/root/static/scripts/edit/utility/isShortenedUrl.js
@@ -55,6 +55,7 @@ const URL_SHORTENERS = [
   'koji.game',
   'koji.sh',
   'laburbain.com',
+  'artists.landr.com',
   'li.sten.to',
   'linkco.re',
   'lnkfi.re',


### PR DESCRIPTION
### Implement MBS-14407

# Description
This adds https://artists.landr.com/ (another link aggregator by Linkfire) to our blocked list in `isShortenedUrl`.

# AI usage
None

# Testing
Quickly tested locally that the example link https://artists.landr.com/EmblemeRural is blocked.