### PR TITLE
MBS-14374: Add "Format" filter to "Releases" page

### DIFF
--- a/lib/MusicBrainz/Server/Data/MediumFormat.pm
+++ b/lib/MusicBrainz/Server/Data/MediumFormat.pm
@@ -62,6 +62,15 @@ sub load
     load_subobjects($self, 'format', @media);
 }
 
+sub find_by_ids
+{
+    my ($self, $ids) = @_;
+
+    my @formats = sort { $a->name cmp $b->name }
+                  values %{ $self->get_by_ids(@$ids) };
+    return \@formats;
+}
+
 sub find_by_name
 {
     my ($self, $name) = @_;
@@ -69,6 +78,36 @@ sub find_by_name
         'SELECT ' . $self->_columns . ' FROM ' . $self->_table . '
           WHERE lower(name) = lower(?)', $name);
     return $row ? $self->_new_from_row($row) : undef;
+}
+
+sub find_by_release_artist
+{
+    my ($self, $artist_id) = @_;
+
+    my $query = 'SELECT DISTINCT m.format
+                 FROM release rel
+                 JOIN medium m
+                     ON m.release = rel.id
+                 JOIN artist_credit_name acn
+                     ON acn.artist_credit = rel.artist_credit
+                 WHERE acn.artist = ?';
+    my $ids = $self->sql->select_single_column_array($query, $artist_id);
+    return $self->find_by_ids($ids);
+}
+
+sub find_by_release_label
+{
+    my ($self, $label_id) = @_;
+
+    my $query = 'SELECT DISTINCT m.format
+                 FROM release rel
+                 JOIN medium m
+                     ON m.release = rel.id
+                 JOIN release_label rl
+                     ON rl.release = rel.id
+                 WHERE rl.label = ?';
+    my $ids = $self->sql->select_single_column_array($query, $label_id);
+    return $self->find_by_ids($ids);
 }
 
 sub in_use {

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -146,6 +146,11 @@ sub _where_filter
                 push @params, $filter->{label_id};
             }
         }
+        if (exists $filter->{format_id}) {
+            push @query, 'medium.format = ?';
+            push @params, $filter->{format_id};
+            push @joins, 'JOIN medium ON release.id = medium.release';
+        }
         if (exists $filter->{status} && $filter->{status}) {
             my @statuses = ref($filter->{status}) ? @{ $filter->{status} } : ( $filter->{status} );
             if (@statuses) {

--- a/lib/MusicBrainz/Server/FilterUtils.pm
+++ b/lib/MusicBrainz/Server/FilterUtils.pm
@@ -50,6 +50,8 @@ sub create_artist_releases_form {
         $c->model('ArtistCredit')->find_by_release_artist($artist_id);
     preserve_selected_artist_credit($c, $form_args{artist_credits});
     $form_args{countries} = [$c->model('CountryArea')->get_all];
+    $form_args{formats} =
+        $c->model('MediumFormat')->find_by_release_artist($artist_id);
     $form_args{labels} =
         [$c->model('Label')->find_by_release_artist($artist_id)];
     $form_args{statuses} = [$c->model('ReleaseStatus')->get_all];
@@ -90,6 +92,8 @@ sub create_label_releases_form {
         $c->model('ArtistCredit')->find_by_release_label($label_id);
     preserve_selected_artist_credit($c, $form_args{artist_credits});
     $form_args{countries} = [$c->model('CountryArea')->get_all];
+    $form_args{formats} =
+        $c->model('MediumFormat')->find_by_release_label($label_id);
     $form_args{labels} =
         [$c->model('Label')->find_by_release_label($label_id)];
     $form_args{statuses} = [$c->model('ReleaseStatus')->get_all];

--- a/lib/MusicBrainz/Server/Form/Filter/Release.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Release.pm
@@ -21,6 +21,12 @@ has 'countries' => (
     required => 1,
 );
 
+has 'formats' => (
+    isa => 'ArrayRef[MediumFormat]',
+    is => 'ro',
+    required => 1,
+);
+
 has 'labels' => (
     isa => 'ArrayRef[Label]',
     is => 'ro',
@@ -45,6 +51,10 @@ has_field 'date' => (
     type => 'Text',
 );
 
+has_field 'format_id' => (
+    type => 'Select',
+);
+
 has_field 'label_id' => (
     type => 'Select',
 );
@@ -54,7 +64,7 @@ has_field 'status_id' => (
 );
 
 sub filter_field_names {
-    return qw/ disambiguation name artist_credit_id country_id date label_id status_id /;
+    return qw/ disambiguation name artist_credit_id country_id date format_id label_id status_id /;
 }
 
 sub options_artist_credit_id {
@@ -71,6 +81,14 @@ sub options_country_id {
         { value => '-1', label => lp('[none]', 'release country') },
         map +{ value => $_->id, label => $_->name },
         @{ $self->countries },
+    ];
+}
+
+sub options_format_id {
+    my ($self, $field) = @_;
+    return [
+        map +{ value => $_->id, label => $_->name },
+        @{ $self->formats },
     ];
 }
 
@@ -96,6 +114,7 @@ around TO_JSON => sub {
     my $json = $self->$orig;
     $json->{options_artist_credit_id} = $self->options_artist_credit_id;
     $json->{options_country_id} = $self->options_country_id;
+    $json->{options_format_id} = $self->options_format_id;
     $json->{options_status_id} = $self->options_status_id;
     return $json;
 };

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -49,6 +49,7 @@ type ReleaseFilterFormT = FormT<{
   readonly artist_credit_id: FieldT<number>,
   readonly country_id: FieldT<number>,
   readonly date: FieldT<string>,
+  readonly format_id: FieldT<number>,
   readonly label_id: FieldT<number>,
   readonly status_id: FieldT<number>,
 }>;
@@ -58,6 +59,7 @@ export type ReleaseFilterT = Readonly<{
   readonly entity_type: 'release',
   readonly options_artist_credit_id: SelectOptionsT,
   readonly options_country_id: SelectOptionsT,
+  readonly options_format_id: SelectOptionsT,
   readonly options_label_id: SelectOptionsT,
   readonly options_status_id: SelectOptionsT,
 }>;
@@ -292,6 +294,22 @@ component FilterForm(
                       options={{
                         grouped: false,
                         options: form.options_country_id,
+                      }}
+                      style={{maxWidth: '40em'}}
+                      uncontrolled
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    {addColonText(l('Format'))}
+                  </td>
+                  <td>
+                    <SelectField
+                      field={form.field.format_id}
+                      options={{
+                        grouped: false,
+                        options: form.options_format_id,
                       }}
                       style={{maxWidth: '40em'}}
                       uncontrolled


### PR DESCRIPTION
### Implement MBS-14374

# Description
This allows filtering artist and label release pages by the format of at least one medium of the release. It loads the formats that are in use for the form to avoid overwhelming the user with useless choices. 

# Known issues
This uses the same mechanism we currently use for artist credit filtering, which means in the same way as that, it does not currently work on the artist's VA releases page. See MBS-14410. We can merge it as is with the understanding that VA filters are already broken and update that ticket to cover formats too, or we can wait until it is fixed and copy the fixed implementation here.

# AI usage
None

# Testing
Locally, with sample data - works fine in `/artist/ae0b2424-d4c5-4c54-82ac-fe3be5453270/releases` and in `label/615fa478-3901-42b8-80bc-bf58b1ff0e03` and does not work (as known) in `artist/ae0b2424-d4c5-4c54-82ac-fe3be5453270/releases?va=1`