### PR TITLE
MBS-14415: Strip locale and mibextid in Facebook URL cleanup

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2895,7 +2895,7 @@ export const CLEANUPS: CleanupEntries = {
        */
       url = url.replace(new RegExp(
         '([&?])(__tn__|_fb_noscript|_rdr|acontext|em|entry_point|filter|' +
-        'focus_composer|fref|hc_location|pnref|qsefr|ref|' +
+        'focus_composer|fref|hc_location|pnref|qsefr|ref|locale|mibextid|' +
         'ref_dashboard_filter|ref_page_id|ref_type|refsrc|rf|' +
         'sid_reminder|sk|tab|viewas)=([^?&]*)',
         'g',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2852,7 +2852,7 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://www.facebook.com/TheSullivanSees',
   },
   {
-                     input_url: 'https://www.facebook.com/searchingforabby',
+                     input_url: 'https://www.facebook.com/searchingforabby?mibextid=ZbWKwL&locale=en_GB',
              input_entity_type: 'artist',
     expected_relationship_type: 'socialnetwork',
             expected_clean_url: 'https://www.facebook.com/searchingforabby',


### PR DESCRIPTION
### Implement MBS-14415

# Description
Remove two seemingly relatively common arguments that are of no use to us. `mibextid` seems to be "Mobile Interface Bridge Extension ID" and `locale` is, well, that.

# AI usage
None

# Testing
Added the arguments to an existing test URL to ensure they get dropped.