### PR TITLE
Webhook error handling improvements

### DIFF
--- a/lib/MusicBrainz/Server/Controller/MetaBrainz.pm
+++ b/lib/MusicBrainz/Server/Controller/MetaBrainz.pm
@@ -440,7 +440,7 @@ sub _verify_webhook_signature {
 }
 
 sub _webhook_error_response {
-    my ($self, $c, $status, $message) = @_;
+    my ($c, $status, $message) = @_;
 
     my $res = $c->response;
     $res->status($status);
@@ -459,7 +459,7 @@ sub webhook_callback : Chained('base') : PathPart('webhook/callback') : Args(0) 
 
     my $webhook_secret = DBDefs->METABRAINZ_WEBHOOK_SECRET;
     unless (non_empty($webhook_secret)) {
-        $self->_webhook_error_response($c, 503, 'Webhook receiver not properly configured');
+        _webhook_error_response($c, 503, 'Webhook receiver not properly configured');
         return;
     }
 
@@ -470,7 +470,7 @@ sub webhook_callback : Chained('base') : PathPart('webhook/callback') : Args(0) 
         non_empty($event_type) &&
         non_empty($signature)
     ) {
-        $self->_webhook_error_response($c, 400, 'Missing required headers');
+        _webhook_error_response($c, 400, 'Missing required headers');
         return;
     }
 
@@ -483,7 +483,7 @@ sub webhook_callback : Chained('base') : PathPart('webhook/callback') : Args(0) 
     }
 
     unless ($self->_verify_webhook_signature($c, $payload_bytes, $signature)) {
-        $self->_webhook_error_response($c, 401, 'Invalid signature');
+        _webhook_error_response($c, 401, 'Invalid signature');
         return;
     }
 
@@ -494,14 +494,14 @@ sub webhook_callback : Chained('base') : PathPart('webhook/callback') : Args(0) 
         },
         sub {
             $failure = 1;
-            $self->_webhook_error_response($c, 400, 'Invalid JSON payload');
+            _webhook_error_response($c, 400, 'Invalid JSON payload');
         },
     );
     return if $failure;
 
     my $handler = $webhook_handlers{$event_type};
     unless (defined $handler) {
-        $self->_webhook_error_response($c, 400, "Unknown event type: $event_type");
+        _webhook_error_response($c, 400, "Unknown event type: $event_type");
         return;
     }
 
@@ -515,7 +515,7 @@ sub webhook_callback : Chained('base') : PathPart('webhook/callback') : Args(0) 
         sub {
             my $error = shift;
             $c->log->error($error);
-            $self->_webhook_error_response(
+            _webhook_error_response(
                 $c,
                 500,
                 'Internal error processing webhook (check Sentry)',

--- a/lib/MusicBrainz/Server/Controller/MetaBrainz.pm
+++ b/lib/MusicBrainz/Server/Controller/MetaBrainz.pm
@@ -12,7 +12,6 @@ use namespace::autoclean;
 use Readonly;
 use Scalar::Util qw( looks_like_number );
 use String::Compare::ConstantTime;
-use Try::Tiny;
 use URI;
 use URI::QueryParam;
 
@@ -23,8 +22,11 @@ use MusicBrainz::Server::Authentication::Utils qw(
     oauth_expires_in_to_iso8601
     set_remember_login_cookie
 );
-use MusicBrainz::Server::Data::Editor;
-use MusicBrainz::Server::Data::Utils qw( generate_token non_empty );
+use MusicBrainz::Server::Data::Utils qw(
+    generate_token
+    is_valid_username
+    non_empty
+);
 use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Validation qw( is_database_row_id );
 use aliased 'MusicBrainz::Server::DatabaseConnectionFactory';
@@ -371,18 +373,7 @@ sub _user_updated_handler {
         push @params, $old->{name};
         push @conditions, 'name = $' . scalar(@params);
 
-        my $is_username_invalid = 0;
-        try {
-            MusicBrainz::Server::Data::Editor::_die_if_username_invalid($new->{name});
-        } catch {
-            if ($_ =~ /^Invalid user name/) {
-                $is_username_invalid = 1;
-            } else {
-                die $_;
-            }
-        };
-
-        if ($is_username_invalid) {
+        unless (is_valid_username($new->{name})) {
             _webhook_error_response($c, 400, 'Invalid user name');
             return 0;
         }

--- a/lib/MusicBrainz/Server/Controller/MetaBrainz.pm
+++ b/lib/MusicBrainz/Server/Controller/MetaBrainz.pm
@@ -12,6 +12,7 @@ use namespace::autoclean;
 use Readonly;
 use Scalar::Util qw( looks_like_number );
 use String::Compare::ConstantTime;
+use Try::Tiny;
 use URI;
 use URI::QueryParam;
 
@@ -285,7 +286,10 @@ sub _user_created_handler {
     my ($c, $payload) = @_;
 
     my $user_id = $payload->{user_id};
-    die 'Invalid user_id' unless is_database_row_id($user_id);
+    unless (is_database_row_id($user_id)) {
+        _webhook_error_response($c, 400, 'Invalid user_id');
+        return 0;
+    }
 
     $c->model('MB')->with_transaction(sub {
         $c->model('Editor')->insert_from_metabrainz(
@@ -294,17 +298,20 @@ sub _user_created_handler {
             $payload->{member_since},
         );
     });
-    return;
+    return 1;
 }
 
 sub _user_deleted_handler {
     my ($c, $payload) = @_;
 
     my $user_id = $payload->{user_id};
-    die 'Invalid user_id' unless is_database_row_id($user_id);
+    unless (is_database_row_id($user_id)) {
+        _webhook_error_response($c, 400, 'Invalid user_id');
+        return 0;
+    }
 
     my $editor = $c->model('Editor')->get_by_id($user_id);
-    return unless defined $editor && !$editor->deleted;
+    return 1 unless defined $editor && !$editor->deleted;
 
     $c->model('MB')->with_transaction(sub {
         $c->model('Editor')->delete($user_id);
@@ -312,7 +319,7 @@ sub _user_deleted_handler {
 
     $c->forward('/discourse/sync_sso', [$editor]);
     $c->forward('/discourse/log_out', [$editor]);
-    return;
+    return 1;
 }
 
 sub _user_updated_handler {
@@ -327,7 +334,10 @@ sub _user_updated_handler {
     # state.
 
     my $user_id = $payload->{user_id};
-    die 'Invalid user_id' unless is_database_row_id($user_id);
+    unless (is_database_row_id($user_id)) {
+        _webhook_error_response($c, 400, 'Invalid user_id');
+        return 0;
+    }
 
     my $editor = $c->model('Editor')->get_by_id($user_id);
     unless (defined $editor && !$editor->deleted) {
@@ -335,7 +345,7 @@ sub _user_updated_handler {
             'user.updated event received for nonexistent or deleted user ' .
             "(id=$user_id)",
         );
-        return;
+        return 1;
     }
 
     my $old = $payload->{old};
@@ -361,14 +371,30 @@ sub _user_updated_handler {
         push @params, $old->{name};
         push @conditions, 'name = $' . scalar(@params);
 
-        MusicBrainz::Server::Data::Editor::_die_if_username_invalid($new->{name});
+        my $is_username_invalid = 0;
+        try {
+            MusicBrainz::Server::Data::Editor::_die_if_username_invalid($new->{name});
+        } catch {
+            if ($_ =~ /^Invalid user name/) {
+                $is_username_invalid = 1;
+            } else {
+                die $_;
+            }
+        };
+
+        if ($is_username_invalid) {
+            _webhook_error_response($c, 400, 'Invalid user name');
+            return 0;
+        }
 
         push @params, $new->{name};
         push @updates, 'name = $' . scalar(@params);
     }
 
-    die 'Malformed user.updated payload (no updates?)'
-        unless @updates;
+    unless (@updates) {
+        _webhook_error_response($c, 400, 'Malformed user.updated payload (no updates?)');
+        return 0;
+    }
 
     my $query = 'UPDATE editor SET ' .
         (join q(, ), @updates) .
@@ -413,14 +439,20 @@ sub _user_updated_handler {
         }
     });
 
-    die 'Neither the old nor new values in the payload match the current ' .
-        'editor row data.'
-        unless $is_new_data_applied;
+    unless ($is_new_data_applied) {
+        _webhook_error_response(
+            $c,
+            400,
+            'Neither the old nor new values in the payload match ' .
+                'the current editor row data.',
+        );
+        return 0;
+    }
 
     $editor = $c->model('Editor')->get_by_id($user_id);
     $c->forward('/discourse/sync_sso', [$editor]);
 
-    return;
+    return 1;
 }
 
 Readonly our %webhook_handlers => (
@@ -451,11 +483,20 @@ sub _webhook_error_response {
     }));
 }
 
+sub _webhook_success_response {
+    my ($c) = @_;
+
+    my $res = $c->response;
+    $res->status(200);
+    $res->content_type('application/json');
+    $res->body($c->json_utf8->encode({ status => 'success' }));
+    return;
+}
+
 sub webhook_callback : Chained('base') : PathPart('webhook/callback') : Args(0) {
     my ($self, $c) = @_;
 
     my $req = $c->request;
-    my $res = $c->response;
 
     my $webhook_secret = DBDefs->METABRAINZ_WEBHOOK_SECRET;
     unless (non_empty($webhook_secret)) {
@@ -507,19 +548,14 @@ sub webhook_callback : Chained('base') : PathPart('webhook/callback') : Args(0) 
 
     capture_exceptions(
         sub {
-            $handler->($c, $payload);
-            $res->status(200);
-            $res->content_type('application/json');
-            $res->body($c->json_utf8->encode({ status => 'success' }));
+            if ($handler->($c, $payload)) {
+                _webhook_success_response($c);
+            }
         },
         sub {
             my $error = shift;
             $c->log->error($error);
-            _webhook_error_response(
-                $c,
-                500,
-                'Internal error processing webhook (check Sentry)',
-            );
+            _webhook_error_response($c, 500, "$error");
         },
     );
 

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -33,10 +33,10 @@ use MusicBrainz::Server::Data::Utils qw(
     generate_token
     ha1_password
     hash_to_row
+    is_valid_username
     load_subobjects
     non_empty
     placeholders
-    sanitize_username
 );
 
 extends 'MusicBrainz::Server::Data::Entity';
@@ -350,13 +350,8 @@ sub find_subscribers
 
 sub _die_if_username_invalid {
     my $name = shift;
-    my $sanitized_name = sanitize_username($name);
 
-    die 'Invalid user name' if (
-        $name ne $sanitized_name ||
-        $sanitized_name =~ qr{^deleted editor \#\d+$}i ||
-        $sanitized_name =~ qr{://}
-    );
+    die 'Invalid user name' unless is_valid_username($name);
 }
 
 sub insert

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -57,6 +57,7 @@ our @EXPORT_OK = qw(
     is_special_artist
     is_special_label
     is_valid_token
+    is_valid_username
     localized_note
     load_everything_for_edits
     load_meta
@@ -271,6 +272,19 @@ sub is_valid_token {
     # most older OAuth applications still use the shorter token length for
     # their ID/secret.
     defined $token && $token =~ /^[A-Za-z0-9_-]+$/;
+}
+
+sub is_valid_username {
+    my $name = shift;
+
+    my $sanitized_name = sanitize_username($name);
+
+    return 0 if (
+        $name ne $sanitized_name ||
+        $sanitized_name =~ qr{^deleted editor \#\d+$}i ||
+        $sanitized_name =~ qr{://}
+    );
+    return 1;
 }
 
 sub get_area_containment_join {

--- a/t/lib/t/MusicBrainz/Server/Controller/MetaBrainz.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/MetaBrainz.pm
@@ -534,6 +534,11 @@ test 'The user.updated webhook errors on an empty update' => sub {
 
     my $content = decode_json($res->content);
     is($content->{status}, 'error', 'response contains an error');
+    is(
+        $content->{message},
+        'Malformed user.updated payload (no updates?)',
+        'response error mentions no updates',
+    );
 };
 
 test 'The user.updated webhook ignores nonexistent or deleted users' => sub {

--- a/t/lib/t/MusicBrainz/Server/Controller/MetaBrainz.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/MetaBrainz.pm
@@ -249,6 +249,22 @@ test 'Webhooks returns 400 for unknown event types' => sub {
          'error message mentions unknown event type');
 };
 
+test 'Webhooks returns 400 for invalid user IDs' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    for my $event (qw( user.created user.updated user.deleted )) {
+        my $res = $mech->request(_make_webhook_request(
+            event => $event,
+            payload => { user_id => -1 },
+        ));
+
+        is($res->code, HTTP_BAD_REQUEST, 'webhook response is 400');
+        like($res->content, qr/Invalid user_id/,
+             "$event error message mentions an invalid user_id");
+    }
+};
+
 test 'The user.created webhook can insert an editor' => sub {
     my $test = shift;
     my $c = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/MetaBrainz.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/MetaBrainz.pm
@@ -367,7 +367,7 @@ test 'The user.updated webhook errors if neither the old or new values match' =>
         },
     ));
 
-    is($res->code, HTTP_INTERNAL_SERVER_ERROR, 'webhook response is 500');
+    is($res->code, HTTP_BAD_REQUEST, 'webhook response is 400');
 
     my $content = decode_json($res->content);
     is($content->{status}, 'error', 'response contains an error');
@@ -426,7 +426,7 @@ test 'The user.updated webhook rejects an invalid username' => sub {
         },
     ));
 
-    is($res->code, HTTP_INTERNAL_SERVER_ERROR, 'webhook response is 500');
+    is($res->code, HTTP_BAD_REQUEST, 'webhook response is 400');
 
     my $editor = $c->model('Editor')->get_by_id(1);
     is($editor->name, 'new_editor', 'editor name is unchanged');
@@ -514,7 +514,7 @@ test 'The user.updated webhook errors on an empty update' => sub {
         },
     ));
 
-    is($res->code, HTTP_INTERNAL_SERVER_ERROR, 'webhook response is 500');
+    is($res->code, HTTP_BAD_REQUEST, 'webhook response is 400');
 
     my $content = decode_json($res->content);
     is($content->{status}, 'error', 'response contains an error');


### PR DESCRIPTION
# Problem

Certain webhook events are retried unnecessarily when it's impossible for them to succeed.

# Solution

Returns a 400 error in more cases, which MetaBrainz will not retry in the future.

Note: This PR is opened against production because webhooks are not used on beta.

# AI usage

None.

# Testing

Updated and ran the existing automated tests for webhooks via `prove -vl t/tests.t :: --tests Controller::MetaBrainz`, which should cover all of the current `_webhook_error_response` cases.
