### PR TITLE
MBS-14440: Set `Cache-Control` headers on authenticated web service responses

### DIFF
--- a/lib/MusicBrainz/Server/Controller/MetaBrainz.pm
+++ b/lib/MusicBrainz/Server/Controller/MetaBrainz.pm
@@ -159,6 +159,7 @@ sub oauth2_callback : Chained('base') PathPart('oauth2/callback') Args(0) Requir
 
     $c->res->headers->header(
         'Cache-Control' => 'private, no-store',
+        'Expires' => '0',
         'Pragma' => 'no-cache',
         'Referrer-Policy' => 'strict-origin-when-cross-origin',
     );

--- a/lib/MusicBrainz/Server/Controller/MetaBrainz.pm
+++ b/lib/MusicBrainz/Server/Controller/MetaBrainz.pm
@@ -158,7 +158,7 @@ sub oauth2_callback : Chained('base') PathPart('oauth2/callback') Args(0) Requir
     my ($self, $c) = @_;
 
     $c->res->headers->header(
-        'Cache-Control' => 'no-store',
+        'Cache-Control' => 'private, no-store',
         'Pragma' => 'no-cache',
         'Referrer-Policy' => 'strict-origin-when-cross-origin',
     );

--- a/lib/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/lib/MusicBrainz/Server/Controller/OAuth2.pm
@@ -386,7 +386,7 @@ sub _send_response
     my ($self, $c, $response) = @_;
 
     $c->response->headers->header(
-        'Cache-Control' => 'no-store',
+        'Cache-Control' => 'private, no-store',
         'Pragma' => 'no-cache',
     );
 

--- a/lib/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/lib/MusicBrainz/Server/Controller/OAuth2.pm
@@ -387,6 +387,7 @@ sub _send_response
 
     $c->response->headers->header(
         'Cache-Control' => 'private, no-store',
+        'Expires' => '0',
         'Pragma' => 'no-cache',
     );
 

--- a/lib/MusicBrainz/Server/Controller/WS/js.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js.pm
@@ -592,7 +592,7 @@ sub _art_upload {
         nonce => $nonce,
     };
 
-    $c->res->headers->header( 'Cache-Control' => 'no-cache', 'Pragma' => 'no-cache' );
+    $c->res->headers->header( 'Cache-Control' => 'no-store', 'Pragma' => 'no-cache' );
     $c->res->content_type($c->stash->{serializer}->mime_type . '; charset=utf-8');
     $c->res->body(encode_json($data));
 }

--- a/lib/MusicBrainz/Server/Controller/WS/js.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js.pm
@@ -592,7 +592,10 @@ sub _art_upload {
         nonce => $nonce,
     };
 
-    $c->res->headers->header( 'Cache-Control' => 'no-store', 'Pragma' => 'no-cache' );
+    $c->res->headers->header(
+        'Cache-Control' => 'private, no-store',
+        'Pragma' => 'no-cache',
+    );
     $c->res->content_type($c->stash->{serializer}->mime_type . '; charset=utf-8');
     $c->res->body(encode_json($data));
 }
@@ -1029,7 +1032,7 @@ sub check_login : Chained('root') PathPart('check-login') {
 
     $c->res->content_type('application/json; charset=utf-8');
     $c->res->headers->header(
-        'Cache-Control' => 'no-store',
+        'Cache-Control' => 'private, no-store',
         'Pragma' => 'no-cache',
     );
     $c->res->status(HTTP_OK);

--- a/lib/MusicBrainz/Server/Controller/WS/js.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js.pm
@@ -1029,7 +1029,7 @@ sub check_login : Chained('root') PathPart('check-login') {
 
     $c->res->content_type('application/json; charset=utf-8');
     $c->res->headers->header(
-        'Cache-Control' => 'no-store',
+        'Cache-Control' => 'private, no-store',
         'Pragma' => 'no-cache',
     );
     $c->res->status(HTTP_OK);

--- a/lib/MusicBrainz/Server/Controller/WS/js.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js.pm
@@ -594,6 +594,7 @@ sub _art_upload {
 
     $c->res->headers->header(
         'Cache-Control' => 'private, no-store',
+        'Expires' => '0',
         'Pragma' => 'no-cache',
     );
     $c->res->content_type($c->stash->{serializer}->mime_type . '; charset=utf-8');
@@ -1033,6 +1034,7 @@ sub check_login : Chained('root') PathPart('check-login') {
     $c->res->content_type('application/json; charset=utf-8');
     $c->res->headers->header(
         'Cache-Control' => 'private, no-store',
+        'Expires' => '0',
         'Pragma' => 'no-cache',
     );
     $c->res->status(HTTP_OK);

--- a/lib/MusicBrainz/Server/ControllerBase/WS/2.pm
+++ b/lib/MusicBrainz/Server/ControllerBase/WS/2.pm
@@ -153,6 +153,11 @@ sub root : Chained('/') PathPart('ws/2') CaptureArgs(0)
 sub authenticate {
     my ($self, $c, $scope) = @_;
 
+    $c->response->headers->header(
+        'Cache-Control' => 'private, no-store',
+        'Pragma' => 'no-cache',
+    );
+
     $c->authenticate({}, 'webservice_oauth');
 
     unless ($c->user_exists) {

--- a/lib/MusicBrainz/Server/ControllerBase/WS/2.pm
+++ b/lib/MusicBrainz/Server/ControllerBase/WS/2.pm
@@ -153,6 +153,12 @@ sub root : Chained('/') PathPart('ws/2') CaptureArgs(0)
 sub authenticate {
     my ($self, $c, $scope) = @_;
 
+    $c->response->headers->header(
+        'Cache-Control' => 'private, no-store',
+        'Expires' => '0',
+        'Pragma' => 'no-cache',
+    );
+
     $c->authenticate({}, 'webservice_oauth');
 
     unless ($c->user_exists) {

--- a/t/lib/t/MusicBrainz/Server/Authentication/WS.pm
+++ b/t/lib/t/MusicBrainz/Server/Authentication/WS.pm
@@ -202,4 +202,104 @@ test 'Digest authentication' => sub {
     is($mech->status, HTTP_UNAUTHORIZED, 'Account password is rejected after setting new digest auth token');
 };
 
+test 'Caching is prevented for authenticated requests' => sub {
+    my $test = shift;
+    my $c = $test->c;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+oauth');
+
+    $c->sql->do(<<~'SQL');
+        INSERT INTO artist (id, gid, name, sort_name)
+             VALUES (100, 'd3121246-9507-44df-aea1-c860df871f69', 'Artist', 'Artist');
+        INSERT INTO tag (id, name)
+             VALUES (1, 'rock');
+        INSERT INTO artist_tag_raw (tag, artist, editor)
+             VALUES (1, 100, 11);
+        SQL
+
+    my $assert_caching_allowed = sub {
+        is(
+            $mech->response->header('Cache-Control'),
+            undef,
+            'Cache-Control header is unset',
+        );
+        is(
+            $mech->response->header('Expires'),
+            undef,
+            'Expires header is unset',
+        );
+        is(
+            $mech->response->header('Pragma'),
+            undef,
+            'Pragma header is unset',
+        );
+    };
+
+    my $assert_caching_prevented = sub {
+        is(
+            $mech->response->header('Cache-Control'),
+            'private, no-store',
+            'Cache-Control header prevents caching',
+        );
+        is(
+            $mech->response->header('Expires'),
+            '0',
+            'Expires header prevents caching',
+        );
+        is(
+            $mech->response->header('Pragma'),
+            'no-cache',
+            'Pragma header prevents caching',
+        );
+    };
+
+    # Fetching data, anonymously
+    $mech->get_ok(
+        '/ws/2/collection/933a199c-7121-4900-9beb-b42006a73f5d',
+        'Public collection is fetched, anonymously',
+    );
+    $assert_caching_allowed->();
+
+    $mech->get_ok(
+        '/ws/2/artist/d3121246-9507-44df-aea1-c860df871f69',
+        'Artist is fetched, anonymously',
+    );
+    $assert_caching_allowed->();
+
+    $mech->get('/ws/2/collection/181685d4-a23a-4140-a343-b7d15de26ff7');
+    is($mech->status, HTTP_UNAUTHORIZED, 'Private collection cannot be fetched, anonymously');
+    $assert_caching_prevented->();
+
+    $mech->get('/ws/2/artist/d3121246-9507-44df-aea1-c860df871f69?inc=user-tags');
+    is($mech->status, HTTP_UNAUTHORIZED, 'Artist with user-tags cannot be fetched, anonymously');
+    $assert_caching_prevented->();
+
+    # Fetching the same data, now authenticated, still the same caching policy though
+    $mech->credentials('localhost:80', 'musicbrainz.org', 'editor1', 'pass');
+    $mech->get_ok(
+        '/ws/2/collection/933a199c-7121-4900-9beb-b42006a73f5d',
+        'Public collection is fetched, authenticated',
+    );
+    $assert_caching_allowed->();
+
+    $mech->get_ok(
+        '/ws/2/artist/d3121246-9507-44df-aea1-c860df871f69',
+        'Artist is fetched, authenticated',
+    );
+    $assert_caching_allowed->();
+
+    $mech->get_ok(
+        '/ws/2/collection/181685d4-a23a-4140-a343-b7d15de26ff7',
+        'Private collection is fetched, authenticated',
+    );
+    $assert_caching_prevented->();
+
+    $mech->get_ok(
+        '/ws/2/artist/d3121246-9507-44df-aea1-c860df871f69?inc=user-tags',
+        'Artist with user-tags is fetched, authenticated',
+    );
+    $assert_caching_prevented->();
+};
+
 1;

--- a/t/lib/t/MusicBrainz/Server/Authentication/WS.pm
+++ b/t/lib/t/MusicBrainz/Server/Authentication/WS.pm
@@ -202,4 +202,73 @@ test 'Digest authentication' => sub {
     is($mech->status, HTTP_UNAUTHORIZED, 'Account password is rejected after setting new digest auth token');
 };
 
+test 'Caching is prevented for authenticated requests' => sub {
+    my $test = shift;
+    my $c = $test->c;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+oauth');
+
+    $c->sql->do(<<~'SQL');
+        INSERT INTO artist (id, gid, name, sort_name)
+             VALUES (100, 'd3121246-9507-44df-aea1-c860df871f69', 'Artist', 'Artist');
+        INSERT INTO tag (id, name)
+             VALUES (1, 'rock');
+        INSERT INTO artist_tag_raw (tag, artist, editor)
+             VALUES (1, 100, 11);
+        SQL
+
+    my $assert_caching_allowed = sub {
+        is(
+            $mech->response->header('Cache-Control'),
+            undef,
+            'Cache-Control header is unset',
+        );
+        is(
+            $mech->response->header('Pragma'),
+            undef,
+            'Pragma header is unset',
+        );
+    };
+
+    my $assert_caching_prevented = sub {
+        is(
+            $mech->response->header('Cache-Control'),
+            'private, no-store',
+            'Cache-Control header prevents caching',
+        );
+        is(
+            $mech->response->header('Pragma'),
+            'no-cache',
+            'Pragma header prevents caching',
+        );
+    };
+
+    $mech->get_ok(
+        '/ws/2/collection/933a199c-7121-4900-9beb-b42006a73f5d',
+        'Public collection is fetched',
+    );
+    $assert_caching_allowed->();
+
+    $mech->get_ok(
+        '/ws/2/artist/d3121246-9507-44df-aea1-c860df871f69',
+        'Artist is fetched',
+    );
+    $assert_caching_allowed->();
+
+    $mech->credentials('localhost:80', 'musicbrainz.org', 'editor1', 'pass');
+
+    $mech->get_ok(
+        '/ws/2/collection/181685d4-a23a-4140-a343-b7d15de26ff7',
+        'Private collection is fetched',
+    );
+    $assert_caching_prevented->();
+
+    $mech->get_ok(
+        '/ws/2/artist/d3121246-9507-44df-aea1-c860df871f69?inc=user-tags',
+        'Artist with user-tags is fetched',
+    );
+    $assert_caching_prevented->();
+};
+
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/CheckLogin.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/CheckLogin.pm
@@ -17,6 +17,7 @@ test all => sub {
 
     $mech->get_ok('/ws/js/check-login');
     $test->mech->header_is('Cache-Control', 'private, no-store');
+    $test->mech->header_is('Expires', '0');
     $test->mech->header_is('Pragma', 'no-cache');
 
     my $json = JSON->new;
@@ -29,6 +30,7 @@ test all => sub {
 
     $mech->get_ok('/ws/js/check-login');
     $test->mech->header_is('Cache-Control', 'private, no-store');
+    $test->mech->header_is('Expires', '0');
     $test->mech->header_is('Pragma', 'no-cache');
 
     $data = $json->decode($mech->content);

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/CheckLogin.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/CheckLogin.pm
@@ -16,7 +16,7 @@ test all => sub {
     MusicBrainz::Server::Test->prepare_test_database($test->c);
 
     $mech->get_ok('/ws/js/check-login');
-    $test->mech->header_is('Cache-Control', 'no-store');
+    $test->mech->header_is('Cache-Control', 'private, no-store');
     $test->mech->header_is('Pragma', 'no-cache');
 
     my $json = JSON->new;
@@ -28,7 +28,7 @@ test all => sub {
     $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
 
     $mech->get_ok('/ws/js/check-login');
-    $test->mech->header_is('Cache-Control', 'no-store');
+    $test->mech->header_is('Cache-Control', 'private, no-store');
     $test->mech->header_is('Pragma', 'no-cache');
 
     $data = $json->decode($mech->content);

--- a/t/sql/oauth.sql
+++ b/t/sql/oauth.sql
@@ -24,4 +24,5 @@ INSERT INTO editor_oauth_token (editor, application, refresh_token, access_token
 
 INSERT INTO editor_collection (gid, editor, name, public, type)
     VALUES ('181685d4-a23a-4140-a343-b7d15de26ff7', 11, 'editor1''s super secret collection', FALSE, 1),
-           ('906dddc8-91c8-4a1c-8237-31b6d24c988d', 14, 'æditorⅣ''s super secret collection', FALSE, 1);
+           ('906dddc8-91c8-4a1c-8237-31b6d24c988d', 14, 'æditorⅣ''s super secret collection', FALSE, 1),
+           ('933a199c-7121-4900-9beb-b42006a73f5d', 11, 'editor1''s highly public collection', TRUE, 1);


### PR DESCRIPTION
# Problem

MBS-14440

# Solution

What the title says.

This is already mitigated on the gateways, so I'm not proposing to hotfix this.

# AI usage

None.

# Testing

Added new automated tests.
