### PR TITLE
feat(MBS-14442): implement Guess Punctuation button with single quote conversion logic

### DIFF
--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -138,6 +138,7 @@
     [% r.label('name', options.label || add_colon(l('Name'))) %]
     [% r.text('name', { class => 'with-guesscase' _ (options.guessfeat ? '-guessfeat' : '') }) %]
     <button type="button" class="guesscase-title icon" title="[% l('Guess case') %]"></button>
+    <button type="button" class="guess-punctuation icon" title="[% l('Guess punctuation') %]"></button>
     [%- IF options.guessfeat -%]
       <button type="button" class="guessfeat icon" title="[% l('Guess feat. artists') %]"></button>
     [%- END -%]

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -12,6 +12,7 @@
               <td colspan="2" style="padding: 0">
                 <input id="name" class="with-guesscase-guessfeat" type="text" size="47" required="required" data-bind="value: name, valueUpdate: 'input', controlsBubble: $root.titleBubble"" />
                 <button type="button" class="guesscase-title icon" title="[% l('Guess case') %]"></button>
+                <button type="button" class="guess-punctuation icon" title="[% l('Guess punctuation') %]"></button>
                 <button type="button" class="guessfeat icon" title="[% l('Guess feat. artists') %]" data-click="guessReleaseFeatArtists"></button>
                 <button type="button" class="guesscase-options icon" title="[% l('Guess case options') %]"></button>
               </td>

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -222,6 +222,7 @@
 
     <td class="icon">
       <button type="button" class="icon guesscase-title" title="[% l('Guess case track') %]" data-bind="click: $root.guessCaseTrackName, event: { mouseenter: $root.guessCaseTrackName, mouseleave: $root.guessCaseTrackName }"></button>
+      <button type="button" class="icon guess-punctuation" title="[% l('Guess punctuation') %]" data-bind="click: $root.guessPunctuationTrackName, event: { mouseenter: $root.guessPunctuationTrackName, mouseleave: $root.guessPunctuationTrackName }"></button>
       <button type="button" class="icon guessfeat" title="[% l('Guess feat. artists') %]" data-click="guessTrackFeatArtists"></button>
       <!-- ko ifnot: (medium.hasToc() && !isDataTrack()) -->
       <button type="button" class="icon remove-item remove-track" title="[% l('Remove track') %]" data-click="removeTrack"></button>
@@ -318,6 +319,7 @@
             <label data-bind="attr: { for: 'medium-title-' + uniqueID }">[% l('Medium title:') %]</label>
             <input type="text" data-bind="attr: { id: 'medium-title-' + uniqueID }, value: inputName, valueUpdate: 'input', css: { modified: nameModified(), preview: previewNameDiffers() }, event: { focus: $root.focusMediumName }" />
             <button type="button" class="icon guesscase-title" title="[% l('Guess case medium title') %]" data-bind="click: $root.guessCaseMediumName, event: { mouseenter: $root.guessCaseMediumName, mouseleave: $root.guessCaseMediumName }"></button>
+            <button type="button" class="icon guess-punctuation" title="[% l('Guess punctuation medium title') %]" data-bind="click: $root.guessPunctuationMediumName, event: { mouseenter: $root.guessPunctuationMediumName, mouseleave: $root.guessPunctuationMediumName }"></button>
           <!-- /ko -->
           <p class="error field-error" style="padding-left: 1em" data-bind="showErrorWhenTabIsSwitched: needsFormat">
             [%~ l('A format is required. If you don’t know it, tick the “I don’t know” checkbox next to the format dropdown.') %]

--- a/root/static/images/icons/guess-punctuation.svg
+++ b/root/static/images/icons/guess-punctuation.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" rx="2" fill="#eee"/>
+  <path fill="#555" d="M3 4h4v4H5c0 1.2.6 2 2 2.5V12C4.3 11.5 3 9.9 3 7.2V4Zm6 0h4v4h-2c0 1.2.6 2 2 2.5V12c-2.7-.5-4-2.1-4-4.8V4Z"/>
+</svg>

--- a/root/static/scripts/edit/components/FormRowNameWithGuessCase.js
+++ b/root/static/scripts/edit/components/FormRowNameWithGuessCase.js
@@ -12,6 +12,7 @@ import * as React from 'react';
 import {flushSync} from 'react-dom';
 
 import GuessCase from '../../guess-case/MB/GuessCase/Main.js';
+import guessPunctuation from '../../guess-punctuation.js';
 
 import FormRowText from './FormRowText.js';
 import {
@@ -31,6 +32,7 @@ type NamedEntityT = {
 /* eslint-disable ft-flow/sort-keys */
 export type ActionT =
   | {readonly type: 'guess-case', readonly entity: NamedEntityT}
+  | {readonly type: 'guess-punctuation'}
   | {readonly type: 'open-guess-case-options'}
   | {readonly type: 'close-guess-case-options'}
   | {
@@ -66,6 +68,11 @@ export function runReducer(
         'field', 'value', GuessCase.entities[entity.entityType].guess(
           newState.read().field.value ?? '',
         ),
+      );
+    }
+    {type: 'guess-punctuation'} => {
+      newState.set(
+        'field', 'value', guessPunctuation(newState.read().field.value ?? ''),
       );
     }
     {type: 'open-guess-case-options'} => {
@@ -116,6 +123,17 @@ component FormRowNameWithGuessCase(
     }
   }
 
+  function handleGuessPunctuation() {
+    flushSync(() => {
+      dispatch({type: 'guess-punctuation'});
+      setPreview(null);
+    });
+
+    if (inputRef.current) {
+      inputRef.current.dispatchEvent(new Event('input'));
+    }
+  }
+
   function showGuessCasePreview(
     event: SyntheticMouseEvent<HTMLButtonElement>,
   ) {
@@ -124,6 +142,14 @@ component FormRowNameWithGuessCase(
       setPreview(
         GuessCase.entities[entity.entityType].guess(field.value ?? ''),
       );
+    }
+  }
+
+  function showGuessPunctuationPreview(
+    event: SyntheticMouseEvent<HTMLButtonElement>,
+  ) {
+    if (event.nativeEvent.buttons === 0) {
+      setPreview(guessPunctuation(field.value ?? ''));
     }
   }
 
@@ -169,6 +195,14 @@ component FormRowNameWithGuessCase(
         onMouseEnter={showGuessCasePreview}
         onMouseLeave={hidePreview}
         title={l('Guess case')}
+        type="button"
+      />
+      <button
+        className="guess-punctuation icon"
+        onClick={handleGuessPunctuation}
+        onMouseEnter={showGuessPunctuationPreview}
+        onMouseLeave={hidePreview}
+        title={l('Guess punctuation')}
         type="button"
       />
       {guessFeat ? (

--- a/root/static/scripts/guess-case/MB/Control/GuessCase.js
+++ b/root/static/scripts/guess-case/MB/Control/GuessCase.js
@@ -14,6 +14,7 @@ import '../../../common/dialogs.js';
 
 import getBooleanCookie from '../../../common/utility/getBooleanCookie.js';
 import setCookie from '../../../common/utility/setCookie.js';
+import guessPunctuation from '../../../guess-punctuation.js';
 import * as modes from '../../modes.js';
 import gc from '../GuessCase/Main.js';
 
@@ -60,6 +61,15 @@ export default function initializeGuessCase(type, formPrefix) {
       // Don't change the value while the user is dragging to select text.
       if (event.originalEvent.buttons === 0) {
         showPreview($name, guess.guess($name.val()));
+      }
+    })
+    .on('mouseleave', () => hidePreview($name))
+    .end()
+    .find('button.guess-punctuation')
+    .on('click', () => setVal($name, guessPunctuation($name.val())))
+    .on('mouseenter', (event) => {
+      if (event.originalEvent.buttons === 0) {
+        showPreview($name, guessPunctuation($name.val()));
       }
     })
     .on('mouseleave', () => hidePreview($name))

--- a/root/static/scripts/guess-punctuation.js
+++ b/root/static/scripts/guess-punctuation.js
@@ -46,6 +46,11 @@ export default function guessPunctuation(inputString: string): string {
       /\b(lovin|talkin)'(?=[^\p{L}]|$)/gi,
       '$1’',
     )
+    // French definite article elided before a word.
+    .replace(
+      /(^|[^\p{L}\p{N}])(l)'(?=\p{L})/giu,
+      '$1$2’',
+    )
     // Apostrophes standing in for the century in abbreviated years.
     .replace(
       /(^|[^\p{L}\p{N}])'(?=\d{2}(?!\d))/gu,

--- a/root/static/scripts/guess-punctuation.js
+++ b/root/static/scripts/guess-punctuation.js
@@ -11,7 +11,8 @@
  * Main repository of punctuation guessing logic. Used by various text fields that support punctuation guessing.
  *
  * Guesses the punctuation of a string, replacing straight single quotes with
- * typographic quotes or apostrophes as appropriate.
+ * typographic quotes or apostrophes in recognized constructions. Ambiguous
+ * straight single quotes are left unchanged.
  *
  * @param {string} inputString - The string to guess punctuation for.
  * @returns {string} - The string with guessed punctuation.
@@ -19,9 +20,40 @@
 export default function guessPunctuation(inputString: string): string {
   return inputString
     // 'n' is an elision rather than text enclosed in single quotes.
-    .replace(/(^|\W)'(n)'(?=\W|$)/gi, '$1’$2’')
+    .replace(
+      /(^|[^\p{L}\p{N}])'(n)'(?=[^\p{L}\p{N}]|$)/giu,
+      '$1’$2’',
+    )
     // Match quote pairs only when they are bounded by non-word characters.
-    .replace(/(^|[^\p{L}\d])'(.+?)'(?=[^\p{L}\d]|$)/gu, '$1‘$2’')
-    // Any remaining single quotes are apostrophes.
-    .replace(/'/g, '’');
+    .replace(
+      /(^|[^\p{L}\p{N}])'(.+?)'(?=[^\p{L}\p{N}]|$)/gu,
+      '$1‘$2’',
+    )
+    // Common English contractions and possessives.
+    .replace(
+      /(\p{L})'(?=(?:d|ll|m|re|ve)(?!\p{L}))/giu,
+      '$1’',
+    )
+    .replace(/([\p{L}\p{N}])'(?=s(?!\p{L}))/giu, '$1’')
+    .replace(/(\p{L}n)'(?=t(?!\p{L}))/giu, '$1’')
+    // Common English elisions at the start of a word.
+    .replace(
+      /(^|[^\p{L}\p{N}])'(?=(?:bout|cause|cept|em|gainst|round|til|twas|tween|twere)(?!\p{L}))/giu,
+      '$1’',
+    )
+    // Terminal elisions are deliberately limited to known forms.
+    .replace(
+      /\b(lovin|talkin)'(?=[^\p{L}]|$)/gi,
+      '$1’',
+    )
+    // Apostrophes standing in for the century in abbreviated years.
+    .replace(
+      /(^|[^\p{L}\p{N}])'(?=\d{2}(?!\d))/gu,
+      '$1’',
+    )
+    // Common Greek elisions present in MusicBrainz titles.
+    .replace(
+      /(^|[^\p{L}])(Σ|Υπ)'(?=[^\p{L}]|$)/giu,
+      '$1$2’',
+    );
 }

--- a/root/static/scripts/guess-punctuation.js
+++ b/root/static/scripts/guess-punctuation.js
@@ -1,0 +1,27 @@
+/*
+ * @flow strict
+ * Copyright (C) 2026 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+/**
+ * Main repository of punctuation guessing logic. Used by various text fields that support punctuation guessing.
+ *
+ * Guesses the punctuation of a string, replacing straight single quotes with
+ * typographic quotes or apostrophes as appropriate.
+ *
+ * @param {string} inputString - The string to guess punctuation for.
+ * @returns {string} - The string with guessed punctuation.
+ */
+export default function guessPunctuation(inputString: string): string {
+  return inputString
+    // 'n' is an elision rather than text enclosed in single quotes.
+    .replace(/(^|\W)'(n)'(?=\W|$)/gi, '$1’$2’')
+    // Match quote pairs only when they are bounded by non-word characters.
+    .replace(/(^|[^\p{L}\d])'(.+?)'(?=[^\p{L}\d]|$)/gu, '$1‘$2’')
+    // Any remaining single quotes are apostrophes.
+    .replace(/'/g, '’');
+}

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -20,6 +20,7 @@ import request from '../common/utility/request.js';
 import deferFocus from '../edit/utility/deferFocus.js';
 import guessFeat from '../edit/utility/guessFeat.js';
 import GuessCase from '../guess-case/MB/GuessCase/Main.js';
+import guessPunctuation from '../guess-punctuation.js';
 
 import fields from './fields.js';
 import utils from './utils.js';
@@ -264,6 +265,32 @@ const actions = {
     }
   },
 
+  /*
+   * Shows or hides a preview if event.type is 'mouseenter' or 'mouseleave'.
+   * Otherwise, updates the current name.
+   */
+  guessPunctuationMediumName(medium, event) {
+    const name = medium.name.peek();
+    if (!name) {
+      return;
+    }
+
+    switch (event.type) {
+      case 'mouseenter':
+        if (event.buttons === 0) {
+          medium.previewName(guessPunctuation(name));
+        }
+        break;
+      case 'mouseleave':
+        medium.previewName(null);
+        break;
+      default:
+        medium.name(medium.previewName() ?? guessPunctuation(name));
+        medium.nameModified(medium.name() !== name);
+        medium.previewName(null);
+    }
+  },
+
   moveTrackUp(track) {
     var previous = track.previous();
 
@@ -424,6 +451,30 @@ const actions = {
         track.name(
           track.previewName() ?? GuessCase.entities.track.guess(origName),
         );
+        track.nameModified(track.name() !== origName);
+        track.previewName(null);
+        break;
+      }
+    }
+  },
+
+  /*
+   * Shows or hides a preview if event.type is 'mouseenter' or 'mouseleave'.
+   * Otherwise, updates the current name.
+   */
+  guessPunctuationTrackName(track, event) {
+    switch (event.type) {
+      case 'mouseenter':
+        if (event.buttons === 0) {
+          track.previewName(guessPunctuation(track.name.peek()));
+        }
+        break;
+      case 'mouseleave':
+        track.previewName(null);
+        break;
+      default: {
+        const origName = track.name.peek();
+        track.name(track.previewName() ?? guessPunctuation(origName));
         track.nameModified(track.name() !== origName);
         track.previewName(null);
         break;

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -116,7 +116,7 @@ class Track {
       owner: this,
     });
 
-    // True after the name has been modified by the "guess case" button.
+    // True after the name has been modified by a guessing button ("guess case" or "guess punctuation").
     this.nameModified = ko.observable(false);
 
     this.length = ko.observable(data.length);
@@ -440,7 +440,7 @@ class Medium {
       write: this.name,
       owner: this,
     });
-    // True after the name has been modified by the "guess case" button.
+    // True after the name has been modified by a guessing button ("guess case" or "guess punctuation").
     this.nameModified = ko.observable(false);
     this.position = ko.observable(data.position || 1);
     this.formatID = ko.observable(data.format_id);

--- a/root/static/scripts/tests/GuessPunctuation.js
+++ b/root/static/scripts/tests/GuessPunctuation.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import test from 'tape';
+
+import guessPunctuation from '../guess-punctuation.js';
+
+test('Guess punctuation', function (t) {
+  const tests = [
+    ['Are \'Friends\' Electric?', 'Are ‘Friends’ Electric?'],
+    [
+      'One of These Days (\'French Windows\')',
+      'One of These Days (‘French Windows’)',
+    ],
+    ['I\'m Free', 'I’m Free'],
+    ['Lovin\' You', 'Lovin’ You'],
+    ['Talkin\' \'Bout You', 'Talkin’ ’Bout You'],
+    ['Summer \'68', 'Summer ’68'],
+    ['\'39', '’39'],
+    ['Rock \'n\' Roll', 'Rock ’n’ Roll'],
+    ['Rock \'N\' Roll', 'Rock ’N’ Roll'],
+    ['Back to the 70\'s', 'Back to the 70’s'],
+    [
+      'Little Billy (aka \'Little Billy\'s Doing Fine\')',
+      'Little Billy (aka ‘Little Billy’s Doing Fine’)',
+    ],
+    [
+      'Όσο Και Να Σ\' Αγαπάω (Υπ\' Ευθύνη Μου)',
+      'Όσο Και Να Σ’ Αγαπάω (Υπ’ Ευθύνη Μου)',
+    ],
+  ];
+
+  t.plan(tests.length);
+
+  for (const [input, expected] of tests) {
+    t.equal(guessPunctuation(input), expected, input);
+  }
+});

--- a/root/static/scripts/tests/GuessPunctuation.js
+++ b/root/static/scripts/tests/GuessPunctuation.js
@@ -23,8 +23,12 @@ test('Guess punctuation', function (t) {
       'One of These Days (‘French Windows’)',
     ],
     ['I\'m Free', 'I’m Free'],
+    ['You\'re Here and I\'ve Had It', 'You’re Here and I’ve Had It'],
+    ['She\'ll Say He\'d Go', 'She’ll Say He’d Go'],
+    ['It Isn\'t John\'s', 'It Isn’t John’s'],
     ['Lovin\' You', 'Lovin’ You'],
     ['Talkin\' \'Bout You', 'Talkin’ ’Bout You'],
+    ['\'Cause I Said So', '’Cause I Said So'],
     ['Summer \'68', 'Summer ’68'],
     ['\'39', '’39'],
     ['Rock \'n\' Roll', 'Rock ’n’ Roll'],
@@ -38,6 +42,10 @@ test('Guess punctuation', function (t) {
       'Όσο Και Να Σ\' Αγαπάω (Υπ\' Ευθύνη Μου)',
       'Όσο Και Να Σ’ Αγαπάω (Υπ’ Ευθύνη Μου)',
     ],
+    ['4\'33"', '4\'33"'],
+    ['Blue Hawai\'i', 'Blue Hawai\'i'],
+    ['O\'Connor', 'O\'Connor'],
+    ['He Is 6\'2"', 'He Is 6\'2"'],
   ];
 
   t.plan(tests.length);

--- a/root/static/scripts/tests/GuessPunctuation.js
+++ b/root/static/scripts/tests/GuessPunctuation.js
@@ -29,6 +29,8 @@ test('Guess punctuation', function (t) {
     ['Lovin\' You', 'Lovin’ You'],
     ['Talkin\' \'Bout You', 'Talkin’ ’Bout You'],
     ['\'Cause I Said So', '’Cause I Said So'],
+    ['L\'amour toujours', 'L’amour toujours'],
+    ['Le temps de l\'été', 'Le temps de l’été'],
     ['Summer \'68', 'Summer ’68'],
     ['\'39', '’39'],
     ['Rock \'n\' Roll', 'Rock ’n’ Roll'],

--- a/root/static/scripts/tests/GuessPunctuation.js
+++ b/root/static/scripts/tests/GuessPunctuation.js
@@ -4,6 +4,11 @@
  * This file is part of MusicBrainz, the open internet music database,
  * and is licensed under the GPL version 2, or (at your option) any
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * The test cases compiled in this file are derived from:
+ * https://github.com/kellnerd/es-utils/raw/refs/heads/main/string/punctuation.test.ts
+ * Original version Copyright (C) 2021-2023 David Kellner, and released under
+ * the MIT license: http://opensource.org/licenses/MIT
  */
 
 import test from 'tape';

--- a/root/static/scripts/tests/index-web.js
+++ b/root/static/scripts/tests/index-web.js
@@ -13,6 +13,7 @@ require('./edit/utility/isUselessMediumTitle.js');
 require('./edit/utility/linkPhrase.js');
 require('./entity.js');
 require('./GuessCase.js');
+require('./GuessPunctuation.js');
 require('./guessFeat.js');
 require('./i18n.js');
 require('./i18n/expand2.js');

--- a/root/static/scripts/tests/release-editor/actions.js
+++ b/root/static/scripts/tests/release-editor/actions.js
@@ -56,6 +56,46 @@ test('removing a medium should change the medium positions', function (t) {
   );
 });
 
+test('guessing punctuation in release-editor titles', function (t) {
+  t.plan(8);
+
+  const release = common.setupReleaseEdit();
+  const medium = release.mediums()[0];
+  const track = medium.tracks()[0];
+
+  medium.name('Rock \'n\' Roll');
+  actions.guessPunctuationMediumName(medium, {
+    buttons: 0,
+    type: 'mouseenter',
+  });
+  t.equal(medium.name(), 'Rock \'n\' Roll', 'medium name is unchanged');
+  t.equal(medium.previewName(), 'Rock ’n’ Roll', 'medium preview is set');
+
+  actions.guessPunctuationMediumName(medium, {type: 'click'});
+  t.equal(medium.name(), 'Rock ’n’ Roll', 'medium name is updated');
+  t.equal(medium.previewName(), null, 'medium preview is cleared');
+
+  track.name('Are \'Friends\' Electric?');
+  actions.guessPunctuationTrackName(track, {
+    buttons: 0,
+    type: 'mouseenter',
+  });
+  t.equal(
+    track.name(),
+    'Are \'Friends\' Electric?',
+    'track name is unchanged',
+  );
+  t.equal(
+    track.previewName(),
+    'Are ‘Friends’ Electric?',
+    'track preview is set',
+  );
+
+  actions.guessPunctuationTrackName(track, {type: 'click'});
+  t.equal(track.name(), 'Are ‘Friends’ Electric?', 'track name is updated');
+  t.equal(track.previewName(), null, 'track preview is cleared');
+});
+
 test((
   'reordering tracks that have non-consecutive "position" properties (MBS-7227)'
 ), function (t) {

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -308,6 +308,10 @@ button.guesscase-title, button.guesscase-sortname {
     background-image: data-uri('../images/icons/guesscase.png');
 }
 
+button.guess-punctuation {
+    background-image: data-uri('../images/icons/guess-punctuation.svg');
+}
+
 button.sortname-copy {
     background-image: data-uri('../images/icons/copy.png');
 }
@@ -438,11 +442,11 @@ div.half-width fieldset {
     }
 
     input.with-guesscase {
-        width: @form-input-width - (@form-icon-size * 2) - 6 !important;
+        width: @form-input-width - (@form-icon-size * 3) - 9 !important;
     }
 
     input.with-guesscase-guessfeat {
-        width: @form-input-width - (@form-icon-size * 3) - 9 !important;
+        width: @form-input-width - (@form-icon-size * 4) - 13 !important;
     }
 }
 

--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -167,7 +167,7 @@ fieldset.advanced-medium {
         &.icon {
             padding: 0 5px;
             text-align: right;
-            width: (@form-icon-size + 4) * 3;
+            width: (@form-icon-size + 4) * 4;
         }
 
         &.guesscase a { color: @light-grey; font-weight: bolder; }


### PR DESCRIPTION
- my first PR here, so please let me know if there's something I missed;
- this is narrowly scoped to single quotes detection and replacement only; once I'm confirmed this is the direction we want to move in, I'll extend the logic to double quotes, dashes, ellipses, etc in future PRs.

# Problem

[MBS-14442](https://tickets.metabrainz.org/browse/MBS-14442).

Add a **Guess Punctuation** button similar to the existing **Guess Case** functionality.

When clicked, the button should automatically detect ASCII punctuation in entered titles and replace it with the appropriate preferred Unicode punctuation where applicable.

This issue is intentionally limited to implementing the punctuation-guessing/replacement functionality. Highlighting changes, character-level diffs, undo support, and improvements to Guess Case should be handled separately.

This is a smaller scoped part of [MBS-11646](https://tickets.metabrainz.org/browse/MBS-11646).

# Solution

The conversion logic, as well as the collection of test cases is based on (or entirely copied from) @kellnerd's [Guess Unicode punctuation](https://github.com/kellnerd/musicbrainz-scripts/blob/main/README.md#guess-unicode-punctuation) script, which is amazing and I've been using it for years.

---

Most of the logic is just a replica of Guess Case functionality with a different handler function just for punctuation.

One oddity to mention, in https://github.com/metabrainz/musicbrainz-server/pull/3833/changes#diff-f013e29e5dd3ed65921c393fa6ec6b329e2929a36fd87b67c2a4cc602f180557R449 the spacing between buttons is achieved with a literal white space character and its size is not constrained to integer pixels. So whereas 9px space allocation worked for 3 buttons, for 4 buttons setting it to 12px is not enough, since the width of a single white space is 5.28px.

<img width="195" height="108" alt="image" src="https://github.com/user-attachments/assets/32c1fd59-cf79-422d-9746-5ebd675bc88e" />

So I had to set it to 13px.

```js
    input.with-guesscase-guessfeat {
        width: @form-input-width - (@form-icon-size * 4) - 13 !important;
    }
```

Screenshots:

<img width="887" height="397" alt="image" src="https://github.com/user-attachments/assets/8ff8c8fa-fbdd-42bc-ba72-ecb3ba74243f" />
<img width="887" height="397" alt="image" src="https://github.com/user-attachments/assets/b6a0d996-1f8a-4c4a-a513-ce6e4ed22786" />
<img width="1056" height="305" alt="image" src="https://github.com/user-attachments/assets/97f52ab8-33e2-4790-b55e-3c631138bc7a" />

# AI usage

Yes, plumbing the new logic based on the existing Guess Case functionality, adding tests and full review.

# Testing

All automated tests were ran by the LLM.

Manual testing and polishing done with a local musicbrainz docker container.

# Documenting

:beginner: If you updated documentation pages, mention them here, such as:
Updated [WikiDocs page](https://wiki.musicbrainz.org/Category:WikiDocs_Page)

Not yet, I need a confirmation first if this is the right direction.