### PR TITLE
MBS-14445: Stop using OAuth refresh tokens in RememberLoginCredential

### DIFF
--- a/lib/MusicBrainz/Server/Authentication/Utils.pm
+++ b/lib/MusicBrainz/Server/Authentication/Utils.pm
@@ -19,7 +19,10 @@ use MusicBrainz::Server::Data::Utils qw(
 );
 use MusicBrainz::Server::Entity::EditorOAuthToken;
 use MusicBrainz::Server::Constants qw( :access_scope );
-use MusicBrainz::Server::Validation qw( is_database_row_id );
+use MusicBrainz::Server::Validation qw(
+    is_database_row_id
+    is_positive_integer
+);
 
 our @EXPORT_OK = qw(
     $METABRAINZ_OAUTH_LWP
@@ -89,10 +92,10 @@ sub clear_remember_login_data {
 
     my @remember_login_fields = parse_remember_login_cookie($c);
     if (@remember_login_fields) {
-        my ($user_id, $remember_login_token) = @remember_login_fields;
+        my ($version, $user_id, $remember_login_token) = @remember_login_fields;
         clear_remember_login_cookie($c);
 
-        if (is_database_row_id($user_id) && non_empty($remember_login_token)) {
+        if ($version == 4) {
             my $store = $c->model('MB')->context->store;
             my $remember_login_key = "remember_login:$user_id:$remember_login_token";
 
@@ -228,10 +231,15 @@ sub parse_remember_login_cookie {
     my @fields = split /\t/, $cookie->value, -1;
     if (@fields == 3) {
         my ($version, $user_id, $token) = @fields;
-        return ($user_id, $token)
-            if $version == $REMEMBER_LOGIN_COOKIE_VERSION;
+        if (
+            is_positive_integer($version) &&
+            is_database_row_id($user_id) &&
+            non_empty($token)
+        ) {
+            return @fields;
+        }
     }
-    return ();
+    return (-1, -1, '');
 }
 
 sub revoke_metabrainz_oauth_refresh_token {

--- a/lib/MusicBrainz/Server/Authentication/Utils.pm
+++ b/lib/MusicBrainz/Server/Authentication/Utils.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base 'Exporter';
 use DateTime;
-use DateTime::Duration;
+use Digest::SHA qw( sha256_hex );
 use HTTP::Request::Common qw( POST );
 use HTTP::Status qw( is_server_error is_success );
 use IO::Socket::SSL;
@@ -14,11 +14,12 @@ use Readonly;
 
 use DBDefs;
 use MusicBrainz::Server::Data::Utils qw(
-    datetime_to_iso8601
+    generate_token
     non_empty
 );
 use MusicBrainz::Server::Entity::EditorOAuthToken;
 use MusicBrainz::Server::Constants qw( :access_scope );
+use MusicBrainz::Server::Log qw( log_error );
 use MusicBrainz::Server::Validation qw(
     is_database_row_id
     is_positive_integer
@@ -29,10 +30,8 @@ our @EXPORT_OK = qw(
     can_user_login
     clear_remember_login_cookie
     clear_remember_login_data
-    exchange_metabrainz_oauth_refresh_token
     find_active_metabrainz_oauth_access_token
     find_active_oauth_access_token
-    oauth_expires_in_to_iso8601
     parse_remember_login_cookie
     revoke_metabrainz_oauth_refresh_token
     set_remember_login_cookie
@@ -65,7 +64,7 @@ Readonly our %METABRAINZ_OAUTH_SCOPE_MAPPING => (
     'musicbrainz:tag'               => 'tag',
     'profile'                       => 'profile',
 );
-Readonly our $REMEMBER_LOGIN_COOKIE_VERSION => 4;
+Readonly our $REMEMBER_LOGIN_COOKIE_VERSION => 5;
 Readonly our $REMEMBER_LOGIN_COOKIE_EXPIRES => '+1y';
 
 sub can_user_login {
@@ -95,10 +94,10 @@ sub clear_remember_login_data {
         my ($version, $user_id, $remember_login_token) = @remember_login_fields;
         clear_remember_login_cookie($c);
 
-        if ($version == 4) {
-            my $store = $c->model('MB')->context->store;
-            my $remember_login_key = "remember_login:$user_id:$remember_login_token";
+        my $store = $c->model('MB')->context->store;
 
+        if ($version == 4) {
+            my $remember_login_key = "remember_login:$user_id:$remember_login_token";
             my $remember_login_data = $store->get($remember_login_key);
             if (defined $remember_login_data) {
                 revoke_metabrainz_oauth_refresh_token(
@@ -106,31 +105,9 @@ sub clear_remember_login_data {
                 );
                 $store->delete($remember_login_key);
             }
+        } elsif ($version == 5) {
+            $store->delete('remember_login:' . sha256_hex($remember_login_token));
         }
-    }
-    return;
-}
-
-sub exchange_metabrainz_oauth_refresh_token {
-    my ($c, $refresh_token) = @_;
-
-    my $token_uri = DBDefs->METABRAINZ_INTERNAL_URL . '/oauth2/token';
-    my $res = $METABRAINZ_OAUTH_LWP->request(
-        POST $token_uri,
-        [
-            grant_type => 'refresh_token',
-            refresh_token => $refresh_token,
-            client_id => DBDefs->METABRAINZ_OAUTH_CLIENT_ID,
-            client_secret => DBDefs->METABRAINZ_OAUTH_CLIENT_SECRET,
-        ],
-    );
-
-    if (is_success($res->code)) {
-        my $token_data = $c->json_utf8->decode($res->content);
-        return $token_data;
-    } elsif (is_server_error($res->code)) {
-        die 'An internal error occurred while attempting to refresh ' .
-            'the MetaBrainz OAuth token.';
     }
     return;
 }
@@ -203,25 +180,6 @@ sub find_active_oauth_access_token {
     return find_active_musicbrainz_oauth_access_token($c, $access_token);
 }
 
-=sub oauth_expires_in_to_iso8601()
-
-Converts C<expires_in> (in seconds), as you would receive from an
-OAuth token endpoint, to an ISO8601 datetime string.
-
- * This subroutine should be called right after the token endpoint returns,
-   since the returned datetime is relative to "now".
-
- * 10 seconds is subtracted from C<expires_in> as a buffer.
-
-=cut
-
-sub oauth_expires_in_to_iso8601 {
-    my ($expires_in) = @_;
-
-    my $offset = DateTime::Duration->new(seconds => ($expires_in - 10));
-    return datetime_to_iso8601(DateTime->now->add($offset));
-}
-
 sub parse_remember_login_cookie {
     my ($c) = @_;
 
@@ -256,29 +214,23 @@ sub revoke_metabrainz_oauth_refresh_token {
         },
     );
     if (is_server_error($res->code)) {
-        die 'An internal error occurred while attempting to revoke ' .
-            'the refresh token.';
+        log_error {
+            'Failed to revoke MetaBrainz OAuth refresh token ' .
+            '(' . substr($refresh_token, 0, 11) . '..., HTTP ' . $res->code . ')'
+        };
+        return 0;
     }
-    return;
+    return 1;
 }
 
 sub set_remember_login_cookie {
-    my ($c, $user_id, $remember_login_data) = @_;
+    my ($c, $user_id) = @_;
 
-    # The caller is responsible for generating a `remember_login_token` (via
-    # `generate_token`) when a new one is wanted. It's stored alongside
-    # the OAuth tokens because it may differ from the Valkey key it's stored
-    # under during token rotation.
-    my $remember_login_token = $remember_login_data->{remember_login_token};
+    my $remember_login_token = generate_token();
 
     $c->model('MB')->context->store->set(
-        "remember_login:$user_id:$remember_login_token",
-        {
-            access_token => $remember_login_data->{access_token},
-            access_token_expiration => $remember_login_data->{access_token_expiration},
-            refresh_token => $remember_login_data->{refresh_token},
-            remember_login_token => $remember_login_token,
-        },
+        'remember_login:' . sha256_hex($remember_login_token),
+        $user_id,
         31536000,  # 1 year (60 * 60 * 24 * 365)
     );
 

--- a/lib/MusicBrainz/Server/Authentication/Website/RememberLoginCredential.pm
+++ b/lib/MusicBrainz/Server/Authentication/Website/RememberLoginCredential.pm
@@ -19,9 +19,8 @@ use MusicBrainz::Server::Authentication::Utils qw(
     revoke_metabrainz_oauth_refresh_token
     set_remember_login_cookie
 );
-use MusicBrainz::Server::Data::Utils qw( generate_token non_empty );
+use MusicBrainz::Server::Data::Utils qw( generate_token );
 use MusicBrainz::Server::Log qw( log_debug );
-use MusicBrainz::Server::Validation qw( is_database_row_id );
 
 Readonly my $TOKEN_ROTATION_TTL => 600; # 10 minutes
 
@@ -41,12 +40,9 @@ sub authenticate {
 
     my @remember_login_fields = parse_remember_login_cookie($c);
     return unless @remember_login_fields;
-    my ($user_id, $remember_login_token) = @remember_login_fields;
+    my ($version, $user_id, $remember_login_token) = @remember_login_fields;
 
-    unless (
-        is_database_row_id($user_id) &&
-        non_empty($remember_login_token)
-    ) {
+    if ($version == -1) {
         clear_remember_login_cookie($c);
         log_debug {
             'RememberLoginCredential: malformed cookie value for user ' .

--- a/lib/MusicBrainz/Server/Authentication/Website/RememberLoginCredential.pm
+++ b/lib/MusicBrainz/Server/Authentication/Website/RememberLoginCredential.pm
@@ -3,26 +3,17 @@ package MusicBrainz::Server::Authentication::Website::RememberLoginCredential;
 use strict;
 use warnings;
 
-use Carp qw( croak );
-use DateTime;
-use DateTime::Format::ISO8601;
-use Readonly;
-use Try::Tiny;
+use Digest::SHA qw( sha256_hex );
 
-use DBDefs;
 use MusicBrainz::Server::Authentication::Utils qw(
     can_user_login
     clear_remember_login_cookie
-    exchange_metabrainz_oauth_refresh_token
-    oauth_expires_in_to_iso8601
+    clear_remember_login_data
     parse_remember_login_cookie
     revoke_metabrainz_oauth_refresh_token
     set_remember_login_cookie
 );
-use MusicBrainz::Server::Data::Utils qw( generate_token );
 use MusicBrainz::Server::Log qw( log_debug );
-
-Readonly my $TOKEN_ROTATION_TTL => 600; # 10 minutes
 
 sub new {
     my ($class, $config, $app, $realm) = @_;
@@ -33,166 +24,69 @@ sub new {
 sub authenticate {
     my ($self, $c, $realm, $auth_info) = @_;
 
-    # This subroutine may die and propagate errors to its caller (for
-    # example, if the MetaBrainz OAuth API is unavailable). Callers should
-    # invoke `authenticate` inside `capture_exceptions` (see Root.pm and
-    # `Controller::WS::js` for examples).
+    # This subroutine may die and propagate errors to its caller.
+    # Callers should invoke `authenticate` inside `capture_exceptions`
+    # (see Root.pm and `Controller::WS::js` for examples).
 
     my @remember_login_fields = parse_remember_login_cookie($c);
     return unless @remember_login_fields;
-    my ($version, $user_id, $remember_login_token) = @remember_login_fields;
+    my ($cookie_version, $cookie_user_id, $remember_login_token) = @remember_login_fields;
 
-    if ($version == -1) {
+    if ($cookie_version == -1) {
         clear_remember_login_cookie($c);
         log_debug {
             'RememberLoginCredential: malformed cookie value for user ' .
-            $user_id
+            $cookie_user_id
         };
         return;
     }
 
     my $context = $c->model('MB')->context;
-    my $remember_login_data = $context->store->get(
-        "remember_login:$user_id:$remember_login_token",
-    );
-    if (defined $remember_login_data) {
-        my $user = $self->_authenticate_with_access_token(
-            $c,
-            $user_id,
-            $remember_login_data,
-        );
-        return $user if defined $user;
+    my ($remember_login_key, $authenticated_user_id);
+
+    if ($cookie_version == 4) {
+        # MBS-14445: For version 4 cookies, we no longer use the stored
+        # refresh token except to revoke it before issuing a version 5
+        # cookie. Existence of the `remember_login` data in Valkey is itself
+        # sufficient for authentication.
+        $remember_login_key = "remember_login:$cookie_user_id:$remember_login_token";
+
+        my $remember_login_data = $context->store->get($remember_login_key);
+        if (defined $remember_login_data) {
+            revoke_metabrainz_oauth_refresh_token($remember_login_data->{refresh_token});
+            $authenticated_user_id = $cookie_user_id;
+        }
+    } elsif ($cookie_version == 5) {
+        $remember_login_key = 'remember_login:' . sha256_hex($remember_login_token);
+        $authenticated_user_id = $context->store->get($remember_login_key);
     }
-
-    return $context->sql->auto_transaction(sub {
-        $self->_rotate_refresh_token($c, $user_id, $remember_login_token);
-    });
-}
-
-sub _authenticate_with_access_token {
-    my (
-        $self,
-        $c,
-        $user_id,
-        $remember_login_data,
-    ) = @_;
-
-    my $access_token_expiration = DateTime::Format::ISO8601->parse_datetime(
-        $remember_login_data->{access_token_expiration},
-    );
-    return unless $access_token_expiration > DateTime->now;
-
-    my $oauth_realm = $c->get_auth_realm('website_oauth');
-    my $user = $oauth_realm->credential->authenticate($c, $oauth_realm, {
-        oauth_access_token => $remember_login_data->{access_token},
-    });
-
-    if (can_user_login($user) && $user->id == $user_id) {
-        set_remember_login_cookie($c, $user_id, $remember_login_data);
-        return $user;
-    }
-    return;
-}
-
-sub _rotate_refresh_token {
-    my ($self, $c, $user_id, $remember_login_token) = @_;
-
-    my $context = $c->model('MB')->context;
-    my $remember_login_subkey = "$user_id:$remember_login_token";
-    my $remember_login_key = "remember_login:$remember_login_subkey";
 
     unless (
-        # The builtin `hashtext` function is not documented by PostgreSQL
-        # but seems to be stable across releases. It's just a hash function
-        # that returns an integer.
-        $context->sql->select_single_value(
-            q{SELECT pg_try_advisory_xact_lock(hashtext('remember_login'), hashtext(?))},
-            $remember_login_subkey,
-        )
+        defined $authenticated_user_id &&
+        $authenticated_user_id == $cookie_user_id
     ) {
-        # Another request holds the lock and is likely rotating the token;
-        # return the page unauthenticated rather than waiting for it.
-        log_debug {
-            'RememberLoginCredential: could not acquire a lock ' .
-            "for user $user_id"
-        };
-        return;
-    }
-
-    # Re-read the data under the lock, in case a concurrent request has
-    # already rotated the token between us reading it in `authenticate`
-    # and acquiring the lock here.
-    my $remember_login_data = $context->store->get($remember_login_key);
-
-    unless (defined $remember_login_data) {
         clear_remember_login_cookie($c);
         return;
     }
 
-    my $user = $self->_authenticate_with_access_token(
-        $c,
-        $user_id,
-        $remember_login_data,
-    );
-    return $user if defined $user;
+    my $oauth_realm = $c->get_auth_realm('website_oauth');
+    my $user = $oauth_realm->store->find_user({
+        editor_id => $authenticated_user_id,
+    }, $c);
 
-    # If this croaks, the existing `remember_login` cookie will be preserved
-    # so it can be retried on a later request.
-    my $new_token_data = exchange_metabrainz_oauth_refresh_token(
-        $c,
-        $remember_login_data->{refresh_token},
-    );
-
-    if (defined $new_token_data) {
-        my $new_remember_login_data = {
-            remember_login_token    => generate_token(),
-            access_token            => $new_token_data->{access_token},
-            access_token_expiration => oauth_expires_in_to_iso8601($new_token_data->{expires_in}),
-            refresh_token           => $new_token_data->{refresh_token},
-        };
-        my $access_token_error;
-        $user = try {
-            $self->_authenticate_with_access_token(
-                $c,
-                $user_id,
-                $new_remember_login_data,
-            );
-        } catch {
-            $access_token_error = $_;
-            return;
-        };
-        if (defined $user || defined $access_token_error) {
-            # Briefly store `$new_remember_login_data` at the old
-            # `$remember_login_key` so that concurrent requests acquiring
-            # the lock with the previous cookie can read the new OAuth
-            # access token. This is done even in cases of 5xx errors
-            # attempting to use the new access token, since it may work on
-            # retry, but the previous `$remember_login_data` will certainly
-            # not.
-            $context->store->set(
-                $remember_login_key,
-                $new_remember_login_data,
-                $TOKEN_ROTATION_TTL,
-            );
-            croak $access_token_error if defined $access_token_error;
-        } else {
-            clear_remember_login_cookie($c);
-            $context->store->delete($remember_login_key);
-
-            revoke_metabrainz_oauth_refresh_token(
-                $new_remember_login_data->{refresh_token},
-            );
-        }
+    if (can_user_login($user)) {
+        # Expire consumed tokens in 5 minutes. This allows the case where
+        # the user has no session, and opens multiple tabs using the same
+        # `remember_login` token.
+        $context->store->expire($remember_login_key, 5 * 60, 'LT');
+        set_remember_login_cookie($c, $authenticated_user_id);
+        return $user;
     } else {
-        log_debug {
-            'RememberLoginCredential: refresh token rejected for ' .
-            "user $user_id, discarding remember_login data"
-        };
-        clear_remember_login_cookie($c);
-        $context->store->delete($remember_login_key);
+        clear_remember_login_data($c);
+        return;
     }
 
-    return $user;
+    return;
 }
 
 1;
@@ -200,20 +94,7 @@ sub _rotate_refresh_token {
 =head1 DESCRIPTION
 
 A credential verifier for `Catalyst::Plugin::Authentication` that reads the
-`remember_login` cookie to verify an associated MetaBrainz OAuth token.
-The cookie stores an access token, its expiration, and a refresh token.
-
-If the access token isn't already expired, we can try to use it for
-authentication as-is. Access tokens expire after 1 hour, which is less than
-the `musicbrainz_server_session` cookie lasts for, so this is unlikely.
-
-Otherwise, we attempt to use the stored refresh token to gain new access and
-refresh tokens. This requires an advisory lock, because presenting an
-already-revoked refresh token would cause MetaBrainz to revoke *every* access
-and refresh token for this user/client pair. (That's also unlikely to happen,
-but consider the case where the user returns with an expired session, and
-opens multiple tabs in quick succession, all using the same `remember_login`
-cookie.)
+`remember_login` cookie to authenticate a user.
 
 =head1 COPYRIGHT AND LICENSE
 

--- a/lib/MusicBrainz/Server/Controller/MetaBrainz.pm
+++ b/lib/MusicBrainz/Server/Controller/MetaBrainz.pm
@@ -19,7 +19,6 @@ use DBDefs;
 use MusicBrainz::Errors qw( capture_exceptions );
 use MusicBrainz::Server::Authentication::Utils qw(
     $METABRAINZ_OAUTH_LWP
-    oauth_expires_in_to_iso8601
     set_remember_login_cookie
 );
 use MusicBrainz::Server::Data::Editor;
@@ -257,12 +256,7 @@ sub oauth2_callback : Chained('base') PathPart('oauth2/callback') Args(0) Requir
     }
 
     if ($token_data->{remember_me}) {
-        set_remember_login_cookie($c, $user->id, {
-            remember_login_token => generate_token(),
-            access_token => $access_token,
-            access_token_expiration => oauth_expires_in_to_iso8601($token_data->{expires_in}),
-            refresh_token => $token_data->{refresh_token},
-        });
+        set_remember_login_cookie($c, $user->id);
     }
 
     if ($method eq 'GET') {

--- a/lib/MusicBrainz/Valkey.pm
+++ b/lib/MusicBrainz/Valkey.pm
@@ -184,9 +184,9 @@ sub exists {
 }
 
 sub expire {
-    my ($self, $key, $seconds) = @_;
+    my ($self, $key, $seconds, @options) = @_;
 
-    $self->_connection->expire($self->_prepare_key($key), $seconds);
+    $self->_connection->expire($self->_prepare_key($key), $seconds, @options);
     return;
 }
 

--- a/t/lib/t/MusicBrainz/Server/Authentication/Website/RememberLoginCredential.pm
+++ b/t/lib/t/MusicBrainz/Server/Authentication/Website/RememberLoginCredential.pm
@@ -3,11 +3,11 @@ package t::MusicBrainz::Server::Authentication::Website::RememberLoginCredential
 use strict;
 use warnings;
 
+use Digest::SHA qw( sha256_hex );
 use HTTP::Response;
 use HTTP::Status qw( :constants );
 use JSON::XS qw( decode_json );
 use LWP::UserAgent::Mockable;
-use Test::Deep qw( cmp_deeply ignore );
 use Test::Routine;
 use Test::More;
 use URI;
@@ -52,6 +52,11 @@ sub _get_remember_login_value {
     split /%09/, _get_cookie_value($mech, 'remember_login');
 }
 
+sub _remember_login_key {
+    my ($token) = @_;
+    return 'remember_login:' . sha256_hex($token);
+}
+
 sub _oauth2_mock_response {
     my ($request, $state) = @_;
 
@@ -59,27 +64,14 @@ sub _oauth2_mock_response {
     if ($path eq '/oauth2/token') {
         my $params = URI->new('?' . $request->content);
         my $grant_type = $params->query_param('grant_type') // '';
-        if ($grant_type eq 'refresh_token') {
-            $state->{refresh_requests}++;
-            $state->{last_refresh_token} = $params->query_param('refresh_token');
-            if ($state->{reject_refresh_token}) {
-                my $response = HTTP::Response->new(HTTP_BAD_REQUEST);
-                $response->header('Content-Type' => 'application/json');
-                $response->content('{"error":"invalid_grant"}');
-                return $response;
-            }
-            return build_json_response({
-                access_token => 'meba_new_access_token',
-                token_type => 'Bearer',
-                expires_in => 3600,
-                refresh_token => 'mebr_new_refresh_token',
-            });
+        if ($grant_type ne 'authorization_code') {
+            return HTTP::Response->new(
+                HTTP_INTERNAL_SERVER_ERROR,
+                "unexpected OAuth grant type: $grant_type",
+            );
         }
         return build_json_response({
             access_token => 'meba_access_token',
-            token_type => 'Bearer',
-            expires_in => $state->{expires_in} // 3600,
-            refresh_token => 'mebr_refresh_token',
             remember_me => JSON::true,
         });
     } elsif ($path eq '/oauth2/introspect') {
@@ -87,8 +79,8 @@ sub _oauth2_mock_response {
         return build_json_response({
             active => JSON::true,
             client_id => DBDefs->METABRAINZ_OAUTH_CLIENT_ID,
-            sub => $state->{sub} // $EDITOR_ID,
-            username => $state->{username} // $EDITOR_NAME,
+            sub => $EDITOR_ID,
+            username => $EDITOR_NAME,
             scope => ['profile'],
             token_type => 'Bearer',
             issued_at => $issued_at,
@@ -96,8 +88,8 @@ sub _oauth2_mock_response {
         });
     } elsif ($path eq '/oauth2/userinfo') {
         return build_json_response({
-            sub => $state->{sub} // $EDITOR_ID,
-            username => $state->{username} // $EDITOR_NAME,
+            sub => $EDITOR_ID,
+            username => $EDITOR_NAME,
             member_since => '2000-01-01T00:00:00+00:00',
         });
     } elsif ($path eq '/oauth2/revoke') {
@@ -134,71 +126,79 @@ test 'Authentication using the remember_login cookie' => sub {
     local *DBDefs::METABRAINZ_OAUTH_CLIENT_ID = sub { 'mb_test_client' };
     use warnings 'redefine';
 
-    my $mock_state = { expires_in => 0, refresh_requests => 0 };
+    my $mock_state = {};
     LWP::UserAgent::Mockable->reset;
     LWP::UserAgent::Mockable->set_record_pre_callback(sub {
         _oauth2_mock_response(shift, $mock_state);
     });
 
-    $mech->max_redirect(0);
-    $mech->get('/login');
-    my $redirect = URI->new($mech->response->header('Location'));
-    my $state = $redirect->query_param('state');
-    $mech->get('/metabrainz/oauth2/callback?code=foo&state=' . $state);
+    _login_with_remember_me($mech);
 
     my @session_cookies = _get_cookies($mech, 'musicbrainz_server_session');
     is(scalar @session_cookies, 1, 'a session cookie was returned');
     _clear_cookies($mech, @session_cookies);
 
-    my (undef, undef, $old_token) = _get_remember_login_value($mech);
+    my ($version, $user_id, $old_token) = _get_remember_login_value($mech);
+    is($version, 5, 'a version 5 remember_login cookie was returned');
+    is($user_id, $EDITOR_ID, 'the cookie contains the expected user ID');
 
-    is($mock_state->{refresh_requests}, 0, 'the access token was not refreshed yet');
+    my $store = $test->c->store;
+    is(
+        $store->get(_remember_login_key($old_token)),
+        $EDITOR_ID,
+        'the hashed remember_login token maps to the user ID',
+    );
+
     $mech->get('/ws/js/check-login');
     my $login_data = decode_json($mech->content);
     is($login_data->{id}, $EDITOR_ID, 'the user was authenticated with only a remember_login cookie');
-    is($mock_state->{refresh_requests}, 1, 'the access token was refreshed once');
-    is(
-        $mock_state->{last_refresh_token},
-        'mebr_refresh_token',
-        'the stored refresh token was exchanged',
-    );
+    ok(!$mock_state->{revoke_requests}, 'no OAuth token was revoked');
 
-    my (undef, undef, $new_token) = _get_remember_login_value($mech);
+    my ($new_version, undef, $new_token) = _get_remember_login_value($mech);
+    is($new_version, 5, 'the rotated cookie is version 5');
     isnt($new_token, $old_token, 'the remember_login token was rotated');
 
-    my $store = $test->c->store;
-    # The old remember_login token should point to the new data briefly
-    # (see the source package for info explaining why).
-    my $old_remember_login_key = "remember_login:$EDITOR_ID:$old_token";
-    cmp_deeply(
-        $store->get($old_remember_login_key),
-        {
-          'access_token_expiration' => ignore(),
-          'access_token' => 'meba_new_access_token',
-          'refresh_token' => 'mebr_new_refresh_token',
-          'remember_login_token' => $new_token,
-        },
-        'the old key points at the new access and remember_login tokens',
-    );
-
     is(
-        $store->get("remember_login:$EDITOR_ID:$new_token")->{access_token},
-        'meba_new_access_token',
-        'the new key holds the new access token',
+        $store->get(_remember_login_key($new_token)),
+        $EDITOR_ID,
+        'the rotated token maps to the user ID',
     );
 
+    my $old_remember_login_key = _remember_login_key($old_token);
     my $old_remember_login_key_ttl =
         $store->_connection->ttl($store->_prepare_key($old_remember_login_key));
     ok(
         $old_remember_login_key_ttl > 0 &&
-        $old_remember_login_key_ttl <= 600,
+        $old_remember_login_key_ttl <= 300,
         'the old key expires within the rotation TTL',
+    );
+
+    $store->expire($old_remember_login_key, 60);
+    $mech->cookie_jar->set_cookie(
+        0, 'remember_login', "5%09$user_id%09$old_token",
+        '/', 'localhost.local');
+    _clear_cookies($mech, _get_cookies($mech, 'musicbrainz_server_session'));
+
+    $mech->get('/ws/js/check-login');
+    my $reused_remember_login_key_ttl =
+        $store->_connection->ttl($store->_prepare_key($old_remember_login_key));
+    ok(
+        $reused_remember_login_key_ttl > 0 &&
+        $reused_remember_login_key_ttl <= 60,
+        'reusing the old token does not extend its rotation TTL',
     );
 
     LWP::UserAgent::Mockable->finished;
 };
 
-test 'remember_login data is discarded on a user ID mismatch' => sub {
+test 'A remember_login cookie is rejected on a user ID mismatch' => sub {
+    # The cookie value itself contains the user ID, and it should match the
+    # user ID stored in Valkey. That's mostly an internal consistency
+    # check ("these should match or something weird happened"). There's
+    # otherwise no reason we have to store the user ID in the cookie,
+    # except that it was previously included in the version 4 cookie.
+    # -mwiencek
+
     my $test = shift;
     my $mech = $test->mech;
     my $store = $test->c->store;
@@ -220,27 +220,13 @@ test 'remember_login data is discarded on a user ID mismatch' => sub {
     is($user_id, $EDITOR_ID, 'the remember_login cookie is set for the expected user');
 
     _clear_cookies($mech, _get_cookies($mech, 'musicbrainz_server_session'));
-    $mock_state->{sub} = $EDITOR_ID + 1;
-    $mock_state->{username} = 'unexpected_username';
+    $store->set(_remember_login_key($token), $EDITOR_ID + 1, 31536000);
 
     $mech->get('/ws/js/check-login');
     LWP::UserAgent::Mockable->finished;
 
-    cmp_deeply(
-        decode_json($mech->content),
-        { id => JSON::null, name => JSON::null },
-        'the user is not authenticated',
-    );
-    is($mock_state->{revoke_requests}, 1, 'the newly issued refresh token is revoked');
-    is(
-        $mock_state->{last_revoked_token},
-        'mebr_new_refresh_token',
-        'the revoked token is the newly issued one',
-    );
-    ok(
-        !$store->exists("remember_login:$user_id:$token"),
-        'the remember_login data is deleted',
-    );
+    is(decode_json($mech->content)->{id}, undef, 'the user is not authenticated');
+    ok($store->exists(_remember_login_key($token)), 'the data in valkey is not deleted');
     is(
         _get_cookie_value($mech, 'remember_login'),
        '',
@@ -248,7 +234,7 @@ test 'remember_login data is discarded on a user ID mismatch' => sub {
     );
 };
 
-test 'remember_login data is discarded when the refresh token is rejected' => sub {
+test 'A version 4 remember_login cookie is migrated to version 5' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $store = $test->c->store;
@@ -258,7 +244,7 @@ test 'remember_login data is discarded when the refresh token is rejected' => su
     local *DBDefs::METABRAINZ_OAUTH_CLIENT_ID = sub { 'mb_test_client' };
     use warnings 'redefine';
 
-    my $mock_state = { expires_in => 0, reject_refresh_token => 1 };
+    my $mock_state = {};
     LWP::UserAgent::Mockable->reset;
     LWP::UserAgent::Mockable->set_record_pre_callback(sub {
         _oauth2_mock_response(shift, $mock_state);
@@ -266,7 +252,15 @@ test 'remember_login data is discarded when the refresh token is rejected' => su
 
     _login_with_remember_me($mech);
 
-    my (undef, $user_id, $token) = _get_remember_login_value($mech);
+    my (undef, $user_id, $version_5_token) = _get_remember_login_value($mech);
+    $store->delete(_remember_login_key($version_5_token));
+
+    my $version_4_token = 'legacy_remember_login_token';
+    my $version_4_key = "remember_login:$user_id:$version_4_token";
+    $store->set($version_4_key, { refresh_token => 'mebr_refresh_token' }, 31536000);
+    $mech->cookie_jar->set_cookie(
+        0, 'remember_login', "4%09$user_id%09$version_4_token",
+        '/', 'localhost.local');
 
     _clear_cookies($mech, _get_cookies($mech, 'musicbrainz_server_session'));
 
@@ -275,19 +269,26 @@ test 'remember_login data is discarded when the refresh token is rejected' => su
 
     is(
         decode_json($mech->content)->{id},
-        undef,
-        'the user is not authenticated',
+        $EDITOR_ID,
+        'the user is authenticated',
     );
-    is($mock_state->{refresh_requests}, 1, 'a refresh was attempted');
-    ok(!$mock_state->{revoke_requests}, 'no token was revoked');
-    ok(
-        !$store->exists("remember_login:$user_id:$token"),
-        'the remember_login data is deleted',
-    );
+    is($mock_state->{revoke_requests}, 1, 'refresh token revocation was attempted');
+    is($mock_state->{last_revoked_token}, 'mebr_refresh_token',
+       'the legacy refresh token was submitted for revocation');
+
+    my ($version, undef, $new_token) = _get_remember_login_value($mech);
+    is($version, 5, 'the cookie was migrated to version 5');
     is(
-        _get_cookie_value($mech, 'remember_login'),
-        '',
-        'the remember_login cookie is cleared',
+        $store->get(_remember_login_key($new_token)),
+        $EDITOR_ID,
+        'the new version 5 token is stored',
+    );
+
+    my $version_4_key_ttl =
+        $store->_connection->ttl($store->_prepare_key($version_4_key));
+    ok(
+        $version_4_key_ttl > 0 && $version_4_key_ttl <= 300,
+        'the version 4 key expires within the rotation TTL',
     );
 };
 
@@ -332,7 +333,7 @@ test 'A malformed remember_login cookie is cleared without authentication' => su
     $store->delete("remember_login:$EDITOR_ID:foo");
 };
 
-test 'Logging out revokes the stored refresh token' => sub {
+test 'Logging out deletes the remember_login token' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $store = $test->c->store;
@@ -350,33 +351,19 @@ test 'Logging out revokes the stored refresh token' => sub {
 
     _login_with_remember_me($mech);
 
-    my (undef, $user_id, $token) = _get_remember_login_value($mech);
-    cmp_deeply(
-        $store->get("remember_login:$user_id:$token"),
-        {
-          'access_token_expiration' => ignore(),
-          'access_token' => 'meba_access_token',
-          'refresh_token' => 'mebr_refresh_token',
-          'remember_login_token' => $token,
-        },
+    my (undef, undef, $token) = _get_remember_login_value($mech);
+    is(
+        $store->get(_remember_login_key($token)),
+        $EDITOR_ID,
         'remember_login data is stored after logging in',
     );
 
     $mech->get('/logout');
     LWP::UserAgent::Mockable->finished;
 
-    is(
-        $mock_state->{revoke_requests},
-        1,
-        'the refresh token is revoked on logout',
-    );
-    is(
-        $mock_state->{last_revoked_token},
-        'mebr_refresh_token',
-        'the revoked token is the stored one',
-    );
+    ok(!$mock_state->{revoke_requests}, 'no OAuth token is revoked on logout');
     ok(
-        !$store->exists("remember_login:$user_id:$token"),
+        !$store->exists(_remember_login_key($token)),
         'the remember_login data is deleted',
     );
     is(


### PR DESCRIPTION
# Problem

MBS-14445

# Solution

Removes refresh token usage from the RememberLoginCredential module. A `remember_login` token on its own is now sufficient for authentication and is rotated on each use, as before.

# AI usage

An LLM was used to assist in updating the test cases under t/lib/t/. Non-test code was modified by hand.

# Testing

Ran the existing `RememberLoginCredential` tests and tested the "remember me" functionality locally.
