### PR TITLE
WS2: fix uninitialized value warning when browsing release groups by artist

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/2/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/ReleaseGroup.pm
@@ -105,7 +105,7 @@ sub release_group_browse : Private
         $c->detach('not_found') unless ($artist);
 
         # Allows requesting only "official" releases with 'website-default'
-        my $show_all = $c->stash->{release_group_status} eq 'website-default'
+        my $show_all = ($c->stash->{release_group_status} // '') eq 'website-default'
                        ? 0
                        : 1;
         my @tmp = $c->model('ReleaseGroup')->find_by_artist(


### PR DESCRIPTION
## Problem

Browsing release groups by artist without the optional `release-group-status` parameter triggers a Perl warning on every request:

```
Use of uninitialized value in string eq at
lib/MusicBrainz/Server/Controller/WS/2/ReleaseGroup.pm line 108
```

This **spams production container logs heavily**: ~1,300 warnings per 50,000 log lines on each webservice backend. Browsing release groups by artist is one of the most common API patterns — beets, Picard, Jellyfin, riplay, Digarr, DroppedNeedle, and many others all trigger it.

The noise makes it difficult to spot real issues in production logs.

## Cause

`$c->stash->{release_group_status}` is `undef` when the parameter is absent. The `validate_release_group_status` function in `Validator.pm` returns early without setting the stash value (line 179: `return unless $release_group_status`), then line 108 in `ReleaseGroup.pm` does `undef eq 'website-default'`.

## Fix

Use Perl's defined-or operator (`//`) to default to empty string before the comparison. Behavior is unchanged: when the parameter is absent, `$show_all` remains 1 (show all release groups).

## Example log entries (from production)

```
[warning] GET https://musicbrainz.org/ws/2/release-group?artist=ba8eaa2d-...&limit=100&offset=0&fmt=json
  caused a warning: Use of uninitialized value in string eq at
  lib/MusicBrainz/Server/Controller/WS/2/ReleaseGroup.pm line 108, <PKGFILE> line 1.
```