### PR TITLE
MBS-14448: Weaken `source` in `Data::Relationship::_new_from_row`

### DIFF
--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -94,7 +94,12 @@ sub _new_from_row
 
     my $rel = MusicBrainz::Server::Entity::Relationship->new(%info);
     # XXX MASSIVE MASSIVE HACK.
-    weaken($rel->{$weaken}) if $obj;
+    # Avoid ref cycles that can't be garbage collected:
+    # ($obj -> relationships -> $rel -> entity0/entity1/source -> $obj).
+    if ($obj) {
+        weaken($rel->{$weaken});
+        weaken($rel->{source});
+    }
 
     return $rel;
 }


### PR DESCRIPTION
# Problem

Fixes a massive memory leak identified by an LLM analysis of the codebase initially run by Zas:

https://gist.github.com/mwiencek/3740511beb036b5324c76d121e37372d

The leak-check.pl script:

https://gist.github.com/mwiencek/df7050c9da4b466fb8cf91c0879d48f6

# AI usage

The issue itself and the proposed fix were all identified by an LLM. The only work I did here was reviewing the changes and writing the comment/commit message.

# Testing

Existing automated tests + the leak-check.pl script linked above.