### PR TITLE
MBS-14424: Block Pinterest URL shortener

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5206,12 +5206,32 @@ export const CLEANUPS: CleanupEntries = {
     },
   },
   'pinterest': {
-    hostname: 'pinterest.com',
-    match: [/^(https?:\/\/)?([^/]+\.)?pinterest\.com\//i],
+    hostname: ['pinterest.com', 'pin.it'],
+    match: [/^(https?:\/\/)?([^/]+\.)?(pinterest\.com|pin\.it)\//i],
     restrict: [LINK_TYPES.socialnetwork],
     clean(url) {
       url = url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?pinterest\.com\/([^?#]*[^/?#])\/*(?:[?#].*)?$/, 'https://www.pinterest.com/$1/');
       return url.replace(/\/(?:boards|pins|likes|followers|following)(?:\/.*)?$/, '/');
+    },
+    validate(url) {
+      if (/pin\.it\//i.test(url)) {
+        return {
+          error: exp.l(
+            `This is a redirect link. Please follow {redirect_url|your link}
+             and add the link it redirects to instead.`,
+            {
+              redirect_url: {
+                href: url,
+                rel: 'noopener noreferrer',
+                target: '_blank',
+              },
+            },
+          ),
+          result: false,
+          target: ERROR_TARGETS.URL,
+        };
+      }
+      return {result: true};
     },
   },
   'pixiv': {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5195,6 +5195,17 @@ limited_link_type_combinations: [
                      input_url: 'http://pinterest.com/tucenter/',
             expected_clean_url: 'https://www.pinterest.com/tucenter/',
   },
+  {
+                     input_url: 'https://pin.it/3NwH9ogoo',
+             input_entity_type: 'artist',
+    expected_relationship_type: undefined,
+       input_relationship_type: 'socialnetwork',
+       only_valid_entity_types: [],
+                expected_error: {
+                                  error: 'is a redirect link',
+                                  target: 'url',
+                                },
+  },
   // pixiv
   {
                      input_url: 'https://www.pixiv.net/en/users/23610071/illustrations',


### PR DESCRIPTION
### Implement MBS-14424

# Description
These links (such as https://pin.it/3NwH9ogoo) are redirect links, so I'm rejecting them with the same "please follow the redirect and add the proper link" message we use for this sort of thing elsewhere. I implemented it inside `URLCleanup` for now since they are associated with Pinterest which we clean up, although I am tempted to just move all of these to `IsShortenedUrl` like we already do with some (but not all) Spotify shorteners.

# AI usage
None

# Testing
Added a test, and tested locally as well to double-check that the error is shown and the redirect link is made clickable in the error text for ease of correction.