### PR TITLE
MBS-14192: Require that tracklist is visited when adding release

### DIFF
--- a/root/static/scripts/release-editor/components/EditNoteTab.js
+++ b/root/static/scripts/release-editor/components/EditNoteTab.js
@@ -24,6 +24,7 @@ type ReleaseEditorFormT = FormT<{
 }>;
 
 component EditNoteTab(
+  addingWithoutVisitingTracklist?: boolean = false,
   editPreviews?: ReadonlyArray<EditPreviewT> = [],
   editsExist?: boolean = false,
   errorsExist?: boolean = false,
@@ -48,6 +49,27 @@ component EditNoteTab(
             {l(`Some errors were detected in the data you’ve entered.
                 Click on the highlighted tabs and correct any visible
                 errors.`)}
+          </p>
+        </div>
+      ) : null}
+
+      {addingWithoutVisitingTracklist ? (
+        <div className="warning">
+          <p>
+            {exp.l(`You didn’t visit the tracklist tab. When adding
+                a release, please check that the tracks follow the
+                MusicBrainz style guidelines for
+                {titles_style|titles} and
+                {credits_style|artist credits}.`, {
+              titles_style: {
+                href: '/doc/Style/Titles',
+                target: '_blank',
+              },
+              credits_style: {
+                href: '/doc/Style/Artist_Credits',
+                target: '_blank',
+              },
+            })}
           </p>
         </div>
       ) : null}

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -49,6 +49,7 @@ import releaseEditor from './viewModel.js';
 Object.assign(releaseEditor, {
   activeTabID: ko.observable('#information'),
   activeTabIndex: ko.observable(0),
+  addingWithoutVisitingTracklist: ko.observable(false),
   loadError: ko.observable(''),
   loadErrorMessage() {
     return texp.l(
@@ -204,6 +205,21 @@ releaseEditor.init = function (options) {
       $tab.tooltip(tooltipEnabled ? 'enable' : 'disable');
     }
   });
+
+  // Monitor tab changes to check that the user visits the tracklist.
+
+  if (self.action === 'add') {
+    let visitedTracklist = false;
+    $('#release-editor').on('tabsbeforeactivate', function (event, ui) {
+      const id = ui.newPanel.attr('id');
+      if (id === 'tracklist') {
+        releaseEditor.addingWithoutVisitingTracklist(false);
+        visitedTracklist = true;
+      } else if (id === 'edit-note' && !visitedTracklist) {
+        releaseEditor.addingWithoutVisitingTracklist(true);
+      }
+    });
+  }
 
   // Display documentation bubbles for external components.
 
@@ -396,6 +412,9 @@ releaseEditor.init = function (options) {
       .final();
     editNoteTabRoot.render(
       <EditNoteTab
+        addingWithoutVisitingTracklist={
+          releaseEditor.addingWithoutVisitingTracklist()
+        }
         editPreviews={releaseEditor.editPreviews()}
         editsExist={releaseEditor.allEdits().length > 0}
         errorsExist={errorsExist()}
@@ -487,6 +506,7 @@ releaseEditor.allowsSubmission = function () {
   return (
     !this.submissionInProgress() &&
     !errorsExist() &&
+    !this.addingWithoutVisitingTracklist() &&
     !this.rootField.invalidEditNote() &&
     !(this.action === 'add' && this.rootField.missingEditNote()) &&
     this.allEdits().length > 0

--- a/root/static/scripts/release-editor/validation.js
+++ b/root/static/scripts/release-editor/validation.js
@@ -36,12 +36,17 @@ function markTabWithErrors($panel) {
   // Mark the previous tab red if it has errors.
   var tabs = releaseEditor.uiTabs;
 
-  var $errors = $('.field-error', $panel).filter(function () {
+  let hasErrors = $('.field-error', $panel).filter(function () {
     return String($(this).data('visible')) === 'true' && $(this).text();
-  });
+  }).length > 0;
+
+  // Ensure that the user visits the tracklist tab when adding a release.
+  hasErrors ||=
+    $panel.attr('id') === 'tracklist' &&
+    releaseEditor.addingWithoutVisitingTracklist();
 
   tabs.tabs.eq(tabs.panels.index($panel))
-    .toggleClass('error-tab', $errors.length > 0);
+    .toggleClass('error-tab', hasErrors);
 }
 
 

--- a/root/static/scripts/tests/release-editor/seeds/mbs-14192.html
+++ b/root/static/scripts/tests/release-editor/seeds/mbs-14192.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <form action="/release/add" method="POST">
+      <input type="hidden" name="name" value="MBS-14192" />
+      <input type="hidden" name="artist_credit.names.0.artist.name" value="Nine Inch Nails" />
+      <input type="hidden" name="artist_credit.names.0.mbid" value="b7ffd2af-418f-4be2-bdd1-22f8b48613da" />
+      <input type="hidden" name="mediums.0.format" value="Digital Media" />
+      <input type="hidden" name="mediums.0.track.0.name" value="Title" />
+      <input type="hidden" name="edit_note" value="Testing MBS-14192" />
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -882,6 +882,7 @@ const seleniumTests = [
   {name: 'release-editor/MBS-13579.json5', login: true},
   {name: 'release-editor/MBS-13692.json5', login: true},
   {name: 'release-editor/MBS-13715.json5', login: true},
+  {name: 'release-editor/MBS-14192.json5', login: true},
   {
     name: 'Check_Duplicates.json5',
     login: true,

--- a/t/selenium/release-editor/MBS-13273.json5
+++ b/t/selenium/release-editor/MBS-13273.json5
@@ -12,6 +12,12 @@
       target: 'css=button[type=submit]',
       value: '',
     },
+    // Visit the tracklist so we can submit the edits (see MBS-14192).
+    {
+      command: 'click',
+      target: 'css=a[href="#tracklist"]',
+      value: '',
+    },
     {
       command: 'click',
       target: 'css=a[href="#edit-note"]',

--- a/t/selenium/release-editor/MBS-14192.json5
+++ b/t/selenium/release-editor/MBS-14192.json5
@@ -1,0 +1,76 @@
+{
+  title: 'MBS-14192',
+  commands: [
+    {
+      command: 'open',
+      target: '/static/scripts/tests/release-editor/seeds/mbs-14192.html',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=button[type=submit]',
+      value: '',
+    },
+
+    // Going straight to the edit note panel should trigger a warning.
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#edit-note']",
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "[...document.querySelectorAll('#edit-note div.warning')].some(x => x.textContent.includes('You didn’t visit the tracklist tab.'))",
+      value: 'true',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelector('a[href=\"#tracklist\"]').parentNode.classList.contains('error-tab')",
+      value: 'true',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelector('#enter-edit').disabled",
+      value: 'true',
+    },
+
+    // Switching to the tracklist should make the warning icon disappear.
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#tracklist']",
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelector('a[href=\"#tracklist\"]').parentNode.classList.contains('error-tab')",
+      value: 'false',
+    },
+
+    // We should be able to add the release now.
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#edit-note']",
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelectorAll('#edit-note div.warning').length",
+      value: '0',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelector('a[href=\"#tracklist\"]').parentNode.classList.contains('error-tab')",
+      value: 'false',
+    },
+    {
+      command: 'assertEval',
+      target: "document.querySelector('#enter-edit').disabled",
+      value: 'false',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'id=enter-edit',
+      value: '',
+    },
+  ],
+}

--- a/t/selenium/release-editor/Seeding.json5
+++ b/t/selenium/release-editor/Seeding.json5
@@ -247,6 +247,12 @@
       target: "document.querySelector('#discid-attachment select').selectedOptions[0].textContent",
       value: '8JrTc74BBFV.d2LEmUkPiYMk6Ww-',
     },
+    // Visit the tracklist so we can submit the edits (see MBS-14192).
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#tracklist']",
+      value: '',
+    },
     {
       command: 'click',
       target: "xpath=//a[@href='#edit-note']",


### PR DESCRIPTION
# MBS-14192

Make the release editor track whether the user has visited the tracklist panel and block submission with a "You didn’t visit the tracklist tab" warning if they're adding a new release and haven't visited the tracklist. The warning is removed after the tracklist panel is visited.

Submission is already blocked when the tracklist is empty; this change is intended to prevent editors from seeding data without at least glancing at it to check whether it follows the style guidelines.

# Problem

Editors sometimes seed releases and click through to the edit note panel without looking at the tracklist. This can result in warnings about e.g. incorrectly-capitalized titles not being displayed.

# Solution

Display a warning if the user visits the edit note panel without looking at the tracklist first:

<img width="1031" height="327" alt="20260825_100142" src="https://github.com/user-attachments/assets/45c4b7c3-7e73-4ebf-bdbc-0d65dd71099e" />

# AI usage

Ugh, no.

# Testing

Manually tested with and without seeded data to make sure that the warning is shown when expected. I also added a Selenium test (which I haven't run yet, since IIRC it's hard to run tests locally when using `musicbrainz-docker` -- I've started a CI run to see what happens).

I strongly suspect that I'll need to update some existing tests to visit the tracklist tab after seeding data.