### PR TITLE
MBS-7017: allow setting recording video attribute from release editor

### DIFF
--- a/admin/cleanup/FixTrackLength.pl
+++ b/admin/cleanup/FixTrackLength.pl
@@ -240,7 +240,8 @@ for my $medium (@mediums)
                         artist_credit => $_->artist_credit,
                         recording_id => $_->recording_id,
                         position => $_->position,
-                        is_data_track => $_->is_data_track
+                        is_data_track => $_->is_data_track,
+                        video => $_->video,
                     )
                 } @tracks;
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -408,6 +408,7 @@ sub process_medium {
             my $ac = $track->{artist_credit};
             $track->{artist_credit} = ArtistCredit->from_array($ac->{names}) if $ac;
             $track->{is_data_track} = boolean_from_json($track->{is_data_track});
+            $track->{video} = boolean_from_json($track->{video});
 
             return Track->new(%$track);
         };

--- a/lib/MusicBrainz/Server/Edit/Medium/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Create.pm
@@ -169,6 +169,7 @@ sub _insert_hash {
     for my $track (@$tracklist) {
         $track->{recording_id} ||= $self->c->model('Recording')->insert({
             %$track,
+            video => $track->{video} || 0,
             artist_credit => $self->c->model('ArtistCredit')->find_or_insert($track->{artist_credit}),
         })->{id};
         delete $track->{medium_id};

--- a/lib/MusicBrainz/Server/Edit/Medium/Util.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Util.pm
@@ -59,6 +59,7 @@ sub tracks_to_hash
         number => $_->number,
         length => $_->length,
         is_data_track => $_->is_data_track,
+        video => $_->video,
     }, @$tracks ];
 
     return $tmp;
@@ -121,6 +122,7 @@ sub track {
         position => Int,
         number => Nullable[Str],
         is_data_track => Optional[Bool],
+        video => Optional[Bool],
     ];
 }
 

--- a/lib/MusicBrainz/Server/Entity/Track.pm
+++ b/lib/MusicBrainz/Server/Entity/Track.pm
@@ -58,6 +58,11 @@ has 'is_data_track' => (
     isa => 'Bool',
 );
 
+has 'video' => (
+    is => 'rw',
+    isa => 'Bool',
+);
+
 around TO_JSON => sub {
     my ($orig, $self) = @_;
 

--- a/root/release/edit/recordings.tt
+++ b/root/release/edit/recordings.tt
@@ -99,6 +99,16 @@
               </label>
             </td>
           </tr>
+
+          <tr data-bind="css: { even: position() % 2 === 0 }">
+            <td></td>
+            <td colspan="5" class="checkbox">
+              <label>
+                <input type="checkbox" class="video-checkbox" data-bind="checked: video" />
+                [% l('Video') %]
+              </label>
+            </td>
+          </tr>
         </tbody>
       </table>
 
@@ -147,6 +157,12 @@
         <label>
           <input id="update-all-recording-artists" type="checkbox" data-bind="checked: $root.copyTrackArtistsToRecordings" />
           [% l('Copy all track artist credits to associated recordings.') %]
+        </label>
+      </p>
+      <p>
+        <label>
+          <input id="mark-all-as-video" type="checkbox" data-bind="checked: $root.markAllRecordingsAsVideo" />
+          [% l('Mark all recordings as video.') %]
         </label>
       </p>
     </fieldset>

--- a/root/static/scripts/edit/MB/edit.js
+++ b/root/static/scripts/edit/MB/edit.js
@@ -259,6 +259,7 @@ var fields = edit.fields = {
       number:         string(track.number),
       length:         number(track.length),
       is_data_track:  Boolean(ko.unwrap(track.isDataTrack)),
+      video:          Boolean(ko.unwrap(track.video)),
     };
   },
 

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -551,6 +551,23 @@ const actions = {
       }
     },
   }),
+
+  markAllRecordingsAsVideo: ko.computed({
+    read: () => {
+      const release = releaseEditor.rootField.release();
+      if (!release) {
+        return false;
+      }
+      const tracks = release.countTracks(Boolean);
+      const checked = release.countTracks((t) => t.video());
+      return tracks > 0 && checked === tracks;
+    },
+    write: (value) => {
+      for (const track of releaseEditor.rootField.release().allTracks()) {
+        track.video(value || track.recording.original().video);
+      }
+    },
+  }),
 };
 
 Object.assign(releaseEditor, actions);

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -192,6 +192,16 @@ class Track {
       this.hasNewRecording(false);
     }
 
+    this.video = ko.computed({
+      read: () => this.recording().video,
+      write: value => {
+        this.recording().video = value;
+        // `video` is a plain property, need to notify manually
+        this.recordingValue.valueHasMutated();
+      },
+      owner: this,
+    });
+
     recordingAssociation.track(this);
 
     this.uniqueID = this.id || uniqueId('new-');

--- a/t/lib/t/MusicBrainz/Server/Edit/Medium/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Medium/Create.pm
@@ -130,12 +130,17 @@ $edit = $c->model('Edit')->create(
     position => 2,
     format_id => 1,
     release => $c->model('Release')->get_by_id(1),
-    tracklist => $tracks_creating_recordings,
+    tracklist => [
+        $tracks_creating_recordings->[0],
+        $tracks_creating_recordings->[0]->meta->clone_object($tracks_creating_recordings->[0], position => 2, video => 1),
+    ],
 );
 
 $c->model('Edit')->load_all($edit);
 ok($edit->display_data);
 ok(defined $edit->display_data->{tracks}->[0]->{recording}{id}, 'New recording was created');
+ok(defined $edit->display_data->{tracks}->[1]->{recording}{id}, 'New recording was created');
+ok($edit->display_data->{tracks}->[1]->{recording}{video}, 'New recording is video');
 
 };
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

MBS-7017


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

- add video checkboxes to release editor recordings tab
- add a `Mark all recordings as video` checkbox which when checked sets all and when unchecked resets to original values

# AI usage
<!--
    If you used AI / LLM tools while working on this pull request, you must
    disclose it as per the MetaBrainz Foundation's contribution guidelines
    (https://github.com/metabrainz/guidelines).
-->

Used for debugging help only.

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

- verified locally creating new and editing recordings
- added a video track to medium create test


# Documenting
<!--
    List changes to the documentation, which can be placed in the WikiDoc pages,
    in this Git repository, in another repository, in the database...
-->

Will update https://test.musicbrainz.org/doc/How_to_Add_a_Release#Recordings once this is approved.
