### PR TITLE
MBS-14443: Support Boomplay’s new non-numeric URL format

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1949,13 +1949,13 @@ export const CLEANUPS: CleanupEntries = {
     restrict: [LINK_TYPES.streamingfree],
     clean(url) {
       url = url.replace(
-        /^https?:\/\/(?:www.)?boomplay.com\/((?:albums|artists|songs)\/\d+).*$/,
+        /^https?:\/\/(?:www.)?boomplay.com\/((?:albums|artists|songs)\/[\w\d-]+).*$/,
         'https://www.boomplay.com/$1',
       );
       return url;
     },
     validate(url, id) {
-      const m = /^https:\/\/www\.boomplay\.com\/(albums|artists|songs)\/\d+$/.exec(url);
+      const m = /^https:\/\/www\.boomplay\.com\/(albums|artists|songs)\/[\w\d-]+$/.exec(url);
       if (m) {
         const prefix = m[1];
         switch (id) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1749,6 +1749,13 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist'],
   },
   {
+                     input_url: 'https://www.boomplay.com/artists/EQIATIegUocAxeO6d3vrR4zE?from=artists',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'streamingfree',
+            expected_clean_url: 'https://www.boomplay.com/artists/EQIATIegUocAxeO6d3vrR4zE',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'http://www.boomplay.com/songs/99760140?from=home',
              input_entity_type: 'recording',
     expected_relationship_type: 'streamingfree',
@@ -1760,6 +1767,13 @@ limited_link_type_combinations: [
              input_entity_type: 'release',
     expected_relationship_type: 'streamingfree',
             expected_clean_url: 'https://www.boomplay.com/albums/53557880',
+       only_valid_entity_types: ['release'],
+  },
+  {
+                     input_url: 'https://www.boomplay.com/albums/EQUABbK_Gy8KOODzT4ow4hGX?srModel=openapi_featurefm&ffm=FFM_04511e3b346d53f7e395d55c79e0d5b5',
+             input_entity_type: 'release',
+    expected_relationship_type: 'streamingfree',
+            expected_clean_url: 'https://www.boomplay.com/albums/EQUABbK_Gy8KOODzT4ow4hGX',
        only_valid_entity_types: ['release'],
   },
   // Brahms Ircam


### PR DESCRIPTION
### Fix MBS-14443

# Description
It seems Boomplay no longer uses numbers only for IDs, but longer, alphanumeric ones. I am just doing `[\w\d-]+` to play it safe. Marking as regression since this seems to currently block adding Boomplay URLs.

# AI usage
None

# Testing
Added two tests of new URLs linked from the ticket.