### PR TITLE
Replace no-break spaces (U+00A0) with normal spaces (U+0020)

### DIFF
--- a/docs/database_schema_diagrams/README.md
+++ b/docs/database_schema_diagrams/README.md
@@ -1,4 +1,4 @@
-# Database Schema Diagrams
+# Database Schema Diagrams
 
 Diagrams for the database schemas are:
 - defined in JSON format under the subdirectory `source/`,


### PR DESCRIPTION
# Problem
The readme in `/docs/database_schema_diagrams` has a no-break space in front of the main title, which breaks some formatters and highlighters.

This is a very minor change. I was originally looking into all of the no-break spaces in the repo (there are quite a few in some of the documentation), and had a prepared a PR to "fix them"... but they actually all make sense as far as I can tell, so instead the PR is just the one definite mistake.

# Solution
```bash
sed -i 's/ / /g' -- docs/database_schema_diagrams/README.md
```

# AI usage
no.