### PR TITLE
Set track artists immediately in release editor

### DIFF
--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -244,7 +244,10 @@ releaseEditor.init = function (options) {
     const releaseACChanged =
       !artistCreditsAreEqual(releaseAC, savedReleaseAC);
 
-    if (tabID === '#tracklist' && releaseACChanged) {
+    if (
+      releaseACChanged &&
+      (tabID === '#tracklist' || release.needsTrackArtists())
+    ) {
       if (!hasVariousArtists(releaseAC)) {
         for (const medium of release.mediums()) {
           for (const track of medium.tracks()) {


### PR DESCRIPTION
As suggested by mwiencek on #3841, make the release editor copy the release artist credits to the tracklist even if the tracklist pane isn't currently active.

# Problem

When seeding a release without track artist credits, release artist credits are only copied to tracks if the tracklist panel is active.

# Solution

Copy release ACs to tracks regardless of whether the tracklist panel is open.

# AI usage

None.

# Testing

Manually verified that this seems to work:

1. Seeded a release without track credits (e.g. using my dev instance with test data, where URL-to-MBID lookups fail).
2. Assigned an artist credit to the release on the info panel.
3. Switched to the edit note panel and noticed that I no longer get the "Some errors were detected" warning. (I still get the "You didn’t visit the tracklist tab" warning added by #3841, as expected.)