### PR TITLE
MBS-14388: Standardise trailing slash for RateYourMusic URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5399,7 +5399,10 @@ export const CLEANUPS: CleanupEntries = {
     match: [/^(https?:\/\/)?([^/]+\.)?rateyourmusic\.com\/(?!feature)/i],
     restrict: [LINK_TYPES.otherdatabases],
     clean(url) {
-      return url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?rateyourmusic\.com\/([^#?]+).*$/, 'https://rateyourmusic.com/$1');
+      url = url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?rateyourmusic\.com\/([^#?]+)\/?.*$/, 'https://rateyourmusic.com/$1');
+      // Ensure trailing slash to avoid accidental duplicates
+      url = url.replace(/\/?$/, '/');
+      return url;
     },
     validate(url, id) {
       const m = /^https:\/\/rateyourmusic\.com\/(\w+)\/(?:(\w+)\/)?/.exec(url);

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5336,14 +5336,14 @@ limited_link_type_combinations: [
                      input_url: 'http://www.rateyourmusic.com/artist/johanna_beyer?__cf_chl_f_tk=d9ucwvyvsyPN6wYqKhaxZAloHggP6RNt.iEnchyh1qc-1720128733-0.0.1.1-4862',
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',
-            expected_clean_url: 'https://rateyourmusic.com/artist/johanna_beyer',
+            expected_clean_url: 'https://rateyourmusic.com/artist/johanna_beyer/',
         only_valid_entity_types: ['artist'],
   },
   {
                      input_url: 'https://rateyourmusic.com/concert/riverside_theatre_f1/merzbow_f3',
              input_entity_type: 'event',
     expected_relationship_type: 'otherdatabases',
-            expected_clean_url: 'https://rateyourmusic.com/concert/riverside_theatre_f1/merzbow_f3',
+            expected_clean_url: 'https://rateyourmusic.com/concert/riverside_theatre_f1/merzbow_f3/',
         only_valid_entity_types: ['event'],
   },
   {


### PR DESCRIPTION
### Implement MBS-14388

# Description
RYM cannot figure out whether URLs should end in a slash or not (some entity types do, other do not). Both options work though, so this just standardizes all to have a slash to avoid users entering duplicates with and without one (which has happened).

# AI usage
None

# Testing
Changed the existing tests to always expect ending slash.