### PR TITLE
MBS-9526: reuse length & number when options turned off

### DIFF
--- a/root/static/scripts/release-editor/trackParser.js
+++ b/root/static/scripts/release-editor/trackParser.js
@@ -109,10 +109,6 @@ const trackParser = releaseEditor.trackParser = {
       currentPosition += 1;
       data.position = currentPosition;
 
-      if (data.number === undefined) {
-        data.number = currentPosition;
-      }
-
       if (!currentTracks || !currentTracks.length) {
         return data;
       }
@@ -221,6 +217,19 @@ const trackParser = releaseEditor.trackParser = {
         }
 
         return matchedTrack;
+      }
+
+      // reuse previous length and number if not asked to override
+      if (previousTrack) {
+        if (!options.useTrackLengths && data.length === undefined) {
+          data.length = previousTrack.length();
+        }
+
+        if (!options.useTrackNumbers && data.number === undefined) {
+          data.number = previousTrack.number();
+        }
+      } else if (data.number === undefined) {
+        data.number = data.position;
       }
 
       return new fields.Track(data, medium);

--- a/root/static/scripts/tests/release-editor/trackParser.js
+++ b/root/static/scripts/tests/release-editor/trackParser.js
@@ -592,3 +592,51 @@ parserTest('force number of tracks to equal CD TOC', function (t) {
     ['Track A', 'Very Different Title', 'Another Data Track'],
   );
 });
+
+parserTest('keeps length and track number unchanged when useTrackLengths is off (MBS-9526)', function (t) {
+  t.plan(1);
+
+  trackParser.options.useTrackNames = true;
+
+  /* eslint-disable sort-keys */
+  const release = new fields.Release({
+    id: 1,
+    mediums: [
+      {
+        id: 1,
+        tracks: [
+          {id: 1, number: 'A1', name: 'Track A', length: 42},
+          // data tracks should not be included in count
+          {id: 2, number: 'A2', name: 'Track B', length: 43},
+        ],
+      },
+    ],
+  });
+  /* eslint-enable sort-keys */
+
+  releaseEditor.rootField.release(release);
+
+  const medium = release.mediums()[0];
+  medium.tracks(trackParser.parse(
+    'Track A\n' +
+    'Very Different Title\n',
+    medium,
+  ));
+
+  t.deepEqual(
+    medium.tracks().map(x => ({
+      length: x.length(),
+      name: x.name(),
+      number: x.number(),
+    })),
+    [{
+      length: 42,
+      name: 'Track A',
+      number: 'A1',
+    }, {
+      length: 43,
+      name: 'Very Different Title',
+      number: 'A2',
+    }],
+  );
+});


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

MBS-9526

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

When there's an existing track in the same position, reuse its length and number if the respective option to use the parsed value is turned off.

This is similar to how artist credit is reused.

# AI usage
<!--
    If you used AI / LLM tools while working on this pull request, you must
    disclose it as per the MetaBrainz Foundation's contribution guidelines
    (https://github.com/metabrainz/guidelines).
-->

Only for debugging.

# Testing
<!--
    Talk about the testing you have or haven’t done (whether you rely
    on automated tests, or don’t know how to test something). It’s useful
    for others to know what you’ve already tested so that they can avoid
    repeating the same steps, and instead consider what you might’ve
    missed.
-->

Added a unit test to reproduce the failure and verify the fix.

