### PR TITLE
MBS-14455: Limit the depth of search results

### DIFF
--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -283,6 +283,11 @@ sub WEB_SERVER                { 'www.musicbrainz.example.com' }
 # indicates that no expiration is set.
 # sub ENTITY_CACHE_TTL { 0 }
 
+# The maximum amount of results requested to search.
+# It helps with saving resources through better caching.
+# If undef, the amount of results is not limited.
+# sub MAX_SEARCH_RESULTS { undef }
+
 ################################################################################
 # Sessions (advanced)
 ################################################################################

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -270,6 +270,11 @@ sub ENTITY_CACHE_TTL {
     return 86400;
 }
 
+# The maximum amount of results requested to search.
+# It helps with saving resources through better caching.
+# If undef, the amount of results is not limited.
+sub MAX_SEARCH_RESULTS { undef }
+
 ################################################################################
 # Sessions (advanced)
 ################################################################################

--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -74,6 +74,7 @@ sub search : Path('')
                 pager => serialize_pager($stash->{pager}),
                 query => $stash->{query},
                 results => to_json_array($stash->{results}),
+                uncappedTotalHits => $stash->{uncapped_total_hits} // 0,
             );
 
             $c->stash(
@@ -235,6 +236,15 @@ sub direct : Private
         $c->model('ArtistCredit')->load(@entities);
     }
 
+    if (defined DBDefs->MAX_SEARCH_RESULTS) {
+        my $pager = $c->stash->{pager};
+        my $total_hits = $pager->total_entries;
+        if ($total_hits > DBDefs->MAX_SEARCH_RESULTS) {
+            $c->stash->{uncapped_total_hits} = $total_hits;
+            $pager->total_entries(DBDefs->MAX_SEARCH_RESULTS);
+        }
+    }
+
     $c->stash(
         query    => $query,
         results  => $results,
@@ -323,6 +333,7 @@ sub do_external_search {
         $c->stash->{offset}   = $ret->{offset};
         $c->stash->{results}  = $ret->{results};
         $c->stash->{last_updated}  = $ret->{last_updated};
+        $c->stash->{uncapped_total_hits}  = $ret->{uncapped_total_hits};
     }
 }
 

--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -116,10 +116,35 @@ sub direct : Private
 
     my $type   = $form->field('type')->value;
     my $query  = $form->field('query')->value;
+    my $limit  = $form->field('limit')->value;
+
+    if (defined DBDefs->MAX_SEARCH_RESULTS) {
+        my $page = looks_like_number($c->request->query_params->{page})
+            ? $c->request->query_params->{page} : 1;
+        $page = max(1, $page);
+        my $depth = $page * $limit;
+        if ($depth > DBDefs->MAX_SEARCH_RESULTS) {
+            my %props = (
+                form => $form->TO_JSON,
+                error => 'Must retrieve at most ' .
+                    DBDefs->MAX_SEARCH_RESULTS .
+                    " search results, not $depth.",
+                query => $query,
+                type => $type,
+            );
+            $c->stash(
+                component_path => 'search/error/Invalid',
+                component_props => \%props,
+                current_view => 'Node',
+            );
+            $c->response->status(HTTP_BAD_REQUEST);
+            $c->detach;
+        }
+    }
 
     my $results = $self->_load_paged($c, sub {
        $c->model('Search')->search($type, $query, shift, shift);
-    }, limit => $form->field('limit')->value);
+    }, limit => $limit);
 
     my @entities = map { $_->entity } @$results;
 
@@ -287,6 +312,8 @@ sub do_external_search {
             component_props => \%props,
             current_view => 'Node',
         );
+
+        $c->response->status($code);
 
         $c->detach;
     }

--- a/lib/MusicBrainz/Server/Controller/TagLookup.pm
+++ b/lib/MusicBrainz/Server/Controller/TagLookup.pm
@@ -232,6 +232,7 @@ sub index : Path('')
             pager => serialize_pager($c->stash->{pager}),
             query => $c->stash->{query},
             results => to_json_array($c->stash->{results}),
+            uncappedTotalHits => $c->stash->{uncapped_total_hits},
         },
     );
 }

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -988,12 +988,16 @@ sub external_search
             $self->c->model('Series')->load_entity_count(@entities);
         }
 
+        my $capped_total_hits = $total_hits;
+        $capped_total_hits = DBDefs->MAX_SEARCH_RESULTS if defined DBDefs->MAX_SEARCH_RESULTS &&
+            $total_hits > DBDefs->MAX_SEARCH_RESULTS;
+
         my $pager = Data::Page->new;
         $pager->current_page($page);
         $pager->entries_per_page($limit);
-        $pager->total_entries($total_hits);
+        $pager->total_entries($capped_total_hits);
 
-        return { pager => $pager, offset => $offset, results => \@results, last_updated => $last_updated };
+        return { pager => $pager, offset => $offset, results => \@results, last_updated => $last_updated, uncapped_total_hits => $total_hits };
     }
 }
 

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -997,7 +997,13 @@ sub external_search
         $pager->entries_per_page($limit);
         $pager->total_entries($capped_total_hits);
 
-        return { pager => $pager, offset => $offset, results => \@results, last_updated => $last_updated, uncapped_total_hits => $total_hits };
+        return {
+            pager => $pager,
+            offset => $offset,
+            results => \@results,
+            last_updated => $last_updated,
+            uncapped_total_hits => $total_hits,
+        };
     }
 }
 

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -829,6 +829,18 @@ sub external_search
     load_class($entity_model);
     my $offset = ($page - 1) * $limit;
 
+    if (defined DBDefs->MAX_SEARCH_RESULTS) {
+        my $depth = $offset + $limit;
+        if ($depth > DBDefs->MAX_SEARCH_RESULTS) {
+            return {
+                error => 'Must retrieve at most ' .
+                    DBDefs->MAX_SEARCH_RESULTS .
+                    " search results, not $depth.",
+                code  => HTTP_BAD_REQUEST,
+            };
+        }
+    }
+
     $query = uri_escape_utf8($query);
     $type =~ s/release_group/release-group/;
 

--- a/lib/MusicBrainz/Server/Data/WebService.pm
+++ b/lib/MusicBrainz/Server/Data/WebService.pm
@@ -41,6 +41,18 @@ sub xml_search
 
     $limit = 25 if ($limit < 1 || $limit > 100);
 
+    if (defined DBDefs->MAX_SEARCH_RESULTS) {
+        my $depth = $offset + $limit;
+        if ($depth > DBDefs->MAX_SEARCH_RESULTS) {
+            return {
+                error => 'Must retrieve at most ' .
+                    DBDefs->MAX_SEARCH_RESULTS .
+                    " search results, not $depth.",
+                code  => HTTP_BAD_REQUEST,
+            };
+        }
+    }
+
     if (defined $args->{query} && $args->{query} ne '')
     {
         if (ref($args->{query})) {

--- a/root/components/PaginatedResults.js
+++ b/root/components/PaginatedResults.js
@@ -32,6 +32,9 @@ component PaginatedResults(
       pageVar={pageVar}
     />
   );
+  const isLastCappedPage =
+    uncappedTotalHits > pager.total_entries &&
+    pager.current_page === pager.last_page;
   const totalCount = Math.max(pager.total_entries, uncappedTotalHits);
 
   return (
@@ -56,6 +59,14 @@ component PaginatedResults(
                 q: query,
               },
             )
+          )}
+        </p>
+      ) : null}
+      {isLastCappedPage ? (
+        <p>
+          {texp.l(
+            'Only the first {n} results could be returned.',
+            {n: pager.total_entries},
           )}
         </p>
       ) : null}

--- a/root/components/PaginatedResults.js
+++ b/root/components/PaginatedResults.js
@@ -20,6 +20,7 @@ component PaginatedResults(
   pager: PagerT,
   pageVar?: 'apps_page' | 'page' | 'tokens_page',
   query?: string,
+  uncappedTotalHits?: number = 0,
   search: boolean = false,
   total: boolean = false,
 ) {
@@ -31,6 +32,7 @@ component PaginatedResults(
       pageVar={pageVar}
     />
   );
+  const totalCount = Math.max(pager.total_entries, uncappedTotalHits);
 
   return (
     <>
@@ -41,16 +43,16 @@ component PaginatedResults(
             texp.ln(
               'Found {n} result',
               'Found {n} results',
-              pager.total_entries,
-              {n: formatCount($c, pager.total_entries)},
+              totalCount,
+              {n: formatCount($c, totalCount)},
             )
           ) : (
             texp.ln(
               'Found {n} result for "{q}"',
               'Found {n} results for "{q}"',
-              pager.total_entries,
+              totalCount,
               {
-                n: formatCount($c, pager.total_entries),
+                n: formatCount($c, totalCount),
                 q: query,
               },
             )

--- a/root/search/components/AnnotationResults.js
+++ b/root/search/components/AnnotationResults.js
@@ -45,6 +45,7 @@ component AnnotationResults(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: ResultsPropsT<AnnotationT>) {
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>
@@ -60,6 +61,7 @@ component AnnotationResults(...{
         pager={pager}
         query={query}
         results={results}
+        uncappedTotalHits={uncappedTotalHits}
       />
     </ResultsLayout>
   );

--- a/root/search/components/AreaResults.js
+++ b/root/search/components/AreaResults.js
@@ -52,6 +52,7 @@ component AreaResults(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: ResultsPropsT<AreaT>) {
   const $c = React.useContext(CatalystContext);
   return (
@@ -70,6 +71,7 @@ component AreaResults(...{
         pager={pager}
         query={query}
         results={results}
+        uncappedTotalHits={uncappedTotalHits}
       />
       {isLocationEditor($c.user) ? (
         <p>

--- a/root/search/components/ArtistResults.js
+++ b/root/search/components/ArtistResults.js
@@ -43,6 +43,7 @@ export component ArtistResultsInline(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: InlineResultsPropsT<ArtistT>) {
   return (
     <PaginatedSearchResults
@@ -63,6 +64,7 @@ export component ArtistResultsInline(...{
       pager={pager}
       query={query}
       results={results}
+      uncappedTotalHits={uncappedTotalHits}
     />
   );
 }
@@ -73,6 +75,7 @@ component ArtistResults(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: ResultsPropsT<ArtistT>) {
   const $c = React.useContext(CatalystContext);
   return (
@@ -81,6 +84,7 @@ component ArtistResults(...{
         pager={pager}
         query={query}
         results={results}
+        uncappedTotalHits={uncappedTotalHits}
       />
       {isEditingEnabled($c.user) ? (
         <p>

--- a/root/search/components/CDStubResults.js
+++ b/root/search/components/CDStubResults.js
@@ -35,6 +35,7 @@ component CDStubResults(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: ResultsPropsT<CDStubT>) {
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>
@@ -50,6 +51,7 @@ component CDStubResults(...{
         pager={pager}
         query={query}
         results={results}
+        uncappedTotalHits={uncappedTotalHits}
       />
     </ResultsLayout>
   );

--- a/root/search/components/EditorResults.js
+++ b/root/search/components/EditorResults.js
@@ -33,6 +33,7 @@ component EditorResults(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: ResultsPropsT<EditorT>) {
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>
@@ -42,6 +43,7 @@ component EditorResults(...{
         pager={pager}
         query={query}
         results={results}
+        uncappedTotalHits={uncappedTotalHits}
       />
     </ResultsLayout>
   );

--- a/root/search/components/EventResults.js
+++ b/root/search/components/EventResults.js
@@ -68,6 +68,7 @@ component EventResults(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: ResultsPropsT<EventT>) {
   const $c = React.useContext(CatalystContext);
   const buildResult = getResultBuilder(results
@@ -90,6 +91,7 @@ component EventResults(...{
         pager={pager}
         query={query}
         results={results}
+        uncappedTotalHits={uncappedTotalHits}
       />
       {isEditingEnabled($c.user) ? (
         <p>

--- a/root/search/components/InstrumentResults.js
+++ b/root/search/components/InstrumentResults.js
@@ -42,6 +42,7 @@ component InstrumentResults(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: ResultsPropsT<InstrumentT>) {
   const $c = React.useContext(SanitizedCatalystContext);
   return (
@@ -58,6 +59,7 @@ component InstrumentResults(...{
         pager={pager}
         query={query}
         results={results}
+        uncappedTotalHits={uncappedTotalHits}
       />
       {isRelationshipEditor($c.user) ? (
         <p>

--- a/root/search/components/LabelResults.js
+++ b/root/search/components/LabelResults.js
@@ -55,6 +55,7 @@ component LabelResults(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: ResultsPropsT<LabelT>) {
   const $c = React.useContext(CatalystContext);
   return (
@@ -74,6 +75,7 @@ component LabelResults(...{
         pager={pager}
         query={query}
         results={results}
+        uncappedTotalHits={uncappedTotalHits}
       />
       {isEditingEnabled($c.user) ? (
         <p>

--- a/root/search/components/PaginatedSearchResults.js
+++ b/root/search/components/PaginatedSearchResults.js
@@ -20,6 +20,7 @@ component PaginatedSearchResults<T>(
   pager: PagerT,
   query: string,
   results: ReadonlyArray<SearchResultT<T>>,
+  uncappedTotalHits: number,
 ) {
   const $c = React.useContext(CatalystContext);
   const hasLastPage = pager.total_entries > 0;
@@ -28,7 +29,7 @@ component PaginatedSearchResults<T>(
     : null;
 
   return results.length ? (
-    <PaginatedResults pager={pager} query={query} search>
+    <PaginatedResults pager={pager} query={query} uncappedTotalHits={uncappedTotalHits} search>
       <table className="tbl">
         <thead>
           <tr>

--- a/root/search/components/PaginatedSearchResults.js
+++ b/root/search/components/PaginatedSearchResults.js
@@ -29,7 +29,12 @@ component PaginatedSearchResults<T>(
     : null;
 
   return results.length ? (
-    <PaginatedResults pager={pager} query={query} uncappedTotalHits={uncappedTotalHits} search>
+    <PaginatedResults
+      pager={pager}
+      query={query}
+      search
+      uncappedTotalHits={uncappedTotalHits}
+    >
       <table className="tbl">
         <thead>
           <tr>

--- a/root/search/components/PlaceResults.js
+++ b/root/search/components/PlaceResults.js
@@ -54,6 +54,7 @@ component PlaceResults(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: ResultsPropsT<PlaceT>) {
   const $c = React.useContext(CatalystContext);
   return (
@@ -73,6 +74,7 @@ component PlaceResults(...{
         pager={pager}
         query={query}
         results={results}
+        uncappedTotalHits={uncappedTotalHits}
       />
       {isEditingEnabled($c.user) ? (
         <p>

--- a/root/search/components/RecordingResults.js
+++ b/root/search/components/RecordingResults.js
@@ -126,6 +126,7 @@ export component RecordingResultsInline(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: InlineResultsPropsT<RecordingT>) {
   const $c = React.useContext(CatalystContext);
 
@@ -150,6 +151,7 @@ export component RecordingResultsInline(...{
       pager={pager}
       query={query}
       results={results}
+      uncappedTotalHits={uncappedTotalHits}
     />
   );
 }
@@ -160,6 +162,7 @@ component RecordingResults(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: ResultsPropsT<RecordingT>) {
   const $c = React.useContext(CatalystContext);
   linenum = 0;
@@ -169,6 +172,7 @@ component RecordingResults(...{
         pager={pager}
         query={query}
         results={results}
+        uncappedTotalHits={uncappedTotalHits}
       />
       {isEditingEnabled($c.user) ? (
         <p>

--- a/root/search/components/ReleaseGroupResults.js
+++ b/root/search/components/ReleaseGroupResults.js
@@ -59,6 +59,7 @@ component ReleaseGroupResults(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: ResultsPropsT< ReleaseGroupT >) {
   const $c = React.useContext(CatalystContext);
   const buildResult = getResultBuilder(
@@ -79,6 +80,7 @@ component ReleaseGroupResults(...{
         pager={pager}
         query={query}
         results={results}
+        uncappedTotalHits={uncappedTotalHits}
       />
       {isEditingEnabled($c.user) ? (
         <p>

--- a/root/search/components/ReleaseResults.js
+++ b/root/search/components/ReleaseResults.js
@@ -102,6 +102,7 @@ export component ReleaseResultsInline(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: InlineResultsPropsT<ReleaseT>) {
   const $c = React.useContext(CatalystContext);
   const buildResult = getResultBuilder(
@@ -134,6 +135,7 @@ export component ReleaseResultsInline(...{
       pager={pager}
       query={query}
       results={results}
+      uncappedTotalHits={uncappedTotalHits}
     />
   );
 }
@@ -144,6 +146,7 @@ component ReleaseResults(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: ResultsPropsT<ReleaseT>) {
   const $c = React.useContext(CatalystContext);
   return (
@@ -152,6 +155,7 @@ component ReleaseResults(...{
         pager={pager}
         query={query}
         results={results}
+        uncappedTotalHits={uncappedTotalHits}
       />
       {isEditingEnabled($c.user) ? (
         <p>

--- a/root/search/components/SeriesResults.js
+++ b/root/search/components/SeriesResults.js
@@ -49,6 +49,7 @@ component SeriesResults(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: ResultsPropsT<SeriesT>) {
   const $c = React.useContext(CatalystContext);
   return (
@@ -65,6 +66,7 @@ component SeriesResults(...{
         pager={pager}
         query={query}
         results={results}
+        uncappedTotalHits={uncappedTotalHits}
       />
       {isEditingEnabled($c.user) ? (
         <p>

--- a/root/search/components/TagResults.js
+++ b/root/search/components/TagResults.js
@@ -42,6 +42,7 @@ component TagResults(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: ResultsPropsT<TagT>) {
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>
@@ -56,6 +57,7 @@ component TagResults(...{
         pager={pager}
         query={query}
         results={results}
+        uncappedTotalHits={uncappedTotalHits}
       />
     </ResultsLayout>
   );

--- a/root/search/components/WorkResults.js
+++ b/root/search/components/WorkResults.js
@@ -43,6 +43,7 @@ component WorkResults(...{
   pager,
   query,
   results,
+  uncappedTotalHits,
 }: ResultsPropsT<WorkT>) {
   const $c = React.useContext(CatalystContext);
   return (
@@ -63,6 +64,7 @@ component WorkResults(...{
         pager={pager}
         query={query}
         results={results}
+        uncappedTotalHits={uncappedTotalHits}
       />
       {isEditingEnabled($c.user) ? (
         <p>

--- a/root/search/types.js
+++ b/root/search/types.js
@@ -11,6 +11,7 @@ export type InlineResultsPropsT<T> = {
   readonly pager: PagerT,
   readonly query: string,
   readonly results: ReadonlyArray<SearchResultT<T>>,
+  readonly uncappedTotalHits: number,
 };
 
 export type ResultsPropsT<T> = Readonly<{

--- a/root/taglookup/ArtistResults.js
+++ b/root/taglookup/ArtistResults.js
@@ -21,6 +21,7 @@ component TagLookupArtistResults(...props: {
         pager={props.pager}
         query={props.query}
         results={props.results}
+        uncappedTotalHits={props.uncappedTotalHits}
       />
     </TagLookupResults>
   );

--- a/root/taglookup/RecordingResults.js
+++ b/root/taglookup/RecordingResults.js
@@ -23,6 +23,7 @@ component TagLookupRecordingResults(...props: {
         pager={props.pager}
         query={props.query}
         results={props.results}
+        uncappedTotalHits={props.uncappedTotalHits}
       />
       {manifest('common/components/TaggerIcon', {async: true})}
     </TagLookupResults>

--- a/root/taglookup/ReleaseResults.js
+++ b/root/taglookup/ReleaseResults.js
@@ -22,6 +22,7 @@ component TagLookupReleaseResults(...props: {
         pager={props.pager}
         query={props.query}
         results={props.results}
+        uncappedTotalHits={props.uncappedTotalHits}
       />
       {manifest('common/components/TaggerIcon', {async: true})}
     </TagLookupResults>

--- a/t/lib/t/MusicBrainz/Server/Controller/Search/Direct.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Search/Direct.pm
@@ -2,6 +2,8 @@ package t::MusicBrainz::Server::Controller::Search::Direct;
 use strict;
 use warnings;
 
+use HTTP::Status qw( :constants );
+use Test::More;
 use Test::Routine;
 use MusicBrainz::Server::Test qw( html_ok );
 
@@ -80,6 +82,28 @@ $mech->content_contains('1 result', 'has result count');
 $mech->content_contains('musical', 'has correct search result');
 $mech->content_contains('/tag/musical', 'has link to the tag');
 
+};
+
+test 'MBS-14455: Direct search is filtered on depth' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c);
+
+    no warnings 'redefine';
+    local *DBDefs::MAX_SEARCH_RESULTS = sub { 500 };
+
+    # limit 25 * page 21 = depth 525 > 500
+    $mech->get('/search?limit=25&method=direct&page=21&query=Kate&type=artist');
+    is($mech->status, HTTP_BAD_REQUEST, 'Deep direct search gives a bad request error');
+    html_ok($mech->content);
+    $mech->content_contains('deemed invalid', 'Deep direct search gives an invalid search message');
+
+    # limit 25 * page 20 = depth 500
+    $mech->get_ok('/search?limit=25&method=direct&page=20&query=Kate&type=artist',
+                  'Last page of direct search still works');
+    html_ok($mech->content);
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Search/Direct.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Search/Direct.pm
@@ -104,6 +104,15 @@ test 'MBS-14455: Direct search is filtered on depth' => sub {
     $mech->get_ok('/search?limit=25&method=direct&page=20&query=Kate&type=artist',
                   'Last page of direct search still works');
     html_ok($mech->content);
+
+    # limit 25 * page 1 = depth 25 < 500
+    $mech->get_ok('/search?limit=25&method=direct&query=Kate&type=artist',
+                  'First page of indexed search still works');
+    html_ok($mech->content);
+
+    # Note: Since direct search is implemented with hard_search_limit,
+    # the returned total number of hits is not accurate, it actually
+    # depends on the requested page, thus not testing the pager here.
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Search/Indexed.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Search/Indexed.pm
@@ -123,6 +123,8 @@ test 'MBS-14455: Indexed search is filtered on depth' => sub {
     $mech->get_ok('/search?query=Love&type=artist&limit=25&page=20',
                   'Last page of indexed search still works');
     html_ok($mech->content);
+    $mech->content_contains('Only the first 500 results could be returned',
+        'Last capped page contains an explanation');
 
     # limit 25 * page 1 = depth 25 < 500
     $mech->get_ok('/search?query=Love&type=artist&limit=25',

--- a/t/lib/t/MusicBrainz/Server/Controller/Search/Indexed.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Search/Indexed.pm
@@ -104,8 +104,6 @@ test all => sub {
     $mech->content_contains('L.O.V.E.', 'has correct search result');
     $mech->content_contains('Love, Laura', 'has artist sortname');
     $mech->content_contains('/artist/406bca37-056f-405e-a974-624864c9f641', 'has link to artist');
-
-    LWP::UserAgent::Mockable->finished;
 };
 
 test 'MBS-14455: Indexed search is filtered on depth' => sub {
@@ -125,6 +123,18 @@ test 'MBS-14455: Indexed search is filtered on depth' => sub {
     $mech->get_ok('/search?query=Love&type=artist&limit=25&page=20',
                   'Last page of indexed search still works');
     html_ok($mech->content);
+
+    # limit 25 * page 1 = depth 25 < 500
+    $mech->get_ok('/search?query=Love&type=artist&limit=25',
+                  'First page of indexed search still works');
+    html_ok($mech->content);
+    $mech->content_contains('784 results', 'Show uncapped total hits');
+    # max search results 500 / limit 25 = last capped page 20
+    $mech->content_contains('page=20', 'Last page button matches the cap');
+    # uncapped total hits 784 / limit 25 =< last uncapped page 32
+    $mech->content_lacks('page=32', 'Pager does not offer pages beyond the cap');
+
+    LWP::UserAgent::Mockable->finished;
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Search/Indexed.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Search/Indexed.pm
@@ -5,6 +5,7 @@ use warnings;
 use HTTP::Response;
 use HTTP::Status qw( :constants );
 use LWP::UserAgent::Mockable;
+use Test::More;
 use Test::Routine;
 use MusicBrainz::Server::Test qw( html_ok );
 
@@ -105,6 +106,25 @@ test all => sub {
     $mech->content_contains('/artist/406bca37-056f-405e-a974-624864c9f641', 'has link to artist');
 
     LWP::UserAgent::Mockable->finished;
+};
+
+test 'MBS-14455: Indexed search is filtered on depth' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    no warnings 'redefine';
+    local *DBDefs::MAX_SEARCH_RESULTS = sub { 500 };
+
+    # limit 25 * page 21 = depth 525 > 500
+    $mech->get('/search?query=Love&type=artist&limit=25&page=21');
+    is($mech->status, HTTP_BAD_REQUEST, 'Deep indexed search gives a bad request error');
+    html_ok($mech->content);
+    $mech->content_contains('deemed invalid', 'Deep indexed search gives an invalid search message');
+
+    # limit 25 * page 20 = depth 500
+    $mech->get_ok('/search?query=Love&type=artist&limit=25&page=20',
+                  'Last page of indexed search still works');
+    html_ok($mech->content);
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/TagLookup.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/TagLookup.pm
@@ -6,6 +6,7 @@ use warnings;
 use HTTP::Response;
 use HTTP::Status qw( :constants );
 use LWP::UserAgent::Mockable;
+use Test::More;
 use Test::Routine;
 
 use MusicBrainz::Server::Test qw( html_ok );
@@ -180,6 +181,25 @@ test 'Can perform tag lookups with artist and release titles' => sub {
     $test->mech->content_contains('Make a donation now', 'has nag screen');
 
     LWP::UserAgent::Mockable->finished;
+};
+
+test 'MBS-14455: Tag lookup is filtered on depth' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    no warnings 'redefine';
+    local *DBDefs::MAX_SEARCH_RESULTS = sub { 500 };
+
+    # limit 25 * page 21 = depth 525 > 500
+    $mech->get('/taglookup/index?tag-lookup.release=love&page=21');
+    is($mech->status, HTTP_BAD_REQUEST, 'Deep tag lookup gives a bad request error');
+    html_ok($mech->content);
+    $mech->content_contains('deemed invalid', 'Deep tag lookup gives an invalid search message');
+
+    # limit 25 * page 20 = depth 500
+    $mech->get_ok('/taglookup/index?tag-lookup.release=love&page=20',
+                  'Last page of tag lookup still works');
+    html_ok($mech->content);
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/TagLookup.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/TagLookup.pm
@@ -198,6 +198,8 @@ test 'MBS-14455: Tag lookup is filtered on depth' => sub {
     $mech->get_ok('/taglookup/index?tag-lookup.release=love&page=20',
                   'Last page of tag lookup still works');
     html_ok($mech->content);
+    $mech->content_contains('Only the first 500 results could be returned',
+        'Last capped page contains an explanation');
 
     # limit 25 * page 1 = depth 25 < 500
     $mech->get_ok('/taglookup/index?tag-lookup.release=love',

--- a/t/lib/t/MusicBrainz/Server/Controller/TagLookup.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/TagLookup.pm
@@ -179,8 +179,6 @@ test 'Can perform tag lookups with artist and release titles' => sub {
     $test->mech->content_contains('中島', 'has correct artist result');
     $test->mech->content_contains('LOVE', 'has correct release result');
     $test->mech->content_contains('Make a donation now', 'has nag screen');
-
-    LWP::UserAgent::Mockable->finished;
 };
 
 test 'MBS-14455: Tag lookup is filtered on depth' => sub {
@@ -200,6 +198,18 @@ test 'MBS-14455: Tag lookup is filtered on depth' => sub {
     $mech->get_ok('/taglookup/index?tag-lookup.release=love&page=20',
                   'Last page of tag lookup still works');
     html_ok($mech->content);
+
+    # limit 25 * page 1 = depth 25 < 500
+    $mech->get_ok('/taglookup/index?tag-lookup.release=love',
+                  'First page of tag lookup still works');
+    html_ok($mech->content);
+    $mech->content_contains('20,859 results', 'Show uncapped total hits');
+    # max search results 500 / limit 25 = last capped page 20
+    $mech->content_contains('page=20', 'Last page button matches the cap');
+    # uncapped total hits 20859 / limit 25 =< last uncapped page 835
+    $mech->content_lacks('page=835', 'Pager does not offer pages beyond the cap');
+
+    LWP::UserAgent::Mockable->finished;
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/Search.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/Search.pm
@@ -1,0 +1,57 @@
+package t::MusicBrainz::Server::Controller::WS::2::Search;
+use strict;
+use warnings;
+
+use HTTP::Status qw( :constants );
+use LWP::UserAgent::Mockable;
+use Test::More;
+use Test::Routine;
+
+with 't::Mechanize';
+
+test 'MBS-14455: WS/2 search is filtered on depth' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    no warnings 'redefine';
+    local *DBDefs::MAX_SEARCH_RESULTS = sub { 500 };
+
+    # limit 25 + offset 476 = depth 501 > 500
+    $mech->get('/ws/2/artist?query=Duo&limit=25&offset=476');
+    is($mech->status, HTTP_BAD_REQUEST, 'Deep WS/2 search gives a bad request error');
+    $mech->content_contains('Must retrieve at most 500 search results, not 501.',
+        'Deep WS/2 search gives an explanatory message.');
+
+    LWP::UserAgent::Mockable->set_record_pre_callback(sub {
+        my $response = HTTP::Response->new;
+        $response->code(HTTP_OK);
+        $response->content(<<~'EOF');
+            {
+              "offset": 0,
+              "count": 1755,
+              "artists": [
+                {
+                  "id": "3931e712-b43a-4271-b8e6-dd70a74c1d57",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "score": 87,
+                  "name": "Duo",
+                  "sort-name": "Duo",
+                  "life-span": {
+                    "ended": null
+                  }
+                }
+              ]
+            }
+            EOF
+        return $response;
+    });
+
+    # limit 25 + offset 475 = 500
+    $mech->get_ok('/ws/2/artist?query=Duo&limit=25&offset=475',
+                  'Maxed out WS/2 search still works');
+
+    LWP::UserAgent::Mockable->finished;
+};
+
+1;

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/Search.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/Search.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 
 use HTTP::Status qw( :constants );
+use JSON::XS qw( decode_json );
 use LWP::UserAgent::Mockable;
 use Test::More;
 use Test::Routine;
@@ -50,6 +51,12 @@ test 'MBS-14455: WS/2 search is filtered on depth' => sub {
     # limit 25 + offset 475 = 500
     $mech->get_ok('/ws/2/artist?query=Duo&limit=25&offset=475',
                   'Maxed out WS/2 search still works');
+
+    # limit 25 + offset 0 = 25 < 500
+    $mech->get_ok('/ws/2/artist?query=Duo&limit=25&offset=0&fmt=json',
+                  'First page of WS/2 search still works');
+    is(decode_json($mech->content)->{count}, 1755,
+        'First page of WS/2 search still counts uncapped total hits');
 
     LWP::UserAgent::Mockable->finished;
 };


### PR DESCRIPTION
# MBS-14455

## Problem 

Search service cache/performance/stability is impaired by deep searches
which are most often illegitimately requested by bad actors.

## Solution

Set a limit on the depth of results returned by all kind of entity search:
advanced, direct, indexed, and even autocompletion and taglookup,
since those could be diverted by bad actors.

See commit messages for implementation details.

# AI usage
<!--
    If you used AI / LLM tools while working on this pull request, you must
    disclose it as per the MetaBrainz Foundation's contribution guidelines
    (https://github.com/metabrainz/guidelines).
-->

An LLM was used to draft the added test cases.

# Testing

Manually tested with `MAX_SEARCH_RESULTS` set to 500 in DBDefs:

* Indexed search:
  * [x] [first page](https://musicbrainz.org/search?query=Duo&type=artist&limit=25) (reduced available pages)
  * [x] [last page](https://musicbrainz.org/search?query=Duo&type=artist&limit=25&page=20) (added message)
  * [x] [abyss](https://musicbrainz.org/search?query=Duo&type=artist&limit=25&page=21) (rejected)
* Advanced search:
  * [x] [first page](https://musicbrainz.org/search?query=artist%3ADuo&type=artist&limit=25&method=advanced) (reduced available pages)
  * [x] [last page](https://musicbrainz.org/search?query=artist%3ADuo&type=artist&limit=25&method=advanced&page=20) (added message)
  * [x] [abyss](https://musicbrainz.org/search?query=artist%3ADuo&type=artist&limit=25&method=advanced&page=21) (rejected)
* Direct search:
  * [x] [first page](https://musicbrainz.org/search?query=Duo&type=artist&limit=25&method=direct) (reduced available pages)
  * [x] [last page](https://musicbrainz.org/search?query=Duo&type=artist&limit=25&method=direct&page=20) (added message)
  * [x] [abyss](https://musicbrainz.org/search?query=Duo&type=artist&limit=25&method=direct&page=21) (rejected)
* Tag lookup:
  * [x] [first page](https://musicbrainz.org/taglookup/index?tag-lookup.tracknum=13) (reduced available pages)
  * [x] [last page](https://musicbrainz.org/taglookup/index?tag-lookup.tracknum=13&page=20) (added message)
  * [x] [abyss](https://musicbrainz.org/taglookup/index?tag-lookup.tracknum=13&page=21) (rejected)
* Autocomplete:
  * [x] [edit artist’s area](https://musicbrainz.org/artist/ff2fa07a-774e-42ea-8503-c4cb4583c313/edit) (unchanged)


# Documenting

:beginner: If you updated documentation pages, mention them here, such as:
Updated [WikiDocs page](https://wiki.musicbrainz.org/Category:WikiDocs_Page)

# Draft progress
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Add CI tests for
  * [x] Throwing error on deep searches
  * [x] Displaying the uncapped number of results
  * [x] Displaying pager buttons for the reachable pages only
  * [x] Displaying a message for the last page of capped search results
* [x] Update the [wiki page for Search documentation](https://wiki.musicbrainz.org/Search) with the depth limit
* [x] Update `DBDefs.pm` files (with default value) in MusicBrainz Docker Compose project for mirrors

# Further action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Transclude the [WikiDoc page for Search documentation](https://musicbrainz.org/doc/Search)
2. Set `MAX_SEARCH_RESULTS` to 500 (?) for deployment
3. Merge the corresponding pull request to `musicbrainz-docker`